### PR TITLE
Prepare task for serialization

### DIFF
--- a/gnr/task/gnrtask.py
+++ b/gnr/task/gnrtask.py
@@ -106,6 +106,27 @@ class GNRTask(Task):
         self.tmp_dir = None
         self.verification_options = None
 
+    def __getstate__(self):
+        self.task_resources = set()
+
+        self.total_tasks = 0
+        self.last_task = 0
+
+        self.num_tasks_received = 0
+        self.subtasks_given = {}
+        self.num_failed_subtasks = 0
+
+        self.full_task_timeout = 2200
+        self.counting_nodes = {}
+
+        self.root_path = None
+
+        self.stdout = {}  # for each subtask keep information about stdout received from computing node
+        self.stderr = {}  # for each subtask keep information about stderr received from computing node
+        self.results = {}  # for each subtask keep information about files containing results
+
+        self.res_files = {}
+
     def is_docker_task(self):
         return self.header.docker_images is not None
 

--- a/gnr/task/gnrtask.py
+++ b/gnr/task/gnrtask.py
@@ -106,27 +106,6 @@ class GNRTask(Task):
         self.tmp_dir = None
         self.verification_options = None
 
-    def __getstate__(self):
-        self.task_resources = set()
-
-        self.total_tasks = 0
-        self.last_task = 0
-
-        self.num_tasks_received = 0
-        self.subtasks_given = {}
-        self.num_failed_subtasks = 0
-
-        self.full_task_timeout = 2200
-        self.counting_nodes = {}
-
-        self.root_path = None
-
-        self.stdout = {}  # for each subtask keep information about stdout received from computing node
-        self.stderr = {}  # for each subtask keep information about stderr received from computing node
-        self.results = {}  # for each subtask keep information about files containing results
-
-        self.res_files = {}
-
     def is_docker_task(self):
         return self.header.docker_images is not None
 

--- a/gnr/task/gnrtask.py
+++ b/gnr/task/gnrtask.py
@@ -13,7 +13,7 @@ from golem.resource.resource import prepare_delta_zip, TaskResourceHeader
 from golem.task.taskbase import Task, TaskHeader, TaskBuilder, result_types, resource_types
 from golem.task.taskstate import SubtaskStatus
 
-from gnr.renderingdirmanager import get_tmp_path
+from gnr.gnrtaskstate import AdvanceVerificationOptions
 
 logger = logging.getLogger("gnr.task")
 
@@ -104,7 +104,7 @@ class GNRTask(Task):
 
         self.res_files = {}
         self.tmp_dir = None
-        self.verification_options = None
+        self.verification_options = AdvanceVerificationOptions()
 
     def is_docker_task(self):
         return self.header.docker_images is not None
@@ -272,6 +272,10 @@ class GNRTask(Task):
 
     def after_test(self, results, tmp_dir):
         return None
+
+    def notify_update_task(self):
+        for l in self.listeners:
+            l.notify_update_task(self.header.task_id)
 
     @handle_key_error
     def should_accept(self, subtask_id):

--- a/gnr/task/luxrendertask.py
+++ b/gnr/task/luxrendertask.py
@@ -453,7 +453,7 @@ class LuxTask(RenderingTask):
             except (IOError, OSError) as err:
                 logger.warning("Couldn't rename and copy img file. {}".format(err))
 
-        self.notify_update_task(self.header.task_id)
+        self.notify_update_task()
 
     def __final_img_error(self, error):
         logger.error("Cannot generate final image: {}".format(error))

--- a/gnr/task/renderingtask.py
+++ b/gnr/task/renderingtask.py
@@ -404,5 +404,8 @@ class RenderingTask(GNRTask):
 
     def __get_path(self, path):
         if is_windows():
-            return self.__get_path(path)
+            return self.__get_path_windows(path)
         return path
+
+    def __get_path_windows(self, path):
+        return path.replace("\\", "/")

--- a/gnr/task/renderingtask.py
+++ b/gnr/task/renderingtask.py
@@ -15,7 +15,6 @@ from golem.task.taskbase import ComputeTaskDef
 from golem.task.taskclient import TaskClient
 from golem.task.taskstate import SubtaskStatus
 
