### PR TITLE
Unsupported task stats #1448.

### DIFF
--- a/golem/appconfig.py
+++ b/golem/appconfig.py
@@ -42,6 +42,14 @@ PUBLISH_TASKS_INTERVAL = 1.0
 NODE_SNAPSHOT_INTERVAL = 10.0
 NETWORK_CHECK_INTERVAL = 10.0
 MAX_SENDING_DELAY = 360
+# How frequently task archive should be saved to disk (in seconds)
+TASKARCHIVE_MAINTENANCE_INTERVAL = 30
+# Filename for task archive disk file
+TASKARCHIVE_FILENAME = "task_archive.pickle"
+# Number of past days task archive will store aggregated information for
+TASKARCHIVE_NUM_INTERVALS = 365
+# Limit of the number  of non-expired tasks stored in task archive at any moment
+TASKARCHIVE_MAX_TASKS = 10000000
 
 P2P_SESSION_TIMEOUT = 240
 TASK_SESSION_TIMEOUT = 900

--- a/golem/client.py
+++ b/golem/client.py
@@ -15,7 +15,8 @@ from twisted.internet.defer import (inlineCallbacks, returnValue, gatherResults,
                                     Deferred)
 
 from golem.appconfig import (AppConfig, PUBLISH_BALANCE_INTERVAL,
-                             PUBLISH_TASKS_INTERVAL)
+                             PUBLISH_TASKS_INTERVAL,
+                             TASKARCHIVE_MAINTENANCE_INTERVAL)
 from golem.clientconfigdescriptor import ClientConfigDescriptor, ConfigApprover
 from golem.config.presets import HardwarePresetsMixin
 from golem.core.async import AsyncRequest, async_run
@@ -55,6 +56,7 @@ from golem.task.taskbase import ResourceType
 from golem.task.taskserver import TaskServer
 from golem.task.taskstate import TaskTestStatus
 from golem.task.tasktester import TaskTester
+from golem.task.taskarchiver import TaskArchiver
 from golem.tools import filelock
 from golem.transactions.ethereum.ethereumtransactionsystem import \
     EthereumTransactionSystem
@@ -92,6 +94,8 @@ class Client(HardwarePresetsMixin):
         self.__lock_datadir()
         self.lock = Lock()
         self.task_tester = None
+
+        self.task_archiver = TaskArchiver(datadir)
 
         # Read and validate configuration
         config = AppConfig.load_config(datadir)
@@ -143,6 +147,7 @@ class Client(HardwarePresetsMixin):
 
         self.do_work_task = task.LoopingCall(self.__do_work)
         self.publish_task = task.LoopingCall(self.__publish_events)
+        self.archive_task = task.LoopingCall(self.__task_archiver_maintenance)
 
         self.cfg = config
         self.send_snapshot = False
@@ -222,6 +227,7 @@ class Client(HardwarePresetsMixin):
 
         self.do_work_task.start(1, False)
         self.publish_task.start(1, True)
+        self.archive_task.start(TASKARCHIVE_MAINTENANCE_INTERVAL, False)
 
     @report_calls(Component.client, 'stop', stage=Stage.post)
     def stop(self):
@@ -230,6 +236,8 @@ class Client(HardwarePresetsMixin):
             self.do_work_task.stop()
         if self.publish_task.running:
             self.publish_task.stop()
+        if self.archive_task.running:
+            self.archive_task.stop()
         if self.task_server:
             self.task_server.task_computer.quit()
         if self.use_monitor and self.monitor:
@@ -256,7 +264,8 @@ class Client(HardwarePresetsMixin):
                 self.config_desc,
                 self.keys_auth, self,
                 use_ipv6=self.config_desc.use_ipv6,
-                use_docker_machine_manager=self.use_docker_machine_manager)
+                use_docker_machine_manager=self.use_docker_machine_manager,
+                task_archiver = self.task_archiver)
 
         dir_manager = self.task_server.task_computer.dir_manager
 
@@ -334,6 +343,8 @@ class Client(HardwarePresetsMixin):
             self.do_work_task.stop()
         if self.publish_task.running:
             self.publish_task.stop()
+        if self.archive_task.running:
+            self.archive_task.stop()
 
         if self.p2pservice:
             self.p2pservice.pause()
@@ -348,6 +359,8 @@ class Client(HardwarePresetsMixin):
             self.do_work_task.start(1, False)
         if not self.publish_task.running:
             self.publish_task.start(1, True)
+        if not self.archive_task.running:
+            self.archive_task.start(TASKARCHIVE_MAINTENANCE_INTERVAL, False)
 
         if self.p2pservice:
             self.p2pservice.resume()
@@ -668,6 +681,14 @@ class Client(HardwarePresetsMixin):
 
     def get_error_task_count(self):
         return self.get_task_computer_stat('tasks_with_errors')
+
+    def get_unsupport_reasons(self, last_days):
+        if last_days < 0:
+            raise ValueError("Incorrect number of days: {}".format(last_days))
+        if last_days > 0:
+            return self.task_archiver.get_unsupport_reasons(last_days)
+        else:
+            return self.task_server.task_keeper.get_unsupport_reasons()
 
     def get_payment_address(self):
         address = self.transaction_system.get_payment_address()
@@ -1055,6 +1076,10 @@ class Client(HardwarePresetsMixin):
                     'GNT_available': str(av_gnt),
                     'ETH': str(eth)
                 })
+
+    def __task_archiver_maintenance(self):
+        if self.task_archiver:
+            self.task_archiver.do_maintenance()
 
     def __make_node_state_snapshot(self, is_running=True):
         peers_num = len(self.p2pservice.peers)

--- a/golem/client.py
+++ b/golem/client.py
@@ -265,7 +265,7 @@ class Client(HardwarePresetsMixin):
                 self.keys_auth, self,
                 use_ipv6=self.config_desc.use_ipv6,
                 use_docker_machine_manager=self.use_docker_machine_manager,
-                task_archiver = self.task_archiver)
+                task_archiver=self.task_archiver)
 
         dir_manager = self.task_server.task_computer.dir_manager
 

--- a/golem/environments/environment.py
+++ b/golem/environments/environment.py
@@ -19,6 +19,9 @@ class SupportStatus(object):
     def __bool__(self) -> bool:
         return self.is_ok()
 
+    def __eq__(self, other) -> bool:
+        return self.is_ok() == other.is_ok() and self.desc == other.desc
+
     def join(self, other) -> 'SupportStatus':
         desc = self.desc.copy()
         desc.update(other.desc)
@@ -43,6 +46,8 @@ class UnsupportReason(enum.Enum):
     ENVIRONMENT_NOT_ACCEPTING_TASKS = 'environment_not_accepting_tasks'
     MAX_PRICE = 'max_price'
     APP_VERSION = 'app_version'
+    DENY_LIST = 'deny_list'
+    REQUESTOR_TRUST = 'requesting_trust'
 
 
 class Environment():

--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -72,7 +72,7 @@ class Tasks:
         default=False,
         help="Skip task testing phase"
     )
