### PR TITLE
Initial block synchronization

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -161,6 +161,12 @@ class Client(object):
         if self.rpc_publisher:
             self.rpc_publisher.publish(Task.evt_task_status, kwargs['task_id'])
 
+    def sync(self):
+        if self.use_transaction_system():
+            log.info('Waiting for block synchronization...')
+            self.transaction_system.sync()
+            log.info('Block synchronization complete')
+
     def start(self):
         if self.use_monitor:
             self.init_monitor()

--- a/golem/node.py
+++ b/golem/node.py
@@ -36,6 +36,7 @@ class Node(object):
 
     def initialize(self):
         self.load_environments(self.default_environments)
+        self.client.sync()
         self.client.start()
 
     def load_environments(self, environments):

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -1,6 +1,6 @@
 import logging
 
-import time
+from time import sleep
 from ethereum import keys
 
 from golem.ethereum import Client
@@ -80,4 +80,4 @@ class EthereumTransactionSystem(TransactionSystem):
                 log.error("IPC error: {}".format(e))
                 syncing = False
             else:
-                time.sleep(0.5)
+                sleep(0.5)

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -1,6 +1,6 @@
 import logging
-from os import path
 
+import time
 from ethereum import keys
 
 from golem.ethereum import Client
@@ -70,3 +70,14 @@ class EthereumTransactionSystem(TransactionSystem):
                  'value': payment.value,
                  'block_number': payment.extra['block_number']
                  } for payment in self.__monitor.get_incoming_payments()]
+
+    def sync(self):
+        syncing = True
+        while syncing:
+            try:
+                syncing = self.__eth_node.is_syncing()
+            except Exception as e:
+                log.error("IPC error: {}".format(e))
+                syncing = False
+            else:
+                time.sleep(0.5)

--- a/golem/transactions/transactionsystem.py
+++ b/golem/transactions/transactionsystem.py
@@ -69,3 +69,6 @@ class TransactionSystem(object):
         # return after_deadline
 
         return []
+
+    def sync(self):
+        pass

--- a/gui/startapp.py
+++ b/gui/startapp.py
@@ -73,6 +73,8 @@ def start_client(start_ranking, datadir=None,
     docker_manager.check_environment()
     environments = load_environments()
 
+    client.sync()
+
     for env in environments:
         client.environments_manager.add_environment(env)
     client.environments_manager.load_config(client.datadir)

--- a/loggingconfig.py
+++ b/loggingconfig.py
@@ -30,7 +30,7 @@ LOGGING = {
     'handlers': {
         'console': {
             'class': 'logging.StreamHandler',
-            'level': 'WARNING',
+            'level': 'INFO',
             'formatter': 'simple',
             'filters': [],
             'stream': 'ext://sys.stderr',
@@ -54,6 +54,10 @@ LOGGING = {
     'loggers': {
         'golem': {
             'level': 'WARNING',
+            'propagate': True,
+        },
+        'golem.client': {
+            'level': 'INFO',
             'propagate': True,
         },
         'apps': {

--- a/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
+++ b/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
@@ -28,8 +28,10 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase):
         e = EthereumTransactionSystem(self.tempdir, PRIV_KEY)
         assert e.get_balance() == (None, None, None)
 
-    @patch('time.sleep')
-    def test_sync(self, sleep):
+    @patch('golem.ethereum.paymentprocessor.PaymentProcessor.start')
+    @patch('golem.ethereum.paymentmonitor.PaymentMonitor.start')
+    @patch('golem.transactions.ethereum.ethereumtransactionsystem.sleep')
+    def test_sync(self, sleep, *_):
 
         switch_value = [True]
 

--- a/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
+++ b/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
@@ -1,13 +1,14 @@
 from ethereum import keys
 from mock import patch
 
+from golem.tools.assertlogs import LogTestCase
 from golem.tools.testwithdatabase import TestWithDatabase
 from golem.transactions.ethereum.ethereumtransactionsystem import EthereumTransactionSystem
 
 PRIV_KEY = '\7' * 32
 
 
-class TestEthereumTransactionSystem(TestWithDatabase):
+class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase):
     def test_init(self):
         e = EthereumTransactionSystem(self.tempdir, PRIV_KEY)
         self.assertIsInstance(e, EthereumTransactionSystem)
@@ -26,6 +27,35 @@ class TestEthereumTransactionSystem(TestWithDatabase):
     def test_get_balance(self):
         e = EthereumTransactionSystem(self.tempdir, PRIV_KEY)
         assert e.get_balance() == (None, None, None)
+
+    @patch('time.sleep')
+    def test_sync(self, sleep):
+
+        switch_value = [True]
+
+        def switch(*_):
+            switch_value[0] = not switch_value[0]
+            return not switch_value[0]
+
+        def error(*_):
+            raise Exception
+
+        e = EthereumTransactionSystem(self.tempdir, PRIV_KEY)
+
+        sleep.call_count = 0
+        with patch('golem.ethereum.Client.is_syncing', side_effect=lambda: False):
+            e.sync()
+            assert sleep.call_count == 1
+
+        sleep.call_count = 0
+        with patch('golem.ethereum.Client.is_syncing', side_effect=switch):
+            e.sync()
+            assert sleep.call_count == 2
+
+        sleep.call_count = 0
+        with patch('golem.ethereum.Client.is_syncing', side_effect=error):
+            e.sync()
+            assert sleep.call_count == 0
 
     def test_stop(self):
 

--- a/tests/golem/transactions/test_transactionsystem.py
+++ b/tests/golem/transactions/test_transactionsystem.py
@@ -11,6 +11,7 @@ class TestTransactionSystem(TestWithDatabase):
     def test_init(self):
         e = TransactionSystem()
         self.assertIsInstance(e, TransactionSystem)
+        e.sync()  # nop
 
     def test_add_payment_info(self):
         e = TransactionSystem()

--- a/tests/gui/test_startapp.py
+++ b/tests/gui/test_startapp.py
@@ -68,6 +68,7 @@ class TestStartAppFunc(TestDirFixtureWithReactor):
 
         with patch('gui.startapp.start_gui'), \
              patch('golem.client.Client.start', side_effect=lambda *_: queue.put(u"Success")), \
+             patch('golem.client.Client.sync'), \
              patch('gui.startapp.start_error', side_effect=lambda err: queue.put(err)), \
              patch('golem.rpc.router.CrossbarRouter.start', router_start(router_fails)), \
              patch('golem.rpc.session.Session.connect', session_connect(session_fails)):


### PR DESCRIPTION
`is_syncing` method reworked:
- waits for `highestBlock` to be downloaded
- makes sure that the last known block's timestamp isn't below a certain threshold (120s); this prevents false-positives

IPC errors in `EthereumTransactionSystem.sync` stop the initial sync process.

Resolves #954