### PR TITLE
IPFS API client

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -10,7 +10,7 @@ dependencies:
   pre:
     - sudo apt-get install -y python-qt4 pyqt4-dev-tools
     - if [ ! -e /home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/PyQt4 ]; then ln -s /usr/lib/python2.7/dist-packages/PyQt4/ /home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/; ln -s /usr/lib/python2.7/dist-packages/sip.so /home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/; ln -s /usr/lib/python2.7/dist-packages/sip.x86_64-linux-gnu.so /home/ubuntu/virtualenvs/venv-system/lib/python2.7/site-packages/; fi
-    - if [ ! -e /usr/local/bin/ipfs ]; then wget http://52.40.149.24:9999/go-ipfs_v0.4.1_linux-amd64.tar.gz; tar xvfz go-ipfs_v0.4.1_linux-amd64.tar.gz; sudo mv go-ipfs/ipfs /usr/local/bin/ipfs; /usr/local/bin/ipfs init; fi
+    - if [ ! -e /usr/local/bin/ipfs ]; then wget https://dist.ipfs.io/go-ipfs/v0.4.5/go-ipfs_v0.4.5_linux-amd64.tar.gz; tar xvfz go-ipfs_v0.4.5_linux-amd64.tar.gz; sudo mv go-ipfs/ipfs /usr/local/bin/ipfs; /usr/local/bin/ipfs init; fi
     - /usr/local/bin/ipfs config --json Bootstrap "[]"
     - /usr/local/bin/ipfs config --json SupernodeRouting.Servers "[]"
     - /usr/local/bin/ipfs config --json Addresses.Swarm '["/ip6/::/tcp/4001", "/ip6/::/udp/4002/utp", "/ip4/0.0.0.0/udp/4002/utp"]'

--- a/golem/network/ipfs/client.py
+++ b/golem/network/ipfs/client.py
@@ -1,27 +1,12 @@
-import abc
-import copy
-
-import subprocess
-from enum import Enum
-
-import jsonpickle as json
 import logging
 import os
-import shutil
-import tarfile
-import urllib
-import uuid
-from functools import wraps
-from threading import Lock
-from types import FunctionType
+import subprocess
 
-import ipfsApi
-import requests
-from ipfsApi.commands import ArgCommand
-from ipfsApi.http import HTTPClient, pass_defaults
+import ipfsapi
+import shutil
+from enum import Enum
 
 from golem.core.hostaddress import ip_address_private
-from golem.http.stream import StreamMonitor, ChunkStream
 from golem.network.transport.tcpnetwork import SocketAddress
 from golem.resource.client import ClientConfig, ClientHandler, IClient, ClientOptions
 
@@ -42,8 +27,8 @@ class IPFSCommands(Enum):
     add = 0
     get = 1
     id = 2
-    pin = 3
-    unpin = 4
+    pin_add = 3
+    pin_rm = 4
 
     bootstrap_add = 5
     bootstrap_rm = 6
@@ -68,238 +53,44 @@ class IPFSConfig(ClientConfig):
             self.bootstrap_nodes = IPFS_BOOTSTRAP_NODES
 
 