-    last_days = Argument('last_days', optional=True, default = "0",
+    last_days = Argument('last_days', optional=True, default="0",
                          help="Number of last days to compute statistics on")
 
     application_logic = None
@@ -165,8 +165,8 @@ class Tasks:
     @command(argument=last_days, help="Show statistics for unsupported tasks")
     def unsupport(self, last_days):
         deferred = Tasks.client.get_unsupport_reasons(int(last_days))
-        result =  sync_wait(deferred)
-        values = [[r['reason'], r['ntasks'],r['avg']] for r in result]
+        result = sync_wait(deferred)
+        values = [[r['reason'], r['ntasks'], r['avg']] for r in result]
         return CommandResult.to_tabular(Tasks.unsupport_reasons_table_headers,
                                         values)
 

--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -40,6 +40,8 @@ class Tasks:
 
     task_table_headers = ['id', 'remaining', 'subtasks', 'status', 'completion']
     subtask_table_headers = ['node', 'id', 'remaining', 'status', 'completion']
+    unsupport_reasons_table_headers = ['reason', 'no of tasks',
+                                       'avg for all tasks']
 
     id_req = Argument('id', help="Task identifier")
     id_opt = Argument.extend(id_req, optional=True)
@@ -70,6 +72,8 @@ class Tasks:
         default=False,
         help="Skip task testing phase"
     )
+    last_days = Argument('last_days', optional=True, default = "0",
+                         help="Number of last days to compute statistics on")
 
     application_logic = None
 
@@ -157,6 +161,14 @@ class Tasks:
     def stats(self):
         deferred = Tasks.client.get_task_stats()
         return sync_wait(deferred)
+
+    @command(argument=last_days, help="Show statistics for unsupported tasks")
+    def unsupport(self, last_days):
+        deferred = Tasks.client.get_unsupport_reasons(int(last_days))
+        result =  sync_wait(deferred)
+        values = [[r['reason'], r['ntasks'],r['avg']] for r in result]
+        return CommandResult.to_tabular(Tasks.unsupport_reasons_table_headers,
+                                        values)
 
     @staticmethod
     def __dump_dict(dictionary: dict, outfile: Optional[str]) -> None:

--- a/golem/rpc/mapping/aliases.py
+++ b/golem/rpc/mapping/aliases.py
@@ -76,6 +76,7 @@ class Task:
     tasks_check             = 'comp.tasks.check'
     tasks_check_abort       = 'comp.tasks.check.abort'
     tasks_stats             = 'comp.tasks.stats'
+    tasks_unsupport_reasons = 'comp.tasks.unsupport'
     tasks_known             = 'comp.tasks.known'
     tasks_known_delete      = 'comp.tasks.known.delete'
     tasks_save_preset       = 'comp.tasks.preset.save'

