### PR TITLE
Added durations and maxfail to each unit test platform

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_install:
   - export ARG_RUNSLOW=$(python3 scripts/get-slow-argument.py ${TRAVIS_PULL_REQUEST})
 
 script:
-  - python3 -m pytest --cov=golem${ARG_RUNSLOW}
+  - python3 -m pytest --cov=golem --durations=5 --maxfail=3 -rxs${ARG_RUNSLOW}
   - if [ -z "${ARG_RUNSLOW}" ]; then echo "Not enough approvals."; exit 1; fi
 
 after_success:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -100,8 +100,8 @@ build_script:
 
 test_script:
   - venv\Scripts\activate.bat
-  - if NOT defined ARG_RUNSLOW pytest --cov=golem && echo "Not enough approvals." && exit 1
-  - if defined ARG_RUNSLOW pytest --cov=golem --runslow
+  - if NOT defined ARG_RUNSLOW pytest --cov=golem --durations=5 --maxfail=3 -rxs && echo "Not enough approvals." && exit 1
+  - if defined ARG_RUNSLOW pytest --cov=golem --durations=5 --maxfail=3 -rxs --runslow
 
 after_test:
   - venv\Scripts\activate.bat

--- a/circle.yml
+++ b/circle.yml
@@ -51,7 +51,7 @@ test:
   pre:
     - pip3 install coverage codecov
   override:
-    - python3 -m coverage run --branch --source=. setup.py test -a "-rxs --junitxml=${CIRCLE_TEST_REPORTS}/test_result.xml${ARG_RUNSLOW}":
+    - python3 -m coverage run --branch --source=. setup.py test -a "--durations=5 --maxfail=3 -rxs --junitxml=${CIRCLE_TEST_REPORTS}/test_result.xml${ARG_RUNSLOW}":
         timeout: 1200
     - if [[ -z "${ARG_RUNSLOW}" ]]; then echo "Not enough approvals."; exit 1; fi
   post:


### PR DESCRIPTION
After investigation on all possible `pytest` arguments these where picked as handy low hanging fruit.

Added:
- Durations -> shows the slowest X tests when finished
- Maxfail -> exits test when the Xth test failed, to free up the queue
- Verbose skipping and failing