### PR TITLE
Luxcodecov

### DIFF
--- a/apps/lux/task/luxrendertask.py
+++ b/apps/lux/task/luxrendertask.py
@@ -64,20 +64,17 @@ class LuxRenderTaskTypeInfo(TaskTypeInfo):
         preview_x = 300
         preview_y = 200
         res_x, res_y = definition.resolution
-        if res_x != 0 and res_y != 0:
-            if float(res_x) / float(res_y) > float(preview_x) / float(
-                    preview_y):
-                scale_factor = float(preview_x) / float(res_x)
-            else:
-                scale_factor = float(preview_y) / float(res_y)
-            scale_factor = min(1.0, scale_factor)
+        if res_x == 0 or res_y == 0:
+            return []
+
+        if float(res_x) / float(res_y) > float(preview_x) / float(preview_y):
+            scale_factor = float(preview_x) / float(res_x)
         else:
-            scale_factor = 1.0
+            scale_factor = float(preview_y) / float(res_y)
+        scale_factor = min(1.0, scale_factor)
+
         x = int(round(res_x * scale_factor))
         y = int(round(res_y * scale_factor))
-        print x
-        print y
-        print scale_factor
         border = [(0, i) for i in range(y)] + [(x - 1, i) for i in range(y)]
         border += [(i, 0) for i in range(x)] + [(i, y - 1) for i in range(x)]
         return border

--- a/apps/lux/task/luxrendertask.py
+++ b/apps/lux/task/luxrendertask.py
@@ -268,18 +268,20 @@ class LuxTask(RenderingTask):
                 self._update_preview(tr_file, num_start)
 
         if self.num_tasks_received == self.total_tasks:
-            if self.num_tasks_received == self.total_tasks:
-                if self.verificator.advanced_verification and os.path.isfile(self.__get_test_flm()):
-                    self.__generate_final_flm_advanced_verification()
-                else:
-                    self.__generate_final_flm()
+            if self.verificator.advanced_verification and os.path.isfile(self.__get_test_flm()):
+                self.__generate_final_flm_advanced_verification()
+            else:
+                self.__generate_final_flm()
 
     def __get_merge_ctd(self, files):
-        with open(find_task_script(APP_DIR, "docker_luxmerge.py")) as f:
-            src_code = f.read()
-        if src_code is None:
+        script_file = find_task_script(APP_DIR, "docker_luxmerge.py")
+
+        if script_file is None:
             logger.error("Cannot find merger script")
             return
+
+        with open(script_file) as f:
+            src_code = f.read()
 
         ctd = ComputeTaskDef()
         ctd.task_id = self.header.task_id

--- a/apps/lux/task/luxrendertask.py
+++ b/apps/lux/task/luxrendertask.py
@@ -73,15 +73,13 @@ class LuxRenderTaskTypeInfo(TaskTypeInfo):
             scale_factor = min(1.0, scale_factor)
         else:
             scale_factor = 1.0
-        border = []
         x = int(round(res_x * scale_factor))
         y = int(round(res_y * scale_factor))
-        for i in range(0, y):
-            border.append((0, i))
-            border.append((x - 1, i))
-        for i in range(0, x):
-            border.append((i, 0))
-            border.append((i, y - 1))
+        print x
+        print y
+        print scale_factor
+        border = [(0, i) for i in range(y)] + [(x - 1, i) for i in range(y)]
+        border += [(i, 0) for i in range(x)] + [(i, y - 1) for i in range(x)]
         return border
 
     @classmethod

--- a/apps/lux/task/luxrendertask.py
+++ b/apps/lux/task/luxrendertask.py
@@ -407,9 +407,8 @@ class LuxTask(RenderingTask):
         logger.debug("Copying " + test_result_flm + " to " + new_flm)
         self.__generate_final_file(new_flm)
 
-    def __get_test_flm(self, dir_=None):
-        if dir_ is None:
-            dir_ = self.tmp_dir
+    def __get_test_flm(self):
+        dir_ = self.tmp_dir
         return os.path.join(dir_, "test_result.flm")
 
 

