### PR TITLE
Overriding node's address with commandline arg

### DIFF
--- a/golem/appconfig.py
+++ b/golem/appconfig.py
@@ -24,6 +24,7 @@ APP_VERSION = "1.021"
 
 logger = logging.getLogger(__name__)
 
+
 class CommonConfig:
 
     def __init__(self, section="Common", **kwargs):
@@ -107,7 +108,6 @@ class NodeConfig:
             estimated_performance = ESTIMATED_DEFAULT
         kwargs["estimated_performance"] = estimated_performance
 
-
         estimated_lux = NodeConfig.read_estimated_lux_performance()
         if estimated_lux <= 0:
             estimated_lux = ESTIMATED_DEFAULT
@@ -162,6 +162,7 @@ class AppConfig:
                                      app_version=APP_VERSION)
 
         node_config = NodeConfig(local_id,
+                                 node_address="",
                                  seed_host="",
                                  seed_port=0,
                                  root_path=DEFAULT_ROOT_PATH,

--- a/golem/client.py
+++ b/golem/client.py
@@ -32,12 +32,16 @@ logger = logging.getLogger(__name__)
 def empty_add_nodes(*args):
     pass
 
-def create_client():
+
+def create_client(**config_overrides):
     init_messages()
 
     app_config = AppConfig.load_config()
     config_desc = ClientConfigDescriptor()
     config_desc.init_from_app_config(app_config)
+
+    for key, val in config_overrides.iteritems():
+        setattr(config_desc, key, val)
 
     logger.info("Adding tasks {}".format(app_config.get_add_tasks()))
     logger.info("Creating public client interface named: {}".format(app_config.get_node_name()))
@@ -81,7 +85,9 @@ class Client:
         self.config_approver = ConfigApprover(config_desc)
 
         # NETWORK
-        self.node = Node(self.config_desc.node_name, self.keys_auth.get_key_id())
+        self.node = Node(node_name=self.config_desc.node_name,
+                         key=self.keys_auth.get_key_id(),
+                         prv_addr=self.config_desc.node_address)
         self.node.collect_network_info(self.config_desc.seed_host, use_ipv6=self.config_desc.use_ipv6)
         logger.debug("Is super node? {}".format(self.node.is_super_node()))
         self.p2pservice = None

--- a/golem/clientconfigdescriptor.py
+++ b/golem/clientconfigdescriptor.py
@@ -9,6 +9,7 @@ class ClientConfigDescriptor(object):
     def __init__(self):
         """ Create new basic empty configuration scheme """
         self.node_name = ""
+        self.node_address = ""
         self.start_port = 0
         self.end_port = 0
         self.manager_address = ""

--- a/golem/network/p2p/node.py
+++ b/golem/network/p2p/node.py
@@ -1,4 +1,7 @@
+import logging
 from golem.core.hostaddress import get_host_address, get_external_address, get_host_addresses
+
+logger = logging.getLogger(__name__)
 
 
 class Node(object):
@@ -13,12 +16,17 @@ class Node(object):
         self.prv_addresses = []
 
     def collect_network_info(self, seed_host=None, use_ipv6=False):
-        self.prv_addr = get_host_address(seed_host, use_ipv6)
+        if not self.prv_addr:
+            self.prv_addr = get_host_address(seed_host, use_ipv6)
         if self.prv_port:
             self.pub_addr, self.pub_port, self.nat_type = get_external_address(self.prv_port)
         else:
             self.pub_addr, _, self.nat_type = get_external_address()
         self.prv_addresses = get_host_addresses(use_ipv6)
+        if self.prv_addr not in self.prv_addresses:
+            logger.warn("Specified node address {} is not among detected "
+                        "network addresses: {}".format(self.prv_addr,
+                                                       self.prv_addresses))
 
     def is_super_node(self):
         if self.pub_addr is None or self.prv_addr is None:


### PR DESCRIPTION
New `--node-argument` commandline arg may be used to
override autodetected node's address.
