### PR TITLE
Limit the number of task headers per requestor in taskkeeper

### DIFF
--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -171,7 +171,8 @@ class TaskHeaderKeeper(object):
             min_price=0.0,
             app_version=APP_VERSION,
             remove_task_timeout=180,
-            verification_timeout=3600):
+            verification_timeout=3600,
+            max_tasks_per_requestor=10):
         # all computing tasks that this node knows about
         self.task_headers = {}
         # ids of tasks that this node may try to compute
@@ -181,12 +182,15 @@ class TaskHeaderKeeper(object):
         # tasks that were removed from network recently, so they won't
         # be added again to task_headers
         self.removed_tasks = {}
+        # task ids by owner
+        self.tasks_by_owner = {}
 
         self.min_price = min_price
         self.app_version = app_version
         self.verification_timeout = verification_timeout
         self.removed_task_timeout = remove_task_timeout
         self.environments_manager = environments_manager
+        self.max_tasks_per_requestor = max_tasks_per_requestor
 
     def check_support(self, th_dict_repr) -> SupportStatus:
         """Checks if task described with given task header dict
@@ -335,7 +339,11 @@ class TaskHeaderKeeper(object):
                 raise TypeError(err)
 
             if id_ not in list(self.removed_tasks.keys()):  # not recent
-                self.task_headers[id_] = TaskHeader.from_dict(th_dict_repr)
+                th = TaskHeader.from_dict(th_dict_repr)
+                self.task_headers[id_] = th
+
+                self._get_tasks_by_owner_set(th.task_owner_key_id).add(id_)
+
                 support = self.check_support(th_dict_repr)
                 self.support_status[id_] = support
 
@@ -350,16 +358,46 @@ class TaskHeaderKeeper(object):
                     )
                     self.supported_tasks.append(id_)
 
+                self.check_max_tasks_per_owner(th.task_owner_key_id)
+
             return True
         except (KeyError, TypeError) as err:
             logger.warning("Wrong task header received {}".format(err))
             return False
 
+    def _get_tasks_by_owner_set(self, owner_key_id):
+        if owner_key_id not in self.tasks_by_owner:
+            self.tasks_by_owner[owner_key_id] = set()
+
+        return self.tasks_by_owner[owner_key_id]
+
+    def check_max_tasks_per_owner(self, owner_key_id):
+        owner_task_set = self._get_tasks_by_owner_set(owner_key_id)
+
+        if len(owner_task_set) <= self.max_tasks_per_requestor:
+            return
+
+        by_age = sorted(owner_task_set,
+                        key=lambda tid: self.task_headers[tid].last_checking)
+
+        # leave alone the first (oldest) max_tasks_per_requestor
+        # headers, remove the rest
+        to_remove = by_age[self.max_tasks_per_requestor:]
+
+        logger.warning("Too many tasks from %s, dropping %d tasks",
+                       owner_key_id, len(to_remove))
+
+        for tid in to_remove:
+            self.remove_task_header(tid)
+
     def remove_task_header(self, task_id):
         """ Removes task with given id from a list of known task headers.
         """
         if task_id in self.task_headers:
+            owner_key_id = self.task_headers[task_id].task_owner_key_id
             del self.task_headers[task_id]
+            if owner_key_id in self.tasks_by_owner:
+                self.tasks_by_owner[owner_key_id].discard(task_id)
         if task_id in self.supported_tasks:
             self.supported_tasks.remove(task_id)
         if task_id in self.support_status:

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -248,6 +248,7 @@ class TestTaskHeaderKeeper(LogTestCase):
         for i in range(1, limit):
             thd = get_dict_task_header("ta%d" % i)
             tk.add_task_header(thd)
+        last_add_time = time.time()
 
         for i in range(limit):
             self.assertIn("ta%d" % i, tk.task_headers)
@@ -260,6 +261,9 @@ class TestTaskHeaderKeeper(LogTestCase):
             self.assertIn("ta%d" % i, tk.task_headers)
 
         self.assertIn("tb0", tk.task_headers)
+
+        while time.time() == last_add_time:
+            time.sleep(0.1)
 
         thd = get_dict_task_header("ta%d" % limit)
         tk.add_task_header(thd)

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -211,31 +211,43 @@ class TestTaskHeaderKeeper(LogTestCase):
         correct, err = tk.is_correct(th)
         assert correct
         assert err is None
+        tk.check_correct(th)  # shouldn't raise
 
         th['deadline'] = datetime.now()
         correct, err = tk.is_correct(th)
         assert not correct
         assert err == "Deadline is not a timestamp"
+        with self.assertRaisesRegex(TypeError, "Deadline is not a timestamp"):
+            tk.check_correct(th)
 
         th['deadline'] = get_timestamp_utc() - 10
         correct, err = tk.is_correct(th)
         assert not correct
         assert err == "Deadline already passed"
+        with self.assertRaisesRegex(TypeError, "Deadline already passed"):
+            tk.check_correct(th)
 
         th['deadline'] = get_timestamp_utc() + 20
         correct, err = tk.is_correct(th)
         assert correct
         assert err is None
+        tk.check_correct(th)  # shouldn't raise
 
         th['subtask_timeout'] = "abc"
         correct, err = tk.is_correct(th)
         assert not correct
         assert err == "Subtask timeout is not a number"
+        with self.assertRaisesRegex(TypeError,
+                                    "Subtask timeout is not a number"):
+            tk.check_correct(th)
 
         th['subtask_timeout'] = -131
         correct, err = tk.is_correct(th)
         assert not correct
         assert err == "Subtask timeout is less than 0"
+        with self.assertRaisesRegex(TypeError,
+                                    "Subtask timeout is less than 0"):
+            tk.check_correct(th)
 
     def test_task_limit(self):
         tk = TaskHeaderKeeper(EnvironmentsManager(), 10)
@@ -284,6 +296,55 @@ class TestTaskHeaderKeeper(LogTestCase):
         for i in range(1, limit):
             self.assertIn("ta%d" % i, tk.task_headers)
         self.assertIn("tb0", tk.task_headers)
+
+    def test_check_max_tasks_per_owner(self):
+        tk = TaskHeaderKeeper(EnvironmentsManager(), 10,
+                              max_tasks_per_requestor=10)
+        limit = tk.max_tasks_per_requestor
+        new_limit = 3
+
+        for i in range(new_limit):
+            thd = get_dict_task_header("ta%d" % i)
+            tk.add_task_header(thd)
+        last_add_time = time.time()
+
+        thd = get_dict_task_header("tb0")
+        thd["task_owner_key_id"] = "zzzz"
+        tk.add_task_header(thd)
+
+        for i in range(new_limit):
+            self.assertIn("ta%d" % i, tk.task_headers)
+        self.assertIn("tb0", tk.task_headers)
+
+        while time.time() == last_add_time:
+            time.sleep(0.1)
+
+        for i in range(new_limit, limit):
+            thd = get_dict_task_header("ta%d" % i)
+            tk.add_task_header(thd)
+
+        for i in range(limit):
+            self.assertIn("ta%d" % i, tk.task_headers)
+        self.assertIn("tb0", tk.task_headers)
+        self.assertEqual(limit + 1, len(tk.task_headers))
+
+        # shouldn't remove any tasks
+        tk.check_max_tasks_per_owner(thd['task_owner_key_id'])
+
+        for i in range(limit):
+            self.assertIn("ta%d" % i, tk.task_headers)
+        self.assertIn("tb0", tk.task_headers)
+        self.assertEqual(limit + 1, len(tk.task_headers))
+
+        tk.max_tasks_per_requestor = new_limit
+
+        # should remove ta{3..9}
+        tk.check_max_tasks_per_owner(thd['task_owner_key_id'])
+
+        for i in range(new_limit):
+            self.assertIn("ta%d" % i, tk.task_headers)
+        self.assertIn("tb0", tk.task_headers)
+        self.assertEqual(new_limit + 1, len(tk.task_headers))
 
 
 def get_dict_task_header(task_id="xyz"):


### PR DESCRIPTION
This implements (part of) #665