### PR TITLE
major.minor.patch versioning

### DIFF
--- a/golem/core/variables.py
+++ b/golem/core/variables.py
@@ -5,7 +5,7 @@ LONG_STANDARD_SIZE = 4
 #       VARIABLES          #
 ############################
 APP_NAME = "Brass Golem"
-APP_VERSION = "0.4"
+APP_VERSION = "0.4.0"
 PRIVATE_KEY = "golem_private_key.peb"
 PUBLIC_KEY = "golem_public_key.pubkey"
 DEFAULT_PROC_FILE = "node_processes.ctl"

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -224,8 +224,8 @@ class TaskHeaderKeeper(object):
 
     def check_version_compatibility(self, remote):
         """ For local a1.b1.c1 and remote a2.b2.c2, check if "a1.b1" == "a2.b2" and c1 >= c2
-        :param remote: 
-        :return: 
+        :param remote: remote version string
+        :return: whether the local version is compatible with remote version
         """
         remote = Version(remote)
         local = Version(self.app_version, partial=True)

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -6,6 +6,8 @@ import pickle
 import random
 import time
 
+from semantic_version import Version
+
 from golem.core.common import HandleKeyError, get_timestamp_utc
 from golem.core.variables import APP_VERSION
 
@@ -208,11 +210,9 @@ class TaskHeaderKeeper(object):
         :return bool: False if node's version is lower than minimum version for this task, False otherwise.
         """
         min_v = th_dict_repr.get("min_version")
-        if not min_v:
-            return True
+
         try:
-            supported = float(self.app_version) >= float(min_v)
-            return supported
+            return self.check_version_compatibility(min_v)
         except ValueError:
             logger.error(
                 "Wrong app version - app version {}, required version {}".format(
@@ -221,6 +221,17 @@ class TaskHeaderKeeper(object):
                 )
             )
             return False
+
+    def check_version_compatibility(self, remote):
+        """ For local a1.b1.c1 and remote a2.b2.c2, check if "a1.b1" == "a2.b2" and c1 >= c2
+        :param remote: 
+        :return: 
+        """
+        remote = Version(remote)
+        local = Version(self.app_version, partial=True)
+        local_patch = local.patch
+        local.patch = None
+        return local == remote and local_patch >= remote.patch
 
     def get_all_tasks(self):
         """ Return all known tasks

--- a/requirements.txt
+++ b/requirements.txt
@@ -44,3 +44,4 @@ pyreadline
 pytest>=3.0.5
 qt5reactor
 GitPython>=2.1.0
+semantic_version

--- a/setup/setup_commons.py
+++ b/setup/setup_commons.py
@@ -124,8 +124,7 @@ def update_variables():
     file_ = path.join(get_golem_path(), 'golem', 'core', 'variables.py')
     with open(file_, 'rb') as f_:
         variables = f_.read()
-    v = get_version().split('.')
-    version = "{}.{}".format(v[0], v[1])
+    version = get_version()
     variables = re.sub(r"APP_VERSION = \".*\"", "APP_VERSION = \"{}\"".format(version), variables)
     with open(file_, 'wb') as f_:
         f_.write(variables)

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -8,6 +8,7 @@ from mock import Mock
 from mock import patch
 
 from golem.core.common import get_timestamp_utc, timeout_to_deadline
+from golem.core.variables import APP_VERSION
 from golem.environments.environment import Environment
 from golem.environments.environmentsmanager import EnvironmentsManager
 from golem.network.p2p.node import Node
@@ -34,6 +35,8 @@ class TestTaskHeaderKeeper(LogTestCase):
         tk.environments_manager.add_environment(e)
         self.assertFalse(tk.is_supported(task))
         task["max_price"] = 10.0
+        self.assertFalse(tk.is_supported(task))
+        task["min_version"] = APP_VERSION
         self.assertTrue(tk.is_supported(task))
         task["max_price"] = 10.5
         self.assertTrue(tk.is_supported(task))
@@ -44,7 +47,7 @@ class TestTaskHeaderKeeper(LogTestCase):
         config_desc.min_price = 10.0
         tk.change_config(config_desc)
         self.assertTrue(tk.is_supported(task))
-        task["min_version"] = 120
+        task["min_version"] = "120"
         self.assertFalse(tk.is_supported(task))
         task["min_version"] = tk.app_version
         self.assertTrue(tk.is_supported(task))
@@ -241,7 +244,8 @@ def get_dict_task_header():
         "last_checking": time.time(),
         "deadline": timeout_to_deadline(1201),
         "subtask_timeout": 120,
-        "max_price": 10
+        "max_price": 10,
+        "min_version": APP_VERSION
     }
 
 

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -52,6 +52,36 @@ class TestTaskHeaderKeeper(LogTestCase):
         with self.assertLogs(logger=logger, level=1):
             self.assertFalse(tk.is_supported(task))
 
+    def test_check_version_compatibility(self):
+        tk = TaskHeaderKeeper(EnvironmentsManager(), 10.0)
+        tk.app_version = '0.4.5'
+
+        with self.assertRaises(ValueError):
+            tk.check_version_compatibility('')
+        with self.assertRaises(ValueError):
+            tk.check_version_compatibility('0')
+        with self.assertRaises(ValueError):
+            tk.check_version_compatibility('1.5')
+        with self.assertRaises(ValueError):
+            tk.check_version_compatibility('0.4-alpha+build.2004.01.01')
+        with self.assertRaises(ValueError):
+            tk.check_version_compatibility('0.4-alpha')
+        with self.assertRaises(ValueError):
+            tk.check_version_compatibility('0.4-alpha')
+
+        assert not tk.check_version_compatibility('1.5.0')
+        assert not tk.check_version_compatibility('1.4.0')
+        assert not tk.check_version_compatibility('0.5.0')
+        assert not tk.check_version_compatibility('0.4.6')
+        assert not tk.check_version_compatibility('0.3.0')
+
+        assert tk.check_version_compatibility('0.4.5')
+        assert tk.check_version_compatibility('0.4.1')
+        assert tk.check_version_compatibility('0.4.0')
+        assert tk.check_version_compatibility('0.4.0-alpha')
+        assert tk.check_version_compatibility('0.4.0-alpha+build')
+        assert tk.check_version_compatibility('0.4.0-alpha+build.2010')
+
     def test_change_config(self):
         tk = TaskHeaderKeeper(EnvironmentsManager(), 10.0)
         e = Environment()

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -13,6 +13,7 @@ from golem.core.common import timeout_to_deadline
 from golem.core.keysauth import EllipticalKeysAuth
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.core.threads import wait_for
+from golem.core.variables import APP_VERSION
 from golem.network.p2p.node import Node
 from golem.task.taskbase import ComputeTaskDef, TaskHeader
 from golem.task.taskserver import TaskServer, WaitingTaskResult, TaskConnTypes, logger
@@ -35,7 +36,8 @@ def get_example_task_header():
         "max_price": 20,
         "resource_size": 2 * 1024,
         "estimated_memory": 3 * 1024,
-        "signature": None
+        "signature": None,
+        "min_version": APP_VERSION
     }
 
 


### PR DESCRIPTION
- for local `a1.b1.c1` and remote `a2.b2.c2`, checks whether `"a1.b1" == "a2.b2"` and `c1 >= c2`
- does not support partial versions (i.e. `0.4`)