### PR TITLE
removed invalid_logname test

### DIFF
--- a/tests/golem/core/test_common.py
+++ b/tests/golem/core/test_common.py
@@ -40,17 +40,6 @@ class TestConfigLogging(TempDirFixture):
     @patch('logging.config.fileConfig')
     def test(self, file_config):
 
-        invalid_logname = os.path.join(self.path, "/<\0?:/*!\">", "dir", "log.txt")
-        invalid_logname_u = unicode(invalid_logname)
-
-        with self.assertRaises(OSError):
-            config_logging(invalid_logname)
-
-        with self.assertRaises(OSError):
-            config_logging(invalid_logname_u)
-
-        assert not file_config.called
-
         logname = os.path.join(self.path, "dir", "log.txt")
         dirname = os.path.dirname(logname)
 


### PR DESCRIPTION
removed invalid_logname test because it was not invalid on my system  and created the directories.