### PR TITLE
Superfluous CommandHelper.wait_for

### DIFF
--- a/golem/core/deferred.py
+++ b/golem/core/deferred.py
@@ -1,5 +1,24 @@
+from Queue import Queue, Empty
 
-from twisted.internet.defer import DebugInfo
+from twisted.internet.defer import DebugInfo, Deferred, TimeoutError
+from twisted.python.failure import Failure
+
+
+def sync_wait(deferred, timeout=10):
+    if not isinstance(deferred, Deferred):
+        return deferred
+
+    queue = Queue()
+    deferred.addBoth(queue.put)
+
+    try:
+        result = queue.get(True, timeout)
+    except Empty:
+        raise TimeoutError("Command timed out")
+
+    if isinstance(result, Failure):
+        result.raiseException()
+    return result
 
 
 def install_unhandled_error_logger():

--- a/golem/core/threads.py
+++ b/golem/core/threads.py
@@ -1,11 +1,7 @@
 import logging
 import time
-from Queue import Queue, Empty
 from collections import deque
 from threading import Thread, Lock
-
-from twisted.internet.defer import Deferred, TimeoutError
-from twisted.python.failure import Failure
 
 logger = logging.getLogger(__name__)
 
@@ -126,20 +122,3 @@ class ThreadQueueExecutor(QueueExecutor):
             job.setDaemon(True)
             job.start()
         job.join()
-
-
-def wait_for(deferred, timeout=10):
-    if not isinstance(deferred, Deferred):
-        return deferred
-
-    queue = Queue()
-    deferred.addBoth(queue.put)
-
-    try:
-        result = queue.get(True, timeout)
-    except Empty:
-        raise TimeoutError("Command timed out")
-
-    if isinstance(result, Failure):
-        result.raiseException()
-    return result

--- a/golem/interface/client/account.py
+++ b/golem/interface/client/account.py
@@ -1,22 +1,22 @@
 from ethereum.utils import denoms
 
-from golem.interface.command import command, CommandHelper
+from golem.core.deferred import sync_wait
+from golem.interface.command import command
 
 
 @command(help="Display account & financial info", root=True)
 def account():
 
-    wait = CommandHelper.wait_for
     client = account.client
 
-    node = wait(account.client.get_node())
+    node = sync_wait(account.client.get_node())
     node_key = node['key']
 
-    computing_trust = wait(client.get_computing_trust(node_key))
-    requesting_trust = wait(client.get_requesting_trust(node_key))
-    payment_address = wait(client.get_payment_address())
+    computing_trust = sync_wait(client.get_computing_trust(node_key))
+    requesting_trust = sync_wait(client.get_requesting_trust(node_key))
+    payment_address = sync_wait(client.get_payment_address())
 
-    balance = wait(client.get_balance())
+    balance = sync_wait(client.get_balance())
     if any(b is None for b in balance):
         balance = 0, 0, 0
 

--- a/golem/interface/client/environments.py
+++ b/golem/interface/client/environments.py
@@ -1,4 +1,5 @@
-from golem.interface.command import group, CommandHelper, Argument, command, CommandResult
+from golem.core.deferred import sync_wait
+from golem.interface.command import group, Argument, command, CommandResult
 
 
 @group(name="envs", help="Manage environments")
@@ -6,7 +7,8 @@ class Environments(object):
 
     name = Argument('name', help="Environment name")
 
-    table_headers = ['name', 'supported', 'active', 'performance', 'description']
+    table_headers = ['name', 'supported', 'active', 'performance',
+                     'description']
 
     sort = Argument(
         '--sort',
@@ -20,7 +22,7 @@ class Environments(object):
     def show(self, sort):
 
         deferred = Environments.client.get_environments()
-        result = CommandHelper.wait_for(deferred) or []
+        result = sync_wait(deferred) or []
 
         values = []
 
@@ -33,19 +35,20 @@ class Environments(object):
                 env['description']
             ])
 
-        return CommandResult.to_tabular(Environments.table_headers, values, sort=sort)
+        return CommandResult.to_tabular(Environments.table_headers, values,
+                                        sort=sort)
 
     @command(argument=name, help="Enable environment")
     def enable(self, name):
         deferred = Environments.client.enable_environment(name)
