### PR TITLE
Change exception message formatting

### DIFF
--- a/golem/core/hostaddress.py
+++ b/golem/core/hostaddress.py
@@ -74,13 +74,13 @@ def ip_address_private(address):
             return ipaddress.IPv6Address(unicode(address)).is_private
         except Exception as exc:
             logger.error("Cannot parse IPv6 address {}: {}"
-                         .format(address, exc.message))
+                         .format(address, exc))
             return False
     try:
         return ipaddress.IPv4Address(unicode(address)).is_private
     except Exception as exc:
         logger.error("Cannot parse IPv4 address {}: {}"
-                     .format(address, exc.message))
+                     .format(address, exc))
         return False
 
 

--- a/golem/core/keysauth.py
+++ b/golem/core/keysauth.py
@@ -223,7 +223,7 @@ class RSAKeysAuth(KeysAuth):
         try:
             return public_key.verify(data, sig)
         except Exception as exc:
-            logger.error("Cannot verify signature: {}".format(exc.message))
+            logger.error("Cannot verify signature: {}".format(exc))
         return False
 
     def generate_new(self, difficulty):
@@ -398,7 +398,7 @@ class EllipticalKeysAuth(KeysAuth):
         except AssertionError:
             logger.info("Wrong key format")
         except Exception as exc:
-            logger.error("Cannot verify signature: {}".format(exc.message))
+            logger.error("Cannot verify signature: {}".format(exc))
         return False
 
     def generate_new(self, difficulty):

--- a/golem/network/ipfs/client.py
+++ b/golem/network/ipfs/client.py
@@ -306,7 +306,7 @@ class IPFSClientHandler(ClientHandler):
 
     def command_failed(self, exc, cmd, obj_id, **kwargs):
         logger.error("IPFS: Error executing command '{}': {}"
-                     .format(self.commands.names[cmd], exc.message))
+                     .format(self.commands.names[cmd], exc))
 
 
 class IPFSAddress(object):

--- a/golem/network/ipfs/daemon_manager.py
+++ b/golem/network/ipfs/daemon_manager.py
@@ -148,7 +148,7 @@ class IPFSDaemonManager(IPFSClientHandler):
                 IPFSCommands.swarm_peers
             )
         except Exception as exc:
-            logger.error("IPFS: Cannot list swarm peers: {}".format(exc.message))
+            logger.error("IPFS: Cannot list swarm peers: {}".format(exc))
         return []
 
     def list_bootstrap_nodes(self, client=None):

--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -79,7 +79,7 @@ class P2PService(PendingConnectionsServer, DiagnosticsProvider):
             self.__remove_redundant_hosts_from_db()
             self.__sync_seeds()
         except Exception as exc:
-            logger.error("Error reading seed addresses: {}".format(exc.message))
+            logger.error("Error reading seed addresses: {}".format(exc))
 
         # Timers
         self.last_peers_request = time.time()

--- a/golem/resource/base/resourcesmanager.py
+++ b/golem/resource/base/resourcesmanager.py
@@ -62,7 +62,7 @@ class BaseAbstractResourceManager(IClientHandler):
 
     def command_failed(self, exc, cmd, obj_id, **kwargs):
         logger.error("Resource manager: Error executing command '{}': {}"
-                     .format(self.commands.names[cmd], exc.message))
+                     .format(self.commands.names[cmd], exc))
 
     def copy_resources(self, from_dir):
         resource_dir = self.get_root_dir()

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -667,7 +667,7 @@ class TaskSession(MiddlemanSafeSession):
             if isinstance(exc, EnvironmentError):
                 self.task_server.retry_sending_task_result(subtask_id)
             else:
-                self.send(MessageTaskFailure(subtask_id, exc.message))
+                self.send(MessageTaskFailure(subtask_id, '{}'.format(exc)))
                 self.task_server.task_result_sent(subtask_id)
 
             self.dropped()


### PR DESCRIPTION
Refactor `exc.message` to `exc` in error message formatting. One was causing issues in `TaskSession` instances.
