### PR TITLE
Limit stun live test

### DIFF
--- a/golem/core/hostaddress.py
+++ b/golem/core/hostaddress.py
@@ -105,17 +105,15 @@ def get_host_address_from_connection(connect_to=DEFAULT_CONNECT_TO, connect_to_p
             for s in [socket.socket(addr_family, socket.SOCK_DGRAM)]][0][1]
 
 
-def get_external_address(source_port=None):
+def get_external_address(source_port=0):
     """ Method try to get host public address with STUN protocol
-    :param int source_port: port that should be used for connection. Otherwise a free port picked by the OS will be used
-    :return (str, int, str): tuple with host public address, public port that is mapped to local <source_port> and
-     this host nat type
+    :param int source_port: port that should be used for connection.
+    If 0, a free port will be picked by OS.
+    :return (str, int, str): tuple with host public address, public port that is
+    mapped to local <source_port> and this host nat type
     """
-    if source_port:
-        nat_type, external_ip, external_port = stun.get_ip_info(source_port=source_port)
-    else:
-        nat_type, external_ip, external_port = stun.get_ip_info(source_port=0)
-    logger.debug("nat_type {}, external_ip {}, external_port {}".format(nat_type, external_ip, external_port))
+    nat_type, external_ip, external_port = stun.get_ip_info(source_port=source_port)
+    logger.debug("NAT {}, external [{}] {}".format(nat_type, external_ip, external_port))
     return external_ip, external_port, nat_type
 
 

--- a/tests/golem/core/test_hostaddress.py
+++ b/tests/golem/core/test_hostaddress.py
@@ -68,7 +68,7 @@ class TestHostAddress(unittest.TestCase):
         address = get_host_address_from_connection(use_ipv6=False)
         self.assertTrue(is_ip_address(address), "Incorrect IPv4 address: {}".format(address))
 
-    def testGetExternalAddress(self):
+    def test_get_external_address_live(self):
         """ Test getting host public address with STUN protocol """
         nats = ["Blocked", "Open Internet", "Full Cone", "Symmetric UDP Firewall",
                 "Restric NAT", "Restric Port NAT", "Symmetric NAT"]
@@ -78,11 +78,13 @@ class TestHostAddress(unittest.TestCase):
         self.assertTrue(0 < port < 65535, "Incorrect port number")
         self.assertIn(nat, nats, "Incorrect nat type")
 
+    @patch('stun.get_ip_info')
+    def test_get_external_address_argument(self, stun):
+        stun.return_value = ('2607:f0d0:1002:51::4', 1234, "Open Internet")
         address, port, nat = get_external_address(9876)
-        self.assertTrue(is_ip_address(address), "Incorrect IP address: {}".format(address))
-        self.assertIsInstance(port, int, "Incorrect port type")
-        self.assertTrue(0 < port < 65535, "Incorrect port number")
-        self.assertIn(nat, nats, "Incorrect nat type")
+        assert stun.called_once_with(9876)
+        address, port, nat = get_external_address()
+        assert stun.called_once_with(0)
 
     def testGetHostAddress(self):
         self.assertGreater(len(get_host_address('127.0.0.1')), 0)


### PR DESCRIPTION
Each IP check with STUN takes > 8 s. Limit live requests to 1.