### PR TITLE
Restore devp2p requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ tabulate
 PyYAML>=3.12
 crossbar
 jsonpickle
+devp2p>=0.5.1


### PR DESCRIPTION
`devp2p` imports are still used in the project