### PR TITLE
Elaborated logs about docker issues #1416

### DIFF
--- a/golem/docker/manager.py
+++ b/golem/docker/manager.py
@@ -409,6 +409,18 @@ class DockerManager(DockerConfigManager):
             if not retried:
                 self.command('regenerate_certs', self.docker_machine)
                 return self._set_docker_machine_env(retried=True)
+            typical_solution_s = """It seems there is a  problem with your Docker installation.
+Ensure that you try the following before reporting an issue:
+
+ 1. The virtualization of Intel VT-x/EPT or AMD-V/RVI is enabled in BIOS
+    or virtual machine settings.
+ 2. The proper environment is set. On windows powershell please run:
+    & "C:\Program Files\Docker Toolbox\docker-machine.exe" env golem | Invoke-Expression
+ 3. virtualbox driver is available:
+    docker-machine.exe create --driver virtualbox golem
+ 4. Restart Windows machine"""
+            logger.error(typical_solution_s)
+
             raise
 
         if output:


### PR DESCRIPTION
A lot changed since the issue was created. Docker no longer uses ProcessMonitor and hyperg uses it in a different way. So only small portion of #1432 remains. Also #1432 was based on discarded `devp2p` branch.

fixes: #1416 