### PR TITLE
Bumped max geth version to 1.6.x

### DIFF
--- a/golem/ethereum/node.py
+++ b/golem/ethereum/node.py
@@ -60,7 +60,7 @@ class Faucet(object):
 
 class NodeProcess(object):
     MIN_GETH_VERSION = '1.5.0'
-    MAX_GETH_VERSION = '1.5.999'
+    MAX_GETH_VERSION = '1.6.999'
     testnet = True
 
     def __init__(self):


### PR DESCRIPTION
Due to issues with linker in XCode 8.3, the only runnable version of geth on OS X is either:
- from development branch (1.6.x)
- a forked and patched version

This PR increases max allowed geth version for golem.