### PR TITLE
Version for network show

### DIFF
--- a/golem/interface/client/network.py
+++ b/golem/interface/client/network.py
@@ -8,7 +8,7 @@ class Network(object):
 
     client = None
 
-    node_table_headers = ['ip', 'port', 'id', 'name']
+    node_table_headers = ['ip', 'port', 'id', 'name', 'version']
 
     ip_arg = Argument('ip', help='Remote IP address')
     port_arg = Argument('port', help='Remote TCP port')
@@ -60,11 +60,13 @@ class Network(object):
             addr = Network.__one_of(p, 'address', 'pub_addr')
             port = Network.__one_of(p, 'port', 'p2p_pub_port', 'p2p_prv_port')
             key = Network.__one_of(p, 'key_id', 'key')
+            version = Network.__one_of(p, 'degree')
 
             values.append([
                 str(addr), str(port),
                 Network.__key_id(key, full),
-                str(p['node_name'])
+                str(p['node_name']),
+                str(version)
             ])
 
         return CommandResult.to_tabular(Network.node_table_headers, values,

--- a/golem/interface/client/network.py
+++ b/golem/interface/client/network.py
@@ -60,7 +60,7 @@ class Network(object):
             addr = Network.__one_of(p, 'address', 'pub_addr')
             port = Network.__one_of(p, 'port', 'p2p_pub_port', 'p2p_prv_port')
             key = Network.__one_of(p, 'key_id', 'key')
-            version = Network.__one_of(p, 'degree')
+            version = Network.__one_of(p, 'client_ver')
 
             values.append([
                 str(addr), str(port),

--- a/golem/network/p2p/peersession.py
+++ b/golem/network/p2p/peersession.py
@@ -536,9 +536,8 @@ class PeerSession(BasicSafeSession):
 
     def __send_hello(self):
         from golem.core.variables import APP_VERSION
-        self.solve_challenge = self.key_id \
-                               and self.p2p_service.should_solve_challenge \
-                               or False
+        self.solve_challenge = self.key_id and \
+            self.p2p_service.should_solve_challenge or False
         challenge_kwargs = {}
         if self.solve_challenge:
             challenge = self.p2p_service._get_challenge(self.key_id)
@@ -546,16 +545,16 @@ class PeerSession(BasicSafeSession):
             difficulty = self.p2p_service._get_difficulty(self.key_id)
             self.difficulty = challenge_kwargs['difficulty'] = difficulty
         msg = message.MessageHello(
-                                   proto_id=P2P_PROTOCOL_ID,
-                                   port=self.p2p_service.cur_port,
-                                   node_name=self.p2p_service.node_name,
-                                   client_key_id=self.p2p_service.keys_auth.get_key_id(),
-                                   node_info=self.p2p_service.node,
-                                   client_ver=APP_VERSION,
-                                   rand_val=self.rand_val,
-                                   metadata=self.p2p_service.metadata_manager.get_metadata(),
-                                   solve_challenge=self.solve_challenge,
-                                   **challenge_kwargs
+            proto_id=P2P_PROTOCOL_ID,
+            port=self.p2p_service.cur_port,
+            node_name=self.p2p_service.node_name,
+            client_key_id=self.p2p_service.keys_auth.get_key_id(),
+            node_info=self.p2p_service.node,
+            client_ver=APP_VERSION,
+            rand_val=self.rand_val,
+            metadata=self.p2p_service.metadata_manager.get_metadata(),
+            solve_challenge=self.solve_challenge,
+            **challenge_kwargs
         )
         self.send(msg, send_unverified=True)
 

--- a/golem/network/p2p/peersession.py
+++ b/golem/network/p2p/peersession.py
@@ -16,7 +16,7 @@ class PeerSessionInfo(object):
         'address', 'port',
         'verified', 'degree', 'key_id',
         'node_name', 'node_info',
-        'listen_port', 'conn_id'
+        'listen_port', 'conn_id', 'client_ver'
     ]
 
     def __init__(self, session):
@@ -53,6 +53,7 @@ class PeerSession(BasicSafeSession):
         self.degree = 0
         self.node_name = ""
         self.node_info = None
+        self.client_ver = None
         self.listen_port = None
 
         self.conn_id = None
@@ -533,6 +534,7 @@ class PeerSession(BasicSafeSession):
         self.send(message.MessagePong())
 
     def __send_hello(self):
+        from golem.core.variables import APP_VERSION
         self.solve_challenge = self.key_id \
                                and self.p2p_service.should_solve_challenge \
                                or False
@@ -548,6 +550,7 @@ class PeerSession(BasicSafeSession):
             node_name=self.p2p_service.node_name,
             client_key_id=self.p2p_service.keys_auth.get_key_id(),
             node_info=self.p2p_service.node,
+            client_ver=APP_VERSION,
             rand_val=self.rand_val,
             metadata=self.p2p_service.metadata_manager.get_metadata(),
             solve_challenge=self.solve_challenge,

--- a/golem/network/p2p/peersession.py
+++ b/golem/network/p2p/peersession.py
@@ -335,6 +335,7 @@ class PeerSession(BasicSafeSession):
     def _react_to_hello(self, msg):
         self.node_name = msg.node_name
         self.node_info = msg.node_info
+        self.client_ver = msg.client_ver
         self.listen_port = msg.port
 
         next_hello = self.key_id == msg.client_key_id

--- a/golem/network/p2p/peersession.py
+++ b/golem/network/p2p/peersession.py
@@ -546,16 +546,16 @@ class PeerSession(BasicSafeSession):
             difficulty = self.p2p_service._get_difficulty(self.key_id)
             self.difficulty = challenge_kwargs['difficulty'] = difficulty
         msg = message.MessageHello(
-            proto_id=P2P_PROTOCOL_ID,
-            port=self.p2p_service.cur_port,
-            node_name=self.p2p_service.node_name,
-            client_key_id=self.p2p_service.keys_auth.get_key_id(),
-            node_info=self.p2p_service.node,
-            client_ver=APP_VERSION,
-            rand_val=self.rand_val,
-            metadata=self.p2p_service.metadata_manager.get_metadata(),
-            solve_challenge=self.solve_challenge,
-            **challenge_kwargs
+                                   proto_id=P2P_PROTOCOL_ID,
+                                   port=self.p2p_service.cur_port,
+                                   node_name=self.p2p_service.node_name,
+                                   client_key_id=self.p2p_service.keys_auth.get_key_id(),
+                                   node_info=self.p2p_service.node,
+                                   client_ver=APP_VERSION,
+                                   rand_val=self.rand_val,
+                                   metadata=self.p2p_service.metadata_manager.get_metadata(),
+                                   solve_challenge=self.solve_challenge,
+                                   **challenge_kwargs
         )
         self.send(msg, send_unverified=True)
 

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -154,7 +154,7 @@ class TestNetwork(unittest.TestCase):
                 port='2500{}'.format(i),
                 key_id='deadbeef0{}'.format(i) * 8,
                 node_name='node_{}'.format(i),
-                version=u'0.7.0'
+                client_ver=u'0.7.0'
             ) for i in range(1, 1 + 6)
         ]
 

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -154,7 +154,7 @@ class TestNetwork(unittest.TestCase):
                 port='2500{}'.format(i),
                 key_id='deadbeef0{}'.format(i) * 8,
                 node_name='node_{}'.format(i),
