### PR TITLE
Kill task computer

### DIFF
--- a/gnr/admmain.py
+++ b/gnr/admmain.py
@@ -1,3 +1,6 @@
+import sys
+from multiprocessing import freeze_support
+
 from gnrstartapp import start_app, config_logging
 from renderingadmapplicationlogic import RenderingAdmApplicationLogic
 from gnr.ui.administrationmainwindow import AdministrationMainWindow
@@ -12,10 +15,17 @@ def main():
     app = GNRGui(logic, AdministrationMainWindow)
     gui = RenderingAdmMainWindowCustomizer
 
-    start_app(logic, app, gui, rendering=True, start_add_task_client=False, start_add_task_server=False)
+    try:
+        start_app(logic, app, gui, rendering=True, start_add_task_client=False, start_add_task_server=False)
+    finally:
+        try:
+            logic.client.task_server.task_computer.end_task()
+        except Exception as ex:
+            import logging
+            logger = logging.getLogger(__name__)
+            logger.warning("Exception when closing Golem {}".format(ex))
+        sys.exit(0)
 
-
-from multiprocessing import freeze_support
 
 if __name__ == "__main__":
     freeze_support()

--- a/gnr/admmain.py
+++ b/gnr/admmain.py
@@ -15,16 +15,7 @@ def main():
     app = GNRGui(logic, AdministrationMainWindow)
     gui = RenderingAdmMainWindowCustomizer
 
-    try:
-        start_app(logic, app, gui, rendering=True, start_add_task_client=False, start_add_task_server=False)
-    finally:
-        try:
-            logic.client.task_server.task_computer.end_task()
-        except Exception as ex:
-            import logging
-            logger = logging.getLogger(__name__)
-            logger.warning("Exception when closing Golem {}".format(ex))
-        sys.exit(0)
+    start_app(logic, app, gui, rendering=True, start_add_task_client=False, start_add_task_server=False)
 
 
 if __name__ == "__main__":

--- a/gnr/admmain.py
+++ b/gnr/admmain.py
@@ -1,4 +1,3 @@
-import sys
 from multiprocessing import freeze_support
 
 from gnrstartapp import start_app, config_logging

--- a/gnr/gnradmapplicationlogic.py
+++ b/gnr/gnradmapplicationlogic.py
@@ -30,7 +30,7 @@ class GNRAdmApplicationLogic(GNRApplicationLogic):
         self.start_nodes_manager_function()
 
     def send_test_tasks(self):
-        path = os.path.join(appdirs.user_data_dir('golem'), "save" "test")
+        path = os.path.join(appdirs.user_data_dir('golem'), "save", "test")
         self.add_and_start_tasks_from_files(glob.glob(os.path.join(path, '*.gt')))
 
     def update_other_golems(self, golem_dir):

--- a/gnr/node.py
+++ b/gnr/node.py
@@ -4,6 +4,7 @@ import os
 import pickle
 import click
 import uuid
+import sys
 import logging.config
 
 from twisted.internet import reactor
@@ -57,9 +58,14 @@ class Node(object):
                                                       self.client.get_root_path()))
             self.client.enqueue_new_task(golem_task)
 
-    @staticmethod
-    def run():
-        reactor.run()
+    def run(self):
+        try:
+            reactor.run()
+        except Exception as err:
+            logger.error("{}".format(err))
+        finally:
+            self.client.quit()
+            sys.exit(0)
 
 
 class GNRNode(Node):

--- a/gnr/node.py
+++ b/gnr/node.py
@@ -61,8 +61,6 @@ class Node(object):
     def run(self):
         try:
             reactor.run()
-        except Exception as err:
-            logger.error("{}".format(err))
         finally:
             self.client.quit()
             sys.exit(0)

--- a/golem/client.py
+++ b/golem/client.py
@@ -159,6 +159,7 @@ class Client:
         self.task_adder_server.start()
 
     def quit(self):
+        self.task_server.quit()
         if self.task_adder_server:
             self.task_adder_server.terminate()
 

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -210,7 +210,7 @@ class TaskComputer(object):
         self.current_computations.append(tt)
         tt.start()
 
-    def end_task(self):
+    def quit(self):
         for t in self.current_computations:
             t.end_comp()
 

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -206,8 +206,13 @@ class TaskComputer(object):
         tt = PyTaskThread(self, subtask_id, working_directory, src_code, extra_data, short_desc,
                           self.resource_manager.get_resource_dir(task_id), self.resource_manager.get_temporary_dir(task_id),
                           task_timeout)
+        tt.setDaemon(True)
         self.current_computations.append(tt)
         tt.start()
+
+    def end_task(self):
+        for t in self.current_computations:
+            t.end_comp()
 
 
 class AssignedSubTask(object):

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -376,6 +376,9 @@ class TaskServer(PendingConnectionsServer):
             tcp_addresses = [TCPAddress(addr, port)] + tcp_addresses
         return tcp_addresses
 
+    def quit(self):
+        self.task_computer.quit()
+
     def _get_factory(self):
         return self.factory(self)
 


### PR DESCRIPTION
Changes that allow us to kill computations when golem is killed or stopped. Killed: thread is a deamon now, so it should die. Stopped: task computer will kill its active computation in quit method. 
