### PR TITLE
Port reachability check and status

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -11,7 +11,7 @@ from threading import Lock
 from os import path, makedirs
 from pydispatch import dispatcher
 from twisted.internet import task
-from twisted.internet.defer import inlineCallbacks, returnValue
+from twisted.internet.defer import inlineCallbacks, returnValue, gatherResults, Deferred
 
 from golem.appconfig import AppConfig, PUBLISH_BALANCE_INTERVAL
 from golem.clientconfigdescriptor import ClientConfigDescriptor, ConfigApprover
@@ -164,7 +164,7 @@ class Client(HardwarePresetsMixin):
     def p2p_listener(self, sender, signal, event='default', **kwargs):
         if event != 'unreachable':
             return
-        self.unreachable_flag = True
+        self.unreachable_flag = kwargs.get('description', u'')
 
     def taskmanager_listener(self, sender, signal, event='default', **kwargs):
         if event != 'task_status_updated':
@@ -192,16 +192,13 @@ class Client(HardwarePresetsMixin):
         self.publish_task.start(1, True)
 
     def start_network(self):
-        log.info("Starting network ...")
+        log.info("Gathering network information ...")
         self.node.collect_network_info(self.config_desc.seed_host,
                                        use_ipv6=self.config_desc.use_ipv6)
         log.debug("Is super node? %s", self.node.is_super_node())
 
         # self.ipfs_manager = IPFSDaemonManager(connect_to_bootstrap_nodes=self.connect_to_known_hosts)
         # self.ipfs_manager.store_client_info()
-
-        self.daemon_manager = HyperdriveDaemonManager(self.datadir)
-        self.daemon_manager.start()
 
         self.p2pservice = P2PService(self.node, self.config_desc, self.keys_auth,
                                      connect_to_known_hosts=self.connect_to_known_hosts)
@@ -211,30 +208,47 @@ class Client(HardwarePresetsMixin):
 
         dir_manager = self.task_server.task_computer.dir_manager
 
+        log.info("Starting resource server ...")
+        self.daemon_manager = HyperdriveDaemonManager(self.datadir)
+        hyperdrive_ports = self.daemon_manager.start()
+
         self.resource_server = BaseResourceServer(HyperdriveResourceManager(dir_manager),
                                                   dir_manager, self.keys_auth, self)
 
+        def connect((p2p_port, task_port)):
+            log.info('P2P server is listening on port {}'.format(p2p_port))
+            log.info('Task server is listening on port {}'.format(task_port))
+
+            dispatcher.send(signal='golem.p2p', event='listening',
+                            port=[p2p_port, task_port] + list(hyperdrive_ports))
+
+            self.task_server.task_computer.register_listener(ClientTaskComputerEventListener(self))
+            self.p2pservice.connect_to_network()
+
+            if self.monitor:
+                self.diag_service.register(self.p2pservice, self.monitor.on_peer_snapshot)
+                self.monitor.on_login()
+
+        def terminate(*exceptions):
+            log.error("Golem cannot listen on ports: {}".format(exceptions))
+            self.quit()
+
+        task_starting = Deferred()
+        p2p_starting = Deferred()
+
+        gatherResults([p2p_starting, task_starting],
+                      consumeErrors=True).addCallbacks(connect, terminate)
+
         log.info("Starting p2p server ...")
-        self.p2pservice.start_accepting()
-        time.sleep(1.0)
-
-        log.info("Starting resource server...")
-        self.resource_server.start_accepting()
-        time.sleep(1.0)
-
+        self.p2pservice.task_server = self.task_server
         self.p2pservice.set_resource_server(self.resource_server)
         self.p2pservice.set_metadata_manager(self)
+        self.p2pservice.start_accepting(listening_established=p2p_starting.callback,
+                                        listening_failure=p2p_starting.errback)
 
         log.info("Starting task server ...")
-        self.task_server.start_accepting()
-
-        self.p2pservice.task_server = self.task_server
-        self.task_server.task_computer.register_listener(ClientTaskComputerEventListener(self))
-        self.p2pservice.connect_to_network()
-
-        if self.monitor:
-            self.diag_service.register(self.p2pservice, self.monitor.on_peer_snapshot)
-            self.monitor.on_login()
+        self.task_server.start_accepting(listening_established=task_starting.callback,
+                                         listening_failure=task_starting.errback)
 
     def init_monitor(self):
         metadata = self.__get_nodemetadatamodel()
