### PR TITLE
Move image compare functions to imgcompare file

### DIFF
--- a/apps/rendering/resources/imgcompare.py
+++ b/apps/rendering/resources/imgcompare.py
@@ -1,7 +1,8 @@
 import logging
 import math
 
-from apps.rendering.resources.imgrepr import EXRImgRepr, ImgRepr, load_img, PILImgRepr
+from apps.rendering.resources.imgrepr import (EXRImgRepr, ImgRepr, load_img,
+                                              PILImgRepr)
 
 logger = logging.getLogger("apps.rendering")
 
@@ -34,7 +35,9 @@ def calculate_mse(img1, img2, start1=(0, 0), start2=(0, 0), box=None):
         for j in range(0, res_y):
             [r1, g1, b1] = img1.get_pixel((start1[0] + i, start1[1] + j))
             [r2, g2, b2] = img2.get_pixel((start2[0] + i, start2[1] + j))
-            mse += (r1 - r2) * (r1 - r2) + (g1 - g2) * (g1 - g2) + (b1 - b2) * (b1 - b2)
+            mse += (r1 - r2) * (r1 - r2) + \
+                   (g1 - g2) * (g1 - g2) + \
+                   (b1 - b2) * (b1 - b2)
 
     if res_x <= 0 or res_y <= 0:
         raise ValueError("Image or box resolution must be greater than 0")
@@ -42,7 +45,8 @@ def calculate_mse(img1, img2, start1=(0, 0), start2=(0, 0), box=None):
     return mse
 
 
-def compare_imgs(img1, img2, max_col=255, start1=(0, 0), start2=(0, 0), box=None):
+def compare_imgs(img1, img2, max_col=255, start1=(0, 0),
+                 start2=(0, 0), box=None):
     mse = calculate_mse(img1, img2, start1, start2, box)
     logger.debug("MSE = {}".format(mse))
     if mse == 0:
@@ -60,7 +64,8 @@ def compare_pil_imgs(file1, file2):
         img2.load_from_file(file2)
         return compare_imgs(img1, img2)
     except Exception as err:
-        logger.info("Can't compare images {}, {}: {}".format(file1, file2, err))
+        logger.info("Can't compare images {}, {}: {}".format(file1, file2,
+                                                             err))
         return False
 
 
@@ -72,11 +77,13 @@ def compare_exr_imgs(file1, file2):
         img2.load_from_file(file2)
         return compare_imgs(img1, img2, 1)
     except Exception as err:
-        logger.info("Can't compare images {}, {}: {}".format(file1, file2, err))
+        logger.info("Can't compare images {}, {}: {}".format(file1, file2,
+                                                             err))
         return False
 
 
-def advance_verify_img(file_, res_x, res_y, start_box, box_size, compare_file, cmp_start_box):
+def advance_verify_img(file_, res_x, res_y, start_box, box_size, compare_file,
+                       cmp_start_box):
     try:
         img = load_img(file_)
         cmp_img = load_img(compare_file)