--- a/golem/rpc/mapping/core.py
+++ b/golem/rpc/mapping/core.py
@@ -44,6 +44,7 @@ CORE_METHOD_MAP = dict(
     run_test_task=          Task.tasks_check,
     abort_test_task=        Task.tasks_check_abort,
     get_task_stats=         Task.tasks_stats,
+    get_unsupport_reasons=  Task.tasks_unsupport_reasons,
     get_known_tasks=        Task.tasks_known,
     remove_task_header=     Task.tasks_known_delete,
     save_task_preset=       Task.tasks_save_preset,

--- a/golem/task/taskarchiver.py
+++ b/golem/task/taskarchiver.py
@@ -1,0 +1,213 @@
+import threading
+import logging
+import pickle
+import os
+import pytz
+from collections import Counter
+from golem.core.common import get_timestamp_utc, timestamp_to_datetime
+from golem.environments.environment import SupportStatus, UnsupportReason
+from golem.core.async import AsyncRequest, async_run
+from golem.appconfig import TASKARCHIVE_FILENAME, TASKARCHIVE_NUM_INTERVALS, \
+    TASKARCHIVE_MAX_TASKS
+from datetime import datetime, timedelta
+
+log = logging.getLogger('golem.task.taskarchiver')
+
+class TaskArchiver(object):
+    """Utility that archives information on unsupported task reasons and
+    other related task statistics. See get_unsupport_reasons() function.
+    :param datadir: Directory to save the archive to
+    :param max_tasks: Maximum number of non-expired tasks stored in task
+                      archive at any moment
+    """
+
+    def __init__(self, datadir = None, max_tasks = TASKARCHIVE_MAX_TASKS):
+        self._input_tasks = []
+        self._input_statuses = []
+        self._archive_lock = threading.Lock()
+        self._file_lock = threading.Lock()
+        self._archive = Archive()
+        self._dump_file = None
+        self._max_tasks = max_tasks
+        if datadir:
+            try:
+                self._dump_file = os.path.join(datadir, TASKARCHIVE_FILENAME)
+                with open(self._dump_file, 'rb') as f:
+                    archive = pickle.load(f)
+                if archive.class_version == Archive.CLASS_VERSION:
+                    self._archive = archive
+                else:
+                    log.info("Task archive not loaded: unsupported version: "
+                             "%s", archive.class_version)
+            except Exception as e:
+                log.info("Task archive not loaded: %s", str(e))
+
+    def add_task(self, task_header):
+        """Schedule a task to be archived.
+        :param task_header: Header of task to be archived
+        """
+        self._input_tasks.append(ArchTask(task_header))
+
+    def add_support_status(self, uuid, support_status):
+        """Schedule support status of a task to be archived.
+        :param uuid: Identifier of task the status belongs to
+        :param support_status: SupportStatus object denoting the status
+        """
+        self._input_statuses.append((uuid, support_status))
+
+    def do_maintenance(self):
+        """Updates information on unsupported task reasons and
+        other related task statistics by consuming tasks and support statuses
+        scheduled for processing by add_task() and add_support_status()
+        functions. Optimizes internal structures and, if needed, writes the
+        entire structure to a file.
+        """
+        input_tasks, self._input_tasks = self._input_tasks, []
+        input_statuses, self._input_statuses = self._input_statuses, []
+        with self._archive_lock:
+            ntasks_to_take = self._max_tasks - len(self._archive.tasks)
+            if ntasks_to_take < len(input_tasks):
+                log.warning("Maximum number of current tasks exceeded.")
+            input_tasks = input_tasks[:ntasks_to_take]
+            for tsk in input_tasks:
+                self._archive.tasks[tsk.uuid] = tsk
+            for (uuid, status) in input_statuses:
+                if uuid in self._archive.tasks:
+                    if UnsupportReason.REQUESTOR_TRUST in status.desc:
+                        self._archive.tasks[uuid].requesting_trust = \
+                            status.desc[UnsupportReason.REQUESTOR_TRUST]
+                    self._archive.tasks[uuid].unsupport_reasons = \
+                        list(status.desc.keys())
+            cur_time = get_timestamp_utc()
+            for tsk in list(self._archive.tasks.values()):
+                if cur_time > tsk.deadline:
+                    self._merge_to_interval(tsk)
+                    del self._archive.tasks[tsk.uuid]
+            self._purge_old_intervals()
+            if self._dump_file:
+                request = AsyncRequest(self._dump_archive)
+                async_run(request, None,
+                          lambda e: log.info("Dumping archive failed: %s", e))
+
+    def _dump_archive(self):
+        with self._archive_lock:
+            data = pickle.dumps(self._archive)
+        with self._file_lock:
+            with open(self._dump_file, 'wb') as f:
+                f.write(data)
+
+    def _merge_to_interval(self, tsk):
+        day = tsk.interval_start_date
+        if day not in self._archive.intervals:
+            self._archive.intervals[day] = TimeInterval(day)
+        interval = self._archive.intervals[day]
+        interval.merge_task(tsk)
+
+    def _purge_old_intervals(self):
+        today = datetime.now(pytz.utc) \
+            .replace(hour=0, minute=0, second=0, microsecond=0)
+        old = today - timedelta(days=TASKARCHIVE_NUM_INTERVALS)
+        for interval in list(self._archive.intervals.values()):
+            if interval.start_date <= old:
+                del self._archive.intervals[interval.start_date]
+
+    def get_unsupport_reasons(self, last_n_days, today = None):
+        """
+        :param last_n_days: For how many recent calendar days (UTC timezone)
+         the statistics should be computed.
+        :param today: Assume today is a given date
+        :return: list of dictionaries of the form {'reason': reason_type,
+         'ntasks': task_count, 'avg': avg} where reason_type is one of
+         unsupport reason types, task_count is the number of tasks
+         affected with that reason, and avg (if available) is the most typical
+         corresponding value.  For unsupport reason
+         MAX_PRICE avg is the average price of all tasks observed in the network
+         in the given interval. For unsupport reason APP_VERSION avg is
+         the most popular app version of all tasks observed in the network
+         in the given interval. For unsupport reason
+         REQUESTING_TRUST avg is the average trust of all requestors that this
+         node tried to process tasks for where that trust was not high enough.
+         Note: number of unsupported tasks returned for a given period can
+         decrease with time when these tasks become supported for some reason.
+         For each task we only take into consideration the most recent support
+         status of this task.
+        """
+        if not today:
+            today = datetime.now(pytz.utc)
+        today = today.replace(hour=0, minute=0, second=0, microsecond=0)
+        start_date = today - timedelta(days=last_n_days-1)
+        result = TimeInterval(start_date)
+        result.cnt_unsupport_reasons = Counter({r: 0 for r in UnsupportReason})
+        for interval in self._archive.intervals.values():
+            if interval.start_date >= start_date:
+                result.merge_interval(interval)
+        for tsk in self._archive.tasks.values():
+            if tsk.interval_start_date >= start_date:
+                result.merge_task(tsk)
+        ret = []
+        for (reason, count) in result.cnt_unsupport_reasons.most_common():
+            if reason == UnsupportReason.MAX_PRICE and result.num_tasks:
+                avg = int(result.sum_max_price / result.num_tasks)
+            elif reason == UnsupportReason.APP_VERSION and \
+                    result.cnt_min_version:
+                avg = result.cnt_min_version.most_common(1)[0][0]
+            elif reason == UnsupportReason.REQUESTOR_TRUST and \
+                    result.num_requesting_trust:
+                avg = result.sum_requesting_trust / result.num_requesting_trust
+            else:
+                avg = None
+            ret.append({'reason': reason.value, 'ntasks': count, 'avg': avg})
+        return ret
+
+
+
+class Archive(object):
+    CLASS_VERSION = 1
+
+    def __init__(self):
+        self.class_version = Archive.CLASS_VERSION
+        self.tasks = {}
+        self.intervals = {}
+
+
+
+class ArchTask(object):
+    """All known tasks that have not been aggregated yet."""
+    def __init__(self, task_header):
+        self.uuid = task_header.task_id
+        self.interval_start_date = timestamp_to_datetime(task_header.last_checking)\
+            .replace(hour=0, minute=0, second=0, microsecond=0)
+        self.deadline = task_header.deadline
+        self.min_version = task_header.min_version
+        self.max_price = task_header.max_price
+        self.requesting_trust = None
+        self.unsupport_reasons = None
+
+
+class TimeInterval(object):
+    """Aggregate information on tasks belonging to a time interval."""
+    def __init__(self, start_date):
+        self.start_date = start_date
+        self.sum_max_price = 0
+        self.cnt_min_version = Counter()
+        self.num_tasks = 0
+        self.sum_requesting_trust = 0.0
+        self.num_requesting_trust = 0
+        self.cnt_unsupport_reasons = Counter()
+
+    def merge_task(self, tsk):
+        self.sum_max_price += tsk.max_price
+        self.cnt_min_version[tsk.min_version] += 1
+        self.num_tasks += 1
+        self.cnt_unsupport_reasons.update(tsk.unsupport_reasons)
+        if tsk.requesting_trust:
+            self.sum_requesting_trust += tsk.requesting_trust
+            self.num_requesting_trust += 1
+
+    def merge_interval(self, interval):
+        self.sum_max_price += interval.sum_max_price
+        self.cnt_min_version.update(interval.cnt_min_version)
+        self.num_tasks += interval.num_tasks
+        self.sum_requesting_trust += interval.sum_requesting_trust
+        self.num_requesting_trust += interval.num_requesting_trust
+        self.cnt_unsupport_reasons.update(interval.cnt_unsupport_reasons)

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -6,8 +6,8 @@ import time
 
 from typing import Optional
 import typing
-from semantic_version import Version
 from collections import Counter
+from semantic_version import Version
 
 from golem.core.common import HandleKeyError, get_timestamp_utc
 from golem.core.variables import APP_VERSION

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -17,6 +17,7 @@ from golem.task.benchmarkmanager import BenchmarkManager
 from golem.task.deny import get_deny_set
 from golem.task.taskbase import TaskHeader
 from golem.task.taskconnectionshelper import TaskConnectionsHelper
+from golem.environments.environment import SupportStatus, UnsupportReason
 from .taskcomputer import TaskComputer
 from .taskkeeper import TaskHeaderKeeper
 from .taskmanager import TaskManager
@@ -98,13 +99,17 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
                  keys_auth,
                  client,
                  use_ipv6=False,
-                 use_docker_machine_manager=True):
+                 use_docker_machine_manager=True,
+                 task_archiver=None):
         self.client = client
         self.keys_auth = keys_auth
         self.config_desc = config_desc
 
         self.node = node
-        self.task_keeper = TaskHeaderKeeper(client.environments_manager, min_price=config_desc.min_price)
+        self.task_archiver = task_archiver
+        self.task_keeper = TaskHeaderKeeper(client.environments_manager,
+                                            min_price=config_desc.min_price,
+                                            task_archiver=task_archiver)
         self.task_manager = TaskManager(config_desc.node_name, self.node, self.keys_auth,
                                         root_path=TaskServer.__get_task_manager_root(client.datadir),
                                         use_distributed_resources=config_desc.use_distributed_resource_management,
@@ -193,10 +198,14 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
                 performance = env.get_performance()
             else:
                 performance = 0.0
-            is_requestor_accepted = self.should_accept_requestor(
-                theader.task_owner_key_id)
-            is_price_accepted = self.config_desc.min_price < theader.max_price
-            if is_requestor_accepted and is_price_accepted:
+            supported = self.should_accept_requestor(theader.task_owner_key_id)
+            if self.config_desc.min_price > theader.max_price:
+                supported = supported.join(SupportStatus.err({
+                    UnsupportReason.MAX_PRICE: theader.max_price}))
+            if not supported.is_ok() and self.task_archiver:
+                self.task_archiver.add_support_status(theader.task_id,
+                                                      supported)
+            else:
                 price = int(theader.max_price)
                 self.task_manager.add_comp_task_request(theader=theader,
                                                         price=price)
@@ -601,10 +610,14 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
 
     def should_accept_requestor(self, node_id):
         if node_id in self.deny_set:
-            return False
+            return SupportStatus.err(
+                {UnsupportReason.DENY_LIST: node_id})
         trust = self.client.get_requesting_trust(node_id)
         logger.debug("Requesting trust level: {}".format(trust))
-        return trust >= self.config_desc.requesting_trust
+        if trust >= self.config_desc.requesting_trust:
+            return SupportStatus.ok()
+        else:
+            return SupportStatus.err({UnsupportReason.REQUESTOR_TRUST: trust})
 
     def _sync_forwarded_session_requests(self):
         now = time.time()

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -202,9 +202,10 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
             if self.config_desc.min_price > theader.max_price:
                 supported = supported.join(SupportStatus.err({
                     UnsupportReason.MAX_PRICE: theader.max_price}))
-            if not supported.is_ok() and self.task_archiver:
-                self.task_archiver.add_support_status(theader.task_id,
-                                                      supported)
+            if not supported.is_ok():
+                if self.task_archiver:
+                    self.task_archiver.add_support_status(theader.task_id,
+                                                          supported)
             else:
                 price = int(theader.max_price)
                 self.task_manager.add_comp_task_request(theader=theader,

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -511,7 +511,6 @@ class TestTasks(TempDirFixture):
             assert unsupport.data[1][1] == ['max_price', 2, 7]
             assert unsupport.data[1][2] == ['environment_missing', 1, None]
 
-
     @staticmethod
     @contextmanager
     def _run_context(method):

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -367,10 +367,21 @@ class TestTasks(TempDirFixture):
             'progress': i / 100.0
         } for i in range(1, 6)]
 
