### PR TITLE
Rewrite free net port selector

### DIFF
--- a/golem/ethereum/client.py
+++ b/golem/ethereum/client.py
@@ -31,7 +31,7 @@ class Client(EthereumRpcClient):
             assert not Client.__client_rpc_port
             program = find_program('geth')
             assert program  # TODO: Replace with a nice exception
-            rpcport = find_free_net_port(9001)
+            rpcport = find_free_net_port()
             # Data dir must be set the class user to allow multiple nodes running
             if not datadir:
                 datadir = path.join(appdirs.user_data_dir('golem'), 'ethereum9')

--- a/golem/utils.py
+++ b/golem/utils.py
@@ -1,9 +1,8 @@
-import psutil
+import socket
 
 
-def find_free_net_port(start_port):
-    """Finds first free port on host starting from given one"""
-    open_ports = set(c.laddr[1] for c in psutil.net_connections())
-    while start_port in open_ports:
-        start_port += 1
-    return start_port
+def find_free_net_port():
+    """Finds a free port on the host"""
+    s = socket.socket()
+    s.bind(('', 0))            # Bind to a free port provided by the host.
+    return s.getsockname()[1]  # Return the port assigned.

--- a/tests/golem/test_golem_utils.py
+++ b/tests/golem/test_golem_utils.py
@@ -1,0 +1,9 @@
+import unittest
+
+from golem.utils import find_free_net_port
+
+
+class FreePortTest(unittest.TestCase):
+    def test_free_port_selector(self):
+        port = find_free_net_port()
+        assert port >= 1024 and port <= 2**16


### PR DESCRIPTION
Rewrite the function find_free_net_port() to make it more robust. There is still race condition risk.

Fixes https://github.com/imapp-pl/golem/issues/185.
