### PR TITLE
remove accept_result_delay method and connected variables

### DIFF
--- a/golem/network/transport/message.py
+++ b/golem/network/transport/message.py
@@ -1051,14 +1051,11 @@ class MessageGetTaskResult(Message):
     Type = TASK_MSG_BASE + 5
 
     SUB_TASK_ID_STR = u"SUB_TASK_ID"
-    DELAY_STR = u"DELAY"
 
-    def __init__(self, subtask_id="", delay=0.0, sig="", timestamp=None, dict_repr=None):
+    def __init__(self, subtask_id="", sig="", timestamp=None, dict_repr=None):
         """
         Create request for task result
         :param str subtask_id: finished subtask id
-        :param float delay: if delay is 0, than subtask should be send right know. Otherwise other node should wait
-            <delay> seconds before sending result.
         :param str sig: signature
         :param float timestamp: current timestamp
         :param dict dict_repr: dictionary representation of a message
@@ -1066,15 +1063,12 @@ class MessageGetTaskResult(Message):
         Message.__init__(self, MessageGetTaskResult.Type, sig, timestamp)
 
         self.subtask_id = subtask_id
-        self.delay = delay
 
         if dict_repr:
             self.subtask_id = dict_repr[MessageGetTaskResult.SUB_TASK_ID_STR]
-            self.delay = dict_repr[MessageGetTaskResult.DELAY_STR]
 
     def dict_repr(self):
-        return {MessageGetTaskResult.SUB_TASK_ID_STR: self.subtask_id,
-                MessageGetTaskResult.DELAY_STR: self.delay}
+        return {MessageGetTaskResult.SUB_TASK_ID_STR: self.subtask_id}
 
 
 # It's an old form of sending task result (don't use if it isn't necessary)

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -268,15 +268,6 @@ class Task(object):
         return  # Implement in derived class
 
     @abc.abstractmethod
-    def accept_results_delay(self):
-        """ asks there should be a added subtask_id and delay_time as an argument. The name should be also changed
-        from "accept" to "set down" or something similar. The result of this method is a delay value, not a boolean
-        as a name is suggesting.
-        :return:
-        """
-        return 0.0
-
-    @abc.abstractmethod
     def get_resources(self, task_id, resource_header, resource_type=0, tmp_dir=None):
         """ Compare resources that were declared by client in a resource_header and prepare lacking one. Method of
         preparing resources depends from declared resource_type

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -370,12 +370,6 @@ class TaskManager(TaskEventListener):
         task = self.tasks[task_id]
         return task.get_resources(task_id, resource_header, resource_type)
 
-    def accept_results_delay(self, task_id):
-        if task_id in self.tasks:
-            return self.tasks[task_id].accept_results_delay()
-        else:
-            return -1.0
-
     @handle_task_key_error
     def restart_task(self, task_id):
         logger.info("restarting task")


### PR DESCRIPTION
Remove accept_result_delay methods. It was always only an idea, never really implemented (https://github.com/golemfactory/golem/issues/27)  We're going to implement a different mechanism.