+        cls.reasons = [
+            {'avg': '0.8.1', 'reason': 'app_version', 'ntasks': 3},
+            {'avg': 7, 'reason': 'max_price', 'ntasks': 2},
+            {'avg': None, 'reason': 'environment_missing', 'ntasks': 1},
+            {'avg': None,
+             'reason': 'environment_not_accepting_tasks', 'ntasks': 1},
+            {'avg': None, 'reason': 'requesting_trust', 'ntasks': 0},
+            {'avg': None, 'reason': 'deny_list', 'ntasks': 0},
+            {'avg': None, 'reason': 'environment_unsupported', 'ntasks': 0}]
+
         cls.n_tasks = len(cls.tasks)
         cls.n_subtasks = len(cls.subtasks)
         cls.get_tasks = lambda s, _id: cls.tasks[0] if _id else cls.tasks
         cls.get_subtasks = lambda s, x: cls.subtasks
+        cls.get_unsupport_reasons = lambda s, x: cls.reasons
 
     def setUp(self):
         super(TestTasks, self).setUp()
@@ -384,6 +395,7 @@ class TestTasks(TempDirFixture):
 
         client.get_tasks = self.get_tasks
         client.get_subtasks = self.get_subtasks
+        client.get_unsupport_reasons = self.get_unsupport_reasons
 
         self.client = client
 
@@ -487,6 +499,18 @@ class TestTasks(TempDirFixture):
             assert subtasks.data[1][0] == [
                 'node_1', 'subtask_1', '9', 'waiting', '1.00 %'
             ]
+
+    def test_unsupport(self):
+        client = self.client
+
+        with client_ctx(Tasks, client):
+            tasks = Tasks()
+            unsupport = tasks.unsupport(0)
+            assert isinstance(unsupport, CommandResult)
+            assert unsupport.data[1][0] == ['app_version', 3, '0.8.1']
+            assert unsupport.data[1][1] == ['max_price', 2, 7]
+            assert unsupport.data[1][2] == ['environment_missing', 1, None]
+
 
     @staticmethod
     @contextmanager

--- a/tests/golem/task/test_taskarchiver.py
+++ b/tests/golem/task/test_taskarchiver.py
@@ -40,7 +40,7 @@ class TestTaskArchiver(TestCase):
             ret.last_checking = last_checking
         return ret
 
-    def getRow(self, reasonsReport, unsupportReason):
+    def get_row(self, reasonsReport, unsupportReason):
         """From unsupport reasons report gets a row corresponding to given
         unsuportReason as tuple
         (ntasks, avg)"""
@@ -52,7 +52,7 @@ class TestTaskArchiver(TestCase):
         ta = TaskArchiver()
         rep = ta.get_unsupport_reasons(5)
         for r in UnsupportReason:
-            self.assertEqual(self.getRow(rep, r), (0, None))
+            self.assertEqual(self.get_row(rep, r), (0, None))
 
     def test_with_remembering_tasks(self):
         ta = TaskArchiver()
@@ -76,14 +76,14 @@ class TestTaskArchiver(TestCase):
         rep = ta.get_unsupport_reasons(5)
 
         def check1(report):