@@ -851,12 +865,21 @@ class Client(HardwarePresetsMixin):
 
         if listen_port == 0 or task_server_port == 0:
             return u"Application not listening, check config file."
-        elif not self.get_connected_peers():
-            msg = u"Not connected to Golem Network. Check seed parameters."
-            if hasattr(self, 'unreachable_flag'):
-                msg += u" Port unreachable."
-            return msg
-        return u"Connected"
+
+        messages = []
+
+        if hasattr(self, 'unreachable_flag'):
+            statues = self.unreachable_flag.split('\n')
+            failures = filter(lambda e: e.find('open') == -1, statues)
+            messages.append(u"Port " + u", ".join(failures) + u".")
+
+        if self.get_connected_peers():
+            messages.append(u"Connected")
+        else:
+            messages.append(u"Not connected to Golem Network, "
+                            u"check seed parameters.")
+
+        return u' '.join(messages)
 
     def get_metadata(self):
         metadata = dict()

--- a/golem/client.py
+++ b/golem/client.py
@@ -164,7 +164,7 @@ class Client(HardwarePresetsMixin):
     def p2p_listener(self, sender, signal, event='default', **kwargs):
         if event != 'unreachable':
             return
-        self.unreachable_flag = kwargs.get('description', u'')
+        self.node.port_status = kwargs.get('description', u'')
 
     def taskmanager_listener(self, sender, signal, event='default', **kwargs):
         if event != 'task_status_updated':
@@ -861,8 +861,8 @@ class Client(HardwarePresetsMixin):
 
         messages = []
 
-        if hasattr(self, 'unreachable_flag'):
-            statuses = self.unreachable_flag.split('\n')
+        if self.node.port_status:
+            statuses = self.node.port_status.split('\n')
             failures = filter(lambda e: e.find('open') == -1, statuses)
             messages.append(u"Port " + u", ".join(failures) + u".")
 

--- a/golem/client.py
+++ b/golem/client.py
@@ -862,8 +862,8 @@ class Client(HardwarePresetsMixin):
         messages = []
 
         if hasattr(self, 'unreachable_flag'):
-            statues = self.unreachable_flag.split('\n')
-            failures = filter(lambda e: e.find('open') == -1, statues)
+            statuses = self.unreachable_flag.split('\n')
+            failures = filter(lambda e: e.find('open') == -1, statuses)
             messages.append(u"Port " + u", ".join(failures) + u".")
 
         if self.get_connected_peers():

--- a/golem/monitor/monitor.py
+++ b/golem/monitor/monitor.py
@@ -59,10 +59,12 @@ class SystemMonitor(object):
         try:
             result = self.ping_request(kwargs['port'])
             if not result['success']:
-                dispatcher.send('golem.p2p', event='unreachable', port=kwargs['port'])
-                log.warning('Port unreachable: %r -> %r', kwargs['port'], result['description'])
+                status = result['description'].replace('\n', ', ')
+                log.warning('Port status: {}'.format(status))
+                dispatcher.send('golem.p2p', event='unreachable',
+                                port=kwargs['port'], description=result['description'])
         except:
-            log.exception('ping error')
+            log.exception('Port reachability check error')
 
     def ping_request(self, port):
         import requests

--- a/golem/network/hyperdrive/client.py
+++ b/golem/network/hyperdrive/client.py
@@ -34,6 +34,10 @@ class HyperdriveClient(IClient):
         response = self._request(command='id')
         return response['id']
 
+    def addresses(self):
+        response = self._request(command='addresses')
+        return response['addresses']
+
     def add(self, files, client_options=None, **kwargs):
         response = self._request(
             command='upload',
@@ -71,6 +75,5 @@ class HyperdriveClient(IClient):
                                  headers=self._headers,
                                  data=json.dumps(data),
                                  timeout=self.timeout)
-
         response.raise_for_status()
         return json.loads(response.content)

--- a/golem/network/p2p/node.py
+++ b/golem/network/p2p/node.py
@@ -22,6 +22,7 @@ class Node(object):
         self.prv_addresses = []
 
         self.nat_type = nat_type
