### PR TITLE
Fixed version of web3 => ethereum-abi-utils

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ Twisted>=16.5
 web3>=3.5.3
 cffi>=1.1.2
 ethereum>=1.6.0
+ethereum-abi-utils==0.2.2
 autobahn>=0.16.1
 cbor2
 multihash

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,6 +21,7 @@ Twisted>=16.5
 web3==3.6.0
 cffi>=1.1.2
 ethereum>=1.6.0
+ethereum-abi-utils==0.2.2
 autobahn>=0.16.1
 cbor2
 multihash

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,9 @@ qt4reactor==1.6
 requests>=2.12.4
 six==1.10.0
 Twisted>=16.5
-web3>=3.5.3
+web3==3.6.0
 cffi>=1.1.2
 ethereum>=1.6.0
-ethereum-abi-utils==0.2.2
 autobahn>=0.16.1
 cbor2
 multihash


### PR DESCRIPTION
The latest version of `web3` and `ethereum-abi-utils` cause issues with tests / CI.