-                client_ver=u'0.7.0'
+                client_ver=u'0.0.0'
             ) for i in range(1, 1 + 6)
         ]
 
@@ -200,7 +200,7 @@ class TestNetwork(unittest.TestCase):
             result_1 = net.show(None, full=False)
             result_2 = net.show(None, full=True)
 
-            self.__assert_peer_result(result_1, result_2, u'0.7.0')
+            self.__assert_peer_result(result_1, result_2)
 
     def test_dht(self):
         with client_ctx(Network, self.client):
@@ -209,9 +209,9 @@ class TestNetwork(unittest.TestCase):
             result_1 = net.dht(None, full=False)
             result_2 = net.dht(None, full=True)
 
-            self.__assert_peer_result(result_1, result_2, u'None')
+            self.__assert_peer_result(result_1, result_2)
 
-    def __assert_peer_result(self, result_1, result_2, version):
+    def __assert_peer_result(self, result_1, result_2):
         assert result_1.data[1][0] == [
             '10.0.0.1',
             '25001',

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -154,7 +154,7 @@ class TestNetwork(unittest.TestCase):
                 port='2500{}'.format(i),
                 key_id='deadbeef0{}'.format(i) * 8,
                 node_name='node_{}'.format(i),
-                client_ver=u'0.0.0'
+                client_ver='0.0.0'
             ) for i in range(1, 1 + 6)
         ]
 

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -153,7 +153,8 @@ class TestNetwork(unittest.TestCase):
                 address='10.0.0.{}'.format(i),
                 port='2500{}'.format(i),
                 key_id='deadbeef0{}'.format(i) * 8,
-                node_name='node_{}'.format(i)
+                node_name='node_{}'.format(i),
+                version=u'0.7.0'
             ) for i in range(1, 1 + 6)
         ]
 
@@ -215,14 +216,17 @@ class TestNetwork(unittest.TestCase):
             '10.0.0.1',
             '25001',
             'deadbeef01deadbe...beef01deadbeef01',
-            'node_1'
+            'node_1',
+            '0.7.0'
+
         ]
 
         assert result_2.data[1][0] == [
             '10.0.0.1',
             '25001',
             'deadbeef01' * 8,
-            'node_1'
+            'node_1',
+            '0.7.0'
         ]
 
         assert isinstance(result_1, CommandResult)

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -217,7 +217,7 @@ class TestNetwork(unittest.TestCase):
             '25001',
             'deadbeef01deadbe...beef01deadbeef01',
             'node_1',