-from gnr.renderingtaskstate import AdvanceRenderingVerificationOptions
 from gnr.task.gnrtask import GNRTask, GNRTaskBuilder
 from gnr.task.imgrepr import verify_img, advance_verify_img
 from gnr.task.localcomputer import LocalComputer
@@ -46,7 +45,6 @@ class RenderingTaskBuilder(GNRTaskBuilder):
             new_task.advanceVerification = False
         else:
             new_task.advanceVerification = True
-            new_task.verification_options = AdvanceRenderingVerificationOptions()
             new_task.verification_options.type = self.task_definition.verification_options.type
             new_task.verification_options.box_size = (self.task_definition.verification_options.box_size[0],
                                                       (self.task_definition.verification_options.box_size[1] / 2) * 2)
@@ -124,9 +122,6 @@ class RenderingTask(GNRTask):
             self.scale_factor = min(1.0, self.scale_factor)
         else:
             self.scale_factor = 1.0
-
-        if is_windows():
-            self.__get_path = self.__get_path_windows
 
     @GNRTask.handle_key_error
     def computation_failed(self, subtask_id):
@@ -408,7 +403,6 @@ class RenderingTask(GNRTask):
         return False
 
     def __get_path(self, path):
+        if is_windows():
+            return self.__get_path(path)
         return path
-
-    def __get_path_windows(self, path):
-        return path.replace("\\", "/")

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -1,8 +1,11 @@
 import abc
+import logging
 import time
 from copy import deepcopy
 
 from golem.core.variables import APP_VERSION
+
+logger = logging.getLogger(__name__)
 
 
 class TaskHeader(object):
@@ -106,6 +109,7 @@ class Task(object):
             if self.listeners[i] is listener:
                 del self.listeners[i]
                 return
+        logger.warning("Trying to unregister listener that wasn't registered.")
 
     @abc.abstractmethod
     def initialize(self, dir_manager):

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -91,9 +91,9 @@ class Task(object):
         self.listeners = []
 
     def __getstate__(self):
-        state = deepcopy(vars(self))
-        del state['listeners']
-        return state
+        state_attr = vars(self).keys()
+        state_attr.remove('listeners')
+        return {attr: deepcopy(getattr(self, attr)) for attr in state_attr}
 
     def __setstate__(self, dict_):
         self.__dict__ = dict_
@@ -180,7 +180,6 @@ class Task(object):
         :return bool: True if task passed verification, False otherwise
         """
         return  # Implement in derived class
-
 
 
     @abc.abstractmethod

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -1,5 +1,6 @@
-import time
 import abc
+import time
+from copy import deepcopy
 
 from golem.core.variables import APP_VERSION
 
@@ -86,8 +87,17 @@ class Task(object):
 
         self.listeners = []
 
-    def register_listner(self, listener):
-        assert isinstance(TaskEventListener)
+    def __getstate__(self):
+        state = deepcopy(vars(self))
+        del state['listeners']
+        return state
+
+    def __setstate__(self, dict_):
+        self.__dict__ = dict_
+        self.listeners = []
+
+    def register_listener(self, listener):
+        assert isinstance(listener, TaskEventListener)
         self.listeners.append(listener)
 
     def unregister_listener(self, listener):

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -104,7 +104,7 @@ class Task(object):
         self.listeners.append(listener)
 
     def unregister_listener(self, listener):
-        if listener is self.listeners:
+        if listener in self.listeners:
             self.listeners.remove(listener)
         else:
             logger.warning("Trying to unregister listener that wasn't registered.")

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -56,6 +56,14 @@ class ComputeTaskDef(object):
         self.docker_images = None
 
 
+class TaskEventListener(object):
+    def __init__(self):
+        pass
+
+    def notify_update_task(self, task_id):
+        pass
+
+
 class Task(object):
 
     class ExtraData(object):
@@ -76,7 +84,18 @@ class Task(object):
         self.header = header
         self.undeletable = []
 
-        self.notify_update_task = lambda task_id: None
+        self.listeners = []
+
+    def register_listner(self, listener):
+        assert isinstance(TaskEventListener)
+        self.listeners.append(listener)
+
+    def unregister_listener(self, listener):
+        assert isinstance(listener, TaskEventListener)
+        for i in range(len(self.listeners)):
+            if self.listeners[i] is listener:
+                del self.listeners[i]
+                return
 
     @abc.abstractmethod
     def initialize(self, dir_manager):
@@ -268,6 +287,7 @@ class Task(object):
         :return:
         """
         pass
