### PR TITLE
Allow `Any` annotations in mypy.

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,6 @@ max_line_length = 80
 ignore_missing_imports=True
 strict_optional=True
 follow_imports=silent
-disallow_any=explicit
 disallow_untyped_calls=False
 disallow_untyped_defs=False
 check_untyped_defs=False


### PR DESCRIPTION
Some functions used in Golem, such as `golem.core.deferred.sync_wait` are
designed to accept any argument. While this may not be what we want,
fixing such issues is usually out of scope of the commit.
The configuration option disallowing explicit use of `Any` makes it thus
impossible to type check functions, whose only guilt is that they return
a result of such function as `sync_wait`.

This commit will probably be reverted at some point, when our codebase
becomes more typed.