### PR TITLE
issue#852: Made output extensions for Lux uppercase like blender.

### DIFF
--- a/apps/lux/task/luxrendertask.py
+++ b/apps/lux/task/luxrendertask.py
@@ -35,7 +35,7 @@ APP_DIR = os.path.join(get_golem_path(), 'apps', 'lux')
 class LuxRenderDefaults(renderingtaskstate.RendererDefaults):
     def __init__(self):
         super(LuxRenderDefaults, self).__init__()
-        self.output_format = "exr"
+        self.output_format = "EXR"
         self.main_program_file = LuxRenderEnvironment().main_program_file
         self.min_subtasks = 1
         self.max_subtasks = 100
@@ -53,7 +53,7 @@ class LuxRenderTaskTypeInfo(TaskTypeInfo):
             dialog,
             customizer
         )
-        self.output_formats = ["exr", "png", "tga"]
+        self.output_formats = ["EXR", "PNG", "TGA"]
         self.output_file_ext = ["lxs"]
 
     @classmethod

--- a/tests/apps/lux/task/test_luxrendertask.py
+++ b/tests/apps/lux/task/test_luxrendertask.py
@@ -289,7 +289,7 @@ class TestLuxRenderTaskTypeInfo(TempDirFixture):
     def test_init(self):
         typeinfo = LuxRenderTaskTypeInfo("dialog", "controller")
         assert isinstance(typeinfo, TaskTypeInfo)
-        assert typeinfo.output_formats == ["exr", "png", "tga"]
+        assert typeinfo.output_formats == ["EXR", "PNG", "TGA"]
         assert typeinfo.output_file_ext == ["lxs"]
         assert typeinfo.name == "LuxRender"
         assert isinstance(typeinfo.defaults, LuxRenderDefaults)


### PR DESCRIPTION
When investigating issue#852 i have compared Lux vs Blender task creation.

There i saw Blender uses uppercase extensions while Lux uses lowercase.
After changing the extensions used by Lux to uppercase the interface works as expected.

Is there anything else i can add or test to make this better then i found it?

Maaktweluit