+
 
 result_types = {'data': 0, 'files': 1}
 resource_types = {'zip': 0, 'parts': 1, 'hashes': 2}

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -5,7 +5,7 @@ from copy import deepcopy
 
 from golem.core.variables import APP_VERSION
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("golem.task")
 
 
 class TaskHeader(object):
@@ -104,12 +104,10 @@ class Task(object):
         self.listeners.append(listener)
 
     def unregister_listener(self, listener):
-        assert isinstance(listener, TaskEventListener)
-        for i in range(len(self.listeners)):
-            if self.listeners[i] is listener:
-                del self.listeners[i]
-                return
-        logger.warning("Trying to unregister listener that wasn't registered.")
+        if listener is self.listeners:
+            self.listeners.remove(listener)
+        else:
+            logger.warning("Trying to unregister listener that wasn't registered.")
 
     @abc.abstractmethod
     def initialize(self, dir_manager):

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -35,7 +35,7 @@ def log_key_error(*args, **kwargs):
 
 class TMTaskEventListener(TaskEventListener):
     def __init__(self, task_manager):
-        super(TaskEventListener).__init__()
+        super(TaskEventListener, self).__init__()
         self.task_manager = task_manager
 
     def notify_update_task(self, task_id):

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -74,6 +74,16 @@ class TaskManager(object):
 
         self.comp_task_keeper = CompTaskKeeper()
 
+    def save_state(self):
+        comp_task_keeper = SimpleSerializerRelease.dumps(self.comp_task_keeper)
+        tasks = SimpleSerializerRelease.dumps(self.tasks)
+        tasks_states = SimpleSerializerRelease.dumps(self.tasks_states)
+        subtask2task_mapping = SimpleSerializerRelease.dump(self.subtask2task_mapping)
+        print comp_task_keeper
+        print tasks
+        print tasks_states
+        print subtask2task_mapping
+
     def get_task_manager_root(self):
         return self.root_path
 
@@ -519,6 +529,7 @@ class TaskManager(object):
 
     @handle_key_error
     def notice_task_updated(self, task_id):
+        # self.save_state()
         for l in self.listeners:
             l.task_status_updated(task_id)
 

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -306,7 +306,7 @@ class TaskManager(TaskEventListener):
             th.last_checking = cur_time
             if th.ttl <= 0:
                 logger.info("Task {} dies".format(th.task_id))
-                self.tasks[th.task_id].unregister_listener(self.task_events_listener)
+                self.tasks[th.task_id].unregister_listener(self)
                 del self.tasks[th.task_id]
                 continue
             ts = self.tasks_states[th.task_id]
@@ -414,7 +414,7 @@ class TaskManager(TaskEventListener):
                 del self.subtask2task_mapping[sub.subtask_id]
             self.tasks_states[task_id].subtask_states.clear()
 
-            self.tasks[task_id].unregister_listener(self.task_events_listener)
+            self.tasks[task_id].unregister_listener(self)
             del self.tasks[task_id]
             del self.tasks_states[task_id]
 

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -3,7 +3,6 @@ import time
 
 from golem.core.common import HandleKeyError
 from golem.core.hostaddress import get_external_address
-
 from golem.manager.nodestatesnapshot import LocalTaskStateSnapshot
 from golem.resource.dirmanager import DirManager
 
@@ -73,16 +72,6 @@ class TaskManager(object):
         self.task_events_listener = TMTaskEventListener(self)
 
         self.comp_task_keeper = CompTaskKeeper()
