### PR TITLE
IPv4 hostaddress fix / IPv6 zero knowledge on network configuration

### DIFF
--- a/golem/core/hostaddress.py
+++ b/golem/core/hostaddress.py
@@ -40,27 +40,25 @@ def ip_addresses(use_ipv6=False):
     return addresses
 
 
-def ip_networks(use_ipv6=False):
-    if use_ipv6:
-        addr_family = netifaces.AF_INET6
-    else:
-        addr_family = netifaces.AF_INET
+def ipv4_networks():
+    addr_family = netifaces.AF_INET
     addresses = []
+
     for inter in netifaces.interfaces():
         ip = netifaces.ifaddresses(inter).get(addr_family)
         if not ip:
             continue
         for addrInfo in ip:
             addr = unicode(addrInfo.get('addr'))
-            mask = unicode(addrInfo.get('netmask')) or u'255.255.255.0'
+            mask = unicode(addrInfo.get('netmask', '255.255.255.0'))
 
             try:
                 ip_addr = ipaddress.ip_network((addr, mask), strict=False)
             except Exception as exc:
-                logger.error("Error parsing ip address {}: {}".format(addr, exc.message))
+                logger.error("Error parsing ip address {}: {}".format(addr, exc))
                 continue
 
-            if addr != '127.0.0.1' and addr != '::1':
+            if addr != '127.0.0.1':
                 split = unicode(ip_addr).split('/')
                 addresses.append((split[0], split[1]))
     return addresses

--- a/golem/network/transport/tcpserver.py
+++ b/golem/network/transport/tcpserver.py
@@ -5,7 +5,7 @@ import time
 from stun import FullCone, OpenInternet
 from collections import deque
 
-from golem.core.hostaddress import ip_address_private, ip_network_contains, ip_networks
+from golem.core.hostaddress import ip_address_private, ip_network_contains, ipv4_networks
 from server import Server
 from tcpnetwork import TCPListeningInfo, TCPListenInfo, SocketAddress, TCPConnectInfo
 from golem.core.variables import LISTEN_WAIT_TIME, LISTENING_REFRESH_TIME, LISTEN_PORT_TTL
@@ -25,11 +25,7 @@ class TCPServer(Server):
         Server.__init__(self, config_desc, network)
         self.cur_port = 0  # current listening port
         self.use_ipv6 = config_desc.use_ipv6 if config_desc else False
-        self.ipv4_networks = ip_networks()
-        if self.use_ipv6:
-            self.ipv6_networks = ip_networks(use_ipv6=True)
-        else:
-            self.ipv6_networks = []
+        self.ipv4_networks = ipv4_networks()
 
     def change_config(self, config_desc):
         """ Change configuration descriptor. If listening port is changed, than stop listening on old port and start
@@ -161,17 +157,11 @@ class PendingConnectionsServer(TCPServer):
         """
         if not socket_addr:
             return False
-
-        use_ipv6 = self.use_ipv6
-        is_ipv6 = socket_addr.ipv6
-
-        if is_ipv6 and not use_ipv6:
-            return False
+        elif socket_addr.ipv6:
+            return self.use_ipv6
 
         addr = socket_addr.address
         if ip_address_private(addr):
-            if is_ipv6:
-                return self._is_address_in_network(addr, self.ipv6_networks)
             return self._is_address_in_network(addr, self.ipv4_networks)
         return True
 

--- a/tests/golem/core/test_hostaddress.py
+++ b/tests/golem/core/test_hostaddress.py
@@ -1,5 +1,27 @@
 import unittest
+
+import netifaces
 from golem.core.hostaddress import get_host_address, ip_address_private, ip_network_contains, ipv4_networks
+from mock import patch
+
+
+def mock_ifaddresses(*args):
+    addrs = dict()
+    addrs[netifaces.AF_INET] = [
+        dict(
+            addr='127.0.0.1',
+            netmask=None
+        ),
+        dict(
+            addr='10.0.0.10',
+            netmask='255.255.255.0'
+        ),
+        dict(
+            addr='8.8.8.8',
+            netmask='255.255.255.255'
+        ),
+    ]
+    return addrs
 
 
 class TestHostAddress(unittest.TestCase):
@@ -12,6 +34,10 @@ class TestHostAddress(unittest.TestCase):
         self.assertEqual(get_host_address('10.30.10.217'), '10.30.10.216')
 
     def testGetIPNetworks(self):
+        ipv4_networks()
+
+    @patch('netifaces.ifaddresses', side_effect=mock_ifaddresses)
+    def testGetIPNetworks2(self, *_):
         ipv4_networks()
 
     def testIpAddressPrivate(self):

--- a/tests/golem/core/test_hostaddress.py
+++ b/tests/golem/core/test_hostaddress.py
@@ -1,5 +1,5 @@
 import unittest
-from golem.core.hostaddress import get_host_address, ip_address_private, ip_network_contains, ip_networks
+from golem.core.hostaddress import get_host_address, ip_address_private, ip_network_contains, ipv4_networks
 
 
 class TestHostAddress(unittest.TestCase):
@@ -12,8 +12,7 @@ class TestHostAddress(unittest.TestCase):
         self.assertEqual(get_host_address('10.30.10.217'), '10.30.10.216')
 
     def testGetIPNetworks(self):
-        ip_networks()
-        ip_networks(use_ipv6=True)
+        ipv4_networks()
 
     def testIpAddressPrivate(self):
         assert ip_address_private('::1')

--- a/tests/golem/core/test_hostaddress.py
+++ b/tests/golem/core/test_hostaddress.py
@@ -20,6 +20,10 @@ def mock_ifaddresses(*args):
             addr='8.8.8.8',
             netmask='255.255.255.255'
         ),
+        dict(
+            addr='invalid',
+            netmask='invalid'
+        ),
     ]
     return addrs
 

--- a/tests/golem/network/transport/test_tcpserver.py
+++ b/tests/golem/network/transport/test_tcpserver.py
@@ -103,6 +103,25 @@ class TestPendingConnectionServer(unittest.TestCase):
             self.assertEqual(res[i].address, node.prv_addresses[i])
             self.assertEqual(res[i].port, port)
 
+    def test_address_accessible(self):
+        config = Mock()
+        config.use_ipv6 = False
+
+        server = PendingConnectionsServer(config, Mock())
+
+        assert not server._is_address_accessible(None)
+
+        sockv4 = SocketAddress('8.8.8.8', 40100)
+        sockv6 = SocketAddress('2001:0db8:85a3:0000:0000:8a2e:abcd:efea', 40100)
+
+        assert server._is_address_accessible(sockv4)
+        assert not server._is_address_accessible(sockv6)
+
+        server.use_ipv6 = True
+
+        assert server._is_address_accessible(sockv4)
+        assert server._is_address_accessible(sockv6)
+
     def test_pending_conn(self):
         network = Network()
         server = PendingConnectionsServer(None, network)


### PR DESCRIPTION
It's safer to assume no knowledge of node's IPv6 network configuration (i.e. presence of NAT66) and allow connections to all IPv6 addresses.