@@ -84,14 +91,24 @@ def advance_verify_img(file_, res_x, res_y, start_box, box_size, compare_file, c
             return False
         if img.get_size() != (res_x, res_y):
             return False
-        if box_size[0] <= 0 or box_size[1] <= 0 or box_size[0] > res_x or box_size[1] > res_y:
-            logger.error("Wrong box size for advanced verification {}".format(box_size))
+
+        def _box_too_small(box):
+            return box[0] <= 0 or box[1] <= 0
+
+        def _box_too_big(box):
+            return box[0] > res_x or box[1] > res_y
+
+        if _box_too_small(box_size) or _box_too_big(box_size):
+            logger.error("Wrong box size for advanced verification " \
+                         "{}".format(box_size))
 
         if isinstance(img, PILImgRepr) and isinstance(cmp_img, PILImgRepr):
-            return compare_imgs(img, cmp_img, start1=start_box, start2=cmp_start_box, box=box_size)
+            return compare_imgs(img, cmp_img, start1=start_box,
+                                start2=cmp_start_box, box=box_size)
         else:
-            return compare_imgs(img, cmp_img, max_col=1, start1=start_box, start2=cmp_start_box,
-                                box=box_size)
+            return compare_imgs(img, cmp_img, max_col=1, start1=start_box,
+                                start2=cmp_start_box, box=box_size)
     except Exception:
-        logger.exception("Cannot verify images {} and {}".format(file_, compare_file))
+        logger.exception("Cannot verify images {} and {}".format(file_,
+                                                                 compare_file))
         return False

--- a/apps/rendering/resources/imgcompare.py
+++ b/apps/rendering/resources/imgcompare.py
@@ -1,4 +1,11 @@
-from apps.rendering.resources.imgrepr import load_img
+import logging
+import math
+
+from apps.rendering.resources.imgrepr import EXRImgRepr, ImgRepr, load_img, PILImgRepr
+
+logger = logging.getLogger("apps.rendering")
+
+PSNR_ACCEPTABLE_MIN = 30
 
 
 def check_size(file_, res_x, res_y):
@@ -6,3 +13,85 @@ def check_size(file_, res_x, res_y):
     if img is None:
         return False
     return img.get_size() == (res_x, res_y)
+
+
+def calculate_psnr(mse, max_=255):
+    if mse <= 0 or max_ <= 0:
+        raise ValueError("MSE & MAX_ must be higher than 0")
+    return 20 * math.log10(max_) - 10 * math.log10(mse)
+
+
+def calculate_mse(img1, img2, start1=(0, 0), start2=(0, 0), box=None):
+    mse = 0
+    if not isinstance(img1, ImgRepr) or not isinstance(img2, ImgRepr):
+        raise TypeError("img1 and img2 must be ImgRepr")
+
+    if box is None:
+        (res_x, res_y) = img1.get_size()
+    else:
+        (res_x, res_y) = box
+    for i in range(0, res_x):
+        for j in range(0, res_y):
+            [r1, g1, b1] = img1.get_pixel((start1[0] + i, start1[1] + j))
+            [r2, g2, b2] = img2.get_pixel((start2[0] + i, start2[1] + j))
+            mse += (r1 - r2) * (r1 - r2) + (g1 - g2) * (g1 - g2) + (b1 - b2) * (b1 - b2)
+
+    if res_x <= 0 or res_y <= 0:
+        raise ValueError("Image or box resolution must be greater than 0")
+    mse /= res_x * res_y * 3
+    return mse
+
+
+def compare_imgs(img1, img2, max_col=255, start1=(0, 0), start2=(0, 0), box=None):
+    mse = calculate_mse(img1, img2, start1, start2, box)
+    logger.debug("MSE = {}".format(mse))
+    if mse == 0:
+        return True
+    psnr = calculate_psnr(mse, max_col)
+    logger.debug("PSNR = {}".format(psnr))
+    return psnr >= PSNR_ACCEPTABLE_MIN
+
+
+def compare_pil_imgs(file1, file2):
+    try:
+        img1 = PILImgRepr()
+        img1.load_from_file(file1)
+        img2 = PILImgRepr()
+        img2.load_from_file(file2)
+        return compare_imgs(img1, img2)
+    except Exception as err:
+        logger.info("Can't compare images {}, {}: {}".format(file1, file2, err))
+        return False
+
+
+def compare_exr_imgs(file1, file2):
+    try:
+        img1 = EXRImgRepr()
+        img1.load_from_file(file1)
+        img2 = EXRImgRepr()
+        img2.load_from_file(file2)
+        return compare_imgs(img1, img2, 1)
+    except Exception as err:
+        logger.info("Can't compare images {}, {}: {}".format(file1, file2, err))
+        return False
+
+
+def advance_verify_img(file_, res_x, res_y, start_box, box_size, compare_file, cmp_start_box):
+    try:
+        img = load_img(file_)
+        cmp_img = load_img(compare_file)
+        if img is None or cmp_img is None:
+            return False
+        if img.get_size() != (res_x, res_y):
+            return False
+        if box_size[0] <= 0 or box_size[1] <= 0 or box_size[0] > res_x or box_size[1] > res_y:
+            logger.error("Wrong box size for advanced verification {}".format(box_size))
+
+        if isinstance(img, PILImgRepr) and isinstance(cmp_img, PILImgRepr):
+            return compare_imgs(img, cmp_img, start1=start_box, start2=cmp_start_box, box=box_size)
+        else:
+            return compare_imgs(img, cmp_img, max_col=1, start1=start_box, start2=cmp_start_box,
+                                box=box_size)
+    except Exception:
+        logger.exception("Cannot verify images {} and {}".format(file_, compare_file))
+        return False

--- a/apps/rendering/resources/imgrepr.py
+++ b/apps/rendering/resources/imgrepr.py
@@ -1,7 +1,6 @@
 import os
 import abc
 import logging
-import math
 from copy import deepcopy
 import OpenEXR
 import Imath
@@ -160,51 +159,6 @@ def load_as_pil(file_):
         return img.to_pil()
 
 
-def advance_verify_img(file_, res_x, res_y, start_box, box_size, compare_file, cmp_start_box):
-    try:
-        img = load_img(file_)
-        cmp_img = load_img(compare_file)
-        if img is None or cmp_img is None:
-            return False
-        if img.get_size() != (res_x, res_y):
-            return False
-        if box_size[0] <= 0 or box_size[1] <= 0 or box_size[0] > res_x or box_size[1] > res_y:
-            logger.error("Wrong box size for advanced verification {}".format(box_size))
-
-        if isinstance(img, PILImgRepr) and isinstance(cmp_img, PILImgRepr):
-            return compare_imgs(img, cmp_img, start1=start_box, start2=cmp_start_box, box=box_size)
-        else:
-            return compare_imgs(img, cmp_img, max_col=1, start1=start_box, start2=cmp_start_box,
-                                box=box_size)
-    except Exception:
-        logger.exception("Cannot verify images {} and {}".format(file_, compare_file))
-        return False
-
-
-def compare_pil_imgs(file1, file2):
-    try:
-        img1 = PILImgRepr()
-        img1.load_from_file(file1)
-        img2 = PILImgRepr()
-        img2.load_from_file(file2)
-        return compare_imgs(img1, img2)
-    except Exception as err:
-        logger.info("Can't compare images {}, {}: {}".format(file1, file2, err))
-        return False
-
-
-def compare_exr_imgs(file1, file2):
-    try:
-        img1 = EXRImgRepr()
-        img1.load_from_file(file1)
-        img2 = EXRImgRepr()
-        img2.load_from_file(file2)
-        return compare_imgs(img1, img2, 1)
-    except Exception as err:
-        logger.info("Can't compare images {}, {}: {}".format(file1, file2, err))
-        return False
-
-
 def blend(img1, img2, alpha):
     (res_x, res_y) = img1.get_size()
     if img2.get_size() != (res_x, res_y):
@@ -223,41 +177,10 @@ def blend(img1, img2, alpha):
     return img
 
 
-PSNR_ACCEPTABLE_MIN = 30
 
 
-def compare_imgs(img1, img2, max_col=255, start1=(0, 0), start2=(0, 0), box=None):
-    mse = calculate_mse(img1, img2, start1, start2, box)
-    logger.debug("MSE = {}".format(mse))
-    if mse == 0:
-        return True
-    psnr = calculate_psnr(mse, max_col)
-    logger.debug("PSNR = {}".format(psnr))
-    return psnr >= PSNR_ACCEPTABLE_MIN
 
 
-def calculate_psnr(mse, max_=255):
-    if mse <= 0 or max_ <= 0:
-        raise ValueError("MSE & MAX_ must be higher than 0")
-    return 20 * math.log10(max_) - 10 * math.log10(mse)
 
 
-def calculate_mse(img1, img2, start1=(0, 0), start2=(0, 0), box=None):
-    mse = 0
-    if not isinstance(img1, ImgRepr) or not isinstance(img2, ImgRepr):
-        raise TypeError("img1 and img2 must be ImgRepr")
 
-    if box is None:
-        (res_x, res_y) = img1.get_size()
-    else:
-        (res_x, res_y) = box
-    for i in range(0, res_x):
-        for j in range(0, res_y):
-            [r1, g1, b1] = img1.get_pixel((start1[0] + i, start1[1] + j))
-            [r2, g2, b2] = img2.get_pixel((start2[0] + i, start2[1] + j))
-            mse += (r1 - r2) * (r1 - r2) + (g1 - g2) * (g1 - g2) + (b1 - b2) * (b1 - b2)
-
-    if res_x <= 0 or res_y <= 0:
-        raise ValueError("Image or box resolution must be greater than 0")
-    mse /= res_x * res_y * 3
-    return mse

--- a/apps/rendering/resources/imgrepr.py
+++ b/apps/rendering/resources/imgrepr.py
@@ -83,14 +83,16 @@ class EXRImgRepr(ImgRepr):
         self.file_path = file_
 
     def get_size(self):
-        return self.dw.max.x - self.dw.min.x + 1, self.dw.max.y - self.dw.min.y + 1
+        return self.dw.max.x - self.dw.min.x + 1, \
+               self.dw.max.y - self.dw.min.y + 1
 
     def get_pixel(self, (i, j)):
         return [c.getpixel((i, j)) for c in self.rgb]
 
     def set_pixel(self, (i, j), color):
         for c in range(0, len(self.rgb)):
-            self.rgb[c].putpixel((i, j), max(min(self.max, color[c]), self.min))
+            self.rgb[c].putpixel((i, j), max(min(self.max, color[c]),
+                                             self.min))
 
     def get_rgbf_extrema(self):
         extrema = [im.getextrema() for im in self.rgb]
@@ -133,7 +135,8 @@ def load_img(file_):
     """
     Load image from file path and return ImgRepr
     :param str file_: path to the file  
-    :return ImgRepr | None: Return ImgRepr for special file type or None if there was an error 
+    :return ImgRepr | None: Return ImgRepr for special file type or None 
+    if there was an error 
     """
     try:
         _, ext = os.path.splitext(file_)
@@ -151,7 +154,8 @@ def load_img(file_):
 def load_as_pil(file_):
     """ Load image from file path and retun PIL Image representation
      :param str file_: path to the file 
-     :return Image.Image | None: return PIL Image represantion or NOne if there was an error
+     :return Image.Image | None: return PIL Image represantion or None 
+     if there was an error
     """
 
     img = load_img(file_)
@@ -175,12 +179,3 @@ def blend(img1, img2, alpha):
             img.set_pixel((x, y), p)
 
     return img
-
-
-
-
-
-
-
-
-

--- a/apps/rendering/task/verificator.py
+++ b/apps/rendering/task/verificator.py
@@ -12,8 +12,7 @@ from golem.task.taskbase import ComputeTaskDef
 from golem.task.localcomputer import LocalComputer
 
 from apps.core.task.verificator import CoreVerificator, SubtaskVerificationState
-from apps.rendering.resources.imgcompare import check_size
-from apps.rendering.resources.imgrepr import advance_verify_img
+from apps.rendering.resources.imgcompare import advance_verify_img, check_size
 
 
 logger = logging.getLogger("apps.rendering")

--- a/tests/apps/rendering/resources/imghelper.py
+++ b/tests/apps/rendering/resources/imghelper.py
@@ -1,0 +1,34 @@
+import os
+
+from PIL import Image
+
+from apps.rendering.resources.imgrepr import EXRImgRepr, PILImgRepr
+
+
+def make_test_img(img_path, size=(10, 10), color=(255, 0, 0)):
+    img = Image.new('RGB', size, color)
+    img.save(img_path)
+    img.close()
+
+
+def get_test_exr(alt=False):
+    if not alt:
+        filename = 'testfile.EXR'
+    else:
+        filename = 'testfile2.EXR'
+
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
+
+
+def get_pil_img_repr(path, size=(10, 10), color=(255, 0, 0)):
+    make_test_img(path, size, color)
+    p = PILImgRepr()
+    p.load_from_file(path)
+    return p
+
+
+def get_exr_img_repr(alt=False):
+    exr = EXRImgRepr()
+    exr_file = get_test_exr(alt)
+    exr.load_from_file(exr_file)
+    return exr

--- a/tests/apps/rendering/resources/test_imgcompare.py
+++ b/tests/apps/rendering/resources/test_imgcompare.py
@@ -2,12 +2,19 @@ import os
 
 from PIL import Image
 
-from apps.rendering.resources.imgcompare import check_size
+
+from apps.rendering.resources.imgcompare import (advance_verify_img, check_size, compare_exr_imgs,
+                                                 compare_imgs, compare_pil_imgs, calculate_mse,
+                                                 calculate_psnr, logger)
+from apps.rendering.resources.imgrepr import load_img, PILImgRepr
 
 from golem.testutils import TempDirFixture
+from golem.tools.assertlogs import LogTestCase
+
+from imghelper import get_exr_img_repr, get_pil_img_repr, get_test_exr, make_test_img
 
 
-class TestCompareImgFunctions(TempDirFixture):
+class TestCompareImgFunctions(TempDirFixture, LogTestCase):
     def test_check_size(self):
         file1 = self.temp_file_name('img.png')
         for y in [10, 11]:
@@ -19,3 +26,184 @@ class TestCompareImgFunctions(TempDirFixture):
             self.assertFalse(check_size(file1, x, y + 1))
             self.assertFalse(check_size(file1, x, y - 1))
             self.assertFalse(check_size(file1, x + 1, y))
+
+    def test_compare_pil_imgs(self):
+        img_path1 = self.temp_file_name("img1.jpg")
+        img_path2 = self.temp_file_name("img2.jpg")
+        make_test_img(img_path1)
+        make_test_img(img_path2)
+
+        assert compare_pil_imgs(img_path1, img_path2)
+
+        img = load_img(img_path1)
+        img.set_pixel((0, 0), [253, 1, 1])
+        img.img.save(img_path1)
+        assert compare_pil_imgs(img_path1, img_path2)
+
+        make_test_img(img_path1, color=(200, 0, 0))
+        assert not compare_pil_imgs(img_path1, img_path2)
+
+        make_test_img(img_path1, size=[11, 10], color=(255, 0, 0))
+        with self.assertLogs(logger, level="INFO"):
+            assert not compare_pil_imgs(img_path1, img_path2)
+
+        with self.assertLogs(logger, level="INFO"):
+            assert not compare_pil_imgs(img_path2, get_test_exr())
+
+    def test_compar_exr_imgs(self):
+        assert compare_exr_imgs(get_test_exr(), get_test_exr())
+        assert not compare_exr_imgs(get_test_exr(), get_test_exr(alt=True))
+        with self.assertLogs(logger, level="INFO"):
+            assert not compare_exr_imgs(get_test_exr(), "Not existing")
+
+        pil_img_path = self.temp_file_name("img1.png")
+        make_test_img(pil_img_path)
+        with self.assertLogs(logger, level="INFO"):
+            assert not compare_exr_imgs(get_test_exr(), pil_img_path)
+
+    def test_calculate_psnr(self):
+        assert calculate_psnr(10, 10) == 10
+        assert calculate_psnr(10, 1) == -10
+        assert calculate_psnr(1, 10) == 20
+        assert int(calculate_psnr(0.5, 10)) == 23
+        assert calculate_psnr(100, 20)
+        with self.assertRaises(ValueError):
+            calculate_psnr(0, 10)
+
+        with self.assertRaises(ValueError):
+            calculate_psnr(10, 0)
+
+        with self.assertRaises(ValueError):
+            calculate_psnr(-1, 10)
+
+        with self.assertRaises(ValueError):
+            calculate_psnr(10, -1)
+
+        assert round(calculate_psnr(1514.6), 2) == 16.33
+        assert round(calculate_psnr(703.4), 2) == 19.66
+        assert round(calculate_psnr(710.4), 2) == 19.62
+        assert round(calculate_psnr(396.1), 2) == 22.15
+        assert round(calculate_psnr(326.0), 2) == 23.00
+        assert round(calculate_psnr(221.2), 2) == 24.68
+        assert round(calculate_psnr(164.7), 2) == 25.96
+        assert round(calculate_psnr(113.8), 2) == 27.57
+        assert round(calculate_psnr(82.5), 2) == 28.97
+        assert round(calculate_psnr(78.5), 2) == 29.18
+        assert round(calculate_psnr(66.1), 2) == 29.93
+        assert round(calculate_psnr(64.4), 2) == 30.04
+        assert round(calculate_psnr(57.4437), 2) == 30.54
+
+    def test_calculate_mse(self):
+
+        # Both arguments are not ImgRepr
+        with self.assertRaises(TypeError):
+            calculate_mse("notanimgrepr1", "notanimgrepr2")
+
+        img_path = self.temp_file_name("img.png")
+        img1 = get_pil_img_repr(img_path)
+
+        # Only one argument is ImgRepr
+        with self.assertRaises(TypeError):
+            calculate_mse("notanimgrepr", img1)
+
+        with self.assertRaises(TypeError):
+            calculate_mse(img1, "notanimgrepr")
+
+        # ImgRepr before being image is loaded
+        img_before_loaded = PILImgRepr()
+        with self.assertRaises(Exception):
+            calculate_mse(img_before_loaded, img1)
+
+        with self.assertRaises(Exception):
+            calculate_mse(img1, img_before_loaded)
+
+        # Proper comparison (same images)
+        img2_path = self.temp_file_name("img2.png")
+        img2 = get_pil_img_repr(img2_path)
+
+        assert calculate_mse(img1, img2) == 0
+
+        # Wrong box values
+        with self.assertRaises(Exception):
+            calculate_mse(img1, img2, box="Not box")
+
+        with self.assertRaises(ValueError):
+            calculate_mse(img1, img2, box=(0, 1))
+
+        with self.assertRaises(ValueError):
+            calculate_mse(img1, img2, box=(1, 0))
+
+        with self.assertRaises(ValueError):
+            calculate_mse(img1, img2, box=(0, 0))
+
+        # Img2 too small
+        img2 = get_pil_img_repr(img2_path, (5, 5))
+        with self.assertRaises(Exception):
+            calculate_mse(img1, img2)
+
+        # Proper execution with smaller img2
+        assert calculate_mse(img1, img2, box=(5, 5)) == 0
+        assert calculate_mse(img1, img2, start1=(5, 5), box=(5, 5)) == 0
+
+        img2 = get_pil_img_repr(img2_path, (10, 10), (253, 0, 0))
+        assert calculate_mse(img1, img2) == 1
+
+        img2 = get_pil_img_repr(img2_path, (10, 10))
+        img2.set_pixel((0, 0), (0, 0, 0))
+        assert calculate_mse(img1, img2) == 216
+
+        assert calculate_mse(img1, img2, start1=(0, 0), start2=(2, 2), box=(7, 7)) == 0
+
+    def test_compare_imgs(self):
+        img1_path = self.temp_file_name("img1.png")
+        img2_path = self.temp_file_name("img2.png")
+
+        img1 = get_pil_img_repr(img1_path)
+        img2 = get_pil_img_repr(img2_path)
+
+        assert compare_imgs(img1, img2)
+        assert compare_imgs(img1, img2, start1=(4, 4), box=(5, 5))
+
+        with self.assertRaises(Exception):
+            compare_imgs(img1, img2, box=(0, 0))
+
+        with self.assertRaises(Exception):
+            compare_imgs(img1, img2, start2=(3, 3))
+
+        exr_img1 = get_exr_img_repr()
+        exr_img2 = get_exr_img_repr(alt=True)
+
+        assert not compare_imgs(exr_img1, exr_img2, max_col=1)
+        assert compare_imgs(exr_img1, exr_img1, max_col=1)
+        exr_img2_copy = exr_img2.copy()
+
+        for i in range(10):
+            for j in range(10):
+                exr_img2.set_pixel((j, i), [0.1, 0.1, 0.1])
+
+        assert compare_imgs(exr_img2, exr_img2_copy)
+        assert not compare_imgs(exr_img2, exr_img2_copy, max_col=1)
+
+    def test_advance_verify_img(self):
+        img_path = self.temp_file_name("path1.png")
+        make_test_img(img_path)
+
+        assert not advance_verify_img("not an image", 10, 10, (0, 0), (2, 2), img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 2), "not an image", (0, 0))
+
+        assert advance_verify_img(img_path, 10, 10, (0, 0), (2, 2), img_path, (0, 0))
+
+        assert not advance_verify_img(img_path, 10, 9, (0, 0), (2, 2), img_path, (0, 0))
+        assert not advance_verify_img(img_path, 9, 10, (0, 0), (2, 2), img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (0, 2), img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 0), img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (11, 10), img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (10, 11), img_path, (0, 0))
+
+        exr_path = get_test_exr()
+
+        assert advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2), exr_path, (0, 0))
+        exr_path2 = get_test_exr(alt=True)
+        assert not advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2), exr_path2, (0, 0))
+        assert not advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2), img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 2), exr_path, (0, 0))

