### PR TITLE
Fix: re-sign task headers on network info change 

### DIFF
--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -199,7 +199,10 @@ class TaskHeaderKeeper(object):
                 self.task_headers[id_] = TaskHeader.from_dict(th_dict_repr)
                 is_supported = self.is_supported(th_dict_repr)
 
-                if is_supported and not update:
+                if update:
+                    if not is_supported and id_ in self.supported_tasks:
+                        self.supported_tasks.remove(id_)
+                elif is_supported:
                     logger.info("Adding task {} is_supported={}".format(id_, is_supported))
                     self.supported_tasks.append(id_)
 

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -185,21 +185,24 @@ class TaskHeaderKeeper(object):
                 self.supported_tasks.append(id_)
 
     def add_task_header(self, th_dict_repr):
-        """ This function will try to add a task header to a list of known headers. The header will be added only
-        if it isn't already placed in taks_headers or wasn't remove recently. If it's new and supported its id will be
-        put in supported task list.
+        """ This function will try to add to or update a task header in a list of known headers. The header will be
+        added / updated only if it hasn't been removed recently. If it's new and supported its id will be put in
+        supported task list.
         :param dict th_dict_repr: task dictionary representation
         :return bool: True if task header was well formatted and no error occurs, False otherwise
         """
         try:
             id_ = th_dict_repr["task_id"]
-            if id_ not in self.task_headers.keys():  # don't have it
-                if id_ not in self.removed_tasks.keys():  # not removed recently
-                    self.task_headers[id_] = TaskHeader.from_dict(th_dict_repr)
-                    is_supported = self.is_supported(th_dict_repr)
+            update = id_ in self.task_headers.keys()
+
+            if id_ not in self.removed_tasks.keys():  # not removed recently
+                self.task_headers[id_] = TaskHeader.from_dict(th_dict_repr)
+                is_supported = self.is_supported(th_dict_repr)
+
+                if is_supported and not update:
                     logger.info("Adding task {} is_supported={}".format(id_, is_supported))
-                    if is_supported:
-                        self.supported_tasks.append(id_)
+                    self.supported_tasks.append(id_)
+
             return True
         except (KeyError, TypeError) as err:
             logger.error("Wrong task header received {}".format(err))

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -167,11 +167,11 @@ class TaskServer(PendingConnectionsServer):
             task_ids = self.task_manager.tasks.keys()
             new_sig = True
 
-            if task_id in task_ids:
-                header = self.task_manager.tasks[task_id].header
+            if task_id in self.task_keeper.task_headers:
+                header = self.task_keeper.task_headers[task_id]
                 new_sig = th_dict_repr["signature"] != header.signature
 
-            if new_sig and key_id != self.node.key:
+            if task_id not in task_ids and key_id != self.node.key and new_sig:
                 self.task_keeper.add_task_header(th_dict_repr)
 
             return True

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -165,9 +165,15 @@ class TaskServer(PendingConnectionsServer):
             task_id = th_dict_repr["task_id"]
             key_id = th_dict_repr["task_owner_key_id"]
             task_ids = self.task_manager.tasks.keys()
+            new_sig = True
 
-            if task_id not in task_ids and key_id != self.node.key:
+            if task_id in task_ids:
+                header = self.task_manager.tasks[task_id].header
+                new_sig = th_dict_repr["signature"] != header.signature
+
+            if new_sig and key_id != self.node.key:
                 self.task_keeper.add_task_header(th_dict_repr)
+
             return True
         except Exception as err:
             logger.error("Wrong task header received {}".format(err))

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -126,6 +126,36 @@ class TestTaskHeaderKeeper(LogTestCase):
         assert len(tk.supported_tasks) == 1
         assert tk.supported_tasks[0] == "xyz"
 
+    def test_task_header_update(self):
+        e = Environment()
+        e.accept_tasks = True
+
+        tk = TaskHeaderKeeper(EnvironmentsManager(), 10)
+        tk.environments_manager.add_environment(e)
+
+        assert not tk.add_task_header(dict())
+
+        task_header = get_task_header()
+        task_id = task_header["task_id"]
+
+        task_header["deadline"] = timeout_to_deadline(10)
+        assert tk.add_task_header(task_header)
+        assert task_id in tk.supported_tasks
+        assert tk.add_task_header(task_header)
+        assert task_id in tk.supported_tasks
+
+        task_header["max_price"] = 1
+        assert tk.add_task_header(task_header)
+        assert task_id not in tk.supported_tasks
+
+        tk.task_headers = {}
+        tk.supported_tasks = []
+
+        task_header["max_price"] = 1
+        assert tk.add_task_header(task_header)
+        assert task_id not in tk.supported_tasks
+
+
 def get_task_header():
     return {
         "task_id": "xyz",

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -188,6 +188,17 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase):
         ts.add_task_header(task_header)
         assert len(ts.get_tasks_headers()) == 2
 
+        ts.add_task_header(task_header)
+        assert len(ts.get_tasks_headers()) == 2
+
+        task_header["task_owner"].pub_port = 9999
+        task_header["signature"] = keys_auth.sign(TaskHeader.dict_to_binary(task_header))
+
+        ts.add_task_header(task_header)
+        assert len(ts.get_tasks_headers()) == 2
+        saved_task = next(th for th in ts.get_tasks_headers() if th["task_id"] == "xyz_2")
+        assert saved_task["signature"] == task_header["signature"]
+
     def test_sync(self):
         ccd = self.__get_config_desc()
         ts = TaskServer(Node(), ccd, EllipticalKeysAuth(self.path), self.client,


### PR DESCRIPTION
Currently, a reference to `golem.p2p.Node` is kept in the task header. If task owner's external address / port changes, so should the signature.

Peers in the network are allowed to update tasks stored in `TaskKeeper` (if they are still supported).
