### PR TITLE
DataBuffer cleanup

### DIFF
--- a/golem/core/databuffer.py
+++ b/golem/core/databuffer.py
@@ -3,8 +3,6 @@ from golem.core.common import to_unicode
 
 from .variables import LONG_STANDARD_SIZE
 
-MAX_BUFFER_SIZE = 2 * 1024 * 1024
-
 
 class DataBuffer:
     """ Data buffer that helps with network communication. """
@@ -23,17 +21,11 @@ class DataBuffer:
         self.buffered_data = b"".join([self.buffered_data, str_num_rep])
         return str_num_rep
 
-    def append_string(self, data, check_size=True, overflow_prefix=None):
+    def append_string(self, data):
         """ Append given string to data buffer
-        :param check_size: keep buffer size below MAX_BUFFER_SIZE
-        :param overflow_prefix: string to prepend on overflow
         :param str data: string to append
         """
-        new_size = self.data_size() + len(data)
-        if check_size and new_size > MAX_BUFFER_SIZE:
-            self.buffered_data = b"".join([overflow_prefix or '', data])
-        else:
-            self.buffered_data = b"".join([self.buffered_data, data])
+        self.buffered_data = b"".join([self.buffered_data, data])
 
     def data_size(self):
         """ Return size of data in buffer
@@ -114,8 +106,8 @@ class DataBuffer:
         """ Append length of a given data and then given data to the buffer
         :param str data: data to append
         """
-        prefix = self.append_ulong(len(data))
-        self.append_string(data, overflow_prefix=prefix)
+        self.append_ulong(len(data))
+        self.append_string(data)
 
     def clear_buffer(self):
         """ Remove all data from the buffer """

--- a/golem/core/databuffer.py
+++ b/golem/core/databuffer.py
@@ -37,11 +37,10 @@ class DataBuffer:
     def peek_ulong(self):
         """
         Check long number that is located at the beginning of this data buffer
-        :return long: number at the beginning of the buffer
+        :return (long|None): number at the beginning of the buffer if it's there
         """
         if len(self.buffered_data) < LONG_STANDARD_SIZE:
-            raise ValueError(
-                "buffer_data is shorter than {}".format(LONG_STANDARD_SIZE))
+            return None
 
         (ret_val,) = \
             struct.unpack("!L", self.buffered_data[0:LONG_STANDARD_SIZE])
@@ -53,7 +52,10 @@ class DataBuffer:
         :return long: long number removed from the beginning of buffer
         """
         val_ = self.peek_ulong()
-        self.buffered_data = self.buffered_data[4:]
+        if val_ is None:
+            raise ValueError(
+                "buffer_data is shorter than {}".format(LONG_STANDARD_SIZE))
+        self.buffered_data = self.buffered_data[LONG_STANDARD_SIZE:]
 
         return val_
 

--- a/golem/core/databuffer.py
+++ b/golem/core/databuffer.py
@@ -18,14 +18,14 @@ class DataBuffer:
         if num < 0:
             raise AttributeError("num must be grater than 0")
         str_num_rep = struct.pack("!L", num)
-        self.buffered_data = b"".join([self.buffered_data, str_num_rep])
+        self.buffered_data += str_num_rep
         return str_num_rep
 
-    def append_string(self, data):
-        """ Append given string to data buffer
-        :param str data: string to append
+    def append_bytes(self, data):
+        """ Append given bytes to data buffer
+        :param str data: bytes to append
         """
-        self.buffered_data = b"".join([self.buffered_data, data])
+        self.buffered_data += data
 
     def data_size(self):
         """ Return size of data in buffer
@@ -52,7 +52,7 @@ class DataBuffer:
 
         return val_
 
-    def peek_string(self, num_chars):
+    def peek_bytes(self, num_chars):
         """ Return first <num_chars> chars from buffer. Doesn't change the buffer.
         :param long num_chars: how many chars should be read from buffer
         :return str: first <num_chars> chars from buffer
@@ -63,12 +63,12 @@ class DataBuffer:
         ret_str = self.buffered_data[:num_chars]
         return ret_str
 
-    def read_string(self, num_chars):
+    def read_bytes(self, num_chars):
         """ Remove first <num_chars> chars from buffer and return them.
         :param long num_chars: how many chars should be read and removed from buffer
