### PR TITLE
Repeat rmtree in tests if it fails

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -18,5 +18,6 @@ coverage:
     - "scripts/*"
     - "save/*"
     - "apps/rendering/resources/taskcollector/*"
+    - "golem/testutils.py"
 comment:
   layout: header, diff, changes, sunburst, uncovered

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 import unittest
 from os import path
+from time import sleep
 
 from mock import MagicMock
 
@@ -51,8 +52,13 @@ class TempDirFixture(unittest.TestCase):
         # FIXME: This is temporary solution. Ethereum node should always be
         #        the explicit dependency and users should close it correctly.
         Client._kill_node()
-        if path.isdir(self.tempdir):
-            shutil.rmtree(self.tempdir)
+        try:
+            self.__remove_files()
+        except OSError:
+            # On windows there's sometimes a problem with syncing all threads.
+            # Try again after 3 secons
+            sleep(3)
+            self.__remove_files()
 
     def temp_file_name(self, name):
         return path.join(self.tempdir, name)
@@ -89,6 +95,9 @@ class TempDirFixture(unittest.TestCase):
     def _temp_dir_name(self):
         return self.id().rsplit('.', 1)[1]  # Use test method name
 
+    def __remove_files(self):
+        if path.isdir(self.tempdir):
+            shutil.rmtree(self.tempdir)
 
 class DatabaseFixture(TempDirFixture):
     """ Setups temporary database for tests."""


### PR DESCRIPTION
Quite ugly solution, but should reduce appveyor test-failures. 