--- a/tests/apps/rendering/resources/test_imgcompare.py
+++ b/tests/apps/rendering/resources/test_imgcompare.py
@@ -3,15 +3,19 @@ import os
 from PIL import Image
 
 
-from apps.rendering.resources.imgcompare import (advance_verify_img, check_size, compare_exr_imgs,
-                                                 compare_imgs, compare_pil_imgs, calculate_mse,
+from apps.rendering.resources.imgcompare import (advance_verify_img,
+                                                 check_size, compare_exr_imgs,
+                                                 compare_imgs,
+                                                 compare_pil_imgs,
+                                                 calculate_mse,
                                                  calculate_psnr, logger)
 from apps.rendering.resources.imgrepr import load_img, PILImgRepr
 
 from golem.testutils import TempDirFixture
 from golem.tools.assertlogs import LogTestCase
 
-from imghelper import get_exr_img_repr, get_pil_img_repr, get_test_exr, make_test_img
+from imghelper import (get_exr_img_repr, get_pil_img_repr, get_test_exr,
+                       make_test_img)
 
 
 class TestCompareImgFunctions(TempDirFixture, LogTestCase):
@@ -188,22 +192,35 @@ class TestCompareImgFunctions(TempDirFixture, LogTestCase):
         img_path = self.temp_file_name("path1.png")
         make_test_img(img_path)
 
-        assert not advance_verify_img("not an image", 10, 10, (0, 0), (2, 2), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 2), "not an image", (0, 0))
+        assert not advance_verify_img("not an image", 10, 10, (0, 0), (2, 2),
+                                      img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 2),
+                                      "not an image", (0, 0))
 
