### PR TITLE
don't force user to re-run test

### DIFF
--- a/apps/blender/gui/controller/blenderrenderdialogcustomizer.py
+++ b/apps/blender/gui/controller/blenderrenderdialogcustomizer.py
@@ -25,7 +25,3 @@ class BlenderRenderDialogCustomizer(FrameRendererCustomizer):
     def _change_options(self):
         super(BlenderRenderDialogCustomizer, self)._change_options()
         self.options.compositing = self.gui.ui.compositingCheckBox.isChecked()
-
-    def _setup_connections(self):
-        super(BlenderRenderDialogCustomizer, self)._setup_connections()
-        self._connect_with_task_settings_changed([self.gui.ui.compositingCheckBox.stateChanged])

--- a/apps/core/gui/controller/newtaskdialogcustomizer.py
+++ b/apps/core/gui/controller/newtaskdialogcustomizer.py
@@ -78,16 +78,6 @@ class NewTaskDialogCustomizer(Customizer):
             self.__test_task_button_clicked)
         self.gui.ui.resetToDefaultButton.clicked.connect(
             self.__reset_to_defaults)
-        self.__connect_with_task_settings_changed([
-            self.gui.ui.fullTaskTimeoutSecSpinBox.valueChanged,
-            self.gui.ui.fullTaskTimeoutMinSpinBox.valueChanged,
-            self.gui.ui.fullTaskTimeoutHourSpinBox.valueChanged,
-            self.gui.ui.verificationSizeXSpinBox.valueChanged,
-            self.gui.ui.verificationSizeYSpinBox.valueChanged,
-            self.gui.ui.verificationForAllRadioButton.toggled,
-            self.gui.ui.verificationForFirstRadioButton.toggled,
-            self.gui.ui.probabilityLineEdit.textChanged
-        ])
 
     def _setup_payment_connections(self):
         self.gui.ui.taskMaxPriceLineEdit.textChanged.connect(
@@ -182,7 +172,6 @@ class NewTaskDialogCustomizer(Customizer):
 
     def set_options(self, options):
         self.logic.options = options
-        self.task_settings_changed()
 
     def task_settings_changed(self):
         self._change_finish_state(False)
@@ -331,7 +320,6 @@ class NewTaskDialogCustomizer(Customizer):
     def _optimize_total_check_box_changed(self):
         self.gui.ui.totalSpinBox.setEnabled(not self.gui.ui.optimizeTotalCheckBox.isChecked())
         self._set_new_pessimistic_cost()
-        self.task_settings_changed()
 
     def _open_options(self):
         task_name = u"{}".format(self.gui.ui.taskTypeComboBox.currentText())
@@ -362,7 +350,6 @@ class NewTaskDialogCustomizer(Customizer):
                 self.gui.ui.pessimisticCostLabel.setText(u"{:.6f} GNT".format(cost))
         except ValueError:
             self.gui.ui.pessimisticCostLabel.setText("unknown")
-        self.task_settings_changed()
 
     def _advance_settings_button_clicked(self):
         self.gui.ui.advanceNewTaskWidget.setVisible(not self.gui.ui.advanceNewTaskWidget.isVisible())
@@ -434,12 +421,6 @@ class NewTaskDialogCustomizer(Customizer):
     def __advanced_verification_changed(self):
         state = self.gui.ui.advanceVerificationCheckBox.isChecked()
         set_verification_widgets_state(self.gui, state)
-        self.task_settings_changed()
 
     def __verification_random_changed(self):
         verification_random_changed(self.gui)
-        self.task_settings_changed()
-
-    def __connect_with_task_settings_changed(self, list_gui_el):
-        for gui_el in list_gui_el:
-            gui_el.connect(self.task_settings_changed)

--- a/apps/lux/gui/controller/luxrenderdialogcustomizer.py
+++ b/apps/lux/gui/controller/luxrenderdialogcustomizer.py
@@ -22,9 +22,6 @@ class LuxRenderDialogCustomizer(RendererCustomizer):
     def _setup_connections(self):
         super(LuxRenderDialogCustomizer, self)._setup_connections()
         self.gui.ui.stopBySppRadioButton.toggled.connect(self._change_halts_state)
-        self._connect_with_task_settings_changed([self.gui.ui.stopBySppRadioButton.toggled,
-                                                  self.gui.ui.haltTimeLineEdit.textChanged,
-                                                  self.gui.ui.haltSppLineEdit.textChanged])
 
     def _change_halts_values(self):
         set_haltspp = self.options.haltspp > 0

--- a/apps/rendering/gui/controller/renderercustomizer.py
+++ b/apps/rendering/gui/controller/renderercustomizer.py
@@ -83,10 +83,6 @@ class RendererCustomizer(Customizer):
         self._setup_output_connections()
         self._connect_with_task_settings_changed([
             self.gui.ui.mainSceneFileLineEdit.textChanged,
-            self.gui.ui.outputFormatsComboBox.currentIndexChanged,
-            self.gui.ui.outputFileLineEdit.textChanged,
-            self.gui.ui.outputFormatsComboBox.currentIndexChanged,
-            self.gui.ui.outputFileLineEdit.textChanged,
         ])
         self.gui.ui.outputFormatsComboBox.currentIndexChanged.connect(self._add_ext_to_out_filename)
         self.gui.ui.outputFileLineEdit.editingFinished.connect(self._add_ext_to_out_filename)
@@ -147,16 +143,12 @@ class RendererCustomizer(Customizer):
         if file_name:
             self.save_setting('output_file_path', os.path.dirname(file_name))
             self.gui.ui.outputFileLineEdit.setText(file_name)
-            self.logic.task_settings_changed()
 
     def _res_x_changed(self):
         self.logic.change_verification_option(size_x_max=self.gui.ui.outputResXSpinBox.value())
 
-        self.logic.task_settings_changed()
-
     def _res_y_changed(self):
         self.logic.change_verification_option(size_y_max=self.gui.ui.outputResYSpinBox.value())
-        self.logic.task_settings_changed()
 
 
 class FrameRendererCustomizer(RendererCustomizer):

--- a/tests/gui/test_applicationlogic.py
+++ b/tests/gui/test_applicationlogic.py
@@ -559,10 +559,10 @@ class TestApplicationLogicTestTask(TestDirFixtureWithReactor):
         logic.progress_dialog.close()
         self.assertFalse(rpc_publisher.success)
 
-        prev_call_count = logic.customizer.new_task_dialog_customizer.task_settings_changed.call_count
+        ctr = logic.customizer.new_task_dialog_customizer
+        prev_call_count = ctr.task_settings_changed.call_count
         logic.task_settings_changed()
-        self.assertGreater(logic.customizer.new_task_dialog_customizer.task_settings_changed.call_count,
-                           prev_call_count)
+        self.assertGreater(ctr.task_settings_changed.call_count,prev_call_count)
 
         logic.tasks["xyz"] = ts
         logic.clone_task("xyz")


### PR DESCRIPTION
Don't run test again when user changed non-significant configuration element. Preparation to "run test earlier" and new gui integration. 