-            self.assertEqual(self.getRow(report, UnsupportReason.APP_VERSION),
+            self.assertEqual(self.get_row(report, UnsupportReason.APP_VERSION),
                              (2, "4"))
-            self.assertEqual(self.getRow(report, UnsupportReason.DENY_LIST),
+            self.assertEqual(self.get_row(report, UnsupportReason.DENY_LIST),
                              (0, None))
-            self.assertEqual(self.getRow(report,
-                                         UnsupportReason.REQUESTOR_TRUST),
+            self.assertEqual(self.get_row(report,
+                                          UnsupportReason.REQUESTOR_TRUST),
                                          (1, 0.5))
-            self.assertEqual(self.getRow(report, UnsupportReason.MAX_PRICE),
+            self.assertEqual(self.get_row(report, UnsupportReason.MAX_PRICE),
                              (1, (7+8+9+10)//4))
         check1(rep)
         ta.add_task(th2)
@@ -125,24 +125,24 @@ class TestTaskArchiver(TestCase):
         ta.add_support_status(th5.task_id, s5)
         ta.do_maintenance()
         rep = ta.get_unsupport_reasons(1, today)
-        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE), (1, 11))
-        self.assertEqual(self.getRow(rep, UnsupportReason.APP_VERSION),
+        self.assertEqual(self.get_row(rep, UnsupportReason.MAX_PRICE), (1, 11))
+        self.assertEqual(self.get_row(rep, UnsupportReason.APP_VERSION),
                          (1, "4"))
-        self.assertEqual(self.getRow(rep, UnsupportReason.REQUESTOR_TRUST),
+        self.assertEqual(self.get_row(rep, UnsupportReason.REQUESTOR_TRUST),
                          (0, None))
         rep = ta.get_unsupport_reasons(2, today)
-        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE), (1, 10))
-        self.assertEqual(self.getRow(rep, UnsupportReason.APP_VERSION),
+        self.assertEqual(self.get_row(rep, UnsupportReason.MAX_PRICE), (1, 10))
+        self.assertEqual(self.get_row(rep, UnsupportReason.APP_VERSION),
                          (1, "4"))
-        self.assertEqual(self.getRow(rep, UnsupportReason.REQUESTOR_TRUST),
+        self.assertEqual(self.get_row(rep, UnsupportReason.REQUESTOR_TRUST),
                          (0, None))
         rep = ta.get_unsupport_reasons(3, today)
-        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE), (2, 7))
-        self.assertEqual(self.getRow(rep, UnsupportReason.APP_VERSION),
+        self.assertEqual(self.get_row(rep, UnsupportReason.MAX_PRICE), (2, 7))
+        self.assertEqual(self.get_row(rep, UnsupportReason.APP_VERSION),
                          (3, "4"))
-        self.assertEqual(self.getRow(rep, UnsupportReason.REQUESTOR_TRUST),
+        self.assertEqual(self.get_row(rep, UnsupportReason.REQUESTOR_TRUST),
                          (2, 0.5))
-        self.assertEqual(self.getRow(rep, UnsupportReason.DENY_LIST),
+        self.assertEqual(self.get_row(rep, UnsupportReason.DENY_LIST),
                          (0, None))
         # Re-add task that has deadline in the future - should not change the
         # report
@@ -158,12 +158,12 @@ class TestTaskArchiver(TestCase):
         ta.do_maintenance()
         rep3 = ta.get_unsupport_reasons(3, today)
         self.assertNotEqual(rep, rep3)
-        self.assertEqual(self.getRow(rep3, UnsupportReason.MAX_PRICE), (2, 6))
-        self.assertEqual(self.getRow(rep3, UnsupportReason.APP_VERSION),
+        self.assertEqual(self.get_row(rep3, UnsupportReason.MAX_PRICE), (2, 6))
+        self.assertEqual(self.get_row(rep3, UnsupportReason.APP_VERSION),
                          (3, "4"))
-        self.assertEqual(self.getRow(rep3, UnsupportReason.REQUESTOR_TRUST),
+        self.assertEqual(self.get_row(rep3, UnsupportReason.REQUESTOR_TRUST),
                          (3, 0.5))
-        self.assertEqual(self.getRow(rep3, UnsupportReason.DENY_LIST),
+        self.assertEqual(self.get_row(rep3, UnsupportReason.DENY_LIST),
                          (0, None))
 
     def test_max_tasks(self):
@@ -176,11 +176,11 @@ class TestTaskArchiver(TestCase):
         ta.add_support_status(th2.task_id, self.ssmp)
         ta.do_maintenance()
         rep = ta.get_unsupport_reasons(5)
-        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE),
+        self.assertEqual(self.get_row(rep, UnsupportReason.MAX_PRICE),
                          (2, 4))
         th3 = self.header(7)
         ta.add_task(th3)
         ta.add_support_status(th3.task_id, self.ssmp)
         ta.do_maintenance()
         rep = ta.get_unsupport_reasons(5)
-        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE), (2, 4))
+        self.assertEqual(self.get_row(rep, UnsupportReason.MAX_PRICE), (2, 4))

--- a/tests/golem/task/test_taskarchiver.py
+++ b/tests/golem/task/test_taskarchiver.py
@@ -28,14 +28,14 @@ class TestTaskArchiver(TestCase):
             {UnsupportReason.REQUESTOR_TRUST: 0.5})
 
     def header(self, max_price, last_checking=None,
-               deadline = None, min_version = "4"):
+               deadline=None, min_version="4"):
         if not last_checking:
             last_checking = time.time()
         if not deadline:
             deadline = timeout_to_deadline(36000)
         ret = TaskHeader("ABC", str(uuid4()), "10.10.10.10", 10101, "key",
-                         "DEFAULT", max_price = max_price, deadline = deadline,
-                         min_version = min_version)
+                         "DEFAULT", max_price=max_price, deadline=deadline,
+                         min_version=min_version)
         if last_checking:
             ret.last_checking = last_checking
         return ret
@@ -58,7 +58,7 @@ class TestTaskArchiver(TestCase):
         ta = TaskArchiver()
         th1 = self.header(7)
         th2 = self.header(8)
-        th3 = self.header(9, min_version = "2")
+        th3 = self.header(9, min_version="2")
         th4 = self.header(10)
         s1 = self.ssok
         s2 = self.ssmp.join(self.ssav)
@@ -74,13 +74,15 @@ class TestTaskArchiver(TestCase):
         ta.add_support_status(th4.task_id, s4)
         ta.do_maintenance()
         rep = ta.get_unsupport_reasons(5)
+
         def check1(report):
             self.assertEqual(self.getRow(report, UnsupportReason.APP_VERSION),
-                             (2,"4"))
+                             (2, "4"))
             self.assertEqual(self.getRow(report, UnsupportReason.DENY_LIST),
                              (0, None))
-            self.assertEqual(self.getRow(report, UnsupportReason.REQUESTOR_TRUST),
-                             (1, 0.5))
+            self.assertEqual(self.getRow(report,
+                                         UnsupportReason.REQUESTOR_TRUST),
+                                         (1, 0.5))
             self.assertEqual(self.getRow(report, UnsupportReason.MAX_PRICE),
                              (1, (7+8+9+10)//4))
         check1(rep)
@@ -99,12 +101,12 @@ class TestTaskArchiver(TestCase):
         todayts = datetime_to_timestamp(today)
         back1ts = datetime_to_timestamp(back1)
         back2ts = datetime_to_timestamp(back2)
-        th1 = self.header(3, deadline = past_deadline, last_checking = back2ts)
-        th2 = self.header(5, last_checking = back2ts)
-        th3 = self.header(7, min_version="2", deadline = past_deadline,
-                          last_checking = back2ts)
-        th4 = self.header(9, last_checking = back1ts)
-        th5 = self.header(11, deadline = past_deadline, last_checking=todayts)
+        th1 = self.header(3, deadline=past_deadline, last_checking=back2ts)
+        th2 = self.header(5, last_checking=back2ts)
+        th3 = self.header(7, min_version="2", deadline=past_deadline,
+                          last_checking=back2ts)
+        th4 = self.header(9, last_checking=back1ts)
+        th5 = self.header(11, deadline=past_deadline, last_checking=todayts)
         s1 = self.ssrt
         s2 = self.ssmp.join(self.ssav)
         s3 = self.ssav.join(self.ssrt)
@@ -165,7 +167,7 @@ class TestTaskArchiver(TestCase):
                          (0, None))
 
     def test_max_tasks(self):
-        ta = TaskArchiver(max_tasks = 2)
+        ta = TaskArchiver(max_tasks=2)
         th1 = self.header(3)
         th2 = self.header(5)
         ta.add_task(th1)
@@ -181,8 +183,4 @@ class TestTaskArchiver(TestCase):
         ta.add_support_status(th3.task_id, self.ssmp)
         ta.do_maintenance()
         rep = ta.get_unsupport_reasons(5)
-        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE),
-                         (2, 4))
-
-
-
+        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE), (2, 4))

