### PR TITLE
broadcast new node name

### DIFF
--- a/golem/network/p2p/peersession.py
+++ b/golem/network/p2p/peersession.py
@@ -151,6 +151,9 @@ class PeerSession(BasicSafeSession):
         logger.info("Starting peer session {} : {}".format(self.address, self.port))
         self.__send_hello()
 
+    def hello(self):
+        self.__send_hello()
+
     def ping(self, interval):
         """ Will send ping message if time from last message was longer than interval
         :param float interval: number of seconds that should pass until ping message may be send

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -372,8 +372,12 @@ class TestP2PService(DatabaseFixture):
         peer.key_id = keys_auth.key_id
         service.add_peer(keys_auth.key_id, peer)
         ccd = ClientConfigDescriptor()
-        ccd.node_name = "test sending hello on name change"
         assert not peer.hello_called
         service.change_config(ccd)
-        assert peer.hello_called
+        assert not peer.hello_called # negative test
+        ccd = ClientConfigDescriptor()
+        ccd.node_name = "test sending hello on name change"
+        service.change_config(ccd)
+        assert peer.hello_called # positive test
+
 


### PR DESCRIPTION
On config change send hello to peers if node name was changed.
This will allow other users see node name for new nodes.
