### PR TITLE
Fixed: Put quotes on taskcollector invocation args

### DIFF
--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -188,7 +188,7 @@ class RenderingTask(CoreTask):
         else:
             task_collector_path = os.path.normpath(os.path.join(path, "taskcollector"))
 
-        cmd = ['"{}"'.format(task_collector_path), "{}".format(arg), "{}".format(self.res_x), "{}".format(self.res_y),
+        cmd = [task_collector_path, "{}".format(arg), "{}".format(self.res_x), "{}".format(self.res_y),
                '"{}"'.format(output_file_name)] + ['"{}"'.format(f) for f in files]
 
         exec_cmd(cmd)

--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -181,14 +181,16 @@ class RenderingTask(CoreTask):
                 img_task.putpixel((i, j), color)
 
     def _put_collected_files_together(self, output_file_name, files, arg):
+        path = os.path.join(get_golem_path(), "apps", "rendering", "resources", "taskcollector", "Release")
+
         if is_windows():
-            task_collector_path = os.path.normpath(
-                os.path.join(get_golem_path(), "apps", "rendering", "resources", "taskcollector", "Release", "taskcollector.exe"))
+            task_collector_path = os.path.normpath(os.path.join(path, "taskcollector.exe"))
         else:
-            task_collector_path = os.path.normpath(
-                os.path.join(get_golem_path(), "apps", "rendering", "resources", "taskcollector", "Release",
-                             "taskcollector"))
-        cmd = ["{}".format(task_collector_path), "{}".format(arg), "{}".format(self.res_x), "{}".format(self.res_y), "{}".format(output_file_name)] + files
+            task_collector_path = os.path.normpath(os.path.join(path, "taskcollector"))
+
+        cmd = ['"{}"'.format(task_collector_path), "{}".format(arg), "{}".format(self.res_x), "{}".format(self.res_y),
+               '"{}"'.format(output_file_name)] + ['"{}"'.format(f) for f in files]
+
         exec_cmd(cmd)
 
     def _new_compute_task_def(self, hash, extra_data, working_directory, perf_index):

--- a/tests/apps/rendering/task/test_renderingtask.py
+++ b/tests/apps/rendering/task/test_renderingtask.py
@@ -126,8 +126,6 @@ class TestRenderingTask(TestDirFixture):
 
         def assert_command_line(exec_cmd):
             args = exec_cmd.call_args[0][0]
-            print args
-            assert args[0].startswith('"') and args[0].endswith('"')
             assert args[1] == arg
             assert args[2] == str(self.task.res_x)
             assert args[3] == str(self.task.res_y)
@@ -141,7 +139,7 @@ class TestRenderingTask(TestDirFixture):
 
             args = exec_cmd.call_args[0][0]
             assert_command_line(exec_cmd)
-            assert args[0].endswith('.exe"')
+            assert args[0].endswith('.exe')
 
         with mock.patch('apps.rendering.task.renderingtask.is_windows', side_effect=lambda: False), \
              mock.patch('apps.rendering.task.renderingtask.exec_cmd') as exec_cmd:
@@ -150,7 +148,7 @@ class TestRenderingTask(TestDirFixture):
 
             args = exec_cmd.call_args[0][0]
             assert_command_line(exec_cmd)
-            assert not args[0].endswith('.exe"')
+            assert not args[0].endswith('.exe')
 
 
 class TestGetTaskBorder(unittest.TestCase):

--- a/tests/apps/rendering/task/test_renderingtask.py
+++ b/tests/apps/rendering/task/test_renderingtask.py
@@ -1,6 +1,7 @@
 import unittest
 from os import makedirs, path, remove
 
+import mock
 from mock import Mock
 
 from apps.core.task.coretaskstate import TaskDefinition
@@ -116,6 +117,40 @@ class TestRenderingTask(TestDirFixture):
         assert preview.mode == "RGBA"
         assert preview.size == (267, 200)
         preview.close()
+
+    def test_put_collected_files_together(self):
+
+        output_file_name = "out.exr"
+        files = ["file_1", "dir_1/file_2", "dir 2/file_3"]
+        arg = 'EXR'
+
+        def assert_command_line(exec_cmd):
+            args = exec_cmd.call_args[0][0]
+            print args
+            assert args[0].startswith('"') and args[0].endswith('"')
+            assert args[1] == arg
+            assert args[2] == str(self.task.res_x)
+            assert args[3] == str(self.task.res_y)
+            assert args[4] == '"{}"'.format(output_file_name)
+            assert all([af == '"{}"'.format(f) for af, f in zip(args[5:], files)])
+
+        with mock.patch('apps.rendering.task.renderingtask.is_windows', side_effect=lambda: True), \
+             mock.patch('apps.rendering.task.renderingtask.exec_cmd') as exec_cmd:
+
+            self.task._put_collected_files_together(output_file_name, files, arg)
+
+            args = exec_cmd.call_args[0][0]
+            assert_command_line(exec_cmd)
+            assert args[0].endswith('.exe"')
+
+        with mock.patch('apps.rendering.task.renderingtask.is_windows', side_effect=lambda: False), \
+             mock.patch('apps.rendering.task.renderingtask.exec_cmd') as exec_cmd:
+
+            self.task._put_collected_files_together(output_file_name, files, arg)
+
+            args = exec_cmd.call_args[0][0]
+            assert_command_line(exec_cmd)
+            assert not args[0].endswith('.exe"')
 
 
 class TestGetTaskBorder(unittest.TestCase):


### PR DESCRIPTION
Resolves the issue of whitespace in filenames.