+        self.port_status = None
 
     def collect_network_info(self, seed_host=None, use_ipv6=False):
         if not self.pub_addr:

--- a/golem/network/transport/tcpserver.py
+++ b/golem/network/transport/tcpserver.py
@@ -66,7 +66,7 @@ class TCPServer(Server):
 
     def _listening_established(self, port):
         self.cur_port = port
-        logger.info("Port {} opened - listening.".format(self.cur_port))
+        logger.debug("Port {} opened - listening.".format(self.cur_port))
 
     def _listening_failure(self):
         logger.error("Listening on ports {} to {} failure.".format(self.config_desc.start_port,

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -60,9 +60,6 @@ class TaskServer(PendingConnectionsServer):
         network = TCPNetwork(ProtocolFactory(MidAndFilesProtocol, self, SessionFactory(TaskSession)), use_ipv6)
         PendingConnectionsServer.__init__(self, config_desc, network)
 
-    def start_accepting(self):
-        PendingConnectionsServer.start_accepting(self)
-
     def key_changed(self):
         """React to the fact that key id has been changed. Inform task manager about new key """
         self.task_manager.key_id = self.keys_auth.get_key_id()

--- a/tests/golem/monitor/test_monitor.py
+++ b/tests/golem/monitor/test_monitor.py
@@ -81,4 +81,5 @@ class TestSystemMonitor(TestCase):
             response_mock.json = mock.MagicMock(return_value={'success': False, 'description': 'failure'})
             dispatcher.send(signal='golem.p2p', event='listening', port=port)
             signals = [s for s in signals if s[1] != 'listening']
-            self.assertEquals(signals, [('golem.p2p', 'unreachable', {'port': port})])
+            self.assertEquals(signals, [('golem.p2p', 'unreachable',
+                                         {'description': 'failure', 'port': port})])

--- a/tests/golem/network/hyperdrive/test_hyperdrive_daemon_manager.py
+++ b/tests/golem/network/hyperdrive/test_hyperdrive_daemon_manager.py
@@ -1,5 +1,3 @@
-import os
-
 from mock import patch, Mock
 from requests import ConnectionError
 
@@ -15,59 +13,91 @@ class TestHyperdriveDaemonManager(TempDirFixture):
     @patch('atexit.register')
     def test_start(self, register, *_):
 
-        dest_dir = os.path.join(self.path, HyperdriveDaemonManager._executable)
-        if not os.path.exists(dest_dir):
-            os.makedirs(dest_dir)
+        def ports(*_):
+            return dict(
+                UTP=dict(
+                    address='0.0.0.0',
+                    port=3282
+                ),
+                TCP=dict(
+                    address='0.0.0.0',
+                    port=3282
+                )
+            )
 
-        with patch('os.makedirs') as makedirs:
-            daemon_manager = HyperdriveDaemonManager(self.path)
-            assert not makedirs.called
-
-        daemon_manager._monitor.add_callbacks.assert_called_with(daemon_manager._start)
-        register.assert_called_with(daemon_manager.stop)
+        def none(*_):
+            pass
 
         process = Mock()
+        process.poll.return_value = None
 
-        def _running(val=True):
-            daemon_manager._daemon_running = lambda *_: val
+        daemon_manager = HyperdriveDaemonManager(self.path)
+        daemon_manager._monitor.add_callbacks.assert_called_with(daemon_manager._start)
+        # only registered atexit function is monitor.exit
+        register.assert_called_with(daemon_manager._monitor.exit)
+        assert register.call_count == 1
 
-        _running(False)
+        # hyperdrive not running
         process.poll.return_value = True
         daemon_manager._monitor.add_child_processes.called = False
 
-        with patch('time.sleep', side_effect=lambda *_: _running(True)), \
-             patch('subprocess.Popen', return_value=process):
+        with patch.object(daemon_manager, 'addresses', side_effect=none), \
+             patch('subprocess.Popen', return_value=process), \
+             patch('os.makedirs') as makedirs:
 
             with self.assertRaises(RuntimeError):
                 daemon_manager.start()
+
+            register.assert_called_with(daemon_manager.stop)
+
+            assert register.call_count == 2
             assert daemon_manager._monitor.start.called
+            assert makedirs.called
             assert not daemon_manager._monitor.add_child_processes.called
 
-        _running(False)
         process.poll.return_value = None
         daemon_manager._monitor.add_child_processes.called = False
 
-        with patch('time.sleep', side_effect=lambda *_: _running(True)), \
-             patch('subprocess.Popen', return_value=process):
+        with patch.object(daemon_manager, 'addresses', side_effect=none), \
+             patch('subprocess.Popen', return_value=process), \
+             patch('os.makedirs') as makedirs:
 
             daemon_manager.start()
+
+            register.assert_called_with(daemon_manager.stop)
+            assert register.call_count == 3
             assert daemon_manager._monitor.start.called
+            assert makedirs.called
             daemon_manager._monitor.add_child_processes.assert_called_with(process)
+
+        # hyperdrive is running
+        process.poll.return_value = True
+        daemon_manager._monitor.add_child_processes.called = False
+
+        with patch.object(daemon_manager, 'addresses', side_effect=ports), \
+             patch('subprocess.Popen', return_value=process), \
+             patch('os.makedirs') as makedirs:
+
+            daemon_manager.start()
+
+            register.assert_called_with(daemon_manager.stop)
+            assert register.call_count == 4
+            assert daemon_manager._monitor.start.called
+            assert not makedirs.called
+            assert not daemon_manager._monitor.add_child_processes.called
 
     def test_daemon_running(self):
 
-        with patch('os.makedirs') as makedirs:
-            daemon_manager = HyperdriveDaemonManager(self.path)
-            assert makedirs.called
+        daemon_manager = HyperdriveDaemonManager(self.path)
 
         def raise_exc():
             raise ConnectionError()
 
-        with patch('golem.network.hyperdrive.client.HyperdriveClient.id',
+        with patch('golem.network.hyperdrive.client.HyperdriveClient.addresses',
                    side_effect=raise_exc):
-            assert not daemon_manager._daemon_running()
+            assert not daemon_manager.addresses()
 
-        with patch('golem.network.hyperdrive.client.HyperdriveClient.id',
-                   side_effect=lambda *_: '0xdeadbeef'):
-            assert daemon_manager._daemon_running()
+        with patch('golem.network.hyperdrive.client.HyperdriveClient.addresses',
+                   side_effect=lambda *_: {'TCP': {'port': 1234}}):
+            assert daemon_manager.addresses()
 

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -607,17 +607,19 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         c.p2pservice.cur_port = 0
         self.assertTrue(c.connection_status().startswith(u"Application not listening"))
 
-    def test_unreachable_flag(self, *_):
+    def test_port_status(self, *_):
         from pydispatch import dispatcher
         import random
         random.seed()
 
         port = random.randint(1, 50000)
-        self.assertFalse(hasattr(self.client, 'unreachable_flag'))
-        dispatcher.send(signal="golem.p2p", event="no event at all", port=port)
-        self.assertFalse(hasattr(self.client, 'unreachable_flag'))
-        dispatcher.send(signal="golem.p2p", event="unreachable", port=port)
-        self.assertTrue(hasattr(self.client, 'unreachable_flag'))
+        self.assertFalse(self.client.node.port_status)
+        dispatcher.send(signal="golem.p2p", event="no event at all", port=port,
+                        description="port 1234: closed")
+        self.assertFalse(self.client.node.port_status)
+        dispatcher.send(signal="golem.p2p", event="unreachable", port=port,
+                        description="port 1234: closed")
+        self.assertTrue(self.client.node.port_status)
 
     @staticmethod
     def __new_session():

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -52,6 +52,7 @@ class TestCreateClient(TestDirFixture, testutils.PEP8MixIn):
                    use_monitor=False)
 
 
+@patch('signal.signal')
 @patch('golem.network.p2p.node.Node.collect_network_info')
 @patch('golem.ethereum.node.NodeProcess.save_static_nodes')
 class TestClient(TestWithDatabase):
@@ -376,6 +377,7 @@ class TestClient(TestWithDatabase):
         assert config.max_resource_size > 0
 
 
+@patch('signal.signal')
 @patch('golem.network.p2p.node.Node.collect_network_info')
 class TestClientRPCMethods(TestWithDatabase, LogTestCase):
 


### PR DESCRIPTION
- Checks port reachability for p2p, task server and hyperdrive (0.2.0+ required)
- Displays unreachable ports in status bar
- Changes server initialization sequence in `golem.client.Client`