### PR TITLE
add abort test functionality

### DIFF
--- a/gnr/customizers/testingtaskprogresscustomizer.py
+++ b/gnr/customizers/testingtaskprogresscustomizer.py
@@ -4,13 +4,29 @@ from customizer import Customizer
 class TestingTaskProgressDialogCustomizer(Customizer):
     def _setup_connections(self):
         self.gui.ui.okButton.clicked.connect(self.gui.close)
+        self.enable_abort_button(False)
 
     def show_message(self, msg):
         self.gui.ui.message.setText(msg)
 
-    def button_enable(self, enable):
+    def enable_ok_button(self, enable):
         """
         Enable or disable 'ok' button
         :param enable: True if you want to enable button, false otherwise
         """
         self.gui.ui.okButton.setEnabled(enable)
+
+    def enable_abort_button(self, enable):
+        """
+        Enable or disable 'abort' button
+        :param enable: True if you want to enable button, false otherwise
+        """
+        self.gui.ui.abortButton.setEnabled(enable)
+
+    def enable_close(self, enable):
+        """
+        Enable or disable closing of the window via button in the corner.
+        Note! This also affects any other method of closing dialog.
+        :param enable: True if you allow window to close, False otherwise
+        """
+        self.gui.window.enable_close(enable)

--- a/gnr/gnrapplicationlogic.py
+++ b/gnr/gnrapplicationlogic.py
@@ -462,7 +462,14 @@ class GNRApplicationLogic(QtCore.QObject):
 
             self.progress_dialog = TestingTaskProgressDialog(self.customizer.gui.window)
             self.progress_dialog_customizer = TestingTaskProgressDialogCustomizer(self.progress_dialog, self)
-            self.progress_dialog_customizer.button_enable(False)  # disable 'ok' button
+            self.progress_dialog_customizer.enable_ok_button(False)    # disable 'ok' button
+            self.progress_dialog_customizer.enable_abort_button(False) # disable 'abort' button
+            self.progress_dialog_customizer.enable_close(False)        # prevent from closing
+            self.progress_dialog_customizer.show_message("Preparing test...")
+            def on_abort():
+                self.progress_dialog_customizer.show_message("Aborting test...")
+                self.abort_test_task()
+            self.progress_dialog_customizer.gui.ui.abortButton.clicked.connect(on_abort)
             self.customizer.gui.setEnabled('new_task', False)  # disable everything on 'new task' tab
             self.progress_dialog.show()
 
@@ -473,6 +480,13 @@ class GNRApplicationLogic(QtCore.QObject):
             return True
 
         return False
+
+    def test_task_started(self, success):
+        self.progress_dialog_customizer.show_message("Testing...")
+        self.progress_dialog_customizer.enable_abort_button(success)
+
+    def abort_test_task(self):
+        self.client.abort_test_task()
 
     # label param is the gui element to set text
     def run_benchmark(self, benchmark, label):
@@ -491,7 +505,7 @@ class GNRApplicationLogic(QtCore.QObject):
 
         self.progress_dialog = TestingTaskProgressDialog(self.customizer.gui.window)
         self.progress_dialog_customizer = TestingTaskProgressDialogCustomizer(self.progress_dialog, self)
-        self.progress_dialog_customizer.button_enable(False)    # disable 'ok' button
+        self.progress_dialog_customizer.enable_ok_button(False) # disable 'ok' button
         self.customizer.gui.setEnabled('recount', False)        # disable all 'recount' buttons
         self.progress_dialog.show()
 
@@ -500,7 +514,7 @@ class GNRApplicationLogic(QtCore.QObject):
     def _benchmark_computation_success(self, performance, label):
         self.progress_dialog.stop_progress_bar()
         self.progress_dialog_customizer.show_message(u"Recounted")
-        self.progress_dialog_customizer.button_enable(True)     # enable 'ok' button
+        self.progress_dialog_customizer.enable_ok_button(True)  # enable 'ok' button
         self.customizer.gui.setEnabled('recount', True)         # enable all 'recount' buttons
 
         # rounding
@@ -511,7 +525,7 @@ class GNRApplicationLogic(QtCore.QObject):
     def _benchmark_computation_error(self, error):
         self.progress_dialog.stop_progress_bar()
         self.progress_dialog_customizer.show_message(u"Recounting failed: {}".format(error))
-        self.progress_dialog_customizer.button_enable(True)     # enable 'ok' button
+        self.progress_dialog_customizer.enable_ok_button(True)  # enable 'ok' button
         self.customizer.gui.setEnabled('recount', True)         # enable all 'recount' buttons
 
     @inlineCallbacks
@@ -531,7 +545,9 @@ class GNRApplicationLogic(QtCore.QObject):
             ms_box.show()
         msg = u"Task tested successfully"
         self.progress_dialog_customizer.show_message(msg)
-        self.progress_dialog_customizer.button_enable(True)     # enable 'ok' button
+        self.progress_dialog_customizer.enable_ok_button(True)    # enable 'ok' button
+        self.progress_dialog_customizer.enable_close(True)
+        self.progress_dialog_customizer.enable_abort_button(False)# disable 'abort' button
         self.customizer.gui.setEnabled('new_task', True)        # enable everything on 'new task' tab
         if self.customizer.new_task_dialog_customizer:
             self.customizer.new_task_dialog_customizer.test_task_computation_finished(True, est_mem)
