### PR TITLE
Client.delete_task fixes

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -359,7 +359,8 @@ class Client(HardwarePresetsMixin):
         self.task_server.task_manager.resume_task(task_id)
 
     def delete_task(self, task_id):
-        self.task_server.remove_task_header(task_id)
+        self.remove_task_header(task_id)
+        self.remove_task(task_id)
         self.task_server.task_manager.delete_task(task_id)
 
     def get_node(self):

--- a/gui/applicationlogic.py
+++ b/gui/applicationlogic.py
@@ -571,8 +571,7 @@ class GuiApplicationLogic(QtCore.QObject, AppLogic):
             self.tasks[task_id].task_state = ts
             self.customizer.update_tasks(self.tasks)
             if ts.status in task_to_remove_status:
-                self.client.remove_task_header(task_id)
-                self.client.remove_task(task_id)
+                self.client.delete_task(task_id)
         else:
             logger.warning("Unknown task_id {}".format(task_id))
 

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -580,6 +580,17 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         c.create_task(DictSerializer.dump(t))
         self.assertTrue(c.enqueue_new_task.called)
 
+    def test_delete_task(self, *_):
+        c = self.client
+        c.remove_task_header = Mock()
+        c.remove_task = Mock()
+        c.task_server = Mock()
+
+        c.delete_task(str(uuid.uuid4()))
+        assert c.remove_task_header.called
+        assert c.remove_task.called
+        assert c.task_server.task_manager.delete_task.called
+
     def test_connection_status(self, *_):
         c = self.client
 


### PR DESCRIPTION
- `GuiApplicationLogic` calls `client.delete_task` instead of `client.remove_task` and `client.remove_task_header` (bugfix)
- `client.delete_task` sends out `MessageRemoveTask` (bugfix)