### PR TITLE
Show dialog while reconfiguring DockerMachine (Windows only)

### DIFF
--- a/gnr/customizers/updatingconfigdialogcustomizer.py
+++ b/gnr/customizers/updatingconfigdialogcustomizer.py
@@ -1,0 +1,9 @@
+from customizer import Customizer
+
+
+class UpdatingConfigDialogCustomizer(Customizer):
+    def show_message(self, msg):
+        self.gui.ui.message.setText(msg)
+
+    def close(self):
+        self.gui.close()

--- a/gnr/gnrapplicationlogic.py
+++ b/gnr/gnrapplicationlogic.py
@@ -401,8 +401,8 @@ class GNRApplicationLogic(QtCore.QObject):
         return estimated_perf
 
     def toggle_config_dialog(self, on=True):
-        self.customizer.gui.setEnabled('new_task', on)
-        self.customizer.gui.setEnabled('settings', on)  # disable 'change' and 'cancel' buttons
+        self.customizer.gui.setEnabled('new_task', not on)
+        self.customizer.gui.setEnabled('settings', not on)  # disable 'change' and 'cancel' buttons
 
         if on:
             if not self.config_dialog_customizer:

--- a/gnr/gnrapplicationlogic.py
+++ b/gnr/gnrapplicationlogic.py
@@ -11,10 +11,11 @@ from twisted.internet.defer import inlineCallbacks, returnValue
 from gnr.benchmarks.benchmarkrunner import BenchmarkRunner
 from gnr.benchmarks.minilight.src.minilight import makePerfTest
 from gnr.customizers.testingtaskprogresscustomizer import TestingTaskProgressDialogCustomizer
+from gnr.customizers.updatingconfigdialogcustomizer import UpdatingConfigDialogCustomizer
 from gnr.gnrtaskstate import GNRTaskState
 from gnr.renderingdirmanager import get_benchmarks_path
 from gnr.renderingtaskstate import RenderingTaskState
-from gnr.ui.dialog import TestingTaskProgressDialog
+from gnr.ui.dialog import TestingTaskProgressDialog, UpdatingConfigDialog
 from golem.client import GolemClientEventListener, GolemClientRemoteEventListener
 from golem.core.common import get_golem_path
 from golem.core.simpleenv import SimpleEnv
@@ -65,6 +66,8 @@ class GNRApplicationLogic(QtCore.QObject):
         self.client = None
         self.progress_dialog = None
         self.progress_dialog_customizer = None
+        self.config_dialog = None
+        self.config_dialog_customizer = None
         self.add_new_nodes_function = lambda x: None
         self.datadir = None
         self.res_dirs = None
@@ -396,6 +399,21 @@ class GNRApplicationLogic(QtCore.QObject):
         result_file = SimpleEnv.env_file_name("minilight.ini")
         estimated_perf = makePerfTest(test_file, result_file, num_cores)
         return estimated_perf
+
+    def toggle_config_dialog(self, on=True):
+        self.customizer.gui.setEnabled('new_task', on)
+        self.customizer.gui.setEnabled('settings', on)  # disable 'change' and 'cancel' buttons
+
+        if on:
+            if not self.config_dialog_customizer:
+                self.config_dialog = UpdatingConfigDialog(self.customizer.gui.window)
+                self.config_dialog_customizer = UpdatingConfigDialogCustomizer(self.config_dialog, self)
+                self.config_dialog.show()
+        else:
+            if self.config_dialog_customizer:
+                self.config_dialog_customizer.close()
+                self.config_dialog_customizer = None
+                self.config_dialog = None
 
     def run_test_task(self, task_state):
         if self._validate_task_state(task_state):