--- a/apps/lux/task/luxrendertask.py
+++ b/apps/lux/task/luxrendertask.py
@@ -61,16 +61,16 @@ class LuxRenderTaskTypeInfo(TaskTypeInfo):
         :param int output_num: number of final output files
         :return list: list of pixels that belong to a subtask border
         """
-        preview_x = 300
-        preview_y = 200
+        preview_x = 300.0
+        preview_y = 200.0
         res_x, res_y = definition.resolution
         if res_x == 0 or res_y == 0:
             return []
 
-        if float(res_x) / float(res_y) > float(preview_x) / float(preview_y):
-            scale_factor = float(preview_x) / float(res_x)
+        if float(res_x) / res_y > preview_x / preview_y:
+            scale_factor = preview_x / res_x
         else:
-            scale_factor = float(preview_y) / float(res_y)
+            scale_factor = preview_y / res_y
         scale_factor = min(1.0, scale_factor)
 
         x = int(round(res_x * scale_factor))
@@ -408,8 +408,7 @@ class LuxTask(RenderingTask):
         self.__generate_final_file(new_flm)
 
     def __get_test_flm(self):
-        dir_ = self.tmp_dir
-        return os.path.join(dir_, "test_result.flm")
+        return os.path.join(self.tmp_dir, "test_result.flm")
 
 
 class LuxRenderTaskBuilder(RenderingTaskBuilder):

--- a/tests/apps/lux/gui/controller/test_luxrenderdialogcustomizer.py
+++ b/tests/apps/lux/gui/controller/test_luxrenderdialogcustomizer.py
@@ -84,3 +84,12 @@ class TestLuxRenderDialogCustomizer(TestDirFixture, LogTestCase):
         lux_customizer._change_options()
         assert lux_customizer.options.halttime == 0
         assert lux_customizer.options.haltspp == 25
+
+        lux_customizer.options.haltspp = 0
+        lux_customizer._change_halts_values()
+        assert lux_customizer.gui.ui.stopByTimeRadioButton.isChecked()
+        assert not lux_customizer.gui.ui.stopBySppRadioButton.isChecked()
+        lux_customizer.options.haltspp = 24
+        lux_customizer._change_halts_values()
+        assert not lux_customizer.gui.ui.stopByTimeRadioButton.isChecked()
+        assert lux_customizer.gui.ui.stopBySppRadioButton.isChecked()

--- a/tests/apps/lux/resources/test_scenefileeditor.py
+++ b/tests/apps/lux/resources/test_scenefileeditor.py
@@ -45,3 +45,9 @@ class TestSceneFileEditor(TestDirFixture):
         assert len(re.findall('"bool write_exr" \["false"\]', out)) == 1
         out = regenerate_lux_file(scene_file_src2, xres, yres, halttime, haltspp, writeinterval, crop, "exr")
         assert len(re.findall('"bool write_exr" \["true"\]', out)) == 1
+
+        scene_file_src2 = 'Film "fleximage"\n "bool write_exr" ["true"]\n "integer xresolution" [200] "integer yresolution" [100]\n "integer writeinterval" [15]\n "integer halttime" [10]\n "float cropwindow" [0, 1, 0, 1]'
+        out = regenerate_lux_file(scene_file_src2, xres, yres, halttime, haltspp, writeinterval,
+                                  crop, output_format)
+        self.assertTrue('"integer halttime" [' + str(halttime) + ']' in out)
+        self.assertTrue('"integer haltspp" [' + str(haltspp) + ']' in out)

--- a/tests/apps/lux/task/test_luxrendertask.py
+++ b/tests/apps/lux/task/test_luxrendertask.py
@@ -237,6 +237,13 @@ class TestLuxRenderTaskTypeInfo(TempDirFixture):
         assert (20, 0) not in border
         assert (0, 200) not in border
 
+        definition.resolution = (0, 4)
+        assert typeinfo.get_task_border("subtask1", definition, 10) == []
+        definition.resolution = (4, 0)
+        assert typeinfo.get_task_border("subtask1", definition, 10) == []
+        definition.resolution = (0, 0)
+        assert typeinfo.get_task_border("subtask1", definition, 10) == []
+
     def test_get_task_num_from_pixels(self):
         typeinfo = LuxRenderTaskTypeInfo(None, None)
         definition = RenderingTaskDefinition()

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -99,7 +99,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor):
         task_mock = self._get_task_mock()
 
         # Task's initial state is set to 'waiting' (found in activeStatus)
-        wait_for(self.tm.add_new_task(task_mock))
+        wait_for(self.tm.add_new_task(task_mock), 20)
 
         subtask, wrong_task, wait = self.tm.get_next_subtask("DEF", "DEF", "xyz", 1000, 10, 5, 10, 2, "10.10.10.10")
         assert subtask is not None


### PR DESCRIPTION
Full code coverage for `apps.lux` + small refactoring of `luxtask`:

* simplify `get_task_border` function
* return empty list in `get_task_border` if resolution is equal to 0
* remove duplicated line in `if` in `accept_results`
* remove unused parameter in `__get_test_flm`
* in `__get_merge_ctd` check if script was found before trying to open it