-
-    def save_state(self):
-        comp_task_keeper = SimpleSerializerRelease.dumps(self.comp_task_keeper)
-        tasks = SimpleSerializerRelease.dumps(self.tasks)
-        tasks_states = SimpleSerializerRelease.dumps(self.tasks_states)
-        subtask2task_mapping = SimpleSerializerRelease.dump(self.subtask2task_mapping)
-        print comp_task_keeper
-        print tasks
-        print tasks_states
-        print subtask2task_mapping
 
     def get_task_manager_root(self):
         return self.root_path

--- a/tests/gnr/task/test_gnrtask.py
+++ b/tests/gnr/task/test_gnrtask.py
@@ -29,7 +29,7 @@ class TestGNRTask(LogTestCase, TestDirFixture):
 
         subtask_id = "xxyyzz"
 
-        task.subtasks_given[subtask_id] = Mock()
+        task.subtasks_given[subtask_id] = {}
         self.assertEqual(task.get_stdout(subtask_id), "")
         self.assertEqual(task.get_stderr(subtask_id), "")
         self.assertEqual(task.get_results(subtask_id), [])
@@ -55,6 +55,7 @@ class TestGNRTask(LogTestCase, TestDirFixture):
         self.assertEqual(task.get_stderr(subtask_id), files[1])
         
         self.assertEqual(task.after_test(None, None), None)
+
 
     def test_interpret_task_results(self):
         task = self._get_gnr_task()

--- a/tests/gnr/task/test_gnrtask.py
+++ b/tests/gnr/task/test_gnrtask.py
@@ -3,11 +3,9 @@ import os
 import zlib
 import cPickle as pickle
 
-from mock import Mock
-
 from golem.core.fileshelper import outer_dir_path
 from golem.resource.dirmanager import DirManager
-from golem.task.taskbase import result_types
+from golem.task.taskbase import result_types, TaskEventListener
 from golem.tools.assertlogs import LogTestCase
 from golem.tools.testdirfixture import TestDirFixture
 
@@ -55,6 +53,32 @@ class TestGNRTask(LogTestCase, TestDirFixture):
         self.assertEqual(task.get_stderr(subtask_id), files[1])
         
         self.assertEqual(task.after_test(None, None), None)
+
+        assert len(task.listeners) == 0
+        class TestListener(TaskEventListener):
+            def __init__(self):
+                super(TestListener, self).__init__()
+                self.notify_called = False
+                self.task_id = None
+
+            def notify_update_task(self, task_id):
+                self.notify_called = True
+                self.task_id = task_id
+
+        l1 = TestListener()
+        l2 = TestListener()
+        l3 = TestListener()
+        task.register_listener(l1)
+        task.register_listener(l2)
+        task.register_listener(l3)
+        task.unregister_listener(l2)
+        task.notify_update_task()
+        assert not l2.notify_called
+        assert l1.notify_called
+        assert l3.notify_called
+        assert l1.task_id == "xyz"
+        assert l3.task_id == "xyz"
+        assert l2.task_id is None
 
 
     def test_interpret_task_results(self):

--- a/tests/gnr/task/test_renderingtask.py
+++ b/tests/gnr/task/test_renderingtask.py
@@ -1,5 +1,5 @@
 import unittest
-from os import makedirs
+from os import makedirs, path
 
 from gnr.renderingdirmanager import get_tmp_path
 from gnr.renderingtaskstate import AdvanceRenderingVerificationOptions
@@ -19,6 +19,13 @@ class TestRenderingTask(TestDirFixture):
         dm = DirManager(self.path)
         task.initialize(dm)
         return task
+
+    def test_paths(self):
+        rt = self._init_task()
+        res1 = path.join(self.path, "dir1", "dir2", "name1")
+        res2 = path.join(self.path, "dir1", "dir2", "name2")
+        rt.task_resources = {res1, res2}
+        assert rt._get_working_directory() == "../.."
 
     def test_box_start(self):
         rt = self._init_task()

--- a/tests/golem/task/test_taskbase.py
+++ b/tests/golem/task/test_taskbase.py
@@ -3,7 +3,7 @@ import unittest
 
 from mock import Mock
 
