### PR TITLE
add variable to turn of task persistence

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -39,7 +39,7 @@ class TaskManager(TaskEventListener):
     handle_subtask_key_error = HandleKeyError(log_subtask_key_error)
 
     def __init__(self, node_name, node, keys_auth, listen_address="", listen_port=0, root_path="res",
-                 use_distributed_resources=True, tasks_dir="tasks", task_persistance=False):
+                 use_distributed_resources=True, tasks_dir="tasks", task_persistence=False):
         super(TaskManager, self).__init__()
         self.node_name = node_name
         self.node = node
@@ -55,7 +55,7 @@ class TaskManager(TaskEventListener):
 
         # FIXME Remove this variable and make task persistance obligatory after it is more tested
         # Remember to also remove it from init params
-        self.task_persistance = task_persistance
+        self.task_persistence = task_persistence
 
         self.tasks_dir = Path(tasks_dir)
         if not self.tasks_dir.is_dir():
@@ -71,7 +71,7 @@ class TaskManager(TaskEventListener):
         self.use_distributed_resources = use_distributed_resources
 
         self.comp_task_keeper = CompTaskKeeper()
-        if self.task_persistance:
+        if self.task_persistence:
             self.restore_tasks()
 
     def get_task_manager_root(self):
@@ -120,7 +120,7 @@ class TaskManager(TaskEventListener):
 
         self.tasks_states[task.header.task_id] = ts
 
-        if self.task_persistance:
+        if self.task_persistence:
             self.dump_task(task.header.task_id)
             logger.info("Task {} added".format(task.header.task_id))
             self.notice_task_updated(task.header.task_id)
@@ -617,6 +617,6 @@ class TaskManager(TaskEventListener):
     @handle_task_key_error
     def notice_task_updated(self, task_id):
         # self.save_state()
-        if self.task_persistance:
+        if self.task_persistence:
             self.dump_task(task_id)
         dispatcher.send(signal='golem.taskmanager', event='task_status_updated', task_id=task_id)

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -39,7 +39,7 @@ class TaskManager(TaskEventListener):
     handle_subtask_key_error = HandleKeyError(log_subtask_key_error)
 
     def __init__(self, node_name, node, keys_auth, listen_address="", listen_port=0, root_path="res",
-                 use_distributed_resources=True, tasks_dir="tasks"):
+                 use_distributed_resources=True, tasks_dir="tasks", task_persistance=False):
         super(TaskManager, self).__init__()
         self.node_name = node_name
         self.node = node
@@ -54,7 +54,8 @@ class TaskManager(TaskEventListener):
         self.listen_port = listen_port
 
         # FIXME Remove this variable and make task persistance obligatory after it is more tested
-        self.task_persistance = False
+        # Remember to also remove it from init params
+        self.task_persistance = task_persistance
 
         self.tasks_dir = Path(tasks_dir)
         if not self.tasks_dir.is_dir():

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -375,6 +375,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor):
     def test_resource_send(self, mock_addr):
         from pydispatch import dispatcher
         mock_addr.return_value = self.addr_return
+        self.tm.task_persistance = True
         t = Task(TaskHeader("ABC", "xyz", "10.10.10.10", 1023, "abcde", "DEFAULT"), "print 'hello world'")
         listener_mock = Mock()
         def listener(sender, signal, event, task_id):

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -15,6 +15,7 @@ from golem.task.taskclient import TaskClient
 from golem.task.taskmanager import TaskManager, logger
 from golem.task.taskstate import SubtaskStatus, SubtaskState, TaskState, TaskStatus, ComputerState
 from golem.tools.assertlogs import LogTestCase
+from golem.tools.testdirfixture import TestDirFixture
 from golem.tools.testwithreactor import TestDirFixtureWithReactor
 
 
@@ -26,6 +27,14 @@ class TaskMock(Task):
         state = super(TaskMock, self).__getstate__()
         del state['query_extra_data_return_value']
         return state
+
+
+class TestTaskManagerWithPersistance(TestDirFixture, LogTestCase):
+    def test_restore(self):
+        keys_auth = Mock()
+        with self.assertLogs(logger, level="DEBUG") as l:
+            TaskManager("ABC", Node(), keys_auth, root_path=self.path, task_persistance=True)
+        assert any("RESTORE TASKS" in log for log in l.output)
 
 
 class TestTaskManager(LogTestCase, TestDirFixtureWithReactor):

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -33,7 +33,7 @@ class TestTaskManagerWithPersistance(TestDirFixture, LogTestCase):
     def test_restore(self):
         keys_auth = Mock()
         with self.assertLogs(logger, level="DEBUG") as l:
-            TaskManager("ABC", Node(), keys_auth, root_path=self.path, task_persistance=True)
+            TaskManager("ABC", Node(), keys_auth, root_path=self.path, task_persistence=True)
         assert any("RESTORE TASKS" in log for log in l.output)
 
 
@@ -384,7 +384,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor):
     def test_resource_send(self, mock_addr):
         from pydispatch import dispatcher
         mock_addr.return_value = self.addr_return
-        self.tm.task_persistance = True
+        self.tm.task_persistence = True
         t = Task(TaskHeader("ABC", "xyz", "10.10.10.10", 1023, "abcde", "DEFAULT"), "print 'hello world'")
         listener_mock = Mock()
         def listener(sender, signal, event, task_id):


### PR DESCRIPTION
Add variable that turns off saving and restoring task in task manager. It's just a temporary solution before we improve task saving mechanism, ie. make sure that we delete old task and show them in GUI. 
Testnet scaling package should not have this feature turn on. 