### PR TITLE
Fix tee-target deadlock

### DIFF
--- a/golem/ethereum/node.py
+++ b/golem/ethereum/node.py
@@ -157,8 +157,7 @@ class NodeProcess(object):
         log.info("Starting Ethereum node: `{}`".format(" ".join(args)))
         self.__ps = subprocess.Popen(args, stdout=subprocess.PIPE,
                                      stderr=subprocess.PIPE,
-                                     stdin=DEVNULL,
-                                     bufsize=-1)
+                                     stdin=DEVNULL)
 
         tee_kwargs = {
             'proc': self.__ps,

--- a/golem/ethereum/node.py
+++ b/golem/ethereum/node.py
@@ -165,8 +165,8 @@ class NodeProcess(object):
             'path': geth_log_path,
         }
         channels = (
-            ('geth-out', self.__ps.stderr, sys.stderr),
-            ('geth-err', self.__ps.stdout, sys.stdout),
+            ('GETH', self.__ps.stderr, sys.stderr),
+            ('GETHO', self.__ps.stdout, sys.stdout),
         )
         for prefix, in_, out in channels:
             tee_kwargs['prefix'] = prefix + ': '

--- a/golem/utils.py
+++ b/golem/utils.py
@@ -65,7 +65,7 @@ def encode_hex(b):
 
 def tee_target(prefix, proc, input_stream, path, stream):
     """tee emulation for use with threading
-    
+
     First stream is open to a file pointed by `path`
     Second stream is `stream` arg.
     """

--- a/golem/utils.py
+++ b/golem/utils.py
@@ -82,6 +82,4 @@ def tee_target(prefix, proc, input_stream, path, stream):
                 if not line.endswith('\n'):
                     line += '\n'
                 stream.write(prefix + line)
-                stream.flush()
                 log_f.write(prefix + line)
-                log_f.flush()

--- a/golem/utils.py
+++ b/golem/utils.py
@@ -76,7 +76,7 @@ def tee_target(prefix, proc, input_stream, path, stream):
     # bility issues.
     with open(path, 'a') as log_f:
         while proc.poll() is None:
-            line = input_stream.readline(80)
+            line = input_stream.readline(256)
             if line:
                 line = line.decode('utf-8', 'replace')
                 if not line.endswith('\n'):

--- a/golem/utils.py
+++ b/golem/utils.py
@@ -63,21 +63,25 @@ def encode_hex(b):
     raise TypeError('Value must be an instance of str or bytes')
 
 
-def tee_target(prefix, proc, path):
-    """tee emulation for use with threading"""
+def tee_target(prefix, proc, input_stream, path, stream):
+    """tee emulation for use with threading
+    
+    First stream is open to a file pointed by `path`
+    Second stream is `stream` arg.
+    """
 
     # Using unix `tee` or powershell.exe `Tee-Object` causes problems with
     # error codes etc. Probably could be solved by bash's `set -o pipefail`
     # but emulating tee functionality in a thread seems to raise less porta-
     # bility issues.
-    channels = (
-        ('out: ', proc.stderr, sys.stderr),
-        ('err: ', proc.stdout, sys.stdout),
-    )
     with open(path, 'a') as log_f:
         while proc.poll() is None:
-            for stream_prefix, in_, out in channels:
-                line = in_.readline()
-                if line:
-                    out.write(prefix + str(line))
-                    log_f.write(stream_prefix + str(line))
+            line = input_stream.readline(80)
+            if line:
+                line = line.decode('utf-8', 'replace')
+                if not line.endswith('\n'):
+                    line += '\n'
+                stream.write(prefix + line)
+                stream.flush()
+                log_f.write(prefix + line)
+                log_f.flush()


### PR DESCRIPTION
Tee thread hanged on `proc.stderr.read*()`, thus `proc.stdout` buffer would fill up. Splitting `tee stderr` and `tee stdout` to separate threads resolved the issue.

fixes: #1498 
fixes: #1503 
fixes: #1508 

related to: https://github.com/imapp-pl/golem_rd/issues/138