### PR TITLE
Remove from preview check removed from renderingtask.py(#896)

### DIFF
--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -164,8 +164,7 @@ class RenderingTask(CoreTask):
     @CoreTask.handle_key_error
     def _remove_from_preview(self, subtask_id):
         empty_color = (0, 0, 0)
-        if isinstance(self.preview_file_path, list):  # FIXME Add possibility to remove subtask from frame
-            return
+        
         img = self._open_preview()
         self._mark_task_area(self.subtasks_given[subtask_id], img, empty_color)
         img.save(self.preview_file_path, PREVIEW_EXT)


### PR DESCRIPTION
remove_from_preview removed the check if the preview file path was a list as in issue #896.