### PR TITLE
Verify img to compare size

### DIFF
--- a/apps/blender/resources/imgcompare.py
+++ b/apps/blender/resources/imgcompare.py
@@ -1,0 +1,10 @@
+from apps.rendering.resources.imgrepr import load_img
+
+
+def verify_img(file_, res_x, res_y):
+    # allow +/-1 difference in y size - workaround for blender inproperly rounding floats
+    img = load_img(file_)
+    if img is None:
+        return False
+    img_x, img_y = img.get_size()
+    return (img_x == res_x) and (abs(img_y - res_y) <= 1)

--- a/apps/blender/resources/imgcompare.py
+++ b/apps/blender/resources/imgcompare.py
@@ -1,7 +1,7 @@
 from apps.rendering.resources.imgrepr import load_img
 
 
-def verify_img(file_, res_x, res_y):
+def check_size(file_, res_x, res_y):
     # allow +/-1 difference in y size - workaround for blender inproperly rounding floats
     img = load_img(file_)
     if img is None:

--- a/apps/blender/task/verificator.py
+++ b/apps/blender/task/verificator.py
@@ -6,6 +6,7 @@ from golem.core.common import timeout_to_deadline
 
 from apps.rendering.task.verificator import FrameRenderingVerificator
 from apps.blender.resources.scenefileeditor import generate_blender_crop_file
+from apps.blender.resources.imgcompare import verify_img
 
 
 class BlenderVerificator(FrameRenderingVerificator):
@@ -83,3 +84,6 @@ class BlenderVerificator(FrameRenderingVerificator):
             else:
                 res_y = ceiling_height
         return res_y
+
+    def _verify_img(self, file_, res_x, res_y):
+        return verify_img(file_, res_x, res_y)

--- a/apps/blender/task/verificator.py
+++ b/apps/blender/task/verificator.py
@@ -6,7 +6,7 @@ from golem.core.common import timeout_to_deadline
 
 from apps.rendering.task.verificator import FrameRenderingVerificator
 from apps.blender.resources.scenefileeditor import generate_blender_crop_file
-from apps.blender.resources.imgcompare import verify_img
+from apps.blender.resources.imgcompare import check_size
 
 
 class BlenderVerificator(FrameRenderingVerificator):
@@ -85,5 +85,5 @@ class BlenderVerificator(FrameRenderingVerificator):
                 res_y = ceiling_height
         return res_y
 
-    def _verify_img(self, file_, res_x, res_y):
-        return verify_img(file_, res_x, res_y)
+    def _check_size(self, file_, res_x, res_y):
+        return check_size(file_, res_x, res_y)

--- a/apps/rendering/resources/imgcompare.py
+++ b/apps/rendering/resources/imgcompare.py
@@ -1,0 +1,8 @@
+from apps.rendering.resources.imgrepr import load_img
+
+
+def verify_img(file_, res_x, res_y):
+    img = load_img(file_)
+    if img is None:
+        return False
+    return img.get_size() == (res_x, res_y)

--- a/apps/rendering/resources/imgcompare.py
+++ b/apps/rendering/resources/imgcompare.py
@@ -1,7 +1,7 @@
 from apps.rendering.resources.imgrepr import load_img
 
 
-def verify_img(file_, res_x, res_y):
+def check_size(file_, res_x, res_y):
     img = load_img(file_)
     if img is None:
         return False