-        :return str: string removed form buffer
+        :return str: bytes removed form buffer
         """
-        val_ = self.peek_string(num_chars)
+        val_ = self.peek_bytes(num_chars)
         self.buffered_data = self.buffered_data[num_chars:]
 
         return val_
@@ -82,32 +82,32 @@ class DataBuffer:
 
         return ret_data
 
-    def read_len_prefixed_string(self):
-        """ Read long number from the buffer and then read string with that length from the buffer
-        :return str: first string from the buffer (after long)
+    def read_len_prefixed_bytes(self):
+        """ Read long number from the buffer and then read bytes with that length from the buffer
+        :return str: first bytes from the buffer (after long)
         """
         ret_str = None
 
         if (self.data_size() > LONG_STANDARD_SIZE and
                 self.data_size() >= (self.peek_ulong() + LONG_STANDARD_SIZE)):
             num_chars = self.read_ulong()
-            ret_str = self.read_string(num_chars)
+            ret_str = self.read_bytes(num_chars)
 
         return ret_str
 
-    def get_len_prefixed_string(self):
-        """Generator function that return from buffer strings preceded with their length (long) """
+    def get_len_prefixed_bytes(self):
+        """Generator function that return from buffer datas preceded with their length (long) """
         while (self.data_size() > LONG_STANDARD_SIZE and
                self.data_size() >= (self.peek_ulong() + LONG_STANDARD_SIZE)):
             num_chars = self.read_ulong()
-            yield self.read_string(num_chars)
+            yield self.read_bytes(num_chars)
 
-    def append_len_prefixed_string(self, data):
+    def append_len_prefixed_bytes(self, data):
         """ Append length of a given data and then given data to the buffer
         :param str data: data to append
         """
         self.append_ulong(len(data))
-        self.append_string(data)
+        self.append_bytes(data)
 
     def clear_buffer(self):
         """ Remove all data from the buffer """

--- a/golem/core/databuffer.py
+++ b/golem/core/databuffer.py
@@ -12,18 +12,19 @@ class DataBuffer:
 
     def append_ulong(self, num):
         """
-        Append given number to data buffer written as unsigned long in network order
+        Append given number to data buffer written as unsigned long
+        in network order
         :param long num: number to append (must be higher than 0)
         """
         if num < 0:
             raise AttributeError("num must be grater than 0")
-        str_num_rep = struct.pack("!L", num)
-        self.buffered_data += str_num_rep
-        return str_num_rep
+        bytes_num_rep = struct.pack("!L", num)
+        self.buffered_data += bytes_num_rep
+        return bytes_num_rep
 
     def append_bytes(self, data):
         """ Append given bytes to data buffer
-        :param str data: bytes to append
+        :param bytes data: bytes to append
         """
         self.buffered_data += data
 
@@ -34,17 +35,21 @@ class DataBuffer:
         return len(self.buffered_data)
 
     def peek_ulong(self):
-        """ Check long number that is located at the beginning of this data buffer
+        """
+        Check long number that is located at the beginning of this data buffer
         :return long: number at the beginning of the buffer
         """
         if len(self.buffered_data) < LONG_STANDARD_SIZE:
-            raise ValueError("buffer_data is shorter than {}".format(LONG_STANDARD_SIZE))
+            raise ValueError(
+                "buffer_data is shorter than {}".format(LONG_STANDARD_SIZE))
 
-        (ret_val,) = struct.unpack("!L", self.buffered_data[0:LONG_STANDARD_SIZE])
+        (ret_val,) = \
+            struct.unpack("!L", self.buffered_data[0:LONG_STANDARD_SIZE])
         return ret_val
 
     def read_ulong(self):
-        """ Remove long number at the beginning of this data buffer and return it.
+        """
+        Remove long number at the beginning of this data buffer and return it.
         :return long: long number removed from the beginning of buffer
         """
         val_ = self.peek_ulong()
