### PR TITLE
Taskheaders after deadline v2

### DIFF
--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -225,26 +225,27 @@ class TaskHeaderKeeper(object):
         if not isinstance(th_dict_repr['deadline'], (int, float)):
             return False, "Deadline is not a timestamp"
         if th_dict_repr['deadline'] < get_timestamp_utc():
-            msg  = "Deadline already passed \n " \
-                   "task_id = %s \n " \
-                   "node name = %s " % \
-                   (th_dict_repr['task_id'],
-                    th_dict_repr['task_owner']['node_name'])
+            msg = "Deadline already passed \n " \
+                  "task_id = %s \n " \
+                  "node name = %s " % \
+                  (th_dict_repr['task_id'],
+                   th_dict_repr['task_owner']['node_name'])
             return False, msg
         if not isinstance(th_dict_repr['subtask_timeout'], int):
-            msg  = "Subtask timeout is not a number \n " \
-                    "task_id = %s \n " \
-                    "node name = %s " % \
-                    (th_dict_repr['task_id'],
-                     th_dict_repr['task_owner']['node_name'])
+            msg = "Subtask timeout is not a number \n " \
+                  "task_id = %s \n " \
+                  "node name = %s " % \
+                  (th_dict_repr['task_id'],
+                   th_dict_repr['task_owner']['node_name'])
             return False, msg
         if th_dict_repr['subtask_timeout'] < 0:
-            msg  = "Subtask timeout is less than 0 \n " \
-                    "task_id = %s \n " \
-                    "node name = %s " % \
-                    (th_dict_repr['task_id'],
-                     th_dict_repr['task_owner']['node_name'])
+            msg = "Subtask timeout is less than 0 \n " \
+                  "task_id = %s \n " \
+                  "node name = %s " % \
+                  (th_dict_repr['task_id'],
+                   th_dict_repr['task_owner']['node_name'])
             return False, msg
+        return True, None
 
     def check_environment(self, th_dict_repr) -> SupportStatus:
         """Checks if this node supports environment necessary to compute task
@@ -374,7 +375,7 @@ class TaskHeaderKeeper(object):
             logger.warning("Wrong task header received: {}".format(err))
             return False
 
-    def update_supported_set(self,  th_dict_repr, update_header):
+    def update_supported_set(self, th_dict_repr, update_header):
         id_ = th_dict_repr["task_id"]
 
         support = self.check_support(th_dict_repr)

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -225,12 +225,26 @@ class TaskHeaderKeeper(object):
         if not isinstance(th_dict_repr['deadline'], (int, float)):
             return False, "Deadline is not a timestamp"
         if th_dict_repr['deadline'] < get_timestamp_utc():
-            return False, "Deadline already passed"
+            msg  = "Deadline already passed \n " \
+                   "task_id = %s \n " \
+                   "node name = %s " % \
+                   (th_dict_repr['task_id'],
+                    th_dict_repr['task_owner']['node_name'])
+            return False, msg
         if not isinstance(th_dict_repr['subtask_timeout'], int):
-            return False, "Subtask timeout is not a number"
+            msg  = "Subtask timeout is not a number \n " \
+                    "task_id = %s \n " \
+                    "node name = %s " % \
+                    (th_dict_repr['task_id'],
+                     th_dict_repr['task_owner']['node_name'])
+            return False, msg
         if th_dict_repr['subtask_timeout'] < 0:
-            return False, "Subtask timeout is less than 0"
-        return True, None
+            msg  = "Subtask timeout is less than 0 \n " \
+                    "task_id = %s \n " \
+                    "node name = %s " % \
+                    (th_dict_repr['task_id'],
+                     th_dict_repr['task_owner']['node_name'])
+            return False, msg
 
     def check_environment(self, th_dict_repr) -> SupportStatus:
         """Checks if this node supports environment necessary to compute task
@@ -341,7 +355,9 @@ class TaskHeaderKeeper(object):
             self.check_correct(th_dict_repr)
 
             if id_ in list(self.removed_tasks.keys()):  # recent
-                # silently ignore
+                logger.info("Received a task which has been already "
+                            "cancelled/removed/timeout/banned/etc "
+                            "Task id %s .", id_)
                 return True
 
             th = TaskHeader.from_dict(th_dict_repr)
@@ -355,7 +371,7 @@ class TaskHeaderKeeper(object):
 
             return True
         except (KeyError, TypeError) as err:
-            logger.warning("Wrong task header received {}".format(err))
+            logger.warning("Wrong task header received: {}".format(err))
             return False
 
     def update_supported_set(self,  th_dict_repr, update_header):

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -13,10 +13,16 @@ from golem.network.transport.tcpnetwork import SocketAddress
 from golem.resource.dirmanager import DirManager
 from golem.resource.hyperdrive.resourcesmanager import HyperdriveResourceManager
 from golem.task.result.resultmanager import EncryptedResultPackageManager
