### PR TITLE
Re-enable CPU core assignment for Docker containers

### DIFF
--- a/golem/docker/config_manager.py
+++ b/golem/docker/config_manager.py
@@ -30,8 +30,8 @@ class DockerConfigManager(object):
 
     def __init__(self):
         self.container_host_config = dict(DEFAULT_HOST_CONFIG)
-        # Note that this will fail if CPU affinity
-        # has been altered for this process
+        # Note that the number of cores is based on
+        # CPU affinity set for Golem's process
         try:
             process = psutil.Process()
             self.cpu_cores = process.cpu_affinity()
@@ -62,5 +62,5 @@ class DockerConfigManager(object):
     def _try(self):
         try:
             yield
-        except:
+        except Exception:
             pass

--- a/golem/docker/config_manager.py
+++ b/golem/docker/config_manager.py
@@ -1,8 +1,12 @@
+import logging
+
+import psutil
 from contextlib import contextmanager
 
 from golem.docker.task_thread import DockerTaskThread
 
 __all__ = ['DockerConfigManager']
+logger = logging.getLogger(__name__)
 
 DEFAULT_HOST_CONFIG = dict(
     privileged=False,
@@ -24,7 +28,16 @@ DEFAULT_HOST_CONFIG = dict(
 
 class DockerConfigManager(object):
 
-    container_host_config = dict(DEFAULT_HOST_CONFIG)
+    def __init__(self):
+        self.container_host_config = dict(DEFAULT_HOST_CONFIG)
+        # Note that this will fail if CPU affinity
+        # has been altered for this process
+        try:
+            process = psutil.Process()
+            self.cpu_cores = process.cpu_affinity()
+        except Exception as exc:
+            logger.error("Couldn't read CPU affinity: {}".format(exc))
+            self.cpu_cores = None
 
     def build_config(self, config_desc):
         host_config = dict()
@@ -35,8 +48,9 @@ class DockerConfigManager(object):
             max_resource_size = config_desc.max_resource_size
 
             with self._try():
-                cores = [str(c) for c in range(0, int(num_cores))]
-                host_config['cpuset'] = ','.join(cores)
+                max_cpus = min(len(self.cpu_cores), int(num_cores) or 1)
+                cpu_set = [str(c) for c in self.cpu_cores[:max_cpus]]
+                host_config['cpuset'] = ','.join(cpu_set)
 
             with self._try():
                 host_config['mem_limit'] = int(max_memory_size) * 1000

--- a/golem/docker/job.py
+++ b/golem/docker/job.py
@@ -136,8 +136,8 @@ class DockerJob(object):
             volumes=[self.WORK_DIR, self.RESOURCES_DIR, self.OUTPUT_DIR],
             host_config=host_cfg,
             command=[container_script_path],
-            working_dir=self.WORK_DIR
-            # cpuset=cpuset
+            working_dir=self.WORK_DIR,
+            cpuset=cpuset
         )
         self.container_id = self.container["Id"]
         logger.debug("Container {} prepared, image: {}, dirs: {}; {}; {}"

--- a/golem/docker/machine/machine_manager.py
+++ b/golem/docker/machine/machine_manager.py
@@ -43,6 +43,8 @@ class DockerMachineManager(DockerConfigManager):
                  min_cpu_execution_cap=1,
                  min_cpu_count=1):
 
+        super(DockerMachineManager, self).__init__()
+
         self.ISession = None
         self.LockType = None
 

--- a/tests/golem/docker/test_docker_config_manager.py
+++ b/tests/golem/docker/test_docker_config_manager.py
@@ -1,7 +1,6 @@
 import unittest
 
 from golem.docker.config_manager import DockerConfigManager
-from golem.docker.task_thread import DockerTaskThread
 
 
 class TestDockerConfigManager(unittest.TestCase):
@@ -26,7 +25,20 @@ class TestDockerConfigManager(unittest.TestCase):
         cm.build_config(config)
 
         assert len(cm.container_host_config) > len(config.to_dict())
-        assert DockerTaskThread.container_host_config == cm.container_host_config
+        assert cm.container_host_config == cm.container_host_config
+
+        assert cm.cpu_cores
+        assert cm.container_host_config['cpuset']
+
+    def test_failing_build_config(self):
+
+        cm = DockerConfigManager()
+        cm.cpu_cores = None
+        cm.build_config(None)
+
+        assert not cm.cpu_cores
+        assert 'cpuset' not in cm.container_host_config
+        assert 'mem_limit' not in cm.container_host_config
 
     def test_try(self):
         cm = DockerConfigManager()


### PR DESCRIPTION
Available CPU cores are read from Golem's process CPU affinity settings.
