### PR TITLE
Fix golemcli.spec on python 3

### DIFF
--- a/golemcli.spec
+++ b/golemcli.spec
@@ -6,7 +6,7 @@ block_cipher = None
 icon = None
 
 if sys.platform == 'win32':
-    icon = os.path.join(os.getcwdu(), 'Installer', 'favicon.ico')
+    icon = os.path.join(os.getcwd(), 'Installer', 'favicon.ico')
 
 a = Analysis(['golemcli.py'],
              hookspath=['./scripts/pyinstaller/hooks'],


### PR DESCRIPTION
On python 3 proper function is getcwd
http://www.diveintopython3.net/porting-code-to-python-3-with-2to3.html
A.41

Signed-off-by: Lukasz Foniok <lukaszfoniok@gmail.com>