@@ -52,30 +57,34 @@ class DataBuffer:
 
         return val_
 
-    def peek_bytes(self, num_chars):
-        """ Return first <num_chars> chars from buffer. Doesn't change the buffer.
-        :param long num_chars: how many chars should be read from buffer
-        :return str: first <num_chars> chars from buffer
+    def peek_bytes(self, num_bytes):
         """
-        if num_chars > len(self.buffered_data):
-            raise AttributeError("num_chars is grater than buffer length")
-
-        ret_str = self.buffered_data[:num_chars]
-        return ret_str
-
-    def read_bytes(self, num_chars):
-        """ Remove first <num_chars> chars from buffer and return them.
-        :param long num_chars: how many chars should be read and removed from buffer
-        :return str: bytes removed form buffer
+        Return first <num_bytes> bytes from buffer. Doesn't change the buffer.
+        :param long num_bytes: how many bytes should be read from buffer
+        :return bytes: first <num_bytes> bytes from buffer
         """
-        val_ = self.peek_bytes(num_chars)
-        self.buffered_data = self.buffered_data[num_chars:]
+        if num_bytes > len(self.buffered_data):
+            raise AttributeError("num_bytes is grater than buffer length")
+
+        ret_bytes = self.buffered_data[:num_bytes]
+        return ret_bytes
+
+    def read_bytes(self, num_bytes):
+        """
+        Remove first <num_bytes> bytes from buffer and return them.
+        :param long num_bytes: how many bytes should be read and removed
+         from buffer
+        :return bytes: bytes removed form buffer
+        """
+        val_ = self.peek_bytes(num_bytes)
+        self.buffered_data = self.buffered_data[num_bytes:]
 
         return val_
 
     def read_all(self):
-        """ Return all data from buffer and clear the buffer.
-        :return str: all data that was in the buffer.
+        """
+        Return all data from buffer and clear the buffer.
+        :return bytes: all data that was in the buffer.
         """
         ret_data = self.buffered_data
         self.buffered_data = b""
@@ -83,28 +92,34 @@ class DataBuffer:
         return ret_data
 
     def read_len_prefixed_bytes(self):
-        """ Read long number from the buffer and then read bytes with that length from the buffer
-        :return str: first bytes from the buffer (after long)
         """
-        ret_str = None
+        Read long number from the buffer and then read bytes with that length
+        from the buffer
+        :return bytes: first bytes from the buffer (after long)
+        """
+        ret_bytes = None
 
         if (self.data_size() > LONG_STANDARD_SIZE and
                 self.data_size() >= (self.peek_ulong() + LONG_STANDARD_SIZE)):
-            num_chars = self.read_ulong()
-            ret_str = self.read_bytes(num_chars)
+            num_bytes = self.read_ulong()
+            ret_bytes = self.read_bytes(num_bytes)
 
-        return ret_str
+        return ret_bytes
 
     def get_len_prefixed_bytes(self):
-        """Generator function that return from buffer datas preceded with their length (long) """
+        """
+        Generator function that return from buffer datas preceded with
+        their length (long)
+        """
         while (self.data_size() > LONG_STANDARD_SIZE and
                self.data_size() >= (self.peek_ulong() + LONG_STANDARD_SIZE)):
-            num_chars = self.read_ulong()
-            yield self.read_bytes(num_chars)
+            num_bytes = self.read_ulong()
+            yield self.read_bytes(num_bytes)
 
     def append_len_prefixed_bytes(self, data):