-class IPFSHTTPClient(HTTPClient):
-
-    lock = Lock()
-    chunk_size = 1024
-
-    """
-    Class implements a workaround for the download method,
-    which hangs on reading http response stream data.
-    """
-
-    @pass_defaults
-    def download(self, path, args=[], opts={},
-                 filepath=None, filename=None,
-                 compress=True, archive=True, **kwargs):
-        """
-        Downloads a file from IPFS to the directory given by :filepath:
-        Support for :filename: was added (which replaces file's hash)
-        """
-        multihash = args[0]
-
-        url = self.base + path
-        work_dir = filepath or '.'
-        params = [('stream-channels', 'true')]
-        mode = 'r|gz' if compress else 'r|'
-
-        if compress:
-            params += [('compress', 'true')]
-            archive = True
-        if archive:
-            params += [('archive', 'true')]
-
-        if not (archive and compress):
-            raise Exception("Only compress + archive mode is supported")
-
-        for opt in opts.items():
-            params.append(opt)
-        for arg in args:
-            params.append(('arg', arg))
-
-        uri = '/'.join([''] + url.split('/')[3:])
-        query_params = '?' + urllib.urlencode(params) if params else ''
-
-        socket_stream = ChunkStream((self.host, self.port),
-                                    uri + query_params,
-                                    kwargs.pop('timeout', None))
-        socket_stream.connect()
-
-        try:
-            StreamMonitor.monitor(socket_stream)
-
-            with tarfile.open(fileobj=socket_stream, mode=mode) as tar_file:
-                return self._tar_extract(tar_file, work_dir,
-                                         filename, multihash)
-        finally:
-            socket_stream.disconnect()
-
-    @classmethod
-    def _tar_extract(cls, tar_file, work_dir, filename, multihash):
-
-        dst_path = os.path.join(work_dir, filename)
-        tmp_dir = os.path.join(work_dir, str(uuid.uuid4()))
-        tmp_path = os.path.join(tmp_dir, multihash)
-
-        if not os.path.exists(tmp_dir):
-            os.makedirs(tmp_dir)
-
-        with cls.lock:
-            if os.path.exists(dst_path):
-                os.remove(dst_path)
-
-        tar_file.extractall(tmp_dir)
-
-        if os.path.exists(tmp_path):
-            with cls.lock:
-                shutil.move(tmp_path, dst_path)
-
-            shutil.rmtree(tmp_dir, ignore_errors=True)
-            cls.__log_downloaded(filename, multihash, dst_path)
-            return filename, multihash
-
-        return None, None
-
-    @classmethod
-    def __log_downloaded(cls, filename, multihash, dst_path):
-        logger.debug("IPFS: downloaded {} ({}) to {}"
-                     .format(filename, multihash, dst_path))
-
-
-def parse_response(resp):
-    """ Returns python objects from a string """
-    result = []
-
-    if resp:
-        if isinstance(resp, basestring):
-            parsed = parse_response_entry(resp)
-            if parsed:
-                result.append(parsed)
-        elif isinstance(resp, list):
-            for sub_resp in resp:
-                if sub_resp:
-                    result.extend(parse_response(sub_resp))
-        else:
-            result.append(resp)
-
-    return result
-
-
-def parse_response_entry(entry):
-    parts = entry.split('\n')
-    result = []
-
-    for part in parts:
-        if part:
-            try:
-                result.append(json.loads(part))
-            except ValueError:
-                result.append(part)
-
-    return result
-
-
-def response_wrapper(func):
-    @wraps(func)
-    def wrapped(*args, **kwargs):
-        return parse_response(func(*args, **kwargs))
-    return wrapped
-
-
-class IPFSClientMetaClass(abc.ABCMeta):
-
-    """ IPFS api client methods decorated with response wrappers """
-
-    def __new__(mcs, class_name, bases, class_dict):
-        new_dict = {}
-        all_items = copy.copy(class_dict.items())
-
-        for base in bases:
-            all_items.extend(copy.copy(base.__dict__.items()))
-
-        for name, attribute in all_items:
-            if name in class_dict:
-                attribute = class_dict.get(name)
-            if type(attribute) == FunctionType and not name.startswith('_'):
-                attribute = response_wrapper(attribute)
-            new_dict[name] = attribute
-
-        instance = type.__new__(mcs, class_name, bases, new_dict)
-        instance._clientfactory = IPFSHTTPClient
-
-        return instance
-
-
-class IPFSClientFileCommand(ipfsApi.Command):
-
-    def request(self, client, *args, **kwargs):
-        return self.post_files(client, args[0], **kwargs)
-
-    def post_files(self, client, f, **kwargs):
-        responses = []
-        url = client.base + self.path + '?' + urllib.urlencode([
-            ('stream-channels', 'true'),
-            ('encoding', 'json')
-        ])
-
-        if isinstance(f, basestring):
-            responses.append(self.post_file(url, f))
-        else:
-            for file_path in f:
-                responses.append(self.post_file(url, file_path))
-
-        return responses
-
-    @staticmethod
-    def post_file(url, file_path):
-        if os.path.isfile(file_path):
-            with open(file_path, 'rb') as input_file:
-                file_name = os.path.basename(file_path)
-                files = dict(
-                    file=(
-                        file_name,
-                        input_file,
-                        'application/octet-stream'
-                    )
-                )
-                r = requests.post(url, files=files)
-                return r.text
-        return None
-
-
-class IPFSClient(IClient, ipfsApi.Client):
-
-    """ Class of ipfsApi.Client methods decorated with response wrapper """
-
-    __metaclass__ = IPFSClientMetaClass
-    _clientfactory = IPFSHTTPClient
+class IPFSClient(IClient):
 
     CLIENT_ID = 'ipfs'
-    VERSION = 1.0
+    VERSION = 1.1
 