-from golem.task.taskbase import Task, TaskHeader
+from golem.task.taskbase import Task, TaskHeader, TaskEventListener
 from golem.network.p2p.node import Node
 
 
@@ -18,9 +18,16 @@ class TestTaskBase(unittest.TestCase):
         t = Task(TaskHeader("ABC", "xyz", "10.10.10.10", 1023, "key", "DEFAULT",
                             Node()), "print 'Hello world'")
 
+        tl1 = TaskEventListener()
+        tl2 = TaskEventListener()
+        t.register_listener(tl1)
+        t.register_listener(tl2)
+        assert len(t.listeners) == 2
         p = pickle.dumps(t)
         u = pickle.loads(p)
         assert t.src_code == u.src_code
         assert t.header.task_id == u.header.task_id
         assert t.header.task_owner.node_name == u.header.task_owner.node_name
         assert u.get_results("abc") == []
+        assert len(t.listeners) == 2
+        assert len(u.listeners) == 0

--- a/tests/golem/task/test_taskbase.py
+++ b/tests/golem/task/test_taskbase.py
@@ -1,13 +1,13 @@
 import cPickle as pickle
-import unittest
 
 from mock import Mock
 
-from golem.task.taskbase import Task, TaskHeader, TaskEventListener
+from golem.task.taskbase import Task, TaskHeader, TaskEventListener, logger
+from golem.tools.assertlogs import LogTestCase
 from golem.network.p2p.node import Node
 
 
-class TestTaskBase(unittest.TestCase):
+class TestTaskBase(LogTestCase):
     def test_task(self):
         t = Task(Mock(), "")
         self.assertIsInstance(t, Task)
@@ -34,5 +34,8 @@ class TestTaskBase(unittest.TestCase):
         t.unregister_listener(tl2)
         assert len(t.listeners) == 1
         assert t.listeners[0] == tl1
+        t.listeners[0].notify_update_task("abc")
         t.unregister_listener(tl1)
         assert len(t.listeners) == 0
+        with self.assertLogs(logger, level="WARNING"):
+            t.unregister_listener(tl1)

--- a/tests/golem/task/test_taskbase.py
+++ b/tests/golem/task/test_taskbase.py
@@ -1,8 +1,10 @@
+import cPickle as pickle
 import unittest
 
 from mock import Mock
 
-from golem.task.taskbase import Task
+from golem.task.taskbase import Task, TaskHeader
+from golem.network.p2p.node import Node
 
 
 class TestTaskBase(unittest.TestCase):
@@ -12,3 +14,13 @@ class TestTaskBase(unittest.TestCase):
         self.assertEqual(t.get_stdout("abc"), "")
         self.assertEqual(t.get_stderr("abc"), "")
         self.assertEqual(t.get_results("abc"), [])
+
+        t = Task(TaskHeader("ABC", "xyz", "10.10.10.10", 1023, "key", "DEFAULT",
+                            Node()), "print 'Hello world'")
+
+        p = pickle.dumps(t)
+        u = pickle.loads(p)
+        assert t.src_code == u.src_code
+        assert t.header.task_id == u.header.task_id
+        assert t.header.task_owner.node_name == u.header.task_owner.node_name
+        assert u.get_results("abc") == []

--- a/tests/golem/task/test_taskbase.py
+++ b/tests/golem/task/test_taskbase.py
@@ -31,3 +31,8 @@ class TestTaskBase(unittest.TestCase):
         assert u.get_results("abc") == []
         assert len(t.listeners) == 2
         assert len(u.listeners) == 0
+        t.unregister_listener(tl2)
+        assert len(t.listeners) == 1
+        assert t.listeners[0] == tl1
+        t.unregister_listener(tl1)
+        assert len(t.listeners) == 0

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -1,10 +1,13 @@
+from unittest import TestCase
+
 from mock import Mock
 
 from golem.network.p2p.node import Node
-from golem.task.taskbase import Task, TaskHeader, ComputeTaskDef
+from golem.task.taskbase import Task, TaskHeader, ComputeTaskDef, TaskEventListener
 from golem.task.taskclient import TaskClient
