### PR TITLE
Fix lint.sh not returning an error code.

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -90,4 +90,5 @@ if [ $nfailed -gt 0 ]; then
         printf "%-20s" "${names[$i]}..."
         status ${exitcode[$i]}
     done
+    exit 1
 fi


### PR DESCRIPTION
This made shippable builds always pass.