### PR TITLE
change restart mechanism

### DIFF
--- a/gnr/task/blenderrendertask.py
+++ b/gnr/task/blenderrendertask.py
@@ -93,6 +93,15 @@ class PreviewUpdater(object):
         if subtask_number == self.perfectly_placed_subtasks and (subtask_number + 1) in self.chunks:
             self.update_preview(self.chunks[subtask_number + 1], subtask_number + 1)
 
+    def restart(self):
+        self.chunks = {}
+        self.perfect_match_area_y = 0
+        self.perfectly_placed_subtasks = 0
+        if os.path.exists(self.preview_file_path):
+            img = Image.new("RGB", (self.preview_res_x, self.preview_res_y))
+            img.save(self.preview_file_path, "BMP")
+            img.close()
+
 
 def build_blender_renderer_info(dialog, customizer):
     defaults = BlenderDefaults()
@@ -303,6 +312,16 @@ class BlenderRenderTask(FrameRenderingTask):
 
         ctd = self._new_compute_task_def(hash, extra_data, working_directory, perf_index)
         return self.ExtraData(ctd=ctd)
+
+    def restart(self):
+        super(BlenderRenderTask, self).restart()
+        if self.use_frames:
+            for preview in self.preview_updaters:
+                preview.restart()
+                self._update_frame_task_preview()
+        else:
+            self.preview_updater.restart()
+            self._update_task_preview()
 
     ###################
     # GNRTask methods #

--- a/gnr/task/framerenderingtask.py
+++ b/gnr/task/framerenderingtask.py
@@ -68,9 +68,6 @@ class FrameRenderingTask(RenderingTask):
             self.preview_file_path = [None] * len(frames)
             self.preview_task_file_path = [None] * len(frames)
 
-    def restart(self):
-        RenderingTask.restart(self)
-
     @RenderingTask.handle_key_error
     def computation_finished(self, subtask_id, task_results, result_type=0):
         if not self.should_accept(subtask_id):

--- a/gnr/task/framerenderingtask.py
+++ b/gnr/task/framerenderingtask.py
@@ -70,9 +70,6 @@ class FrameRenderingTask(RenderingTask):
 
     def restart(self):
         RenderingTask.restart(self)
-        if self.use_frames:
-            self.preview_file_path = [None] * len(self.frames)
-            self.preview_task_file_path = [None] * len(self.frames)
 
     @RenderingTask.handle_key_error
     def computation_finished(self, subtask_id, task_results, result_type=0):

--- a/gnr/task/gnrtask.py
+++ b/gnr/task/gnrtask.py
@@ -143,7 +143,7 @@ class GNRTask(Task):
 
     @handle_key_error
     def restart_subtask(self, subtask_id):
-        was_failure_before = self.subtasks_given[subtask_id]['status'] == SubtaskStatus.failure
+        was_failure_before = self.subtasks_given[subtask_id]['status'] in [SubtaskStatus.failure, SubtaskStatus.resent]
         if subtask_id in self.subtasks_given:
             if self.subtasks_given[subtask_id]['status'] == SubtaskStatus.starting:
                 self._mark_subtask_failed(subtask_id)

--- a/gnr/task/gnrtask.py
+++ b/gnr/task/gnrtask.py
@@ -138,16 +138,12 @@ class GNRTask(Task):
         return (self.total_tasks - self.last_task) + self.num_failed_subtasks
 
     def restart(self):
-        self.num_tasks_received = 0
-        self.last_task = 0
-        self.subtasks_given.clear()
-
-        self.num_failed_subtasks = 0
-        self.header.last_checking = time.time()
-        self.header.ttl = self.full_task_timeout
+        for subtask_id in self.subtasks_given.keys():
+            self.restart_subtask(subtask_id)
 
     @handle_key_error
     def restart_subtask(self, subtask_id):
+        was_failure_before = self.subtasks_given[subtask_id]['status'] == SubtaskStatus.failure
         if subtask_id in self.subtasks_given:
             if self.subtasks_given[subtask_id]['status'] == SubtaskStatus.starting:
                 self._mark_subtask_failed(subtask_id)
@@ -155,6 +151,8 @@ class GNRTask(Task):
                 self._mark_subtask_failed(subtask_id)
                 tasks = self.subtasks_given[subtask_id]['end_task'] - self.subtasks_given[subtask_id]['start_task'] + 1
                 self.num_tasks_received -= tasks
+        if not was_failure_before:
+            self.subtasks_given[subtask_id]['status'] = SubtaskStatus.restarted
 
     def abort(self):
         pass

--- a/gnr/task/luxrendertask.py
+++ b/gnr/task/luxrendertask.py
@@ -395,8 +395,12 @@ class LuxTask(RenderingTask):
 
         self.preview_file_path = None
         self.numAdd = 0
+
         for f in preview_files:
             self._update_preview(f, None)