--- a/tests/golem/task/test_taskarchiver.py
+++ b/tests/golem/task/test_taskarchiver.py
@@ -1,0 +1,188 @@
+from unittest import TestCase
+from golem.task.taskarchiver import TaskArchiver, Archive, ArchTask, TimeInterval
+from golem.environments.environment import SupportStatus, UnsupportReason
+from golem.task.taskbase import TaskHeader
+from golem.core.common import timeout_to_deadline, datetime_to_timestamp
+import time
+import pytz
+from datetime import datetime, timedelta
+from uuid import uuid4
+
+
+class TestTaskArchiver(TestCase):
+    def setUp(self):
+        self.ssok = SupportStatus.ok()
+        self.ssem = SupportStatus.err(
+            {UnsupportReason.ENVIRONMENT_MISSING: "env1"})
+        self.sseu = SupportStatus.err(
+            {UnsupportReason.ENVIRONMENT_UNSUPPORTED: "env2"})
+        self.ssenat = SupportStatus.err(
+            {UnsupportReason.ENVIRONMENT_NOT_ACCEPTING_TASKS: "env3"})
+        self.ssmp = SupportStatus.err(
+            {UnsupportReason.MAX_PRICE: "0"})
+        self.ssav = SupportStatus.err(
+            {UnsupportReason.APP_VERSION: "5"})
+        self.ssdl = SupportStatus.err(
+            {UnsupportReason.DENY_LIST: "aaa"})
+        self.ssrt = SupportStatus.err(
+            {UnsupportReason.REQUESTOR_TRUST: 0.5})
+
+    def header(self, max_price, last_checking=None,
+               deadline = None, min_version = "4"):
+        if not last_checking:
+            last_checking = time.time()
+        if not deadline:
+            deadline = timeout_to_deadline(36000)
+        ret = TaskHeader("ABC", str(uuid4()), "10.10.10.10", 10101, "key",
+                         "DEFAULT", max_price = max_price, deadline = deadline,
+                         min_version = min_version)
+        if last_checking:
+            ret.last_checking = last_checking
+        return ret
+
+    def getRow(self, reasonsReport, unsupportReason):
+        """From unsupport reasons report gets a row corresponding to given
+        unsuportReason as tuple
+        (ntasks, avg)"""
+        for row in reasonsReport:
+            if row["reason"] == unsupportReason.value:
+                return (row["ntasks"], row["avg"])
+
+    def test_empty_stats(self):
+        ta = TaskArchiver()
+        rep = ta.get_unsupport_reasons(5)
+        for r in UnsupportReason:
+            self.assertEqual(self.getRow(rep, r), (0, None))
+
+    def test_with_remembering_tasks(self):
+        ta = TaskArchiver()
+        th1 = self.header(7)
+        th2 = self.header(8)
+        th3 = self.header(9, min_version = "2")
+        th4 = self.header(10)
+        s1 = self.ssok
+        s2 = self.ssmp.join(self.ssav)
+        s3 = self.ssav.join(self.ssrt)
+        s4 = self.ssok
+        ta.add_task(th1)
+        ta.add_task(th2)
+        ta.add_task(th3)
+        ta.add_task(th4)
+        ta.add_support_status(th1.task_id, s1)
+        ta.add_support_status(th2.task_id, s2)
+        ta.add_support_status(th3.task_id, s3)
+        ta.add_support_status(th4.task_id, s4)
+        ta.do_maintenance()
+        rep = ta.get_unsupport_reasons(5)
+        def check1(report):
+            self.assertEqual(self.getRow(report, UnsupportReason.APP_VERSION),
+                             (2,"4"))
+            self.assertEqual(self.getRow(report, UnsupportReason.DENY_LIST),
+                             (0, None))
+            self.assertEqual(self.getRow(report, UnsupportReason.REQUESTOR_TRUST),
+                             (1, 0.5))
+            self.assertEqual(self.getRow(report, UnsupportReason.MAX_PRICE),
+                             (1, (7+8+9+10)//4))
+        check1(rep)
+        ta.add_task(th2)
+        ta.add_support_status(th2.task_id, s2)
+        ta.do_maintenance()
+        rep2 = ta.get_unsupport_reasons(5)
+        check1(rep2)
+
+    def test_history(self):
+        ta = TaskArchiver()
+        past_deadline = timeout_to_deadline(-36000)
+        today = datetime.now(pytz.utc)
+        back1 = today - timedelta(days=1)
+        back2 = today - timedelta(days=2)
+        todayts = datetime_to_timestamp(today)
+        back1ts = datetime_to_timestamp(back1)
+        back2ts = datetime_to_timestamp(back2)
+        th1 = self.header(3, deadline = past_deadline, last_checking = back2ts)
+        th2 = self.header(5, last_checking = back2ts)
+        th3 = self.header(7, min_version="2", deadline = past_deadline,
+                          last_checking = back2ts)
+        th4 = self.header(9, last_checking = back1ts)
+        th5 = self.header(11, deadline = past_deadline, last_checking=todayts)
+        s1 = self.ssrt
+        s2 = self.ssmp.join(self.ssav)
+        s3 = self.ssav.join(self.ssrt)
+        s4 = self.ssok
+        s5 = self.ssmp.join(self.ssav)
+        ta.add_task(th1)
+        ta.add_support_status(th1.task_id, s1)
+        ta.add_task(th2)
+        ta.add_support_status(th2.task_id, s2)
+        ta.add_task(th3)
+        ta.add_task(th4)
+        ta.add_support_status(th3.task_id, s3)
+        ta.add_support_status(th4.task_id, s4)
+        ta.do_maintenance()
+        ta.add_task(th5)
+        ta.add_support_status(th5.task_id, s5)
+        ta.do_maintenance()
+        rep = ta.get_unsupport_reasons(1, today)
+        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE), (1, 11))
+        self.assertEqual(self.getRow(rep, UnsupportReason.APP_VERSION),
+                         (1, "4"))
+        self.assertEqual(self.getRow(rep, UnsupportReason.REQUESTOR_TRUST),
+                         (0, None))
+        rep = ta.get_unsupport_reasons(2, today)
+        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE), (1, 10))
+        self.assertEqual(self.getRow(rep, UnsupportReason.APP_VERSION),
+                         (1, "4"))
+        self.assertEqual(self.getRow(rep, UnsupportReason.REQUESTOR_TRUST),
+                         (0, None))
+        rep = ta.get_unsupport_reasons(3, today)
+        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE), (2, 7))
+        self.assertEqual(self.getRow(rep, UnsupportReason.APP_VERSION),
+                         (3, "4"))
+        self.assertEqual(self.getRow(rep, UnsupportReason.REQUESTOR_TRUST),
+                         (2, 0.5))
+        self.assertEqual(self.getRow(rep, UnsupportReason.DENY_LIST),
+                         (0, None))
+        # Re-add task that has deadline in the future - should not change the
+        # report
+        ta.add_task(th2)
+        ta.add_support_status(th2.task_id, s2)
+        ta.do_maintenance()
+        rep2 = ta.get_unsupport_reasons(3, today)
+        self.assertEqual(rep, rep2)
+        # Re-add task that has deadline in the past - should change the
+        # report as the task should have been archived
+        ta.add_task(th1)
+        ta.add_support_status(th1.task_id, s1)
+        ta.do_maintenance()
+        rep3 = ta.get_unsupport_reasons(3, today)
+        self.assertNotEqual(rep, rep3)
+        self.assertEqual(self.getRow(rep3, UnsupportReason.MAX_PRICE), (2, 6))
+        self.assertEqual(self.getRow(rep3, UnsupportReason.APP_VERSION),
+                         (3, "4"))
+        self.assertEqual(self.getRow(rep3, UnsupportReason.REQUESTOR_TRUST),
+                         (3, 0.5))
+        self.assertEqual(self.getRow(rep3, UnsupportReason.DENY_LIST),
+                         (0, None))
+
+    def test_max_tasks(self):
+        ta = TaskArchiver(max_tasks = 2)
+        th1 = self.header(3)
+        th2 = self.header(5)
+        ta.add_task(th1)
+        ta.add_task(th2)
+        ta.add_support_status(th1.task_id, self.ssmp)
+        ta.add_support_status(th2.task_id, self.ssmp)
+        ta.do_maintenance()
+        rep = ta.get_unsupport_reasons(5)
+        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE),
+                         (2, 4))
+        th3 = self.header(7)
+        ta.add_task(th3)
+        ta.add_support_status(th3.task_id, self.ssmp)
+        ta.do_maintenance()
+        rep = ta.get_unsupport_reasons(5)
+        self.assertEqual(self.getRow(rep, UnsupportReason.MAX_PRICE),
+                         (2, 4))
+
+
+

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -128,9 +128,9 @@ class TestTaskHeaderKeeper(LogTestCase):
         self.assertNotIn("xyz", tk.supported_tasks)
         self.assertIn("abc", tk.supported_tasks)
         tar.add_support_status.assert_any_call(
-            "xyz", SupportStatus(False,{UnsupportReason.MAX_PRICE: 9.0}))
+            "xyz", SupportStatus(False, {UnsupportReason.MAX_PRICE: 9.0}))
         tar.add_support_status.assert_any_call(
-            "abc", SupportStatus(True,{}))
+            "abc", SupportStatus(True, {}))
 
     def test_get_task(self):
         tk = TaskHeaderKeeper(EnvironmentsManager(), 10)
