### PR TITLE
Hotfix: enable local mining

### DIFF
--- a/golem/ethereum/client.py
+++ b/golem/ethereum/client.py
@@ -25,7 +25,7 @@ class Client(object):
             assert Client.node.datadir == datadir, \
                 "Ethereum node's datadir cannot be changed"
         if not Client.node.is_running():
-            Client.node.start(rpc=True)
+            Client.node.start(rpc=True, mining=True)
         self.web3 = Web3(KeepAliveRPCProvider(host='localhost', port=Client.node.rpcport))
 
     @staticmethod

--- a/golem/ethereum/node.py
+++ b/golem/ethereum/node.py
@@ -1,7 +1,6 @@
 from __future__ import division
 
 import atexit
-import jsonpickle as json
 import logging
 import os
 import re
@@ -105,7 +104,6 @@ class NodeProcess(object):
             '--networkid', '9',
             '--port', str(self.port),
             '--nodiscover',
-            '--etherbase', '0x6528d9354356d7f668c75e9ed97f792bf910c8e5',
             '--ipcdisable',  # Disable IPC transport - conflicts on Windows.
             '--gasprice', '0',
             '--verbosity', '3',


### PR DESCRIPTION
This change enables mining in local Ethereum node. This make the private Ethereum network more robust and not depending too much on single central node on pebble server.