-    def __init__(self,
-                 host=None,
-                 port=None,
-                 base=None,
-                 default_enc='json',
-                 **defaults):
-
-        super(IPFSClient, self).__init__(host=host, port=port,
-                                         base=base, default_enc=default_enc,
-                                         **defaults)
-
-        self._add = IPFSClientFileCommand('/add')
-        self._refs_local = ArgCommand('/refs/local')
-        self._bootstrap_list = ArgCommand('/bootstrap/list')
+    def __init__(self, **kwargs):
+        self._api = ipfsapi.connect(**kwargs)
 
     @staticmethod
     def build_options(node_id, **kwargs):
         return ClientOptions(IPFSClient.CLIENT_ID, IPFSClient.VERSION, **kwargs)
 
-    def swarm_connect(self, *args, **kwargs):
-        return self._swarm_connect.request(self._client, *args, **kwargs)
+    def get_file(self, multihash, client_options=None, **kwargs):
+        file_path = kwargs.get('filepath')
+        file_name = kwargs.pop('filename')
 
-    def refs_local(self, **kwargs):
-        return self._refs_local.request(self._client, **kwargs)
+        if not os.path.exists(file_path):
+            os.makedirs(file_path)
 
-    def bootstrap_list(self, **kwargs):
-        return self._bootstrap_list.request(self._client, **kwargs)
+        self.get(multihash, **kwargs)
 
-    def get_file(self, multihash, **kwargs):
-        return self._get.request(self._client, multihash, **kwargs)
+        file_src = os.path.join(file_path, multihash)
+        file_dst = os.path.join(file_path, file_name)
+        shutil.move(file_src, file_dst)
 
-    def get(self, multihash, **kwargs):
-        raise NotImplementedError("Please use the get_file method")
+        return dict(Hash=multihash, Name=file_dst)
+
+    def __getattribute__(self, attr):
+        if attr in IPFSCommands.__members__:
+            method = getattr(self._api, attr)
+
+            def wrapper(*args, **kwargs):
+                kwargs.pop('client_options', None)
+                return method(*args, **kwargs)
+
+            return wrapper
+
+        return object.__getattribute__(self, attr)
 
 
 class IPFSClientHandler(ClientHandler):

--- a/golem/network/ipfs/client.py
+++ b/golem/network/ipfs/client.py
@@ -78,7 +78,7 @@ class IPFSClient(IClient):
         file_dst = os.path.join(file_path, file_name)
         shutil.move(file_src, file_dst)
 
-        return dict(Hash=multihash, Name=file_dst)
+        return dict(Name=file_dst, Hash=multihash)
 
     def __getattribute__(self, attr):
         if attr in IPFSCommands.__members__:

--- a/golem/network/ipfs/daemon_manager.py
+++ b/golem/network/ipfs/daemon_manager.py
@@ -48,13 +48,12 @@ class IPFSDaemonManager(IPFSClientHandler):
 
         response = self._handle_retries(client.id, IPFSCommands.id)
 
-        if response and response[0]:
-            data = response[0]
-            self.node_id = data.get('ID')
-            self.public_key = data.get('PublicKey')
-            self.addresses = [IPFSAddress.parse(a) for a in data.get('Addresses')]
-            self.agent_version = data.get('AgentVersion')
-            self.proto_version = data.get('ProtoVersion')
+        if response:
+            self.node_id = response.get('ID')
+            self.public_key = response.get('PublicKey')
+            self.addresses = [IPFSAddress.parse(a) for a in response.get('Addresses')]
+            self.agent_version = response.get('AgentVersion')
+            self.proto_version = response.get('ProtoVersion')
 
             for ipfs_addr in self.addresses:
                 # filter out private addresses
@@ -157,8 +156,8 @@ class IPFSDaemonManager(IPFSClientHandler):
         result = self._handle_retries(client.bootstrap_list,
                                       IPFSCommands.bootstrap_list)
 
-        if result and result[0]:
-            return result[0].get('Peers', [])
+        if result:
+            return result.get('Peers', [])
         return []
 
     def _node_action(self, url, method, command, success, error, obj_id=None, async=True):

--- a/golem/resource/base/resourcesmanager.py
+++ b/golem/resource/base/resourcesmanager.py
@@ -341,12 +341,11 @@ class AbstractResourceManager(IClientHandler):
             success(filename, multihash, task_id)
             return
 
-        def success_wrapper(*args, **kwargs):
+        def success_wrapper(result, *args, **kwargs):
             self.__dec_downloads()
 
-            result = args[0][0]
-            result_filename = result[0]
-            result_multihash = result[1]
+            result_filename = result['Name']
+            result_multihash = result['Hash']
             result_path = self.storage.get_path(result_filename, task_id)
 
             self._clear_retry(self.commands.get, result_multihash)