-        assert advance_verify_img(img_path, 10, 10, (0, 0), (2, 2), img_path, (0, 0))
+        assert advance_verify_img(img_path, 10, 10, (0, 0), (2, 2), img_path,
+                                  (0, 0))
 
-        assert not advance_verify_img(img_path, 10, 9, (0, 0), (2, 2), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 9, 10, (0, 0), (2, 2), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (0, 2), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 0), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (11, 10), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (10, 11), img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 9, (0, 0), (2, 2),
+                                      img_path, (0, 0))
+        assert not advance_verify_img(img_path, 9, 10, (0, 0), (2, 2),
+                                      img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (0, 2),
+                                      img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 0),
+                                      img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (11, 10),
+                                      img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (10, 11),
+                                      img_path, (0, 0))
 
         exr_path = get_test_exr()
 
-        assert advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2), exr_path, (0, 0))
+        assert advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2), exr_path,
+                                  (0, 0))
         exr_path2 = get_test_exr(alt=True)
-        assert not advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2), exr_path2, (0, 0))
-        assert not advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 2), exr_path, (0, 0))
+        assert not advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2),
+                                      exr_path2, (0, 0))
+        assert not advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2),
+                                      img_path, (0, 0))
+        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 2),
+                                      exr_path, (0, 0))

