### PR TITLE
Workaround for SEGFAULT during tests

### DIFF
--- a/tests/apps/core/gui/controller/test_newtaskdialogcustomizer.py
+++ b/tests/apps/core/gui/controller/test_newtaskdialogcustomizer.py
@@ -1,4 +1,5 @@
 import re
+import readline # workaround for issue #1338
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtTest import QTest


### PR DESCRIPTION
This is a workaround for issue #1338

Apparently importing readline after opening a QDialog causes a segfault,
but not if readline was already imported before.

This should prevent this from happening during tests by importing readline at the beginning of `test_newtaskdialogcustomizer.py`, before any QDialogs are created.