### PR TITLE
Memory management (+ leak fix)

### DIFF
--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -12,6 +12,7 @@ from taskcomputer import TaskComputer
 from taskkeeper import TaskHeaderKeeper
 from taskmanager import TaskManager
 from tasksession import TaskSession
+from weakreflist.weakreflist import WeakList
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +33,7 @@ class TaskServer(PendingConnectionsServer):
         self.task_connections_helper = TaskConnectionsHelper()
         self.task_connections_helper.task_server = self
         self.task_sessions = {}
-        self.task_sessions_incoming = []
+        self.task_sessions_incoming = WeakList()
 
         self.max_trust = 1.0
         self.min_trust = 0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ base58
 ndg-httpsclient
 ovh
 certifi
+weakreflist


### PR DESCRIPTION
TaskServer:
- `task_sessions_incoming` memory leak fixed via `weakreflist.WeakList`

WebSockets:
- message retransmission for new sessions only

Retransmissions were implemented as a workaround for main (reactor) thread blocking. The latter should be resolved first.
