### PR TITLE
AppVeyor CI: build only main branches

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,11 @@
 os: Visual Studio 2015
 version: '{branch}-{build}'
 
+branches:
+  only:
+  - master
+  - develop
+
 environment:
   matrix:
     - PYTHON: "C:\\Python27"


### PR DESCRIPTION
This avoids double build of PRs.