-from golem.task.taskmanager import TaskManager, logger
+from golem.task.taskmanager import TaskManager, logger, TMTaskEventListener
 from golem.task.taskstate import SubtaskStatus, SubtaskState, TaskState, TaskStatus
+
 from golem.tools.assertlogs import LogTestCase
 from golem.tools.testdirfixture import TestDirFixture
 
@@ -217,3 +220,12 @@ class TestTaskManager(LogTestCase, TestDirFixture):
         tm.task_result_incoming(subtask_id)
         assert not task_mock.result_incoming.called
 
+
+class TestTMTaskEventListener(TestCase):
+    def test_listener(self):
+        manager = Mock()
+        listener = TMTaskEventListener(manager)
+        assert listener.task_manager == manager
+        assert isinstance(listener, TaskEventListener)
+        listener.notify_update_task("xyz")
+        manager.notice_task_update.assert_called_with("xyz")

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -1,3 +1,4 @@
+import time
 from unittest import TestCase
 
 from mock import Mock
@@ -112,14 +113,16 @@ class TestTaskManager(LogTestCase, TestDirFixture):
 
     def test_computed_task_received(self):
         tm = TaskManager("ABC", Node(), root_path=self.path)
+        tm.listeners.append(Mock())
         th = TaskHeader("ABC", "xyz", "10.10.10.10", 1024, "key_id", "DEFAULT")
         th.max_price = 50
 
         class TestTask(Task):
-            def __init__(self, header, src_code, subtasks_id):
+            def __init__(self, header, src_code, subtasks_id, verify_subtasks):
                 super(TestTask, self).__init__(header, src_code)
                 self.finished = {k: False for k in subtasks_id}
                 self.restarted = {k: False for k in subtasks_id}
+                self.verify_subtasks = verify_subtasks
                 self.subtasks_id = subtasks_id
 
             def query_extra_data(self, perf_index, num_cores=1, node_id=None, node_name=None):
@@ -139,7 +142,7 @@ class TestTaskManager(LogTestCase, TestDirFixture):
                     self.finished[subtask_id] = True
 
             def verify_subtask(self, subtask_id):
-                return self.finished[subtask_id]
+                return self.verify_subtasks[subtask_id]
 
             def finished_computation(self):
                 return not self.needs_computation()
@@ -150,7 +153,7 @@ class TestTaskManager(LogTestCase, TestDirFixture):
             def restart_subtask(self, subtask_id):
                 self.restarted[subtask_id] = True
 
-        t = TestTask(th, "print 'Hello world'", ["xxyyzz"])
+        t = TestTask(th, "print 'Hello world'", ["xxyyzz"], verify_subtasks={"xxyyzz": True})
         tm.add_new_task(t)
         ctd, wrong_task, should_wait = tm.get_next_subtask("DEF", "DEF", "xyz", 1030, 10, 10000, 10000, 10000)
         assert not wrong_task
@@ -168,7 +171,7 @@ class TestTaskManager(LogTestCase, TestDirFixture):
         assert tm.tasks_states["xyz"].status == TaskStatus.finished
 
         th.task_id = "qwe"
-        t3 = TestTask(th, "print 'Hello world!", ["qqwwee", "rrttyy"])
+        t3 = TestTask(th, "print 'Hello world!", ["qqwwee", "rrttyy"], {"qqwwee": True, "rrttyy": True})
         tm.add_new_task(t3)
         ctd, wrong_task, should_wait = tm.get_next_subtask("DEF", "DEF", "qwe", 1030, 10, 10000, 10000, 10000)
         assert not wrong_task
@@ -181,6 +184,24 @@ class TestTaskManager(LogTestCase, TestDirFixture):
         assert ss.stderr == "something went wrong"
         with self.assertLogs(logger, level="WARNING"):
             assert not tm.computed_task_received("qqwwee", [], 0)