@@ -226,15 +226,14 @@ class TestTaskHeaderKeeper(LogTestCase):
         assert tk.add_task_header(task_header)
         tar.add_task.assert_called()
         tar.add_support_status.assert_any_call(
-            "good", SupportStatus(True,{}))
+            "good", SupportStatus(True, {}))
         tar.reset_mock()
         task_header['task_id'] = "bad"
         task_header["max_price"] = 1.0
         assert tk.add_task_header(task_header)
         tar.add_task.assert_called()
         tar.add_support_status.assert_any_call(
-            "bad", SupportStatus(False,{UnsupportReason.MAX_PRICE: 1.0}))
-
+            "bad", SupportStatus(False, {UnsupportReason.MAX_PRICE: 1.0}))
 
     def test_is_correct(self):
         tk = TaskHeaderKeeper(EnvironmentsManager(), 10)

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -9,7 +9,8 @@ from mock import patch
 
 from golem.core.common import get_timestamp_utc, timeout_to_deadline
 from golem.core.variables import APP_VERSION
-from golem.environments.environment import Environment, UnsupportReason
+from golem.environments.environment import Environment, UnsupportReason,\
+    SupportStatus
 from golem.environments.environmentsmanager import EnvironmentsManager
 from golem.network.p2p.node import Node
 from golem.task.taskbase import TaskHeader, ComputeTaskDef
@@ -91,8 +92,9 @@ class TestTaskHeaderKeeper(LogTestCase):
         assert tk.check_version_compatibility('0.4.0-alpha+build')
         assert tk.check_version_compatibility('0.4.0-alpha+build.2010')
 
-    def test_change_config(self):
-        tk = TaskHeaderKeeper(EnvironmentsManager(), 10.0)
+    @patch('golem.task.taskarchiver.TaskArchiver')
+    def test_change_config(self, tar):
+        tk = TaskHeaderKeeper(EnvironmentsManager(), 10.0, task_archiver=tar)
         e = Environment()
         e.accept_tasks = True
         tk.environments_manager.add_environment(e)
@@ -119,6 +121,16 @@ class TestTaskHeaderKeeper(LogTestCase):
         tk.change_config(config_desc)
         self.assertNotIn("xyz", tk.supported_tasks)
         self.assertNotIn("abc", tk.supported_tasks)
+        # Make sure the tasks stats are properly archived
+        tar.reset_mock()
+        config_desc.min_price = 9.5
+        tk.change_config(config_desc)
+        self.assertNotIn("xyz", tk.supported_tasks)
+        self.assertIn("abc", tk.supported_tasks)
+        tar.add_support_status.assert_any_call(
+            "xyz", SupportStatus(False,{UnsupportReason.MAX_PRICE: 9.0}))
+        tar.add_support_status.assert_any_call(
+            "abc", SupportStatus(True,{}))
 
     def test_get_task(self):
         tk = TaskHeaderKeeper(EnvironmentsManager(), 10)
@@ -203,6 +215,26 @@ class TestTaskHeaderKeeper(LogTestCase):
         task_header['task_id'] = "newtaskID"
         task_header['deadline'] = "WRONG DEADLINE"
         assert not tk.add_task_header(task_header)
+
+    @patch('golem.task.taskarchiver.TaskArchiver')
+    def test_task_header_update_stats(self, tar):
+        e = Environment()
+        e.accept_tasks = True
+        tk = TaskHeaderKeeper(EnvironmentsManager(), 10, task_archiver=tar)
+        tk.environments_manager.add_environment(e)
+        task_header = get_dict_task_header("good")
+        assert tk.add_task_header(task_header)
+        tar.add_task.assert_called()
+        tar.add_support_status.assert_any_call(
+            "good", SupportStatus(True,{}))
+        tar.reset_mock()
+        task_header['task_id'] = "bad"
+        task_header["max_price"] = 1.0
+        assert tk.add_task_header(task_header)
+        tar.add_task.assert_called()
+        tar.add_support_status.assert_any_call(
+            "bad", SupportStatus(False,{UnsupportReason.MAX_PRICE: 1.0}))
+
 
     def test_is_correct(self):
         tk = TaskHeaderKeeper(EnvironmentsManager(), 10)
@@ -345,6 +377,57 @@ class TestTaskHeaderKeeper(LogTestCase):
             self.assertIn("ta%d" % i, tk.task_headers)
         self.assertIn("tb0", tk.task_headers)
         self.assertEqual(new_limit + 1, len(tk.task_headers))
+
+    def test_get_unsupport_reasons(self):
+        tk = TaskHeaderKeeper(EnvironmentsManager(), 10)
+        e = Environment()
+        e.accept_tasks = True
+        tk.environments_manager.add_environment(e)
+
+        # Supported task
+        thd = get_dict_task_header("good")
+        tk.add_task_header(thd)
+
+        # Wrong version
+        thd = get_dict_task_header("wrong version")
+        thd["min_version"] = "42.0.17"
+        tk.add_task_header(thd)
+
+        # Wrong environment
+        thd = get_dict_task_header("wrong env")
+        thd["environment"] = "UNKNOWN"
+        tk.add_task_header(thd)
+
+        # Wrong price
+        thd = get_dict_task_header("wrong price")
+        thd["max_price"] = 1
+        tk.add_task_header(thd)
+
+        # Wrong price and version
+        thd = get_dict_task_header("wrong price and version")
+        thd["min_version"] = "42.0.17"
+        thd["max_price"] = 1
+        tk.add_task_header(thd)
+
+        # And one more with wrong version
+        thd = get_dict_task_header("wrong version 2")
+        thd["min_version"] = "42.0.44"
+        tk.add_task_header(thd)
+
+        reasons = tk.get_unsupport_reasons()
+        # 3 tasks with wrong version
+        self.assertIn({'avg': APP_VERSION,
+                       'reason': 'app_version',
+                       'ntasks': 3}, reasons)
+        # 2 tasks with wrong price
+        self.assertIn({'avg': 7, 'reason': 'max_price', 'ntasks': 2}, reasons)
+        # 1 task with wrong environment
+        self.assertIn({'avg': None,
+                       'reason': 'environment_missing',
+                       'ntasks': 1}, reasons)
+        self.assertIn({'avg': None,
+                       'reason': 'environment_not_accepting_tasks',
+                       'ntasks': 1}, reasons)
 
 
 def get_dict_task_header(task_id="xyz"):

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -154,7 +154,6 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
         ts.remove_task_header("uvw5")
         ts.deny_set.remove("key")
 
