### PR TITLE
Quick and dirty creating tasks from CLI

### DIFF
--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -154,21 +154,29 @@ class Tasks:
         with open(file_name) as f:
             self.create_from_json(f.read())
 
-    @command(argument=outfile, help="Dump a task template")
-    def template(self, outfile: Optional[str]) -> Any:
-        template = TaskDefinition()
-        template_str = json.dumps(template.to_dict(), indent=4)
+    @command(arguments=(id_req, outfile), help="Dump an existing task")
+    def dump(self, id: str, outfile: Optional[str]) -> None:
+        task_dict = sync_wait(self.client.get_task(id))
+        self.__dump_dict(task_dict, outfile)
 
-        if outfile:
-            with open(outfile, 'w') as dest:
-                print(template_str, file=dest)
-        else:
-            print(template_str)
+    @command(argument=outfile, help="Dump a task template")
+    def template(self, outfile: Optional[str]) -> None:
+        template = TaskDefinition()
+        self.__dump_dict(template.to_dict(), outfile)
 
     @doc("Show statistics for tasks")
     def stats(self):
         deferred = Tasks.client.get_task_stats()
         return sync_wait(deferred)
+
+    @staticmethod
+    def __dump_dict(dictionary: dict, outfile: Optional[str]) -> None:
+        template_str = json.dumps(dictionary, indent=4)
+        if outfile:
+            with open(outfile, 'w') as dest:
+                print(template_str, file=dest)
+        else:
+            print(template_str)
 
     @staticmethod
     def __progress_str(progress):

--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -1,9 +1,16 @@
+
+import json
+from typing import Any
+
 from apps.appsmanager import AppsManager
 from golem.core.deferred import sync_wait
 
 from golem.interface.command import doc, group, command, Argument, CommandResult
 from golem.interface.client.logic import AppLogic
 from golem.resource.dirmanager import DirManager
+
+# For type annotations:
+from golem.client import Client  # pylint: disable=unused-import
 
 
 class CommandAppLogic(AppLogic):
@@ -27,9 +34,9 @@ class CommandAppLogic(AppLogic):
 
 
 @group(help="Manage tasks")
-class Tasks(object):
+class Tasks:
 
-    client = None
+    client = None  # type: Client
 
     task_table_headers = ['id', 'remaining', 'subtasks', 'status', 'completion']
     subtask_table_headers = ['node', 'id', 'remaining', 'status', 'completion']
@@ -132,6 +139,15 @@ class Tasks(object):
         deferred = Tasks.client.resume_task(id)
         return sync_wait(deferred)
 
+    @command(argument=file_name, help="""
+        Create a task from file.
+        Note: no client-side validation is performed yet.
+        This will change in the future
+    """)
+    def create(self, file_name: str) -> Any:
+        with open(file_name) as f:
+            self.create_from_json(f.read())
+
     @doc("Show statistics for tasks")
     def stats(self):
         deferred = Tasks.client.get_task_stats()
@@ -145,9 +161,14 @@ class Tasks(object):
             return progress
         return '{:.2f} %'.format(progress * 100.0)
 
+    def create_from_json(self, jsondata: str) -> Any:
+        dictionary = json.loads(jsondata)
+        deferred = Tasks.client.create_task(dictionary)
+        return sync_wait(deferred)
+
 
 @group(help="Manage subtasks")
-class Subtasks(object):
+class Subtasks:
 
     client = None
 

--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -1,10 +1,11 @@
 
 import json
-from typing import Any
+from typing import Any, Optional
 
 from apps.appsmanager import AppsManager
-from golem.core.deferred import sync_wait
+from apps.core.task.coretaskstate import TaskDefinition
 
+from golem.core.deferred import sync_wait
 from golem.interface.command import doc, group, command, Argument, CommandResult
 from golem.interface.client.logic import AppLogic
 from golem.resource.dirmanager import DirManager