-            version
+            '0.0.0'
 
         ]
 
@@ -226,7 +226,7 @@ class TestNetwork(unittest.TestCase):
             '25001',
             'deadbeef01' * 8,
             'node_1',
-            version
+            '0.0.0'
         ]
 
         assert isinstance(result_1, CommandResult)

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -200,7 +200,7 @@ class TestNetwork(unittest.TestCase):
             result_1 = net.show(None, full=False)
             result_2 = net.show(None, full=True)
 
-            self.__assert_peer_result(result_1, result_2)
+            self.__assert_peer_result(result_1, result_2, u'0.7.0')
 
     def test_dht(self):
         with client_ctx(Network, self.client):
@@ -209,15 +209,15 @@ class TestNetwork(unittest.TestCase):
             result_1 = net.dht(None, full=False)
             result_2 = net.dht(None, full=True)
 
-            self.__assert_peer_result(result_1, result_2)
+            self.__assert_peer_result(result_1, result_2, u'None')
 
-    def __assert_peer_result(self, result_1, result_2):
+    def __assert_peer_result(self, result_1, result_2, version):
         assert result_1.data[1][0] == [
             '10.0.0.1',
             '25001',
             'deadbeef01deadbe...beef01deadbeef01',
             'node_1',
-            '0.7.0'
+            version
 
         ]
 
@@ -226,7 +226,7 @@ class TestNetwork(unittest.TestCase):
             '25001',
             'deadbeef01' * 8,
             'node_1',
-            '0.7.0'
+            version
         ]
 
         assert isinstance(result_1, CommandResult)

--- a/tests/golem/network/p2p/test_peersession.py
+++ b/tests/golem/network/p2p/test_peersession.py
@@ -37,7 +37,7 @@ class TestPeerSession(TestWithKeysAuth, LogTestCase, testutils.PEP8MixIn):
         expected = {
             'CHALLENGE': None,
             'CLIENT_KEY_ID': key_id,
-            'CLI_VER': '0.8.0',
+            'CLI_VER': '0.7.1',
             'DIFFICULTY': 0,
             'METADATA': metadata,
             'NODE_INFO': node,

--- a/tests/golem/network/p2p/test_peersession.py
+++ b/tests/golem/network/p2p/test_peersession.py
@@ -37,7 +37,7 @@ class TestPeerSession(TestWithKeysAuth, LogTestCase, testutils.PEP8MixIn):
         expected = {
             'CHALLENGE': None,
             'CLIENT_KEY_ID': key_id,
-            'CLI_VER': 0,
+            'CLI_VER': u'0.7.0',
             'DIFFICULTY': 0,
             'METADATA': metadata,
             'NODE_INFO': node,

--- a/tests/golem/network/p2p/test_peersession.py
+++ b/tests/golem/network/p2p/test_peersession.py
@@ -5,6 +5,7 @@ import unittest
 
 from golem import testutils
 from golem.core.keysauth import EllipticalKeysAuth, KeysAuth
+from golem.core.variables import APP_VERSION
 from golem.network.p2p.node import Node
 from golem.network.p2p.p2pservice import P2PService
 from golem.network.p2p.peersession import (PeerSession, logger, P2P_PROTOCOL_ID,
@@ -37,7 +38,7 @@ class TestPeerSession(TestWithKeysAuth, LogTestCase, testutils.PEP8MixIn):
         expected = {
             'CHALLENGE': None,
             'CLIENT_KEY_ID': key_id,
-            'CLI_VER': '0.7.1',
+            'CLI_VER': APP_VERSION,
             'DIFFICULTY': 0,
             'METADATA': metadata,
             'NODE_INFO': node,

--- a/tests/golem/network/p2p/test_peersession.py
+++ b/tests/golem/network/p2p/test_peersession.py
@@ -37,7 +37,7 @@ class TestPeerSession(TestWithKeysAuth, LogTestCase, testutils.PEP8MixIn):
         expected = {
             'CHALLENGE': None,
             'CLIENT_KEY_ID': key_id,
-            'CLI_VER': u'0.7.0',
+            'CLI_VER': '0.8.0',
             'DIFFICULTY': 0,
             'METADATA': metadata,
             'NODE_INFO': node,


### PR DESCRIPTION
Resolves #991 

- Reused `client_ver` in the `HelloMessage`, was it meant for this purpose?
- Default was 0, so left it. Could be `None` or `0.6.0`
- How to not hard-code the version in the peersession test, import `APP_VERSION`?

`network dht` now also shows the column printing `None`. Is this a new issue or should it be fixed here?

_edit: added question after tests_