--- a/tests/apps/rendering/resources/test_imgrepr.py
+++ b/tests/apps/rendering/resources/test_imgrepr.py
@@ -7,10 +7,10 @@ from PIL import Image
 from golem.testutils import TempDirFixture
 from golem.tools.assertlogs import LogTestCase
 
-from apps.rendering.resources.imgrepr import (advance_verify_img, blend, compare_exr_imgs,
-                                              compare_imgs, compare_pil_imgs, calculate_mse,
-                                              calculate_psnr, EXRImgRepr, ImgRepr, load_as_pil,
+from apps.rendering.resources.imgrepr import (blend, EXRImgRepr, ImgRepr, load_as_pil,
                                               load_img, logger, PILImgRepr)
+
+from imghelper import get_exr_img_repr, get_pil_img_repr, get_test_exr, make_test_img
 
 
 class TImgRepr(ImgRepr):
@@ -44,19 +44,6 @@ class TestImgRepr(unittest.TestCase):
         t.copy()
         t.to_pil()
         t.set_pixel((0, 0), (0, 0, 0))
-
-
-def make_test_img(img_path, size=(10, 10), color=(255, 0, 0)):
-    img = Image.new('RGB', size, color)
-    img.save(img_path)
-    img.close()
-
-
-def get_pil_img_repr(path, size=(10, 10), color=(255, 0, 0)):
-    make_test_img(path, size, color)
-    p = PILImgRepr()
-    p.load_from_file(path)
-    return p
 
 
 class TestPILImgRepr(TempDirFixture):
@@ -96,22 +83,6 @@ class TestPILImgRepr(TempDirFixture):
         p_copy.set_pixel((5, 3), [200, 210, 220])
         assert p_copy.get_pixel((5, 3)) == [200, 210, 220]
         assert p.get_pixel((5, 3)) == [255, 0, 0]
-
-
-def _get_test_exr(alt=False):
-    if not alt:
-        filename = 'testfile.EXR'
-    else:
-        filename = 'testfile2.EXR'
-
-    return os.path.join(os.path.dirname(os.path.abspath(__file__)), filename)
-
-
-def get_exr_img_repr(alt=False):
-    exr = EXRImgRepr()
-    exr_file = _get_test_exr(alt)
-    exr.load_from_file(exr_file)
-    return exr
 
 
 def almost_equal(v1, v2):
@@ -219,7 +190,7 @@ class TestExrImgRepr(TempDirFixture):
 class TestImgFunctions(TempDirFixture, LogTestCase):
 
     def test_load_img(self):
-        exr_img = load_img(_get_test_exr())
+        exr_img = load_img(get_test_exr())
         assert isinstance(exr_img, EXRImgRepr)
         assert exr_img.get_size() == (10, 10)
 
@@ -292,195 +263,11 @@ class TestImgFunctions(TempDirFixture, LogTestCase):
         exr = blend(exr1, exr2, 0.9)
         almost_equal_pixels(exr.get_pixel((3, 2)), [0.0381, 0.0412, 0.0422])
 
-    def test_advance_verify_imgs(self):
-        pass
-
-    def test_compare_pil_imgs(self):
-        img_path1 = self.temp_file_name("img1.jpg")
-        img_path2 = self.temp_file_name("img2.jpg")
-        make_test_img(img_path1)
-        make_test_img(img_path2)
-
-        assert compare_pil_imgs(img_path1, img_path2)
-
-        img = load_img(img_path1)
-        img.set_pixel((0, 0), [253, 1, 1])
-        img.img.save(img_path1)
-        assert compare_pil_imgs(img_path1, img_path2)
-
-        make_test_img(img_path1, color=(200, 0, 0))
-        assert not compare_pil_imgs(img_path1, img_path2)
-
-        make_test_img(img_path1, size=[11, 10], color=(255, 0, 0))
-        with self.assertLogs(logger, level="INFO"):
-            assert not compare_pil_imgs(img_path1, img_path2)
-
-        with self.assertLogs(logger, level="INFO"):
-            assert not compare_pil_imgs(img_path2, _get_test_exr())
-
-    def test_compar_exr_imgs(self):
-        assert compare_exr_imgs(_get_test_exr(), _get_test_exr())
-        assert not compare_exr_imgs(_get_test_exr(), _get_test_exr(alt=True))
-        with self.assertLogs(logger, level="INFO"):
-            assert not compare_exr_imgs(_get_test_exr(), "Not existing")
-
-        pil_img_path = self.temp_file_name("img1.png")
-        make_test_img(pil_img_path)
-        with self.assertLogs(logger, level="INFO"):
-            assert not compare_exr_imgs(_get_test_exr(), pil_img_path)
-
-    def test_calculate_psnr(self):
-        assert calculate_psnr(10, 10) == 10
-        assert calculate_psnr(10, 1) == -10
-        assert calculate_psnr(1, 10) == 20
-        assert int(calculate_psnr(0.5, 10)) == 23
-        assert calculate_psnr(100, 20)
-        with self.assertRaises(ValueError):
-            calculate_psnr(0, 10)
-
-        with self.assertRaises(ValueError):
-            calculate_psnr(10, 0)
-
-        with self.assertRaises(ValueError):
-            calculate_psnr(-1, 10)
-
-        with self.assertRaises(ValueError):
-            calculate_psnr(10, -1)
-
-        assert round(calculate_psnr(1514.6), 2) == 16.33
-        assert round(calculate_psnr(703.4), 2) == 19.66
-        assert round(calculate_psnr(710.4), 2) == 19.62
-        assert round(calculate_psnr(396.1), 2) == 22.15
-        assert round(calculate_psnr(326.0), 2) == 23.00
-        assert round(calculate_psnr(221.2), 2) == 24.68
-        assert round(calculate_psnr(164.7), 2) == 25.96
-        assert round(calculate_psnr(113.8), 2) == 27.57
-        assert round(calculate_psnr(82.5), 2) == 28.97
-        assert round(calculate_psnr(78.5), 2) == 29.18
-        assert round(calculate_psnr(66.1), 2) == 29.93
-        assert round(calculate_psnr(64.4), 2) == 30.04
-        assert round(calculate_psnr(57.4437), 2) == 30.54
-
-    def test_calculate_mse(self):
-
-        # Both arguments are not ImgRepr
-        with self.assertRaises(TypeError):
-            calculate_mse("notanimgrepr1", "notanimgrepr2")
-
-        img_path = self.temp_file_name("img.png")
-        img1 = get_pil_img_repr(img_path)
-
-        # Only one argument is ImgRepr
-        with self.assertRaises(TypeError):
-            calculate_mse("notanimgrepr", img1)
-
-        with self.assertRaises(TypeError):
-            calculate_mse(img1, "notanimgrepr")
-
-        # ImgRepr before being image is loaded
-        img_before_loaded = PILImgRepr()
-        with self.assertRaises(Exception):
-            calculate_mse(img_before_loaded, img1)
-
-        with self.assertRaises(Exception):
-            calculate_mse(img1, img_before_loaded)
-
-        # Proper comparison (same images)
-        img2_path = self.temp_file_name("img2.png")
-        img2 = get_pil_img_repr(img2_path)
-
-        assert calculate_mse(img1, img2) == 0
-
-        # Wrong box values
-        with self.assertRaises(Exception):
-            calculate_mse(img1, img2, box="Not box")
-
-        with self.assertRaises(ValueError):
-            calculate_mse(img1, img2, box=(0, 1))
-
-        with self.assertRaises(ValueError):
-            calculate_mse(img1, img2, box=(1, 0))
-
-        with self.assertRaises(ValueError):
-            calculate_mse(img1, img2, box=(0, 0))
-
-        # Img2 too small
-        img2 = get_pil_img_repr(img2_path, (5, 5))
-        with self.assertRaises(Exception):
-            calculate_mse(img1, img2)
-
-        # Proper execution with smaller img2
-        assert calculate_mse(img1, img2, box=(5, 5)) == 0
-        assert calculate_mse(img1, img2, start1=(5, 5), box=(5, 5)) == 0
-
-        img2 = get_pil_img_repr(img2_path, (10, 10), (253, 0, 0))
-        assert calculate_mse(img1, img2) == 1
-
-        img2 = get_pil_img_repr(img2_path, (10, 10))
-        img2.set_pixel((0, 0), (0, 0, 0))
-        assert calculate_mse(img1, img2) == 216
-
-        assert calculate_mse(img1, img2, start1=(0, 0), start2=(2, 2), box=(7, 7)) == 0
-
-    def test_compare_imgs(self):
-        img1_path = self.temp_file_name("img1.png")
-        img2_path = self.temp_file_name("img2.png")
-
-        img1 = get_pil_img_repr(img1_path)
-        img2 = get_pil_img_repr(img2_path)
-
-        assert compare_imgs(img1, img2)
-        assert compare_imgs(img1, img2, start1=(4, 4), box=(5, 5))
-
-        with self.assertRaises(Exception):
-            compare_imgs(img1, img2, box=(0, 0))
-
-        with self.assertRaises(Exception):
-            compare_imgs(img1, img2, start2=(3, 3))
-
-        exr_img1 = get_exr_img_repr()
-        exr_img2 = get_exr_img_repr(alt=True)
-
-        assert not compare_imgs(exr_img1, exr_img2, max_col=1)
-        assert compare_imgs(exr_img1, exr_img1, max_col=1)
-        exr_img2_copy = exr_img2.copy()
-
-        for i in range(10):
-            for j in range(10):
-                exr_img2.set_pixel((j, i), [0.1, 0.1, 0.1])
-
-        assert compare_imgs(exr_img2, exr_img2_copy)
-        assert not compare_imgs(exr_img2, exr_img2_copy, max_col=1)
-
-    def test_advance_verify_img(self):
-        img_path = self.temp_file_name("path1.png")
-        make_test_img(img_path)
-
-        assert not advance_verify_img("not an image", 10, 10, (0, 0), (2, 2), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 2), "not an image", (0, 0))
-
-        assert advance_verify_img(img_path, 10, 10, (0, 0), (2, 2), img_path, (0, 0))
-
-        assert not advance_verify_img(img_path, 10, 9, (0, 0), (2, 2), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 9, 10, (0, 0), (2, 2), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (0, 2), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 0), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (11, 10), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (10, 11), img_path, (0, 0))
-
-        exr_path = _get_test_exr()
-
-        assert advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2), exr_path, (0, 0))
-        exr_path2 = _get_test_exr(alt=True)
-        assert not advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2), exr_path2, (0, 0))
-        assert not advance_verify_img(exr_path, 10, 10, (0, 0), (2, 2), img_path, (0, 0))
-        assert not advance_verify_img(img_path, 10, 10, (0, 0), (2, 2), exr_path, (0, 0))
-
     def test_load_as_pil(self):
         img_path = self.temp_file_name("path1.png")
         make_test_img(img_path)
         img = load_as_pil(img_path)
         assert isinstance(img, Image.Image)
