### PR TITLE
Fix create_from_json being displayed in golemcli.

### DIFF
--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -152,7 +152,7 @@ class Tasks:
     """)
     def create(self, file_name: str) -> Any:
         with open(file_name) as f:
-            self.create_from_json(f.read())
+            self.__create_from_json(f.read())
 
     @command(arguments=(id_req, outfile), help="Dump an existing task")
     def dump(self, id: str, outfile: Optional[str]) -> None:
@@ -186,7 +186,7 @@ class Tasks:
             return progress
         return '{:.2f} %'.format(progress * 100.0)
 
-    def create_from_json(self, jsondata: str) -> Any:
+    def __create_from_json(self, jsondata: str) -> Any:
         dictionary = json.loads(jsondata)
         # FIXME CHANGE TASKI ID
         dictionary['id'] = str(uuid4())

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -415,7 +415,7 @@ class TestTasks(TempDirFixture):
 
         with client_ctx(Tasks, client):
             tasks = Tasks()
-            tasks.create_from_json(def_str)
+            tasks._Tasks__create_from_json(def_str)
             task_def = json.loads(def_str)
             task_def['id'] = "new_uuid"
             client.create_task.assert_called_with(task_def)


### PR DESCRIPTION
It appeared that not only functions annotated with `@command` 
are shown in golemcli. Should I raise a bug report?

Alternatively, we can add `create_from_json` to allow creating a task without creating a file.