-        return CommandHelper.wait_for(deferred)
+        return sync_wait(deferred)
 
     @command(argument=name, help="Disable environment")
     def disable(self, name):
         deferred = Environments.client.disable_environment(name)
-        return CommandHelper.wait_for(deferred)
+        return sync_wait(deferred)
 
     @command(argument=name, help="Recount performance for an environment")
     def recount(self, name):
         deferred = Environments.client.run_benchmark(name)
-        return CommandHelper.wait_for(deferred, timeout=1800)
+        return sync_wait(deferred, timeout=1800)

--- a/golem/interface/client/payments.py
+++ b/golem/interface/client/payments.py
@@ -1,5 +1,7 @@
 from ethereum.utils import denoms
-from golem.interface.command import command, Argument, CommandHelper, CommandResult
+
+from golem.core.deferred import sync_wait
+from golem.interface.command import command, Argument, CommandResult
 
 incomes_table_headers = ['payer', 'status', 'value', 'block']
 payments_table_headers = ['subtask', 'payee', 'status', 'value', 'fee']
@@ -32,7 +34,7 @@ def __value(value):
 @command(argument=sort_incomes, help="Display incomes", root=True)
 def incomes(sort):
     deferred = incomes.client.get_incomes_list()
-    result = CommandHelper.wait_for(deferred) or []
+    result = sync_wait(deferred) or []
 
     values = []
 
@@ -52,15 +54,18 @@ def incomes(sort):
 def payments(sort):
 
     deferred = payments.client.get_payments_list()
-    result = CommandHelper.wait_for(deferred) or []
+    result = sync_wait(deferred) or []
 
     values = []
 
     for payment in result:
 
         payment_value = float(payment["value"])