-from golem.task.taskbase import ComputeTaskDef, TaskEventListener, Task, ResourceType
-from golem.task.taskkeeper import CompTaskKeeper, compute_subtask_value
-from golem.task.taskstate import TaskState, TaskStatus, SubtaskStatus, \
-    SubtaskState
+
+from golem.task.taskbase import ComputeTaskDef, \
+    TaskEventListener, Task, \
+    ResourceType, TaskHeader
+
+from golem.task.taskkeeper import \
+    CompTaskKeeper, compute_subtask_value
+
+from golem.task.taskstate import TaskState, \
+    TaskStatus, SubtaskStatus, SubtaskState
 
 logger = logging.getLogger(__name__)
 
@@ -439,7 +445,7 @@ class TaskManager(TaskEventListener):
             cur_time = get_timestamp_utc()
             if cur_time > th.deadline:
                 logger.info("Task {} dies".format(th.task_id))
-                t.task_stats = TaskStatus.timeout
+                t.task_status = TaskStatus.timeout
                 self.tasks_states[th.task_id].status = TaskStatus.timeout
                 self.notice_task_updated(th.task_id)
             ts = self.tasks_states[th.task_id]

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -280,9 +280,10 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
                 logger.error("Error closing incoming session: %s", exc)
 
     def get_tasks_headers(self):
-        ths = self.task_keeper.get_all_tasks() + \
-              self.task_manager.get_tasks_headers()
-        return [th.to_dict() for th in ths]
+        ths_tk = self.task_keeper.get_all_tasks()
+        ths_tm = self.task_manager.get_tasks_headers()
+        ret  = [th.to_dict() for th in ths_tk + ths_tm]
+        return  ret
 
     def add_task_header(self, th_dict_repr):
         try:
@@ -303,7 +304,7 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
 
             return True
         except Exception as err:
-            logger.warning("Wrong task header received {}".format(err))
+            logger.warning("Wrong task header received: {}".format(err))
             return False
 
     def verify_header_sig(self, th_dict_repr):

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -223,7 +223,7 @@ class TestTaskHeaderKeeper(LogTestCase):
         th['deadline'] = get_timestamp_utc() - 10
         correct, err = tk.is_correct(th)
         assert not correct
-        assert err == "Deadline already passed"
+        assert "Deadline already passed" in err
         with self.assertRaisesRegex(TypeError, "Deadline already passed"):
             tk.check_correct(th)
 
@@ -236,7 +236,7 @@ class TestTaskHeaderKeeper(LogTestCase):
         th['subtask_timeout'] = "abc"
         correct, err = tk.is_correct(th)
         assert not correct
-        assert err == "Subtask timeout is not a number"
+        assert "Subtask timeout is not a number" in err
         with self.assertRaisesRegex(TypeError,
                                     "Subtask timeout is not a number"):
             tk.check_correct(th)
@@ -244,7 +244,7 @@ class TestTaskHeaderKeeper(LogTestCase):
         th['subtask_timeout'] = -131
         correct, err = tk.is_correct(th)
         assert not correct
-        assert err == "Subtask timeout is less than 0"
+        assert "Subtask timeout is less than 0" in err
         with self.assertRaisesRegex(TypeError,
                                     "Subtask timeout is less than 0"):
             tk.check_correct(th)
@@ -351,7 +351,7 @@ def get_dict_task_header(task_id="xyz"):
     return {
         "task_id": task_id,
         "node_name": "ABC",
-        "task_owner": dict(),
+        "task_owner": {"node_name": "Bob's node"},
         "task_owner_address": "10.10.10.10",
         "task_owner_port": 10101,
         "task_owner_key_id": "kkkk",

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -441,6 +441,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor):
         time.sleep(0.1)
         self.tm.check_timeouts()
         assert self.tm.tasks_states['xyz'].status == TaskStatus.timeout
+        assert t.task_status == TaskStatus.timeout
         # Task with subtask timeout
         with patch('golem.task.taskbase.Task.needs_computation', return_value=True):
             t2 = self._get_task_mock(task_id="abc", subtask_id="aabbcc", timeout=10, subtask_timeout=0.1)
@@ -449,6 +450,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor):
             self.tm.get_next_subtask("ABC", "ABC", "abc", 1000, 10, 5, 10, 2, "10.10.10.10")
             time.sleep(0.1)
             self.tm.check_timeouts()
+            assert t2.task_status == TaskStatus.waiting
             assert self.tm.tasks_states["abc"].status == TaskStatus.waiting
             assert self.tm.tasks_states["abc"].subtask_states["aabbcc"].subtask_status == SubtaskStatus.failure
         # Task with task and subtask timeout
@@ -459,6 +461,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor):
             self.tm.get_next_subtask("ABC", "ABC", "qwe", 1000, 10, 5, 10, 2, "10.10.10.10")
             time.sleep(0.1)
             self.tm.check_timeouts()
+            assert t3.task_status == TaskStatus.timeout
             assert self.tm.tasks_states["qwe"].status == TaskStatus.timeout
             assert self.tm.tasks_states["qwe"].subtask_states["qwerty"].subtask_status == SubtaskStatus.failure
 


### PR DESCRIPTION
Solves:
Check why TaskHeaders that are after deadline are received after restart #1505

Signed-off-by: ggruszczynski <ggruszczynski@golem.network>