@@ -542,7 +558,9 @@ class GNRApplicationLogic(QtCore.QObject):
         if error:
             err_msg += self.__parse_error_message(error)
         self.progress_dialog_customizer.show_message(err_msg)
-        self.progress_dialog_customizer.button_enable(True)     # enable 'ok' button
+        self.progress_dialog_customizer.enable_ok_button(True) # enable 'ok' button
+        self.progress_dialog_customizer.enable_close(True)
+        self.progress_dialog_customizer.enable_abort_button(False)# disable 'abort' button
         self.customizer.gui.setEnabled('new_task', True)  # enable everything on 'new task' tab
         if self.customizer.new_task_dialog_customizer:
             self.customizer.new_task_dialog_customizer.test_task_computation_finished(False, 0)

--- a/gnr/task/localcomputer.py
+++ b/gnr/task/localcomputer.py
@@ -52,6 +52,13 @@ class LocalComputer(object):
             logger.warning("{}: {}".format(self.comp_failed_warning, exc))
             self.error_callback(str(exc))
 
+    def end_comp(self):
+        if self.tt:
+            self.tt.end_comp()
+            return True
+        else:
+            return False
+
     def get_progress(self):
         if self.tt:
             with self.lock:

--- a/gnr/ui/TestingTaskProgressDialog.ui
+++ b/gnr/ui/TestingTaskProgressDialog.ui
@@ -66,6 +66,13 @@
        </widget>
       </item>
       <item>
+       <widget class="QPushButton" name="abortButton">
+        <property name="text">
+         <string>Abort</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QLabel" name="message">
         <property name="sizePolicy">
          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Expanding">

--- a/gnr/ui/dialog.py
+++ b/gnr/ui/dialog.py
@@ -20,7 +20,7 @@ from gnr.ui.gen.ui_UpdatingConfigDialog import Ui_updatingConfigDialog
 class Dialog(object):
     """ Basic dialog window extension, save specific given class as ui """
     def __init__(self, parent, ui_class):
-        self.window = QDialog(parent)
+        self.window = QDialogPlus(parent)
         self.ui = ui_class()
         self.ui.setupUi(self.window)
 
@@ -28,7 +28,25 @@ class Dialog(object):
         self.window.show()
 
     def close(self):
+        try:
+            self.ui.enable_close(True)
+        except AttributeError:
+            pass
         self.window.close()
+
+class QDialogPlus(QDialog):
+    def __init__(self, parent):
+        QDialog.__init__(self, parent)
+        self.can_be_closed = True
+
+    def closeEvent(self, event):
+        if self.can_be_closed:
+            event.accept()
+        else:
+            event.ignore()
+
+    def enable_close(self, enable):
+        self.can_be_closed = enable
 
 
 # TASK INFO DIALOGS

--- a/tests/gnr/test_gnrapplicationlogic.py
+++ b/tests/gnr/test_gnrapplicationlogic.py
@@ -62,15 +62,21 @@ class RPCClient(object):
     def __init__(self):
         self.success = False
         self.error = False
+        self.started = False
 
     def test_task_computation_success(self, *args, **kwargs):
         self.success = True
         self.error = False
+        self.started = False
 
     def test_task_computation_error(self, *args, **kwargs):
         self.success = False
         self.error = True
+        self.started = False
 
+    def test_task_started(self, *args, **kwargs):
+        print "test_task_started {}".format(args)
+        self.started = args[0]
 
 class MockDeferred(Deferred):
     def __init__(self, result):
@@ -217,6 +223,9 @@ class TestGNRApplicationLogicWithGUI(DatabaseFixture):
     def setUp(self):
         super(TestGNRApplicationLogicWithGUI, self).setUp()
         self.client = Client.__new__(Client)
+        from threading import Lock
+        self.client.lock = Lock()
+        self.client.task_tester = None
         self.logic = GNRApplicationLogic()
         self.app = GNRGui(self.logic, AppMainWindow)
 
@@ -272,6 +281,21 @@ class TestGNRApplicationLogicWithGUI(DatabaseFixture):
         time.sleep(0.5)
 
         assert rpc_client.success
+
+        assert not rpc_client.started
+        ttb.src_code = "import time\ntime.sleep(0.1)\noutput = {'data': n, 'result_type': 0}"
+        logic.run_test_task(ts)
+        time.sleep(1)
+        assert rpc_client.success
+
+        # since PythonTestVM does not support end_comp() method,
+        # this is only a smoke test instead of actual test
+        ttb.src_code = "import time\ntime.sleep(0.1)\noutput = {'data': n, 'result_type': 0}"
+        logic.run_test_task(ts)
+        assert rpc_client.started
+        logic.abort_test_task()
+        time.sleep(0.1)
+        # assert rpc_client.error
 
         ttb.src_code = "raise Exception('some error')"
         logic.run_test_task(ts)


### PR DESCRIPTION
split test in UI into preparation and execution phases
add ability to abort test by killing VM in execution phase
client: limit number of concurrent tests to one
enable and disable 'ok' and 'abort' buttons in appropriate moments
disable closing of dialog window via close window button