-        """ Append length of a given data and then given data to the buffer
-        :param str data: data to append
+        """
+        Append length of a given data and then given data to the buffer
+        :param bytes data: data to append
         """
         self.append_ulong(len(data))
         self.append_bytes(data)

--- a/golem/network/transport/tcpnetwork.py
+++ b/golem/network/transport/tcpnetwork.py
@@ -505,7 +505,7 @@ class BasicProtocol(SessionProtocol):
             self.db.append_bytes(data)
             mess = self._data_to_messages()
 
-        if self.db.data_size() > MAX_MESSAGE_SIZE:
+        if mess is None:
             logger.warning("Too long pending message, closing connection")
             self.close()
             return
@@ -515,6 +515,11 @@ class BasicProtocol(SessionProtocol):
 
     def _data_to_messages(self):
         messages = []
+        def valid_len():
+            msg_len = self.db.peek_ulong()
+            return msg_len is None or msg_len <= MAX_MESSAGE_SIZE
+        if not valid_len():
+            return None
         data = self.db.read_len_prefixed_bytes()
 
         while data:
@@ -525,6 +530,8 @@ class BasicProtocol(SessionProtocol):
             else:
                 logger.error("Failed to deserialize message {}".format(data))
 
+            if not valid_len():
+                return None
             data = self.db.read_len_prefixed_bytes()
 
         return messages

--- a/golem/resource/resourcesmanager.py
+++ b/golem/resource/resourcesmanager.py
@@ -3,7 +3,6 @@ from .resource import TaskResource, TaskResourceHeader, prepare_delta_zip
 import os
 import logging
 
-from golem.core.databuffer import DataBuffer
 from golem.core.fileshelper import copy_file_tree
 from golem.resource.resourcehash import ResourceHash
 
@@ -58,8 +57,6 @@ class ResourcesManager:
         self.recv_size = 0
         self.owner = owner
         self.last_prct = 0
-        self.buff_size = 4 * 1024 * 1024
-        self.buff = DataBuffer()
 
     def get_resource_header(self, task_id):
 

--- a/tests/golem/network/transport/test_message.py
+++ b/tests/golem/network/transport/test_message.py
@@ -141,7 +141,7 @@ class TestMessages(unittest.TestCase):
         set_tz('Europe/Warsaw')
         warsaw_time = time.localtime(epoch_t)
         m = message.MessageHello(timestamp=epoch_t)
-        self.protocol.db.append_len_prefixed_string(m.serialize(fake_sign))
+        self.protocol.db.append_len_prefixed_bytes(m.serialize(fake_sign))
         set_tz('US/Eastern')
         msgs = self.protocol._data_to_messages()
         assert len(msgs) == 1
@@ -155,7 +155,7 @@ class TestMessages(unittest.TestCase):
 
         def serialize_messages(_b):
             for m in [message.MessageRandVal() for _ in range(0, n_messages)]:
-                db.append_len_prefixed_string(m.serialize(fake_sign))
+                db.append_len_prefixed_bytes(m.serialize(fake_sign))
 
         serialize_messages(db)
         self.assertEqual(len(self.protocol._data_to_messages()), n_messages)

--- a/tests/golem/network/transport/test_network.py
+++ b/tests/golem/network/transport/test_network.py
@@ -367,7 +367,7 @@ class TestBasicProtocol(unittest.TestCase):
         self.assertTrue(p.send_message(msg))
         self.assertEqual(len(p.transport.buff), 2)
         db = p.db
-        db.append_string(p.transport.buff[1])
+        db.append_bytes(p.transport.buff[1])
         m = p._data_to_messages()[0]
         self.assertEqual(m.timestamp, msg.timestamp)
         p.connectionLost()

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -457,7 +457,7 @@ class TestTaskSession(LogTestCase, testutils.TempDirFixture,
         db = DataBuffer()
 
         sess = TaskSession(conn)
-        sess.send = lambda m: db.append_string(m.serialize(lambda x: b'\000'*65))
+        sess.send = lambda m: db.append_bytes(m.serialize(lambda x: b'\000'*65))
         sess._can_send = lambda *_: True
         sess.request_resource(str(uuid.uuid4()), TaskResourceHeader("tmp"))
 


### PR DESCRIPTION
Resolves #1504
In particular
- doesn't show warning messages on short data
- removes DataBuffer from ResourceManager since it wasn't used there
- DataBuffer doesn't have buffer size limit now, the limit is checked by the client (currently only tcpnetwork)
- tcpnetwork closes connection on too long messages
- test for the above