+
+        th.task_id = "task4"
+        t2 = TestTask(th, "print 'Hello world!", ["ttt4", "sss4"], {'ttt4': False, 'sss4': True})
+        tm.add_new_task(t2)
+        ctd, wrong_task, should_wait = tm.get_next_subtask("DEF", "DEF", "task4", 1000, 10, 5, 10, 2,
+                                                           "10.10.10.10")
+        assert not wrong_task
+        assert ctd.subtask_id == "ttt4"
+        assert not tm.computed_task_received("ttt4", [], 0)
+        tm.listeners[0].task_status_updated.assert_called_with("task4")
+        assert tm.tasks_states["task4"].subtask_states["ttt4"].subtask_status == SubtaskStatus.failure
+        prev_call = tm.listeners[0].task_status_updated.call_count
+        assert not tm.computed_task_received("ttt4", [], 0)
+        assert tm.listeners[0].task_status_updated.call_count == prev_call + 1
+        ctd, wrong_task, should_wait = tm.get_next_subtask("DEF", "DEF", "task4", 1000, 10, 5, 10, 2, "10.10.10.10")
+        assert not wrong_task
+        assert ctd.subtask_id == "sss4"
+        assert tm.computed_task_received("sss4", [], 0)
 
     def test_task_result_incoming(self):
         subtask_id = "xxyyzz"
@@ -219,6 +240,28 @@ class TestTaskManager(LogTestCase, TestDirFixture):
 
         tm.task_result_incoming(subtask_id)
         assert not task_mock.result_incoming.called
+
+    def test_resource_send(self):
+        tm = TaskManager("ABC", Node(), root_path=self.path)
+        tm.listeners.append(Mock())
+        t = Task(TaskHeader("ABC", "xyz", "10.10.10.10", 1023, "abcde",
+                            "DEFAULT"), "print 'hello world'")
+        tm.add_new_task(t)
+        tm.resources_send("xyz")
+        assert tm.listeners[0].notice_task_updated.called_with("xyz")
+
+    def test_remove_old_tasks(self):
+        tm = TaskManager("ABC", Node(), root_path=self.path)
+        tm.listeners.append(Mock())
+        t = Task(Mock(), "")
+        t.header.task_id = "xyz"
+        t.header.ttl = 0.5
+        t.header.last_checking = time.time()
+        tm.add_new_task(t)
+        assert tm.tasks_states["xyz"].status in tm.activeStatus
+        time.sleep(1)
+        tm.remove_old_tasks()
+        assert tm.tasks.get('xyz') is None
 
 
 class TestTMTaskEventListener(TestCase):

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -1,12 +1,11 @@
 import time
-from unittest import TestCase
 
 from mock import Mock
 
 from golem.network.p2p.node import Node
 from golem.task.taskbase import Task, TaskHeader, ComputeTaskDef, TaskEventListener
 from golem.task.taskclient import TaskClient
-from golem.task.taskmanager import TaskManager, logger, TMTaskEventListener
+from golem.task.taskmanager import TaskManager, logger
 from golem.task.taskstate import SubtaskStatus, SubtaskState, TaskState, TaskStatus
 
 from golem.tools.assertlogs import LogTestCase
@@ -263,12 +262,10 @@ class TestTaskManager(LogTestCase, TestDirFixture):
         tm.remove_old_tasks()
         assert tm.tasks.get('xyz') is None
 
+    def test_task_event_listener(self):
+        tm = TaskManager("ABC", Node(), root_path=self.path)
+        tm.notice_task_updated = Mock()
+        assert isinstance(tm, TaskEventListener)
+        tm.notify_update_task("xyz")
+        tm.notice_task_updated.assert_called_with("xyz")
 
-class TestTMTaskEventListener(TestCase):
-    def test_listener(self):
-        manager = Mock()
-        listener = TMTaskEventListener(manager)
-        assert listener.task_manager == manager
-        assert isinstance(listener, TaskEventListener)
-        listener.notify_update_task("xyz")
-        manager.notice_task_update.assert_called_with("xyz")


### PR DESCRIPTION
Remove lambdas and functions from task variables to make possible to serialize a task instance. 
Serialized tasks may be later saved in the database and resumed after restart.
