### PR TITLE
Accept unicode log file names

### DIFF
--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -82,7 +82,9 @@ def config_logging(logname=LOG_NAME):
 
     if directory:
         try:
+            print "MKDIRS", directory, os.path.exists(directory)
             os.makedirs(directory)
+            print "EXISTS", os.path.exists(directory)
         except OSError as exc:
             if exc.errno != errno.EEXIST:
                 raise

--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -72,7 +72,12 @@ def config_logging(logname=LOG_NAME):
     """Config logger"""
 
     # \t and other special chars cause problems with log handlers
-    logname = logname.encode('string-escape')
+    if isinstance(logname, unicode):
+        escaping = 'unicode-escape'
+    else:
+        escaping = 'string-escape'
+
+    logname = logname.encode(escaping)
     directory = os.path.dirname(logname)
 
     if directory:

--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -82,9 +82,7 @@ def config_logging(logname=LOG_NAME):
 
     if directory:
         try:
-            print "MKDIRS", directory, os.path.exists(directory)
             os.makedirs(directory)
-            print "EXISTS", os.path.exists(directory)
         except OSError as exc:
             if exc.errno != errno.EEXIST:
                 raise

--- a/tests/golem/core/test_common.py
+++ b/tests/golem/core/test_common.py
@@ -1,6 +1,9 @@
+import os
 from unittest import TestCase
 
-from golem.core.common import HandleKeyError, HandleAttributeError
+from golem.core.common import HandleKeyError, HandleAttributeError, config_logging
+from golem.testutils import TempDirFixture
+from mock import patch, ANY
 
 
 def handle_error(*args, **kwargs):
@@ -30,3 +33,42 @@ class TestHandleAttibuteError(TestCase):
     @h
     def test_call_with_dec(self):
         assert self.func("Abc") == 6
+
+
+class TestConfigLogging(TempDirFixture):
+
+    @patch('logging.config.fileConfig')
+    def test(self, file_config):
+
+        invalid_logname = os.path.join("!@#$%&*()/><}{';.,", "dir", "log.txt")
+        invalid_logname_u = unicode(invalid_logname)
+
+        with self.assertRaises(OSError):
+            config_logging(invalid_logname)
+
+        with self.assertRaises(OSError):
+            config_logging(invalid_logname_u)
+
+        assert not file_config.called
+
+        logname = os.path.join(self.path, "dir", "log.txt")
+        dirname = os.path.dirname(logname)
+
+        config_logging(logname)
+
+        assert os.path.exists(dirname)
+        file_config.assert_called_with(ANY,
+                                       defaults={'logname': logname.encode('string-escape')},
+                                       disable_existing_loggers=False)
+
+        file_config.called = False
+
+        logname_u = unicode(logname)
+        dirname_u = unicode(dirname)
+
+        config_logging(logname_u)
+
+        assert os.path.exists(dirname_u)
+        file_config.assert_called_with(ANY,
+                                       defaults={'logname': logname_u.encode('unicode-escape')},
+                                       disable_existing_loggers=False)

--- a/tests/golem/core/test_common.py
+++ b/tests/golem/core/test_common.py
@@ -40,7 +40,7 @@ class TestConfigLogging(TempDirFixture):
     @patch('logging.config.fileConfig')
     def test(self, file_config):
 
-        invalid_logname = os.path.join("!@#$%&*()/><}{';.,", "dir", "log.txt")
+        invalid_logname = os.path.join(self.path, "/<\0?:/*!\">", "dir", "log.txt")
         invalid_logname_u = unicode(invalid_logname)
 
         with self.assertRaises(OSError):


### PR DESCRIPTION
Fixes errors with custom datadirs on Windows.