--- a/apps/rendering/resources/imgrepr.py
+++ b/apps/rendering/resources/imgrepr.py
@@ -181,15 +181,6 @@ def advance_verify_img(file_, res_x, res_y, start_box, box_size, compare_file, c
         return False
 
 
-def verify_img(file_, res_x, res_y):
-    # allow +/-1 difference in y size - workaround for blender inproperly rounding floats
-    img = load_img(file_)
-    if img is None:
-        return False
-    img_x, img_y = img.get_size()
-    return (img_x == res_x) and (abs(img_y - res_y) <= 1)
-
-
 def compare_pil_imgs(file1, file2):
     try:
         img1 = PILImgRepr()

--- a/apps/rendering/task/verificator.py
+++ b/apps/rendering/task/verificator.py
@@ -12,7 +12,9 @@ from golem.task.taskbase import ComputeTaskDef
 from golem.task.localcomputer import LocalComputer
 
 from apps.core.task.verificator import CoreVerificator, SubtaskVerificationState
-from apps.rendering.resources.imgrepr import verify_img, advance_verify_img
+from apps.rendering.resources.imgcompare import verify_img
+from apps.rendering.resources.imgrepr import advance_verify_img
+
 
 logger = logging.getLogger("apps.rendering")
 

--- a/apps/rendering/task/verificator.py
+++ b/apps/rendering/task/verificator.py
@@ -12,7 +12,7 @@ from golem.task.taskbase import ComputeTaskDef
 from golem.task.localcomputer import LocalComputer
 
 from apps.core.task.verificator import CoreVerificator, SubtaskVerificationState
-from apps.rendering.resources.imgcompare import verify_img
+from apps.rendering.resources.imgcompare import check_size
 from apps.rendering.resources.imgrepr import advance_verify_img
 
 
@@ -57,13 +57,13 @@ class RenderingVerificator(CoreVerificator):
                     return False
                 else:
                     self.verified_clients.append(subtask_info['node_id'])
-            if not self._verify_img(tr_file, res_x, res_y):
+            if not self._check_size(tr_file, res_x, res_y):
                 return False
 
         return True
 
-    def _verify_img(self, file_, res_x, res_y):
-        return verify_img(file_, res_x, res_y)
+    def _check_size(self, file_, res_x, res_y):
+        return check_size(file_, res_x, res_y)
 
     def _get_part_size(self, subtask_info):
         return self.res_x, self.res_y

--- a/tests/apps/blender/resources/test_blenderimgcompare.py
+++ b/tests/apps/blender/resources/test_blenderimgcompare.py
@@ -2,20 +2,22 @@ import os
 
 from PIL import Image
 
-from apps.blender.resources.imgcompare import verify_img
+from apps.blender.resources.imgcompare import check_size
 
 from golem.testutils import TempDirFixture
 
 
 class TestCompareImgFunctions(TempDirFixture):
-    def test_verify_img(self):
+    def test_check_size(self):
         file1 = self.temp_file_name('img.png')
         for y in range(100, 200):
             x = 100
             sample_img = Image.new("RGB", (x, y))
             sample_img.save(file1)
             self.assertTrue(os.path.isfile(file1))
-            self.assertTrue(verify_img(file1, x, y))
-            self.assertTrue(verify_img(file1, x, y + 1))
-            self.assertTrue(verify_img(file1, x, y - 1))
-            self.assertFalse(verify_img(file1, x + 1, y))
+            self.assertTrue(check_size(file1, x, y))
+            self.assertTrue(check_size(file1, x, y + 1))
+            self.assertTrue(check_size(file1, x, y - 1))
+            self.assertFalse(check_size(file1, x + 1, y))
+
+        self.assertFalse(check_size("not an image", 10, 10))

--- a/tests/apps/blender/resources/test_blenderimgcompare.py
+++ b/tests/apps/blender/resources/test_blenderimgcompare.py
@@ -1,0 +1,21 @@
+import os
+
+from PIL import Image
+
+from apps.blender.resources.imgcompare import verify_img
+
+from golem.testutils import TempDirFixture
+
+
+class TestCompareImgFunctions(TempDirFixture):
+    def test_verify_img(self):
+        file1 = self.temp_file_name('img.png')
+        for y in range(100, 200):
+            x = 100
+            sample_img = Image.new("RGB", (x, y))
+            sample_img.save(file1)
+            self.assertTrue(os.path.isfile(file1))
+            self.assertTrue(verify_img(file1, x, y))
+            self.assertTrue(verify_img(file1, x, y + 1))
+            self.assertTrue(verify_img(file1, x, y - 1))
+            self.assertFalse(verify_img(file1, x + 1, y))

--- a/tests/apps/blender/resources/test_blenderimgcompare.py
+++ b/tests/apps/blender/resources/test_blenderimgcompare.py
@@ -10,8 +10,8 @@ from golem.testutils import TempDirFixture
 class TestCompareImgFunctions(TempDirFixture):
     def test_check_size(self):
         file1 = self.temp_file_name('img.png')
-        for y in range(100, 200):
-            x = 100
+        for y in [10, 11]:
+            x = 10
             sample_img = Image.new("RGB", (x, y))
             sample_img.save(file1)
             self.assertTrue(os.path.isfile(file1))

--- a/tests/apps/rendering/resources/test_imgcompare.py
+++ b/tests/apps/rendering/resources/test_imgcompare.py
@@ -2,20 +2,20 @@ import os
 
 from PIL import Image
 
-from apps.rendering.resources.imgcompare import verify_img
+from apps.rendering.resources.imgcompare import check_size
 
 from golem.testutils import TempDirFixture
 
 
 class TestCompareImgFunctions(TempDirFixture):
-    def test_verify_img(self):
+    def test_check_size(self):
         file1 = self.temp_file_name('img.png')
         for y in range(100, 200):
             x = 100
             sample_img = Image.new("RGB", (x, y))
             sample_img.save(file1)
             self.assertTrue(os.path.isfile(file1))
-            self.assertTrue(verify_img(file1, x, y))
-            self.assertFalse(verify_img(file1, x, y + 1))
-            self.assertFalse(verify_img(file1, x, y - 1))
-            self.assertFalse(verify_img(file1, x + 1, y))
+            self.assertTrue(check_size(file1, x, y))
+            self.assertFalse(check_size(file1, x, y + 1))
+            self.assertFalse(check_size(file1, x, y - 1))
+            self.assertFalse(check_size(file1, x + 1, y))

--- a/tests/apps/rendering/resources/test_imgcompare.py
+++ b/tests/apps/rendering/resources/test_imgcompare.py
@@ -1,0 +1,21 @@
+import os
+
+from PIL import Image
+
+from apps.rendering.resources.imgcompare import verify_img
+
+from golem.testutils import TempDirFixture
+
+
+class TestCompareImgFunctions(TempDirFixture):
+    def test_verify_img(self):
+        file1 = self.temp_file_name('img.png')
+        for y in range(100, 200):
+            x = 100
+            sample_img = Image.new("RGB", (x, y))
+            sample_img.save(file1)
+            self.assertTrue(os.path.isfile(file1))
+            self.assertTrue(verify_img(file1, x, y))
+            self.assertFalse(verify_img(file1, x, y + 1))
+            self.assertFalse(verify_img(file1, x, y - 1))
+            self.assertFalse(verify_img(file1, x + 1, y))

--- a/tests/apps/rendering/resources/test_imgcompare.py
+++ b/tests/apps/rendering/resources/test_imgcompare.py
@@ -10,8 +10,8 @@ from golem.testutils import TempDirFixture
 class TestCompareImgFunctions(TempDirFixture):
     def test_check_size(self):
         file1 = self.temp_file_name('img.png')
-        for y in range(100, 200):
-            x = 100
+        for y in [10, 11]:
+            x = 10
             sample_img = Image.new("RGB", (x, y))
             sample_img.save(file1)
             self.assertTrue(os.path.isfile(file1))

--- a/tests/apps/rendering/resources/test_imgrepr.py
+++ b/tests/apps/rendering/resources/test_imgrepr.py
@@ -10,7 +10,7 @@ from golem.tools.assertlogs import LogTestCase
 from apps.rendering.resources.imgrepr import (advance_verify_img, blend, compare_exr_imgs,
                                               compare_imgs, compare_pil_imgs, calculate_mse,
                                               calculate_psnr, EXRImgRepr, ImgRepr, load_as_pil,
-                                              load_img, logger, PILImgRepr, verify_img)
+                                              load_img, logger, PILImgRepr)
 
 
 class TImgRepr(ImgRepr):
@@ -217,17 +217,6 @@ class TestExrImgRepr(TempDirFixture):
 
 
 class TestImgFunctions(TempDirFixture, LogTestCase):
-    def test_verify_img(self):
-        file1 = self.temp_file_name('img.png')
-        for y in range(100, 200):
-            x = 100
-            sample_img = Image.new("RGB", (x, y))
-            sample_img.save(file1)
-            self.assertTrue(os.path.isfile(file1))
-            self.assertTrue(verify_img(file1, x, y))
-            self.assertTrue(verify_img(file1, x, y + 1))
-            self.assertTrue(verify_img(file1, x, y - 1))
-            self.assertFalse(verify_img(file1, x + 1, y))
 
     def test_load_img(self):
         exr_img = load_img(_get_test_exr())


### PR DESCRIPTION
Change name of the function to something that better describes what it does. 
Create different implementation for general rendering and for Blender and move it to external file from imgrepr. 