-
     @patch("golem.task.taskserver.Trust")
     def test_send_results(self, trust):
         ccd = ClientConfigDescriptor()

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -64,8 +64,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
         random.seed()
         self.ccd = ClientConfigDescriptor()
         self.ts = TaskServer(Node(), self.ccd, EllipticalKeysAuth(self.path),
-                             self.client, use_docker_machine_manager=False,
-                             task_archiver=None)
+                             self.client, use_docker_machine_manager=False)
 
     def tearDown(self):
         LogTestCase.tearDown(self)
@@ -161,7 +160,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
         n = Node()
         ka = EllipticalKeysAuth(self.path)
         ts = TaskServer(n, ccd, ka, self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         ts.verify_header_sig = lambda x: True
         self.ts = ts
         ts.client.get_suggested_addr.return_value = "10.10.10.10"
@@ -241,7 +240,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
         n = Node()
         ka = EllipticalKeysAuth(self.path)
         ts = TaskServer(n, ccd, ka, self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         session = Mock()
         session.address = "10.10.10.10"
@@ -266,7 +265,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
         ccd.waiting_for_task_timeout = 19
 
         ts = TaskServer(Node(), ccd, EllipticalKeysAuth(self.path), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
 
         ccd2 = ClientConfigDescriptor()
@@ -291,8 +290,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
         keys_auth_2 = EllipticalKeysAuth(os.path.join(self.path, "2"))
 
         self.ts = ts = TaskServer(Node(), config, keys_auth, self.client,
-                                  use_docker_machine_manager=False,
-                                  task_archiver=None)
+                                  use_docker_machine_manager=False)
 
         task_header = get_example_task_header()
         task_header["task_id"] = "xyz"
@@ -331,14 +329,14 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_sync(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, EllipticalKeysAuth(self.path), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.sync_network()
 
     def test_traverse_nat(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, EllipticalKeysAuth(self.path), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
         ts.traverse_nat("ABC", "10.10.10.10", 1312, 310319041904, "DEF")
@@ -348,7 +346,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_forwarded_session_requests(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, EllipticalKeysAuth(self.path), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
 
@@ -380,7 +378,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_retry_sending_task_result(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, EllipticalKeysAuth(self.path), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
 
@@ -396,7 +394,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_send_waiting_results(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
         ts._mark_connected = Mock()
@@ -456,7 +454,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_add_task_session(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
 
@@ -471,7 +469,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
         node.nat_type = FullCone
 
         ts = TaskServer(node, ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
         ts._add_pending_request = Mock()
@@ -498,7 +496,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_remove_task_session(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
 
@@ -513,7 +511,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_respond_to(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
         session = Mock()
@@ -529,7 +527,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_conn_for_task_failure_established(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
         session = Mock()
@@ -548,7 +546,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
 
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
         ts.final_conn_failure = Mock()
@@ -562,7 +560,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
 
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.network = Mock()
         ts.final_conn_failure = Mock()
@@ -625,7 +623,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
         task_result"""
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         ts.network = MagicMock()
         ts.final_conn_failure = Mock()
         ts.task_computer = Mock()
@@ -655,7 +653,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_should_accept_provider(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.client.get_computing_trust = Mock(return_value=0.4)
         ts.config_desc.computing_trust = 0.2
         assert ts.should_accept_provider("ABC")
@@ -673,7 +671,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_should_accept_requestor(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.client.get_requesting_trust = Mock(return_value=0.4)
         ts.config_desc.requesting_trust = 0.2
         assert ts.should_accept_requestor("ABC").is_ok()
@@ -772,7 +770,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
     def test_new_connection(self):
         ccd = ClientConfigDescriptor()
         ts = TaskServer(Node(), ccd, Mock(), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         tss = TaskSession(Mock())
         ts.new_connection(tss)
         assert len(ts.task_sessions_incoming) == 1
@@ -787,8 +785,7 @@ class TestTaskServer2(TestWithKeysAuth, TestDatabaseWithReactor):
         random.seed()
         self.ccd = self._get_config_desc()
         self.ts = TaskServer(Node(), self.ccd, EllipticalKeysAuth(self.path),
-                             self.client, use_docker_machine_manager=False,
-                             task_archiver=None)
+                             self.client, use_docker_machine_manager=False)
         self.ts.task_computer = MagicMock()
 
     def tearDown(self):
@@ -875,7 +872,7 @@ class TestTaskServer2(TestWithKeysAuth, TestDatabaseWithReactor):
     def test_results(self, trust, dump_mock):
         ccd = self._get_config_desc()
         ts = TaskServer(Node(), ccd, EllipticalKeysAuth(self.path), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         self.ts = ts
         ts.task_manager.listen_port = 1111
         ts.task_manager.listen_address = "10.10.10.10"
@@ -914,7 +911,7 @@ class TestTaskServer2(TestWithKeysAuth, TestDatabaseWithReactor):
         # FIXME: This test is too heavy, it starts up whole Golem Client.
         ccd = self._get_config_desc()
         ts = TaskServer(Node(), ccd, EllipticalKeysAuth(self.path), self.client,
-                        use_docker_machine_manager=False, task_archiver=None)
+                        use_docker_machine_manager=False)
         ts.task_manager.listen_address = "10.10.10.10"
         ts.task_manager.listen_port = 1111
         ts.receive_subtask_computation_time("xxyyzz", 1031)
@@ -948,8 +945,7 @@ class TestTaskServer2(TestWithKeysAuth, TestDatabaseWithReactor):
 
     def test_disconnect(self):
         task_server = TaskServer(Node(), Mock(), EllipticalKeysAuth(self.path),
-                                 self.client, use_docker_machine_manager=False,
-                                 task_archiver=None)
+                                 self.client, use_docker_machine_manager=False)
         task_server.task_sessions = {'task_id': Mock()}
         task_server.disconnect()
         assert task_server.task_sessions['task_id'].dropped.called

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -554,8 +554,7 @@ class TestClient(TestWithDatabase, TestWithReactor):
         assert self.client.p2pservice.disconnect.called
         assert self.client.task_server.disconnect.called
 
-    @patch('golem.client.log')
-    def test_task_archiver_maintenance(self, log, *_):
+    def test_task_archiver_maintenance(self, *_):
         self.client = Client(
             datadir=self.path,
             transaction_system=False,
@@ -566,7 +565,7 @@ class TestClient(TestWithDatabase, TestWithReactor):
 
         c = self.client
         c.task_archiver.do_maintenance = Mock()
-        c._Client__task_archiver_maintenance()
+        c._Client__task_archiver_maintenance()   # pylint: disable=no-member
 
         assert c.task_archiver.do_maintenance.called
 
@@ -888,8 +887,7 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         assert c.remove_task.called
         assert c.task_server.task_manager.delete_task.called
 
-    @patch('golem.client.log')
-    def test_get_unsupport_reasons(self, log, *_):
+    def test_get_unsupport_reasons(self, *_):
         c = self.client
         c.task_server.task_keeper.get_unsupport_reasons = Mock()
         c.task_server.task_keeper.get_unsupport_reasons.return_value = [


### PR DESCRIPTION
A new command "tasks unsupport" has been added to client that shows statistics for unsupported tasks that the node currently sees in the network. When this command is followed with a number of days,
the statistics are shown for all tasks seen by this node during the last number of calendar days. The statistics are persistent.