### PR TITLE
Use git version of devp2p w/ coincurve [WIP]

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 --extra-index-url https://builds.golem.network
+-e git+git://github.com/ethereum/pydevp2p.git@3b68d97741d675fdb7e916df1cedbe13caf835cb#egg=devp2p
 setuptools==34.3.3
 appdirs>=1.4
 click>=4.0
@@ -46,7 +47,6 @@ Automat==0.5.0
 zope.interface==4.3.3
 incremental==16.10.1
 OpenEXR
-devp2p==0.9.2
 PyQt5
 pycparser==2.17
 numpy==1.13.1

--- a/setup_util/setup_commons.py
+++ b/setup_util/setup_commons.py
@@ -210,7 +210,7 @@ def parse_requirements(my_path):
     dependency_links = []
     for line in open(path.join(my_path, 'requirements.txt')):
         line = line.strip()
-        if line.startswith('-') or line.startswith('#'):
+        if line.startswith('--extra-index-url') or line.startswith('#'):
             continue
 
         m = re.match('.+#egg=(?P<package>.+)$', line)


### PR DESCRIPTION
Currently, it is not possible to install this version of devp2p on Windows:
- `setup.py` may fail (pending PR: ethereum/pydevp2p#87)
- `miniupnpc` dependency wheels have not yet been uploaded to our package index; `miniupnpc` does not build out-of-the-box
- if the pending PR is merged, the commit version specified in `requirements.txt` should be changed