-        exr_path = _get_test_exr()
+        exr_path = get_test_exr()
         img = load_as_pil(exr_path)
         assert isinstance(img, Image.Image)

--- a/tests/apps/rendering/resources/test_imgrepr.py
+++ b/tests/apps/rendering/resources/test_imgrepr.py
@@ -7,10 +7,12 @@ from PIL import Image
 from golem.testutils import TempDirFixture
 from golem.tools.assertlogs import LogTestCase
 
-from apps.rendering.resources.imgrepr import (blend, EXRImgRepr, ImgRepr, load_as_pil,
-                                              load_img, logger, PILImgRepr)
+from apps.rendering.resources.imgrepr import (blend, EXRImgRepr, ImgRepr,
+                                              load_as_pil, load_img, logger,
+                                              PILImgRepr)
 
-from imghelper import get_exr_img_repr, get_pil_img_repr, get_test_exr, make_test_img
+from imghelper import (get_exr_img_repr, get_pil_img_repr, get_test_exr,
+                       make_test_img)
 
 
 class TImgRepr(ImgRepr):
@@ -125,9 +127,15 @@ class TestExrImgRepr(TempDirFixture):
 
         assert e.get_size() == (10, 10)
 
-        assert e.get_pixel((0, 0)) == [0.5703125, 0.53076171875, 0.432373046875]
-        assert e.get_pixel((5, 5)) == [0.6982421875, 0.73193359375, 0.70556640625]
-        assert e.get_pixel((9, 9)) == [0.461181640625, 0.52392578125, 0.560546875]
+        assert e.get_pixel((0, 0)) == [0.5703125,
+                                       0.53076171875,
+                                       0.432373046875]
+        assert e.get_pixel((5, 5)) == [0.6982421875,
+                                       0.73193359375,
+                                       0.70556640625]
+        assert e.get_pixel((9, 9)) == [0.461181640625,
+                                       0.52392578125,
+                                       0.560546875]
 
         with self.assertRaises(Exception):
             e.get_pixel((10, 10))