@@ -59,6 +60,11 @@ class Tasks:
     file_name = Argument(
         'file_name',
         help="Task file"
+    )
+    outfile = Argument(
+        'outfile',
+        help="Output file",
+        optional=True,
     )
     skip_test = Argument(
         '--skip-test',
@@ -147,6 +153,17 @@ class Tasks:
     def create(self, file_name: str) -> Any:
         with open(file_name) as f:
             self.create_from_json(f.read())
+
+    @command(argument=outfile, help="Dump a task template")
+    def template(self, outfile: Optional[str]) -> Any:
+        template = TaskDefinition()
+        template_str = json.dumps(template.to_dict(), indent=4)
+
+        if outfile:
+            with open(outfile, 'w') as dest:
+                print(template_str, file=dest)
+        else:
+            print(template_str)
 
     @doc("Show statistics for tasks")
     def stats(self):

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -59,7 +59,7 @@ class TempDirFixture(unittest.TestCase):
             sleep(3)
             self.__remove_files()
 
-    def temp_file_name(self, name):
+    def temp_file_name(self, name: str) -> str:
         return path.join(self.tempdir, name)
 
     def additional_dir_content(self, file_num_list, dir_=None, results=None,

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -1,4 +1,5 @@
 import json
+import io
 import unittest
 import uuid
 from collections import namedtuple
@@ -420,6 +421,24 @@ class TestTasks(TempDirFixture):
             with patch(patched_open, mock_open(read_data='{}')):
                 tasks.create("foo")
                 client.create_task.assert_called_with(json.loads('{}'))
+
+    def test_template(self) -> None:
+        with patch('sys.stdout', io.StringIO()) as mock_io:
+            tasks = Tasks()
+            tasks.template(None)
+            output = mock_io.getvalue()
+
+            self.assertIn("bid", output)
+            self.assertIn("0.0", output)
+            self.assertIn('"subtask_timeout": "0:00:00"', output)
+
+            self.assertEqual(json.loads(output), TaskDefinition().to_dict())
+
+            temp = self.temp_file_name("test_template")
+            tasks.template(temp)
+            with open(temp) as f:
+                content = f.read()
+                self.assertEqual(content, output)
 
     def test_show(self):
         client = self.client

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -423,22 +423,31 @@ class TestTasks(TempDirFixture):
                 client.create_task.assert_called_with(json.loads('{}'))
 
     def test_template(self) -> None:
+        tasks = Tasks()
+
         with patch('sys.stdout', io.StringIO()) as mock_io:
-            tasks = Tasks()
             tasks.template(None)
             output = mock_io.getvalue()
 
-            self.assertIn("bid", output)
-            self.assertIn("0.0", output)
-            self.assertIn('"subtask_timeout": "0:00:00"', output)
+        self.assertIn("bid", output)
+        self.assertIn("0.0", output)
+        self.assertIn('"subtask_timeout": "0:00:00"', output)
 
-            self.assertEqual(json.loads(output), TaskDefinition().to_dict())
+        self.assertEqual(json.loads(output), TaskDefinition().to_dict())
 
-            temp = self.temp_file_name("test_template")
-            tasks.template(temp)
-            with open(temp) as f:
-                content = f.read()
-                self.assertEqual(content, output)
+        temp = self.temp_file_name("test_template")
+        tasks.template(temp)
+        with open(temp) as f:
+            content = f.read()
+            self.assertEqual(content, output)
+
+        with client_ctx(Tasks, self.client):
+            Tasks.client.get_task.return_value = TaskDefinition().to_dict()
+            tasks.dump('id', temp)
+
+        with open(temp) as f:
+            content_dump = f.read()
+            self.assertEqual(content, content_dump)
 
     def test_show(self):
         client = self.client

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -1,5 +1,4 @@
 import json
-import os
 import unittest
 import uuid
 from collections import namedtuple
@@ -8,14 +7,9 @@ from contextlib import contextmanager
 from ethereum.utils import denoms
 from mock import Mock, mock_open, patch
 
-from apps.blender.task.blenderrendertask import BlenderRendererOptions, \
-    BlenderRenderTask
-from apps.rendering.task.renderingtaskstate import RenderingTaskDefinition
-from apps.core.task.coretask import CoreTaskBuilder
 from apps.core.task.coretaskstate import TaskDefinition
 from golem.appconfig import AppConfig, MIN_MEMORY_SIZE
 from golem.clientconfigdescriptor import ClientConfigDescriptor
-from golem.core.simpleserializer import DictSerializer
 from golem.interface.client.account import account
 from golem.interface.client.debug import Debug
 from golem.interface.client.environments import Environments
@@ -414,9 +408,7 @@ class TestTasks(TempDirFixture):
 
         definition = TaskDefinition()
         definition.task_name = "The greatest task ever!"
-        # FIXME: use .to_dict() when #1329 gets merged
-        def_dict = CoreTaskBuilder.build_dictionary(definition)
-        def_str = json.dumps(def_dict)
+        def_str = json.dumps(definition.to_dict())
 
         with client_ctx(Tasks, client):
             tasks = Tasks()


### PR DESCRIPTION
Linter report:
```
Comparing 78597ff2...31591663
pylint main...      OK
pylint tests...     OK
pycodestyle...      OK
mypy...             OK
```

Need to be merged first:
- [x] #1254 should be certainly merged first.
- [x] #1329 - I'm using the `to_dict` method