### PR TITLE
Disable refactor messages for the CI, there are too many of them

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -50,9 +50,11 @@ confidence=
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes
 # --disable=W"
-disable=invalid-name,           # Pylint is overzealous here
+disable=invalid-name,                   # Pylint is overzealous here
         missing-docstring,              # We don't need a docstring for obvious things!
         fixme,
+        redefined-builtin,
+        logging-format-interpolation,
 
 # Enable the message, report, category or checker with the given id(s). You can
 # either give multiple identifier separated by comma (,) or put this option

--- a/circle.yml
+++ b/circle.yml
@@ -42,7 +42,8 @@ test:
   pre:
     - pip3 install coverage codecov
   override:
-    - ./lintdiff.sh pylint apps golem gui scripts setup_util tests *.py
+    - ./lintdiff.sh pylint --disable=R apps golem gui scripts setup_util *.py
+    - ./lintdiff.sh pylint --disable=R,protected-access tests
     - ./lintdiff.sh pycodestyle
     - ./lintdiff.sh mypy apps golem gui scripts setup_util tests *.py
     - python3 -m coverage run --branch --source=. setup.py test -a "--junitxml=$CIRCLE_TEST_REPORTS/test_result.xml":


### PR DESCRIPTION
I don't do this in pylintrc, because the may be useful at the time of writing code.