+        if len(preview_files) == 0:
+            img = self._open_preview()
+            img.close()
 
     def __update_preview_from_pil_file(self, new_chunk_file_path):
         img = Image.open(new_chunk_file_path)

--- a/gnr/task/renderingtask.py
+++ b/gnr/task/renderingtask.py
@@ -129,9 +129,7 @@ class RenderingTask(GNRTask):
         self._update_task_preview()
 
     def restart(self):
-        GNRTask.restart(self)
-        self.preview_file_path = None
-        self.preview_task_file_path = None
+        super(RenderingTask, self).restart()
 
         self.collected_file_names = {}
 

--- a/gnr/task/renderingtask.py
+++ b/gnr/task/renderingtask.py
@@ -130,7 +130,6 @@ class RenderingTask(GNRTask):
 
     def restart(self):
         super(RenderingTask, self).restart()
-
         self.collected_file_names = {}
 
     @GNRTask.handle_key_error

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -362,17 +362,14 @@ class TaskManager(TaskEventListener):
         self.tasks_states[task_id].status = TaskStatus.waiting
         self.tasks_states[task_id].time_started = time.time()
 
-        for sub in self.tasks_states[task_id].subtask_states.values():
-            del self.subtask2task_mapping[sub.subtask_id]
-        self.tasks_states[task_id].subtask_states.clear()
+        for ss in self.tasks_states[task_id].subtask_states.values():
+            if ss.subtask_status != SubtaskStatus.failure:
+                ss.subtask_status = SubtaskStatus.restarted
 
         self.notice_task_updated(task_id)
 
+    @handle_subtask_key_error
     def restart_subtask(self, subtask_id):
-        if subtask_id not in self.subtask2task_mapping:
-            logger.error("Subtask {} not in subtasks queue".format(subtask_id))
-            return
-
         task_id = self.subtask2task_mapping[subtask_id]
         self.tasks[task_id].restart_subtask(subtask_id)
         self.tasks_states[task_id].status = TaskStatus.computing

--- a/tests/gnr/task/test_blenderrendertask.py
+++ b/tests/gnr/task/test_blenderrendertask.py
@@ -307,7 +307,6 @@ class TestBlenderTask(TempDirFixture):
         img = Image.open(file4)
         self.assertTrue(img.size == (300, 200))
 
-        print bt.use_frames
         bt.restart()
         for preview in bt.preview_updaters:
             assert preview.chunks == {}

--- a/tests/gnr/task/test_gnrtask.py
+++ b/tests/gnr/task/test_gnrtask.py
@@ -185,7 +185,7 @@ class TestGNRTask(LogTestCase, TestDirFixture):
         assert task.subtasks_given["xyz"]["status"] == SubtaskStatus.restarted
         assert task.subtasks_given["abc"]["status"] == SubtaskStatus.failure
         assert task.subtasks_given["def"]["status"] == SubtaskStatus.restarted
-        assert task.subtasks_given["ghi"]["status"] == SubtaskStatus.restarted
+        assert task.subtasks_given["ghi"]["status"] == SubtaskStatus.resent
 
     def __compress_and_pickle_file(self, file_name, data):
         file_data = zlib.compress(data, 9)

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -185,7 +185,6 @@ class TestTaskManager(LogTestCase, TestDirFixture):
         assert ss.subtask_status == SubtaskStatus.restarted
         assert not t2.finished["aabbcc"]
 
-
         th.task_id = "qwe"
         t3 = TestTask(th, "print 'Hello world!", ["qqwwee", "rrttyy"], {"qqwwee": True, "rrttyy": True})
         tm.add_new_task(t3)

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -336,6 +336,17 @@ class TestTaskManager(LogTestCase, TestDirFixture):
             tm.restart_task("xyz")
         assert tm.tasks["xyz"].task_status == TaskStatus.waiting
         assert tm.tasks_states["xyz"].status == TaskStatus.waiting
+        tm.get_next_subtask("NODEID", "NODENAME", "xyz", 1000, 100, 10000, 10000)
+        t.query_extra_data.return_value.ctd.subtask_id = "xxyyzz2"
+        tm.get_next_subtask("NODEID2", "NODENAME2", "xyz", 1000, 100, 10000, 10000)
+        assert len(tm.tasks_states["xyz"].subtask_states) == 2
+        with self.assertNoLogs(logger, level="WARNING"):
+            tm.restart_task("xyz")
+        assert tm.tasks["xyz"].task_status == TaskStatus.waiting
+        assert tm.tasks_states["xyz"].status == TaskStatus.waiting
+        assert len(tm.tasks_states["xyz"].subtask_states) == 2
+        for ss in tm.tasks_states["xyz"].subtask_states.values():
+            assert ss.subtask_status == SubtaskStatus.restarted
 
     def test_abort_task(self):
         tm = TaskManager("ABC", Node(), root_path=self.path)


### PR DESCRIPTION
- Restart PreviewUpdaters in Blender
- Don't change preview paths to None (clean images instead). 
- Don't clean list of subtasks when restaring the task. Just restart them. 