--- a/gnr/ui/UpdatingConfigDialog.ui
+++ b/gnr/ui/UpdatingConfigDialog.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>updatingConfigDialog</class>
+ <widget class="QDialog" name="updatingConfigDialog">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>446</width>
+    <height>80</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="contextMenuPolicy">
+   <enum>Qt::NoContextMenu</enum>
+  </property>
+  <property name="windowTitle">
+   <string>Updating configuration</string>
+  </property>
+  <property name="sizeGripEnabled">
+   <bool>false</bool>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <widget class="QWidget" name="verticalLayoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>10</y>
+     <width>421</width>
+     <height>54</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="sizeConstraint">
+     <enum>QLayout::SetNoConstraint</enum>
+    </property>
+    <property name="leftMargin">
+     <number>3</number>
+    </property>
+    <property name="topMargin">
+     <number>3</number>
+    </property>
+    <property name="rightMargin">
+     <number>3</number>
+    </property>
+    <property name="bottomMargin">
+     <number>3</number>
+    </property>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="sizeConstraint">
+       <enum>QLayout::SetNoConstraint</enum>
+      </property>
+      <item>
+       <widget class="QLabel" name="message">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Updating configuration, please wait...</string>
+        </property>
+        <property name="textFormat">
+         <enum>Qt::AutoText</enum>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/gnr/ui/appmainwindow.py
+++ b/gnr/ui/appmainwindow.py
@@ -34,6 +34,9 @@ class AppMainWindow(object):
             self.ui.saveButton.setEnabled(enable)
             self.ui.loadButton.setEnabled(enable)
             self.ui.taskTypeComboBox.setEnabled(enable)
+        elif tab_name.lower() == 'settings':
+            self.ui.settingsOkButton.setEnabled(enable)
+            self.ui.settingsCancelButton.setEnabled(enable)
         elif tab_name.lower() == 'recount':
             self.ui.recountBlenderButton.setEnabled(enable)
             self.ui.recountButton.setEnabled(enable)

--- a/gnr/ui/dialog.py
+++ b/gnr/ui/dialog.py
@@ -11,6 +11,7 @@ from gen.ui_ShowTaskResourcesDialog import Ui_ShowTaskResourceDialog
 from gen.ui_SubtaskDetailsDialog import Ui_SubtaskDetailsDialog
 from gen.ui_TaskDetailsDialog import Ui_TaskDetailsDialog
 from gen.ui_TestingTaskProgressDialog import Ui_testingTaskProgressDialog
+from gnr.ui.gen.ui_UpdatingConfigDialog import Ui_updatingConfigDialog
 
 
 class Dialog(object):
@@ -67,6 +68,11 @@ class GeneratingKeyWindow(Dialog):
 class SaveKeysDialog(Dialog):
     def __init__(self, parent):
         Dialog.__init__(self, parent, Ui_SaveKeysDialog)
+
+
+class UpdatingConfigDialog(Dialog):
+    def __init__(self, parent):
+        Dialog.__init__(self, parent, Ui_updatingConfigDialog)
 
 
 # ADDING TASK DIALOGS

--- a/golem/client.py
+++ b/golem/client.py
@@ -61,6 +61,14 @@ class ClientTaskManagerEventListener(TaskManagerEventListener):
             l.task_updated(task_id)
 
 
+class ClientTaskComputerEventListener(object):
+    def __init__(self, client):
+        self.client = client
+
+    def toggle_config_dialog(self, on=True):
+        self.client.toggle_config_dialog(on)
+
+
 class Client(object):
     def __init__(self, datadir=None, transaction_system=False,
                  connect_to_known_hosts=True, **config_overrides):
@@ -177,6 +185,7 @@ class Client(object):
 
         self.p2pservice.set_task_server(self.task_server)
         self.task_server.task_manager.register_listener(ClientTaskManagerEventListener(self))
+        self.task_server.task_computer.register_listener(ClientTaskComputerEventListener(self))
         self.p2pservice.connect_to_network()
 
     def connect(self, socket_address):
@@ -476,6 +485,10 @@ class Client(object):
         after_deadline_nodes = self.transaction_system.check_payments()
         for node_id in after_deadline_nodes:
             self.decrease_trust(node_id, RankingStats.payment)
+
+    def toggle_config_dialog(self, on=True):
+        for rpc_client in self.rpc_clients:
+            rpc_client.toggle_config_dialog(on)
 
     def __try_to_change_to_number(self, old_value, new_value, to_int=False, to_float=False, name="Config"):
         try:

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -44,6 +44,7 @@ class TaskComputer(object):
         self.counting_task = False
         self.task_requested = False
         self.runnable = True
+        self.listeners = []
         self.current_computations = []
         self.last_task_request = time.time()
 
@@ -219,17 +220,27 @@ class TaskComputer(object):
         if not dm.docker_machine_available:
             return
 
+        self.toggle_config_dialog(True)
+
         def status_callback():
             return self.counting_task
 
         def done_callback():
             logger.debug("Resuming new task computation")
+            self.toggle_config_dialog(False)
             self.runnable = True
 
         self.runnable = False
         dm.update_config(status_callback,
                          done_callback,
                          in_background)
