### PR TITLE
Fix type annotation in imgrepr.py.

### DIFF
--- a/apps/rendering/resources/imgrepr.py
+++ b/apps/rendering/resources/imgrepr.py
@@ -178,7 +178,7 @@ def load_as_pil(file_):
         return img.to_pil()
 
 
-def load_as_PILImgRepr(file_) -> PILImgRepr():
+def load_as_PILImgRepr(file_) -> PILImgRepr:
     img = load_img(file_)
 
     if isinstance(img, EXRImgRepr):


### PR DESCRIPTION
The incorrect annotation causes the mypy check to terminate. Thus, this commit blocks #1258.