### PR TITLE
Session: immediately drop the connection on disconnect

### DIFF
--- a/golem/network/transport/session.py
+++ b/golem/network/transport/session.py
@@ -107,17 +107,13 @@ class BasicSession(FileSession):
         self.conn.close_now()
 
     def disconnect(self, reason):
-        """ If it's called for the first time, send "disconnect" message to the peer. Otherwise, drops
-        connection.
+        """ Send "disconnect" message to the peer and drop the connection.
         :param string reason: Reason for disconnecting. Should use global class disconnect reasons, eg. DCRBadProtocol
         """
         logger.info("Disconnecting {} : {} reason: {}".format(self.address, self.port, reason))
         if self.conn.opened:
-            if self.last_disconnect_time:
-                self.dropped()
-            else:
-                self.last_disconnect_time = time.time()
-                self._send_disconnect(reason)
+            self._send_disconnect(reason)
+            self.dropped()
 
     def send(self, message):
         """ Send given message.

--- a/golem/network/transport/session.py
+++ b/golem/network/transport/session.py
@@ -74,7 +74,6 @@ class BasicSession(FileSession):
         self.port = pp.port
 
         self.last_message_time = time.time()
-        self.last_disconnect_time = None
         self._interpretation = {MessageDisconnect.Type: self._react_to_disconnect}
         # Message interpretation - dictionary where keys are messages' types and values are functions that should
         # be called after receiving specific message

--- a/tests/golem/network/p2p/test_peersession.py
+++ b/tests/golem/network/p2p/test_peersession.py
@@ -1,6 +1,6 @@
 import unittest
 
-from mock import MagicMock
+from mock import MagicMock, Mock
 
 from golem.core.keysauth import EllipticalKeysAuth, KeysAuth
 from golem.network.p2p.node import Node
@@ -87,12 +87,26 @@ class TestPeerSession(TestWithKeysAuth, LogTestCase):
         peer_session._react_to_hello(msg)
         peer_session.disconnect.assert_called_with(PeerSession.DCRDuplicatePeers)
 
+    def test_disconnect(self):
+        conn = MagicMock()
+        peer_session = PeerSession(conn)
+        peer_session.p2p_service = MagicMock()
+        peer_session.dropped = MagicMock()
+        peer_session.conn = Mock()
+
+        peer_session.conn.opened = False
+        peer_session.disconnect(PeerSession.DCRProtocolVersion)
+        assert not peer_session.dropped.called
+
+        peer_session.conn.opened = True
+        peer_session.disconnect(PeerSession.DCRProtocolVersion)
+        assert peer_session.dropped.called
+
     def test_dropped(self):
         conn = MagicMock()
         peer_session = PeerSession(conn)
         peer_session.p2p_service = MagicMock()
 
-        peer_session.remove_on_disconnect = True
         peer_session.dropped()
         assert peer_session.p2p_service.remove_peer.called
         assert not peer_session.p2p_service.remove_pending_conn.called


### PR DESCRIPTION
Currently, calling `disconnect` leaves sessions open and waits for the other side to drop the connection.