@@ -394,7 +393,7 @@ class AbstractResourceManager(IClientHandler):
             except Exception as exc:
                 error_wrapper(exc)
             else:
-                success_wrapper([[filename, multihash]])
+                success_wrapper(dict(Name=filename, Hash=multihash))
 
         else:
 

--- a/golem/resource/client.py
+++ b/golem/resource/client.py
@@ -268,9 +268,10 @@ class TestClient(IClient):
             os.makedirs(filepath)
         shutil.copy(path, os.path.join(filepath, filename))
 
-        return [
-            [os.path.join(filepath, filename), multihash]
-        ]
+        return dict(
+            Name=os.path.join(filepath, filename),
+            Hash=multihash
+        )
 
     def id(self, client_options=None, *args, **kwargs):
         return self._id

--- a/golem/resource/client.py
+++ b/golem/resource/client.py
@@ -44,24 +44,19 @@ def file_multihash(file_path):
 
 
 class IClient(object):
-    __metaclass__ = abc.ABCMeta
 
     @classmethod
-    @abc.abstractmethod
     def build_options(cls, node_id, **kwargs):
-        pass
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def add(self, files, recursive=False, client_options=None, **kwargs):
-        pass
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def get_file(self, multihash, client_options=None, **kwargs):
-        pass
+        raise NotImplementedError
 
-    @abc.abstractmethod
     def id(self, client_options=None, *args, **kwargs):
-        pass
+        raise NotImplementedError
 
 
 class IClientHandler(object):

--- a/golem/resource/http/resourcesmanager.py
+++ b/golem/resource/http/resourcesmanager.py
@@ -68,7 +68,7 @@ class HTTPResourceManagerClient(IClient):
         dst_path = os.path.join(file_path, file_name)
         self._download(multihash, dst_path, **kwargs)
 
-        return [(file_name, multihash)]
+        return dict(Name=file_name, Hash=multihash)
 
     def id(self, *args, **kwargs):
         return None

--- a/golem/resource/ipfs/resourcesmanager.py
+++ b/golem/resource/ipfs/resourcesmanager.py
@@ -28,14 +28,14 @@ class IPFSResourceManager(AbstractResourceManager, IPFSClientHandler):
         if not client:
             client = self.new_client()
         return self._handle_retries(client.pin_add,
-                                    self.commands.pin,
+                                    self.commands.pin_add,
                                     multihash)
 
     def unpin_resource(self, multihash, client=None, client_options=None):
         if not client:
             client = self.new_client()
         return self._handle_retries(client.pin_rm,
-                                    self.commands.unpin,
+                                    self.commands.pin_rm,
                                     multihash)
 
     def build_client_options(self, node_id, **kwargs):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ docker-py==1.7.2
 pyvbox
 enum34
 ipaddress
-ipfs-api
+ipfsapi
 netifaces==0.10.4
 OpenEXR==1.2.0
 peewee>=2.8.1

--- a/tests/golem/network/ipfs/test_ipfs_client.py
+++ b/tests/golem/network/ipfs/test_ipfs_client.py
@@ -55,9 +55,12 @@ class TestIpfsClient(TestDirFixture):
 
         tmp_filename = 'tmp_file'
 
-        assert client.get_file(response['Hash'],
-                               filepath=self.test_dir,
-                               filename=tmp_filename)
+        get_response = client.get_file(response['Hash'],
+                                       filepath=self.test_dir,
+                                       filename=tmp_filename)
+
+        assert get_response['Name'] == os.path.join(self.test_dir, tmp_filename)
+        assert get_response['Hash'] == response['Hash']
 
         tmp_file_path = os.path.join(self.test_dir, tmp_filename)
 

--- a/tests/golem/network/ipfs/test_ipfs_daemon_manager.py
+++ b/tests/golem/network/ipfs/test_ipfs_daemon_manager.py
@@ -142,9 +142,9 @@ class TestIPFSDaemonManager(unittest.TestCase):
 
         assert not status[0]
 
-    @patch('golem.network.ipfs.client.IPFSClient', autospec=True)
-    def testConnectToBootstrapNodes(self, MockClient):
-
+    @patch('golem.network.ipfs.client.IPFSClient')
+    @patch('golem.network.ipfs.client.IPFSClient.bootstrap_list', create=True)
+    def testConnectToBootstrapNodes(self, *_):
         invalid_node = 'invalid node'
 
         config = IPFSConfig(bootstrap_nodes=IPFS_BOOTSTRAP_NODES + [invalid_node])


### PR DESCRIPTION
- uses a new(er) IPFS API client library
- removes various `IPFSClient` workarounds