-        payment_fee = payment["fee"]
-        payment_fee = u"{:.1f}%".format(float(payment_fee) * 100 / payment_value) if payment_fee else u""
+        payment_fee = payment["fee"] or u""
+
+        if payment_fee:
+            payment_fee = u"{:.1f}%".format(float(payment_fee) * 100 /
+                                            payment_value)
 
         entry = [
             payment["subtask"],

--- a/golem/interface/client/resources.py
+++ b/golem/interface/client/resources.py
@@ -1,3 +1,4 @@
+from golem.core.deferred import sync_wait
 from golem.interface.command import doc, group, command, CommandResult, Argument, CommandHelper
 from golem.resource.dirmanager import DirectoryType
 
@@ -21,18 +22,20 @@ class Resources(object):
 
     @doc("Show information on used resources")
     def show(self):
-        return CommandHelper.wait_for(Resources.client.get_res_dirs_sizes(),
-                                      timeout=None)
+        return sync_wait(Resources.client.get_res_dirs_sizes(), timeout=None)
 
-    @command(arguments=(provider, requestor), help="Clear provider / requestor resources")
+    @command(arguments=(provider, requestor),
+             help="Clear provider / requestor resources")
     def clear(self, provider, requestor):
 
         if not provider and not requestor:
-            return CommandResult(error="Target role was not specified (provider / requestor)")
+            return CommandResult(error="Target role was not specified "
+                                       "(provider / requestor)")
+
+        clear = Resources.client.clear_dir
 
         if provider:
-            CommandHelper.wait_for(Resources.client.clear_dir(DirectoryType.RECEIVED), timeout=None)
-            return CommandHelper.wait_for(Resources.client.clear_dir(DirectoryType.COMPUTED), timeout=None)
-
+            sync_wait(clear(DirectoryType.RECEIVED), timeout=None)
+            return sync_wait(clear(DirectoryType.COMPUTED), timeout=None)
         elif requestor:
-            return CommandHelper.wait_for(Resources.client.clear_dir(DirectoryType.DISTRIBUTED), timeout=None)
+            return sync_wait(clear(DirectoryType.DISTRIBUTED), timeout=None)

--- a/golem/interface/command.py
+++ b/golem/interface/command.py
@@ -4,7 +4,6 @@ import types
 from contextlib import contextmanager
 from operator import itemgetter
 
-from golem.core.threads import wait_for
 from golem.interface.exceptions import CommandException
 
 
@@ -240,7 +239,8 @@ class CommandHelper(object):
             self.source = source
 
     @classmethod
-    def init_interface(cls, elem, name=None, parent=None, children=None, arguments=None, argument=None, **kwargs):
+    def init_interface(cls, elem, name=None, parent=None, children=None,
+                       arguments=None, argument=None, **kwargs):
 
         interface = cls.get_interface(elem)
 
@@ -404,10 +404,6 @@ class CommandHelper(object):
         else:
             interface['arguments'] = arguments
 
-    @staticmethod
-    def wait_for(deferred, timeout=10):
-        return wait_for(deferred, timeout=timeout)
-
     @classmethod
     def wrap_call(cls, elem, instance=None):
         if not instance:
@@ -417,7 +413,8 @@ class CommandHelper(object):
 
     @staticmethod
     def is_callable(elem):
-        return isinstance(elem, types.FunctionType)  # or hasattr(elem, '__call__')
+        # or hasattr(elem, '__call__')
+        return isinstance(elem, types.FunctionType)
 
     @staticmethod
     def _public_method(entry):
@@ -425,7 +422,8 @@ class CommandHelper(object):
 
     @classmethod
     def debug(cls, elem, level=0):
-        print("{}{} : {}".format("  " * level if level else "", cls.get_name(elem), elem))
+        print("{}{} : {}".format("  " * level if level else "",
+                                 cls.get_name(elem), elem))
         for c in cls.get_children(elem).values():
             cls.debug(c, level + 1)
 

--- a/tests/golem/interface/test_command.py
+++ b/tests/golem/interface/test_command.py
@@ -1,10 +1,10 @@
 import unittest
 
-from mock import Mock
 from twisted.internet.defer import Deferred, TimeoutError
 
-from golem.interface.command import Argument, CommandResult, CommandHelper, group, doc, command, client_ctx, \
-    CommandStorage, storage_context, CommandException
+from golem.core.deferred import sync_wait
+from golem.interface.command import Argument, CommandResult, CommandHelper, \
+    group, doc, command, CommandStorage, storage_context, CommandException
 
 
 class TestArgument(unittest.TestCase):
@@ -108,17 +108,17 @@ class TestCommandHelper(unittest.TestCase):
 
     def test_wait_for_deferred(self):
 
-        self.assertEqual(CommandHelper.wait_for('1234'), '1234')
+        self.assertEqual(sync_wait('1234'), '1234')
 
         deferred = Deferred()
         deferred.result = '5678'
         deferred.called = True
 
-        self.assertEqual(CommandHelper.wait_for(deferred), '5678')
+        self.assertEqual(sync_wait(deferred), '5678')
 
         with self.assertRaises(TimeoutError):
             deferred_2 = Deferred()
-            CommandHelper.wait_for(deferred_2, timeout=0)
+            sync_wait(deferred_2, timeout=0)
 
     def test_structure(self):
 
@@ -160,10 +160,14 @@ class TestCommandHelper(unittest.TestCase):
             def command_root():
                 pass
 
-            self.assertEqual(CommandStorage.roots, [MockPreClass, MockClass, command_root])
-            self.assertEqual(CommandHelper.get_children(MockPreClass).keys(), ['mock_2_renamed'])
-            self.assertEqual(CommandHelper.get_children(MockClass).keys(), ['sub_commands', 'mock_1', 'renamed_mc'])
-            self.assertEqual(CommandHelper.get_children(MockSubClass).keys(), ['command_msc', 'command'])
+            self.assertEqual(CommandStorage.roots, [MockPreClass, MockClass,
+                                                    command_root])
+            self.assertEqual(CommandHelper.get_children(MockPreClass).keys(),
+                             ['mock_2_renamed'])
+            self.assertEqual(CommandHelper.get_children(MockClass).keys(),
+                             ['sub_commands', 'mock_1', 'renamed_mc'])
+            self.assertEqual(CommandHelper.get_children(MockSubClass).keys(),
+                             ['command_msc', 'command'])
 
         with self.assertRaises(TypeError):
             @group("commands", help="command group")

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -12,7 +12,7 @@ from stun import FullCone
 from golem.core.common import timeout_to_deadline
 from golem.core.keysauth import EllipticalKeysAuth
 from golem.clientconfigdescriptor import ClientConfigDescriptor
-from golem.core.threads import wait_for
+from golem.core.deferred import sync_wait
 from golem.core.variables import APP_VERSION
 from golem.network.p2p.node import Node
 from golem.task.taskbase import ComputeTaskDef, TaskHeader
@@ -628,7 +628,7 @@ class TestTaskServer2(TestWithKeysAuth, TestDirFixtureWithReactor):
         task_mock = get_mock_task("xyz", "xxyyzz")
         task_mock.query_extra_data.return_value = extra_data
 
-        wait_for(ts.task_manager.add_new_task(task_mock))
+        sync_wait(ts.task_manager.add_new_task(task_mock))
         ts.task_manager.tasks_states["xyz"].status = ts.task_manager.activeStatus[0]
         subtask, wrong_task, wait = ts.task_manager.get_next_subtask("DEF", "DEF", "xyz",
                                                                      1000, 10,  5, 10, 2,
@@ -669,7 +669,7 @@ class TestTaskServer2(TestWithKeysAuth, TestDirFixtureWithReactor):
         task_mock = get_mock_task("xyz", "xxyyzz")
         task_mock.query_extra_data.return_value = extra_data
 
-        wait_for(ts.task_manager.add_new_task(task_mock))
+        sync_wait(ts.task_manager.add_new_task(task_mock))
         ts.task_manager.tasks_states["xyz"].status = ts.task_manager.activeStatus[0]
         subtask, wrong_task, wait = ts.task_manager.get_next_subtask(
             "DEF", "DEF", "xyz", 1000, 10,  5, 10, 2, "10.10.10.10")

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -10,7 +10,7 @@ from golem import testutils
 from golem.client import Client, ClientTaskComputerEventListener, log
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.core.simpleserializer import DictSerializer
-from golem.core.threads import wait_for
+from golem.core.deferred import sync_wait
 from golem.model import Payment, PaymentStatus
 from golem.network.p2p.node import Node
 from golem.network.p2p.peersession import PeerSessionInfo
@@ -528,22 +528,22 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         c.transaction_system = Mock()
         c.transaction_system.get_balance.return_value = result
 
-        balance = wait_for(c.get_balance())
+        balance = sync_wait(c.get_balance())
         assert balance == (None, None, None)
 
         result = (None, 1, None)
         deferred.result = result
-        balance = wait_for(c.get_balance())
+        balance = sync_wait(c.get_balance())
         assert balance == (None, None, None)
 
         result = (1, 1, None)
         deferred.result = result
-        balance = wait_for(c.get_balance())
+        balance = sync_wait(c.get_balance())
         assert balance == (u"1", u"1", u"None")
         assert all(isinstance(entry, unicode) for entry in balance)
 
         c.transaction_system = None
-        balance = wait_for(c.get_balance())
+        balance = sync_wait(c.get_balance())
         assert balance == (None, None, None)
 
     def test_run_benchmark(self, *_):
@@ -555,9 +555,9 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         task_computer.run_lux_benchmark.side_effect = lambda c, e: c(True)
 
         with self.assertRaises(Exception):
-            wait_for(self.client.run_benchmark(str(uuid.uuid4())))
+            sync_wait(self.client.run_benchmark(str(uuid.uuid4())))
 
-        wait_for(self.client.run_benchmark(BlenderEnvironment.get_id()))
+        sync_wait(self.client.run_benchmark(BlenderEnvironment.get_id()))
 
         assert task_computer.run_blender_benchmark.called
         assert not task_computer.run_lux_benchmark.called
@@ -565,7 +565,7 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         task_computer.run_blender_benchmark.called = False
         task_computer.run_lux_benchmark.called = False
 
-        wait_for(self.client.run_benchmark(LuxRenderEnvironment.get_id()))
+        sync_wait(self.client.run_benchmark(LuxRenderEnvironment.get_id()))
 
         assert not task_computer.run_blender_benchmark.called
         assert task_computer.run_lux_benchmark.called

--- a/tests/gui/test_applicationlogic.py
+++ b/tests/gui/test_applicationlogic.py
@@ -12,7 +12,7 @@ from twisted.internet.defer import Deferred
 from golem import rpc
 from golem.client import Client
 from golem.core.simpleserializer import DictSerializer
-from golem.core.threads import wait_for
+from golem.core.deferred import sync_wait
 from golem.interface.client.logic import logger as int_logger
 from golem.resource.dirmanager import DirManager
 from golem.rpc.mapping.core import CORE_METHOD_MAP
@@ -345,7 +345,7 @@ class TestGuiApplicationLogicWithClient(DatabaseFixture, LogTestCase):
         for env in apps_manager.get_env_list():
             self.client.environments_manager.add_environment(env)
 
-        environments = wait_for(logic.get_environments())
+        environments = sync_wait(logic.get_environments())
 
         assert len(environments) > 0
         assert all([bool(env) for env in environments])
@@ -671,7 +671,7 @@ class TestApplicationLogicTestTask(TestDirFixtureWithReactor):
         logic.task_types["TESTTASK"] = task_type
 
         rpc_publisher.reset()
-        wait_for(logic.run_test_task(ts))
+        sync_wait(logic.run_test_task(ts))
         logic.progress_dialog.close()
         logic.test_task_started(True)
         self.assertTrue(logic.progress_dialog_customizer.gui.ui.abortButton.isEnabled())
@@ -681,7 +681,7 @@ class TestApplicationLogicTestTask(TestDirFixtureWithReactor):
         ttb.src_code = "import time\ntime.sleep(0.1)\n" \
                        "output = {'data': n, 'result_type': 0}"
         rpc_publisher.reset()
-        wait_for(logic.run_test_task(ts))
+        sync_wait(logic.run_test_task(ts))
         logic.progress_dialog.close()
         time.sleep(0.5)
         self.assertTrue(rpc_publisher.success)
@@ -691,20 +691,20 @@ class TestApplicationLogicTestTask(TestDirFixtureWithReactor):
         ttb.src_code = "import time\ntime.sleep(0.1)\n" \
                        "output = {'data': n, 'result_type': 0}"
         rpc_publisher.reset()
-        wait_for(logic.run_test_task(ts))
+        sync_wait(logic.run_test_task(ts))
         logic.progress_dialog.close()
         time.sleep(0.5)
         logic.abort_test_task()
 
         ttb.src_code = "raise Exception('some error')"
         rpc_publisher.reset()
-        wait_for(logic.run_test_task(ts))
+        sync_wait(logic.run_test_task(ts))
         logic.progress_dialog.close()
         time.sleep(1)
         self.assertFalse(rpc_publisher.success)
 
         rpc_publisher.reset()
-        wait_for(logic.run_test_task(ts))
+        sync_wait(logic.run_test_task(ts))
         logic.progress_dialog.close()
         self.assertFalse(rpc_publisher.success)
 
@@ -722,8 +722,8 @@ class TestApplicationLogicTestTask(TestDirFixtureWithReactor):
 
         ttb = TTaskBuilder(self.path, TTaskWithDef)
         logic.task_types["TESTTASK"].task_builder_type.return_value = ttb
-        assert wait_for(logic.run_test_task(ts))
+        assert sync_wait(logic.run_test_task(ts))
 
         ttb = TTaskBuilder(self.path, TTaskWithError)
         logic.task_types["TESTTASK"].task_builder_type.return_value = ttb
-        assert not wait_for(logic.run_test_task(ts))
+        assert not sync_wait(logic.run_test_task(ts))


### PR DESCRIPTION
Precedes the introduction of new features and deprecation of few old ones.

- `threads.wait_for` -> `deferred.sync_wait`
- `CommandHelper.wait_for` removed in favor of `deferred.sync_wait`
- formatting