### PR TITLE
Print errors at the end of setup.py

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -21,5 +21,6 @@ coverage:
     - "save/*"
     - "scripts/*"
     - "tests/*"
+    - "setup.py"
 comment:
   layout: header, diff, changes, sunburst, uncovered

--- a/golem/tools/uigen.py
+++ b/golem/tools/uigen.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 PYUIC_PATH = "pyuic.py"  # Path to Python User Interface Compiler
 
@@ -6,7 +7,7 @@ PYUIC_PATH = "pyuic.py"  # Path to Python User Interface Compiler
 def call_pyrcc(py_file, qrc_file):
     cmd = "pyrcc4 -o " + py_file + " " + qrc_file
     print cmd
-    os.system(cmd)
+    subprocess.call(cmd.split())
 
 
 def regenerate_ui_files(root_path):
@@ -16,7 +17,7 @@ def regenerate_ui_files(root_path):
     """
     dirs = [name for name in os.listdir(root_path) if os.path.isdir(os.path.join(root_path, name))]
     files = [name for name in os.listdir(root_path) if os.path.isfile(os.path.join(root_path, name))]
-    pyuic_path = 'pyuic.py'
+    pyuic_path = PYUIC_PATH
 
     for dir_ in dirs:
         regenerate_ui_files(os.path.join(root_path, dir_))
@@ -41,9 +42,11 @@ def regenerate_ui_files(root_path):
             if not os.path.exists(pyuic_path):
                 raise IOError("Can't open file " + pyuic_path)
 
-            os.system("python " + pyuic_path + " " + os.path.join(root_path, file_) + " > " + os.path.join(root_path,
-                                                                                                           out_file))
-
+            cmd = "python " + pyuic_path + " " + os.path.join(root_path, file_)
+            print cmd
+            result = subprocess.check_output(cmd.split())
+            with open(os.path.join(root_path, out_file), 'w') as f:
+                f.write(result)
 
 
 def gen_ui_files(path):
@@ -54,7 +57,6 @@ def gen_ui_files(path):
     :param str path: path to directory where ui files are placed
     """
     if os.path.exists(path):
-
         regenerate_ui_files(path)
     else:
         cwd = os.getcwd()

--- a/gui/view/generateui.py
+++ b/gui/view/generateui.py
@@ -6,17 +6,13 @@ from golem.tools.uigen import gen_ui_files
 
 def generate_ui_files():
     golem_path = get_golem_path()
-    print golem_path
     ui_path = os.path.normpath(os.path.join(golem_path, "gui", "view"))
-    print ui_path
     gen_ui_files(ui_path)
 
     apps_path = os.path.normpath(os.path.join(golem_path, "apps"))
     apps_candidates = os.listdir(apps_path)
     apps = [os.path.join(apps_path, app) for app in apps_candidates if os.path.isdir(os.path.join(apps_path, app))]
-    print apps
     for app in apps:
         ui_path = os.path.join(app, "gui", "view")
-        print ui_path
         if os.path.isdir(ui_path):
             gen_ui_files(ui_path)

--- a/setup.py
+++ b/setup.py
@@ -22,20 +22,34 @@ except ImportError:
 from gui.view.generateui import generate_ui_files
 
 
-generate_ui_files()
+ui_err = ""
+
+try:
+    generate_ui_files()
+except EnvironmentError as err:
+    ui_err = \
+            """
+            ***************************************************************
+            Generating UI elements was not possible.
+            Golem will work only in command line mode
+            Generate_ui_files function returned {}
+            ***************************************************************
+            """.format(err)
 
 
 def try_building_docker_images():
     try:
         subprocess.check_call(["docker", "info"])
     except Exception as err:
-        print("""
-              ***************************************************************"
-              Docker not available, not building images."
-              Command 'docker info' returned {}"
-              ***************************************************************"
-              """.format(err))
-        return
+        return \
+              """
+              ***************************************************************
+              Docker not available, not building images.
+              Golem will not be able to compute anything.
+              Command 'docker info' returned {}
+              ***************************************************************
+              """.format(err)
+
     images_dir = 'apps'
     cwd = os.getcwdu()
 
@@ -65,7 +79,7 @@ def try_building_docker_images():
             finally:
                 os.chdir(cwd)
 
-try_building_docker_images()
+docker_err = try_building_docker_images()
 
 
 class PyTest(TestCommand):
@@ -184,3 +198,12 @@ setup(
     test_suite='tests',
     tests_require=test_requirements
 )
+
+
+def print_errors(ui_err, docker_err):
+    if ui_err:
+        print(ui_err)
+    if docker_err:
+        print(docker_err)
+
+print_errors(ui_err, docker_err)

--- a/tests/golem/tools/test_uigen.py
+++ b/tests/golem/tools/test_uigen.py
@@ -1,0 +1,16 @@
+from os import path, makedirs
+from shutil import copyfile
+
+from golem.tools.testdirfixture import TestDirFixture
+from golem.tools.uigen import regenerate_ui_files
+from golem.core.common import get_golem_path
+
+
+class TestRegenerateUIFiles(TestDirFixture):
+    def test_regenerate_cmd_called(self):
+        makedirs(path.join(self.path, "gen"))
+        test_ui_file_name = "NodeNameDialog.ui"
+        test_ui_file = path.join(get_golem_path(), "gui", "view",  test_ui_file_name)
+        tmp_ui_file = path.join(self.path, test_ui_file_name)
+        copyfile(test_ui_file, tmp_ui_file)
+        regenerate_ui_files(self.path)


### PR DESCRIPTION
In `setup.py` we may ignored errors caused by missing docker (to allow tests on AppVeyor) or by missing pyrcc4 - it's not necessary if user wants to use only command line interface. In these cases error message should be more visible.