### PR TITLE
Fix for #146

### DIFF
--- a/gnr/node.py
+++ b/gnr/node.py
@@ -129,16 +129,15 @@ def node_cli():
 @click.option('--node-address', '-a', multiple=False, type=click.STRING,
               callback=parse_node_addr,
               help="Network address to use for this node")
-@click.option('--public-address', '-A', multiple=False, type=click.STRING,
-              callback=parse_node_addr,
-              help="Public network address to use for this node")
 @click.option('--peer', '-p', multiple=True, callback=parse_peer,
               help="Connect with given peer: <ipv4_addr>:<port> or [<ipv6_addr>]:<port>")
-@click.option('--task', '-t', multiple=True, type=click.File(lazy=True), callback=parse_task_file,
+@click.option('--task', '-t', multiple=True, type=click.File(lazy=True),
+              callback=parse_task_file,
               help="Request task from file")
-def start(node_address, public_address, peer, task, **kwargs):
+def start(node_address, peer, task, **extra_args):
+    del extra_args
 
-    node = GNRNode(node_address=node_address, public_address=public_address)
+    node = GNRNode(node_address=node_address)
     node.initialize()
 
     node.connect_with_peers(peer)

--- a/golem/client.py
+++ b/golem/client.py
@@ -41,10 +41,11 @@ def create_client(**config_overrides):
     config_desc.init_from_app_config(app_config)
 
     for key, val in config_overrides.iteritems():
-        # For safety we only allow here overriding properties that are
-        # fields of ClientConfigDescriptor. Hence the getattr() here:
-        getattr(config_desc, key)
-        setattr(config_desc, key, val)
+        if hasattr(config_desc, key):
+            setattr(config_desc, key, val)
+        else:
+            raise AttributeError(
+                "Can't override nonexistent config attribute '{}'".format(key))
 
     logger.info("Adding tasks {}".format(app_config.get_add_tasks()))
     logger.info("Creating public client interface named: {}".format(app_config.get_node_name()))

--- a/golem/client.py
+++ b/golem/client.py
@@ -41,6 +41,9 @@ def create_client(**config_overrides):
     config_desc.init_from_app_config(app_config)
 
     for key, val in config_overrides.iteritems():
+        # For safety we only allow here overriding properties that are
+        # fields of ClientConfigDescriptor. Hence the getattr() here:
+        getattr(config_desc, key)
         setattr(config_desc, key, val)
 
     logger.info("Adding tasks {}".format(app_config.get_add_tasks()))
@@ -87,8 +90,7 @@ class Client:
         # NETWORK
         self.node = Node(node_name=self.config_desc.node_name,
                          key=self.keys_auth.get_key_id(),
-                         prv_addr=self.config_desc.node_address,
-                         pub_addr=self.config_desc.public_address)
+                         prv_addr=self.config_desc.node_address)
         self.node.collect_network_info(self.config_desc.seed_host, use_ipv6=self.config_desc.use_ipv6)
         logger.debug("Is super node? {}".format(self.node.is_super_node()))
         self.p2pservice = None

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1,0 +1,40 @@
+from mock import patch
+import unittest
+
+from golem.client import create_client
+from golem.clientconfigdescriptor import ClientConfigDescriptor
+from golem.tools.testwithappconfig import TestWithAppConfig
+
+
+class TestCreateClient(TestWithAppConfig):
+
+    @patch('golem.client.Client')
+    def test_config_default(self, mock_client):
+        create_client()
+        for name, args, kwargs in mock_client.mock_calls:
+            if name == "":  # __init__ call
+                config_desc = args[0]
+                self.assertIs(type(config_desc), ClientConfigDescriptor)
+                return
+        self.fail("__init__ call not found")
+
+    @patch('golem.client.Client')
+    def test_config_override_valid(self, mock_client):
+        self.assertTrue(hasattr(ClientConfigDescriptor(), "node_address"))
+        create_client(node_address='1.0.0.0')
+        for name, args, kwargs in mock_client.mock_calls:
+            if name == "":  # __init__ call
+                config_desc = args[0]
+                self.assertEqual(config_desc.node_address, '1.0.0.0')
+                return
+        self.fail("__init__ call not found")
+
+    @patch('golem.client.Client')
+    def test_config_override_invalid(self, mock_client):
+        """Test that create_client() does not allow to override properties
+        that are not in ClientConfigDescriptor.
+        """
+        self.assertFalse(hasattr(ClientConfigDescriptor(), "node_colour"))
+        with self.assertRaises(AttributeError):
+            create_client(node_colour='magenta')
+

