### PR TITLE
Move the linter tests to Shippable CI.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -19,8 +19,8 @@ dependencies:
   pre:
     - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
     - sudo add-apt-repository -y ppa:ethereum/ethereum && sudo apt-get update
-    - sudo apt-get install -y qt5-default qtbase5-dev-tools geth unzip gcc-5 g++-5 libfreeimage3 libfreeimage-dev colordiff
-    - cd apps/rendering/resources/taskcollector && make && cd ../../../../..
+    - sudo apt-get install -y qt5-default qtbase5-dev-tools geth unzip gcc-5 g++-5 libfreeimage3 libfreeimage-dev
+    - make -C apps/rendering/resources/taskcollector
 
     - pip3 install six
     - pip3 install -r requirements.txt
@@ -42,10 +42,6 @@ test:
   pre:
     - pip3 install coverage codecov
   override:
-    - ./lintdiff.sh pylint --disable=R apps golem gui scripts setup_util '*.py' || echo "pylint failed"
-    - ./lintdiff.sh pylint --disable=R,protected-access tests || echo "pylint for tests failed"
-    - ./lintdiff.sh pycodestyle || echo "pycodestyle failed"
-    - ./lintdiff.sh mypy apps golem gui scripts setup_util tests '*.py' || echo "mypy failed"
     - python3 -m coverage run --branch --source=. setup.py test -a "--junitxml=$CIRCLE_TEST_REPORTS/test_result.xml":
         timeout: 1200
   post:

--- a/lint.sh
+++ b/lint.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+# a more basic version of lint.sh from marmistrz/lintdiff
+
+hline() {
+    printf %"$COLUMNS"s | tr " " "-"
+}
+
+usage() {
+    echo "Usage: $0 <reference-branch>"
+}
+
+case $# in
+    1)
+        if [ "$1" == "-h" ]; then
+            usage
+            exit 0
+        else
+            BRANCH="$1"
+        fi
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac
+
+RED=$(
+    tput bold
+    tput setaf 1
+) 2>/dev/null
+GREEN=$(
+    tput bold
+    tput setaf 2
+) 2>/dev/null
+RESET=$(tput sgr0) 2>/dev/null
+
+nfailed=0
+
+status() {
+    if [ "$1" -eq 0 ]; then
+        echo "${GREEN}OK${RESET}"
+    else
+        echo "${RED}FAIL${RESET}"
+    fi
+}
+
+LINTDIFF="./lintdiff.sh -o -b $BRANCH"
+
+commands=(
+    "$LINTDIFF pylint --disable=R apps golem gui scripts setup_util '*.py'"
+    "$LINTDIFF pylint --disable=R,protected-access tests"
+    "$LINTDIFF pycodestyle"
+    "$LINTDIFF mypy apps golem gui scripts setup_util tests '*.py'"
+)
+
+names=(
+    "pylint main"
+    "pylint tests"
+    "pycodestyle"
+    "mypy"
+)
+
+cur_hash=$(git rev-parse --short HEAD)
+ref_hash=$(git rev-parse --short "$BRANCH")
+
+echo "Comparing $ref_hash...$cur_hash"
+
+for i in "${!names[@]}"; do
+    printf "%-20s" "${names[$i]}..."
+    outputs[$i]=$(${commands[$i]} 2>&1)
+    exitcode[$i]=$?
+    status ${exitcode[$i]}
+done
+
+for i in "${!names[@]}"; do
+    if [ ${exitcode[$i]} -ne 0 ]; then
+        let "nfailed++"
+
+        hline
+        echo "${names[$i]} failed, output:"
+        echo -e "\n"
+        echo "${outputs[$i]}"
+        hline
+    fi
+done
+
+if [ $nfailed -gt 0 ]; then
+    echo "Errors occurred, summary:"
+    for i in "${!names[@]}"; do
+        printf "%-20s" "${names[$i]}..."
+        status ${exitcode[$i]}
+    done
+fi

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -57,17 +57,17 @@ fi
 
 cleanup_artifacts() {
     git reset --hard HEAD
-    git checkout "$CURRENT_BRANCH" || exit 1
+    git checkout "$CURRENT_BRANCH" -- || exit 1
 }
 
 # we checkout the reference branch first in case there are
 # uncommitted changes to be overwritten by the merge
-git checkout "$REF_BRANCH" || exit 1
+git checkout "$REF_BRANCH" -- || exit 1
 trap cleanup_artifacts EXIT
 commit=$(git rev-parse HEAD)
 # We need to take files responsible for the linting configuration from
 # the new commit.
-git checkout "$CURRENT_BRANCH" .pylintrc setup.cfg
+git checkout "$CURRENT_BRANCH" -- .pylintrc setup.cfg
 echo "Checking branch $REF_BRANCH, commit: $commit..."
 echo $@
 $@ >$REF_OUT
@@ -75,7 +75,7 @@ check_errcode $?
 
 # Now take back the checked out config, go back to the new branch
 git reset --hard HEAD
-git checkout "$CURRENT_BRANCH" || exit 1
+git checkout "$CURRENT_BRANCH" -- || exit 1
 # The trap is no longer needed
 trap - EXIT
 commit=$(git rev-parse HEAD)

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,19 @@
+language: python
+
+python:
+  - 3.5
+
+install:
+  - sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+  - sudo add-apt-repository -y ppa:ethereum/ethereum && sudo apt-get update
+  - sudo apt-get install -y qt5-default qtbase5-dev-tools geth unzip gcc-5 g++-5 libfreeimage3 libfreeimage-dev
+  - pip3 install six
+  - pip3 install -r requirements.txt
+  - pip3 install -r requirements-lint.txt
+  - make -C apps/rendering/resources/taskcollector
+
+script:
+  - git checkout -b shippable-lint  # Shippable doesn't make a branch for us, unlike CircleCI
+  - git merge origin/develop        # Update the changes from develop to avoid false positives
+  - ./lint.sh origin/develop        # Run all the checks. We can't just enumerate them here,
+                                    # because the CI aborts the job after first failure


### PR DESCRIPTION
Additionally, fix a minor bug of git refusing to switch branches when the branch name is the same as a file name (or similar, in this case `git checkout shippable`)

At some point it would be nice to replace the embedded lintdiff with just a submodule from here: https://github.com/marmistrz/lintdiff

A non-trivial to fix issue is that if one linter check fails, the subsequent are not run (the whole CI aborts). I didn't find a trivial way to change it and I have to focus on other tasks. @maaktweluit let me know if you have any idea.