@@ -169,7 +177,7 @@ class TestExrImgRepr(TempDirFixture):
         p.load_from_file(img_file)
 
         img2 = e.to_pil(use_extremas=True)
-        assert isinstance(img2, Image.Image )
+        assert isinstance(img2, Image.Image)
         img_alt = get_exr_img_repr(alt=True)
         img3 = img_alt.to_pil(use_extremas=True)
         assert isinstance(img3, Image.Image)
@@ -254,7 +262,9 @@ class TestImgFunctions(TempDirFixture, LogTestCase):
 
         assert exr2.get_pixel((3, 2)) == [0, 0, 0]
 
-        assert exr1.get_pixel((3, 2)) == [0.381103515625, 0.412353515625, 0.42236328125]
+        assert exr1.get_pixel((3, 2)) == [0.381103515625,
+                                          0.412353515625,
+                                          0.42236328125]
         assert exr2.get_pixel((3, 2)) == [0,  0, 0]
 
         exr = blend(exr1, exr2, 0.5)

--- a/tests/apps/rendering/resources/test_renderingtaskcollector.py
+++ b/tests/apps/rendering/resources/test_renderingtaskcollector.py
@@ -6,7 +6,8 @@ from golem.tools.testdirfixture import TestDirFixture
 
 
 from apps.rendering.resources.renderingtaskcollector import RenderingTaskCollector
-from apps.rendering.resources.imgrepr import compare_pil_imgs, advance_verify_img, load_img
+from apps.rendering.resources.imgcompare import compare_pil_imgs, advance_verify_img
+from apps.rendering.resources.imgrepr import load_img
 
 
 def make_test_img(img_path, size=(10, 10), color=(255, 0, 0)):

--- a/tests/apps/rendering/resources/test_renderingtaskcollector.py
+++ b/tests/apps/rendering/resources/test_renderingtaskcollector.py
@@ -6,7 +6,8 @@ from golem.tools.testdirfixture import TestDirFixture
 
 
 from apps.rendering.resources.renderingtaskcollector import RenderingTaskCollector
-from apps.rendering.resources.imgcompare import compare_pil_imgs, advance_verify_img
+from apps.rendering.resources.imgcompare import (advance_verify_img,
+                                                 compare_pil_imgs)
 from apps.rendering.resources.imgrepr import load_img
 
 


### PR DESCRIPTION
It's a next step in code refactoring that will be useful for adding redundancy & fixing bugs in some verification border cases. 