--- a/tests/imunes/node.py
+++ b/tests/imunes/node.py
@@ -1,6 +1,6 @@
 import click
 
-from gnr.node import start, GNRNode, node_cli
+from gnr.node import start, GNRNode, node_cli, parse_node_addr
 
 
 def disable_blender(ctx, param, value):
@@ -9,23 +9,39 @@ def disable_blender(ctx, param, value):
         GNRNode.default_environments = []
 
 
-# This command group is created only to create a `--blender` option somewhere.
+def set_network_info(ctx, param, value):
+    addr = parse_node_addr(ctx, param, value)
+    if addr:
+        import golem.network.p2p.node
+        # Patch the Node.collect_network_info() method to set the provided
+        # address as the node's public address.
+
+        def override_network_info(self, *args, **kwargs):
+            self.pub_addr = addr
+            self.prv_addr = addr
+
+        golem.network.p2p.node.Node.collect_network_info = override_network_info
+
+
+# This command group is created only to create extra options for running in
+# imunes simulation.
 @click.group()
 @click.option('--blender/--no-blender', default=True, callback=disable_blender,
               help="Enable/disable Blender environment (enabled by default)")
+@click.option('--public-address', '-A', multiple=False, type=click.STRING,
+              callback=set_network_info,
+              help="Public network address to use for this node")
 def dummy_cli():
     pass
 
 
-# Extract the `blender` option from `dummy_cli` and add it to the `node_cli`
+# Copy the extra options from `dummy_cli` to the `node_cli`
 # group defined in `gnr.node`.
-# This is probably a lame way of adding an option to an existing command...
-assert len(dummy_cli.params) == 1
-blender_option = dummy_cli.params[0]
-assert blender_option.name == 'blender'
-
+# This is probably a lame way of adding options to an existing command...
 start_command = node_cli.commands['start']
-start_command.params.append(blender_option)
+for param in dummy_cli.params:
+    start_command.params.append(param)
+
 
 if __name__ == "__main__":
     start()

--- a/tests/imunes/test_imunes_node.py
+++ b/tests/imunes/test_imunes_node.py
@@ -4,6 +4,7 @@ from click.testing import CliRunner
 from golem.core.simpleenv import SimpleEnv
 from gnr.renderingenvironment import BlenderEnvironment
 from golem.tools.testwithappconfig import TestWithAppConfig
+# from golem.client import create_client
 
 import shutil
 import tempfile
@@ -53,3 +54,15 @@ class TestNode(TestWithAppConfig):
                 (env_arg, ) = args
                 env_types.append(type(env_arg))
         self.assertTrue(BlenderEnvironment not in env_types)
+
+    @patch('gnr.node.Node.initialize')
+    @patch('gnr.node.Node.run', autospec = True)
+    def test_public_address(self, mock_run, mock_initialize):
+        public_address = '1.0.0.1'
+        runner = CliRunner()
+        return_value = runner.invoke(start, ['--public-address', public_address])
+        self.assertEquals(return_value.exit_code, 0)
+        (gnr_node, ) = mock_run.call_args[0]
+        self.assertEqual(gnr_node.client.node.pub_addr, public_address)
+        self.assertTrue(gnr_node.client.node.is_super_node())
+

--- a/tests/imunes/test_imunes_node.py
+++ b/tests/imunes/test_imunes_node.py
@@ -4,7 +4,6 @@ from click.testing import CliRunner
 from golem.core.simpleenv import SimpleEnv
 from gnr.renderingenvironment import BlenderEnvironment
 from golem.tools.testwithappconfig import TestWithAppConfig
-# from golem.client import create_client
 
 import shutil
 import tempfile
@@ -65,4 +64,3 @@ class TestNode(TestWithAppConfig):
         (gnr_node, ) = mock_run.call_args[0]
         self.assertEqual(gnr_node.client.node.pub_addr, public_address)
         self.assertTrue(gnr_node.client.node.is_super_node())
-


### PR DESCRIPTION
The option `--public-address` is now only valid for `tests/imunes/node.py`, not for `gnr/node.py`. Specifying `--public-address` results in bypassing `Node's` `collect_network_info`  (stun is not used) and setting `Node.pub_addr` and `Node.priv_addr` to the specified value.