+
+    def register_listener(self, listener):
+        self.listeners.append(listener)
+
+    def toggle_config_dialog(self, on=True):
+        for l in self.listeners:
+            l.toggle_config_dialog(on)
 
     def session_timeout(self):
         self.session_closed()

--- a/tests/gnr/test_gnrapplicationlogic.py
+++ b/tests/gnr/test_gnrapplicationlogic.py
@@ -244,9 +244,16 @@ class TestGNRApplicationLogic(TestDirFixture):
                            RenderingMainWindowCustomizer)
 
         logic.toggle_config_dialog(True)
+
+        assert not logic.customizer.gui.ui.settingsOkButton.isEnabled()
+        assert not logic.customizer.gui.ui.settingsCancelButton.isEnabled()
+
         logic.toggle_config_dialog(True)
         logic.toggle_config_dialog(False)
         logic.toggle_config_dialog(False)
+
+        assert logic.customizer.gui.ui.settingsOkButton.isEnabled()
+        assert logic.customizer.gui.ui.settingsCancelButton.isEnabled()
 
         app.app.exit(0)
         app.app.deleteLater()

--- a/tests/gnr/test_gnrapplicationlogic.py
+++ b/tests/gnr/test_gnrapplicationlogic.py
@@ -2,6 +2,7 @@ import os
 import time
 import uuid
 
+from gnr.renderingapplicationlogic import RenderingApplicationLogic
 from mock import Mock, MagicMock
 from twisted.internet.defer import Deferred
 
@@ -233,3 +234,19 @@ class TestGNRApplicationLogic(TestDirFixture):
         logic.get_incomes()
 
         golem_client.quit()
+
+    def test_updating_config_dialog(self):
+        logic = RenderingApplicationLogic()
+        app = GNRGui(logic, AppMainWindow)
+
+        logic.client = Mock()
+        logic.register_gui(app.get_main_window(),
+                           RenderingMainWindowCustomizer)
+
+        logic.toggle_config_dialog(True)
+        logic.toggle_config_dialog(True)
+        logic.toggle_config_dialog(False)
+        logic.toggle_config_dialog(False)
+
+        app.app.exit(0)
+        app.app.deleteLater()

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -1,6 +1,7 @@
 import os
 import time
 
+from golem.client import ClientTaskComputerEventListener
 from mock import MagicMock, Mock
 
 from golem.task.taskbase import ComputeTaskDef
@@ -169,6 +170,23 @@ class TestTaskComputer(TestDirFixture, LogTestCase):
                                                         "key", "owner", "ABC")
         tt.end_comp()
         time.sleep(0.5)
+
+    def test_event_listeners(self):
+        client = Mock()
+        task_server = MagicMock()
+        tc = TaskComputer("ABC", task_server)
+
+        tc.toggle_config_dialog(True)
+        tc.toggle_config_dialog(False)
+
+        listener = ClientTaskComputerEventListener(client)
+        tc.register_listener(listener)
+
+        tc.toggle_config_dialog(True)
+        client.toggle_config_dialog.assert_called_with(True)
+
+        tc.toggle_config_dialog(False)
+        client.toggle_config_dialog.assert_called_with(False)
 
     @staticmethod
     def __wait_for_tasks(tc):

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -5,7 +5,7 @@ import uuid
 from mock import Mock, MagicMock
 
 from gnr.gnrapplicationlogic import GNRClientRemoteEventListener
-from golem.client import Client, GolemClientRemoteEventListener
+from golem.client import Client, GolemClientRemoteEventListener, ClientTaskComputerEventListener
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.tools.testdirfixture import TestDirFixture
 from golem.tools.testwithdatabase import TestWithDatabase
@@ -172,3 +172,14 @@ class TestEventListener(unittest.TestCase):
 
         gnr_listener.check_network_state()
         assert gnr_listener.remote_client.check_network_state.called
+
+    def test_task_computer_event_listener(self):
+
+        client = Mock()
+        listener = ClientTaskComputerEventListener(client)
+
+        listener.toggle_config_dialog(True)
+        client.toggle_config_dialog.assert_called_with(True)
+
+        listener.toggle_config_dialog(False)
+        client.toggle_config_dialog.assert_called_with(False)


### PR DESCRIPTION
- a dialog is shown while reconfiguring `DockerMachine`
- change and cancel buttons are disabled in config tab
- new task tab disabled
