### PR TITLE
Move linux unit tests to buildbot

### DIFF
--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
@@ -136,10 +136,7 @@ class StepsFactory(object):
                     logfile='stop hyperg',
                     haltOnFailure=True,
                     command=['scripts/test-daemon-stop.sh']),
-            ],
-            env={
-                'LANG': 'en_US.UTF-8',  # required for some tests
-            })
+            ])
 
 
 class WindowsStepsFactory(StepsFactory):

--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
@@ -19,8 +19,8 @@ class StepsFactory(object):
 
     def git_step(self):
         return steps.Git(
-            repourl='https://github.com/maaktweluit/golem.git',
-            mode='full', method='fresh', branch='no_gui-bb')
+            repourl='https://github.com/golemfactory/golem.git',
+            mode='full', method='fresh')
 
     def venv_step(self):
         return steps.ShellCommand(

--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
@@ -19,8 +19,8 @@ class StepsFactory(object):
 
     def git_step(self):
         return steps.Git(
-            repourl='https://github.com/golemfactory/golem.git',
-            mode='full', method='fresh')
+            repourl='https://github.com/maaktweluit/golem.git',
+            mode='full', method='fresh', branch='no_gui')
 
     def venv_step(self):
         return steps.ShellCommand(
@@ -38,6 +38,10 @@ class StepsFactory(object):
         return steps.ShellSequence(
             name='pip',
             commands=[
+                util.ShellArg(
+                    logfile='install wheel',
+                    haltOnFailure=True,
+                    command=self.pip_command + ['install', 'wheel']),
                 util.ShellArg(
                     logfile='upgrade pip',
                     haltOnFailure=True,
@@ -79,8 +83,61 @@ class StepsFactory(object):
                 platform=self.platform,
                 ext=self.golem_package_extension),
             blocksize=640 * 1024,
-            mode=0644,
+            mode=0o644,
         )
+
+    def test_factory(self):
+        factory = util.BuildFactory()
+        factory.addStep(self.git_step())
+        factory.addStep(self.venv_step())
+        factory.addStep(self.requirements_step())
+        factory.addStep(self.test_step())
+        return factory
+
+    def test_step(self):
+        install_req_cmd = self.pip_command + ['install', '-r',
+                                              'requirements-test.txt']
+
+        return steps.ShellSequence(
+            name='run tests',
+            commands=[
+                util.ShellArg(
+                    logfile='install requirements',
+                    haltOnFailure=True,
+                    command=install_req_cmd),
+                # TODO: move to requirements itself?
+                util.ShellArg(
+                    logfile='install missing requirement',
+                    haltOnFailure=True,
+                    command=self.pip_command + ['install', 'pyasn1==0.2.3',
+                                                'coverage', 'codecov']),
+                util.ShellArg(
+                    logfile='prepare for test',
+                    haltOnFailure=True,
+                    command=self.python_command + ['setup.py', 'develop']),
+                util.ShellArg(
+                    logfile='start hyperg',
+                    haltOnFailure=True,
+                    command=['scripts/test-deamon-start.sh']),
+                # TODO: add xml results
+                # TODO 2: add run slow
+                util.ShellArg(
+                    logfile='run tests',
+                    command=self.python_command + ['-m', 'coverage', 'run',
+                                                   '--branch', '--source=.',
+                                                   'setup.py', 'test',
+                                                   '-a', '"-rxs --runslow"']),
+                util.ShellArg(
+                    logfile='handle coverage',
+                    command=self.python_command + ['-m', 'codecov']),
+                util.ShellArg(
+                    logfile='stop hyperg',
+                    haltOnFailure=True,
+                    command=['scripts/test-deamon-stop.sh']),
+            ],
+            env={
+                'LANG': 'en_US.UTF-8',  # required for some tests
+            })
 
 
 class WindowsStepsFactory(StepsFactory):
@@ -160,6 +217,9 @@ builders = [
     util.BuilderConfig(name="buildpackage_macOS",
         workernames=["macOS"],
         factory=MacOsStepsFactory().build_factory()),
+    util.BuilderConfig(name="unittest_linux",
+        workernames=["linux"],
+        factory=LinuxStepsFactory().test_factory()),
     util.BuilderConfig(name="buildpackage_linux",
         workernames=["linux"],
         factory=LinuxStepsFactory().build_factory()),

--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
@@ -20,7 +20,7 @@ class StepsFactory(object):
     def git_step(self):
         return steps.Git(
             repourl='https://github.com/maaktweluit/golem.git',
-            mode='full', method='fresh', branch='no_gui')
+            mode='full', method='fresh', branch='no_gui-bb')
 
     def venv_step(self):
         return steps.ShellCommand(
@@ -110,7 +110,7 @@ class StepsFactory(object):
                     logfile='install missing requirement',
                     haltOnFailure=True,
                     command=self.pip_command + ['install', 'pyasn1==0.2.3',
-                                                'coverage', 'codecov']),
+                                                'codecov', 'pytest-cov']),
                 util.ShellArg(
                     logfile='prepare for test',
                     haltOnFailure=True,
@@ -118,22 +118,24 @@ class StepsFactory(object):
                 util.ShellArg(
                     logfile='start hyperg',
                     haltOnFailure=True,
-                    command=['scripts/test-deamon-start.sh']),
+                    command=['scripts/test-daemon-start.sh']),
                 # TODO: add xml results
                 # TODO 2: add run slow
                 util.ShellArg(
                     logfile='run tests',
-                    command=self.python_command + ['-m', 'coverage', 'run',
-                                                   '--branch', '--source=.',
-                                                   'setup.py', 'test',
-                                                   '-a', '"-rxs --runslow"']),
+                    warnOnFailure=True,
+                    command=self.python_command + ['-m', 'pytest',
+                                                   '--cov=golem',
+                                                   '--durations=5',
+                                                   '-rxs', '--runslow']),
                 util.ShellArg(
                     logfile='handle coverage',
+                    warnOnFailure=True,
                     command=self.python_command + ['-m', 'codecov']),
                 util.ShellArg(
                     logfile='stop hyperg',
                     haltOnFailure=True,
-                    command=['scripts/test-deamon-stop.sh']),
+                    command=['scripts/test-daemon-stop.sh']),
             ],
             env={
                 'LANG': 'en_US.UTF-8',  # required for some tests

--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/schedulers.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/schedulers.py
@@ -7,6 +7,7 @@ schedulers = [
         treeStableTimer=20,
         builderNames=[
             'buildpackage_macOS',
+            'unittest_linux',
             'buildpackage_linux',
             'buildpackage_windows',
         ]),
@@ -14,6 +15,7 @@ schedulers = [
         name='force',
         builderNames=[
             'buildpackage_macOS',
+            'unittest_linux',
             'buildpackage_linux',
             'buildpackage_windows',
         ]),

--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/www.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/www.py
@@ -6,16 +6,13 @@ from .settings import local_settings
 www = dict(
     port=8010,
     plugins=dict(waterfall_view={}, console_view={}),
-    auth=util.GitHubAuth(
-        local_settings['github_client_id'],
-        local_settings['github_client_secret'],
-        apiVersion=4, getTeamsMembership=True),
+    auth=util.UserPasswordAuth({'maaktweluit@gmail.com': local_settings['worker_pass']}),
     authz=util.Authz(
         allowRules=[
-            util.AnyControlEndpointMatcher(role="golem"),
+            util.AnyControlEndpointMatcher(role="admins"),
         ],
         roleMatchers=[
-            util.RolesFromGroups(groupPrefix='golemfactory/')
+            util.RolesFromEmails(admins=local_settings['admin_emails'])
         ]),
     change_hook_dialects={
         'github': {

--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/www.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/www.py
@@ -2,18 +2,35 @@ from buildbot.plugins import util
 
 from .settings import local_settings
 
+# Testing auth for local instances
+# _auth = util.UserPasswordAuth({'tst@mail.com': local_settings['worker_pass']})
+# _authz = util.Authz(
+#     allowRules=[
+#         util.AnyControlEndpointMatcher(role="admins")
+#     ],
+#     roleMatchers=[
+#         util.RolesFromEmails(admins=local_settings['admin_emails'])
+#     ])
+
+
+_auth = util.GitHubAuth(local_settings['github_client_id'],
+                        local_settings['github_client_secret'],
+                        apiVersion=4, getTeamsMembership=True)
+
+_authz = util.Authz(
+    allowRules=[
+        util.AnyControlEndpointMatcher(role="golem")
+    ],
+    roleMatchers=[
+        util.RolesFromGroups(groupPrefix='golemfactory/')
+    ])
+
 
 www = dict(
     port=8010,
     plugins=dict(waterfall_view={}, console_view={}),
-    auth=util.UserPasswordAuth({'maaktweluit@gmail.com': local_settings['worker_pass']}),
-    authz=util.Authz(
-        allowRules=[
-            util.AnyControlEndpointMatcher(role="admins"),
-        ],
-        roleMatchers=[
-            util.RolesFromEmails(admins=local_settings['admin_emails'])
-        ]),
+    auth=_auth,
+    authz=_authz,
     change_hook_dialects={
         'github': {
             'strict': True,

--- a/scripts/ci/roles/buildbot-worker-linux/tasks/main.yml
+++ b/scripts/ci/roles/buildbot-worker-linux/tasks/main.yml
@@ -66,12 +66,28 @@
     src: https://github.com/mfranciszkiewicz/golem-hyperdrive/releases/download/v0.2.1/hyperg_0.2.1_linux-x64.tar.gz
     dest: /opt
     remote_src: yes
+  creates: /opt/hyperg
 
 
 - name: Link hyperg
   file:
     src: /opt/hyperg/hyperg
     dest: /usr/local/bin/hyperg
+    state: link
+
+
+- name: Install ipfs
+  unarchive:
+    src: https://dist.ipfs.io/go-ipfs/v0.4.5/go-ipfs_v0.4.5_linux-amd64.tar.gz
+    dest: /opt
+    remote_src: yes
+  creates: /opt/go-ipfs
+
+
+- name: Link ipfs
+  file:
+    src: /opt/go-ipfs/ipfs
+    dest: /usr/local/bin/ipfs
     state: link
 
 
@@ -87,6 +103,14 @@
     groups: 
       - docker
     home: /home/buildbot-worker
+
+
+- name: Init ipfs
+  command: ipfs init
+  become_user: buildbot-worker
+  args:
+    creates: /home/buildbot-worker/.ipfs
+
 
 - name: instll golemapp dependencies
   apt:

--- a/scripts/ci/roles/buildbot-worker-linux/tasks/main.yml
+++ b/scripts/ci/roles/buildbot-worker-linux/tasks/main.yml
@@ -3,17 +3,93 @@
     name: site_settings
 
 
-- group:
+- name: Install docker-ce dependencies
+  apt:
+    name: "{{ item }}"
+    update_cache: yes
+  with_items:
+    - software-properties-common
+    - apt-transport-https
+    - ca-certificates
+    - curl
+
+
+- name: Install docker-ce key
+  apt_key:
+    url: "https://download.docker.com/linux/ubuntu/gpg"
+
+
+- debug:
+    msg: "TODO purge all other docker repositories"
+
+
+- name: Add docker repo, 64bit ONLY!
+  apt_repository:
+    repo: "deb [arch=amd64] https://download.docker.com/linux/ubuntu {{ ansible_lsb['codename'] }} stable"
+
+
+- name: Install docker-ce
+  apt:
+    name: docker-ce
+    update_cache: yes
+
+
+- name: Add GETH repo
+  apt_repository:
+    repo: "ppa:ethereum/ethereum"
+
+
+- name: Install GETH
+  apt:
+    name: ethereum
+    update_cache: yes
+
+
+- name: Install taskcollector dependencies
+  apt:
+    name: "{{item}}"
+  with_items:
+    - gcc-5 
+    - g++-5 
+    - libfreeimage3 
+    - libfreeimage-dev
+
+
+- name: Prepare hyperg directory
+  file:
+    dest: /opt
+    state: directory
+
+
+- name: Install hyperg
+  unarchive:
+    src: https://github.com/mfranciszkiewicz/golem-hyperdrive/releases/download/v0.2.1/hyperg_0.2.1_linux-x64.tar.gz
+    dest: /opt
+    remote_src: yes
+
+
+- name: Link hyperg
+  file:
+    src: /opt/hyperg/hyperg
+    dest: /usr/local/bin/hyperg
+    state: link
+
+
+- name: setup buildbot-worker group
+  group:
     name: buildbot-worker
 
 
-- user:
+- name: setup buildbot-worker user
+  user:
     name: buildbot-worker
     group: buildbot-worker
+    groups: 
+      - docker
     home: /home/buildbot-worker
 
-
-- apt:
+- name: instll golemapp dependencies
+  apt:
     name: "{{ item }}"
   with_items:
     - python-pip

--- a/scripts/ci/roles/buildbot-worker-linux/tasks/main.yml
+++ b/scripts/ci/roles/buildbot-worker-linux/tasks/main.yml
@@ -112,7 +112,7 @@
     creates: /home/buildbot-worker/.ipfs
 
 
-- name: instll golemapp dependencies
+- name: install golemapp dependencies
   apt:
     name: "{{ item }}"
   with_items:

--- a/scripts/test-daemon-start.sh
+++ b/scripts/test-daemon-start.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+echo "Starting hyperg"
+hyperg > /dev/null 2>&1 &
+H_PID=$!
+
+echo $H_PID > ./.test-daemon-hyperg.pid
+
+echo "Starting ipfs"
+ipfs config --json Bootstrap "[]"
+ipfs config --json SupernodeRouting.Servers "[]"
+ipfs config --json Addresses.Swarm '["/ip6/::/tcp/4001", "/ip6/::/udp/4002/utp", "/ip4/0.0.0.0/udp/4002/utp"]'
+ipfs daemon > /dev/null 2>&1 &
+I_PID=$!
+
+echo $I_PID > ./.test-daemon-ipfs.pid
+
+exit 0

--- a/scripts/test-daemon-stop.sh
+++ b/scripts/test-daemon-stop.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+H_FILE=./.test-daemon-hyperg.pid
+H_PID=$(cat $H_FILE)
+rm $H_FILE || echo "Error, not able to delete '$H_FILE'" 
+
+kill $H_PID || echo "Error, not able to stop hyperg"
+
+
+I_FILE=./.test-daemon-ipfs.pid
+I_PID=$(cat $I_FILE)
+rm $I_FILE || echo "Error, not able to delete '$I_FILE'" 
+
+kill $I_PID || echo "Error, not able to stop ipfs"
+
+
+exit 0


### PR DESCRIPTION
First step in #1400 

Adds the linux unit tests to the buildbot:
- Installs the dependencies with ansible
- Adds `test_factory` with all test steps from circleci
- Needed test-daemon scripts, buildbot does not start background tasks

TODO:
- [x] When cancelling the build the daemons remain running, maybe kill on start as well?
- [x] Requires #1301 to be merged, else the tests will fail on the linux server based on error in the description.
- [ ] Upload coverage to s3, will setup a test account
- [x] Blender cycles test is failing, investigate and fix ( #1579 )