### PR TITLE
Fix: Show a progress dialog for benchmarks

### DIFF
--- a/gnr/benchmarks/benchmarkrunner.py
+++ b/gnr/benchmarks/benchmarkrunner.py
@@ -27,11 +27,14 @@ class BenchmarkRunner(LocalComputer):
             return LocalComputer._get_task_thread(self, ctd)
         else:
             raise Exception("No docker container found")
-    
-    def run(self):
+
+    def start(self):
         self.start_time = time.time()
         logger.debug("Started at {}".format(self.start_time))
         LocalComputer.run(self)
+
+    def run(self):
+        self.start()
         if self.tt:
             self.tt.join()
     

--- a/gnr/gnrapplicationlogic.py
+++ b/gnr/gnrapplicationlogic.py
@@ -495,7 +495,7 @@ class GNRApplicationLogic(QtCore.QObject):
         self.customizer.gui.setEnabled('recount', False)        # disable all 'recount' buttons
         self.progress_dialog.show()
 
-        self.br.run()
+        self.br.start()
 
     def _benchmark_computation_success(self, performance, label):
         self.progress_dialog.stop_progress_bar()

--- a/tests/gnr/benchmarks/blender/test_blenderbenchmark.py
+++ b/tests/gnr/benchmarks/blender/test_blenderbenchmark.py
@@ -2,12 +2,17 @@ import os
 import tempfile
 import unittest
 
+from gnr.benchmarks.benchmarkrunner import BenchmarkRunner
 from gnr.benchmarks.blender.blenderbenchmark import BlenderBenchmark
 from gnr.benchmarks.benchmark import Benchmark
-from gnr.renderingtaskstate import RenderingTaskDefinition
-from gnr.task.blenderrendertask import BlenderRendererOptions
+from gnr.renderingtaskstate import RenderingTaskDefinition, RenderingTaskState
+from gnr.task.blenderrendertask import BlenderRendererOptions, BlenderRenderTaskBuilder
 
 from gnr.renderingdirmanager import get_benchmarks_path
+from golem.resource.dirmanager import DirManager
+from golem.task.taskbase import Task
+from golem.task.taskstate import TaskStatus
+from golem.testutils import TempDirFixture
 
 
 class TestBlenderBenchmark(unittest.TestCase):
@@ -32,3 +37,30 @@ class TestBlenderBenchmark(unittest.TestCase):
         self.assertTrue(self.bb.task_definition.task_id == u"{}".format("blender_benchmark"))
         self.assertTrue(os.path.isfile(self.bb.task_definition.main_scene_file))
         self.assertTrue(os.path.isfile(self.bb.task_definition.main_program_file))
+
+
+class TestBenchmarkRunner(TempDirFixture):
+
+    def test_run(self):
+        benchmark = BlenderBenchmark()
+        task_definition = benchmark.query_benchmark_task_definition()
+
+        task_state = RenderingTaskState()
+        task_state.status = TaskStatus.notStarted
+        task_state.definition = task_definition
+
+        dir_manager = DirManager(self.path)
+        task = Task.build_task(BlenderRenderTaskBuilder("node name", task_definition, self.path, dir_manager))
+
+        result = [None]
+
+        def success(*_):
+            result[0] = True
+
+        def error(*_):
+            result[0] = False
+
+        self.br = BenchmarkRunner(task, self.path, success, error, benchmark)
+        self.br.run()
+
+        assert result[0]

--- a/tests/gnr/benchmarks/test_benchmark.py
+++ b/tests/gnr/benchmarks/test_benchmark.py
@@ -1,10 +1,7 @@
 from PIL import Image
-
-from golem.testutils import TempDirFixture
 from gnr.benchmarks.benchmark import Benchmark
 from gnr.renderingtaskstate import RenderingTaskDefinition
-
-from gnr.renderingdirmanager import get_benchmarks_path
+from golem.testutils import TempDirFixture
 
 
 class TestBlenderBenchmark(TempDirFixture):


### PR DESCRIPTION
Main thread is no longer blocked by `join`ing the benchmark's thread. The progress dialog is shown prior to (not after) the test.
