### PR TITLE
Typo fix in MessageSubtaskResultAccepted

### DIFF
--- a/golem/network/transport/message.py
+++ b/golem/network/transport/message.py
@@ -308,13 +308,19 @@ P2P_MESSAGE_BASE = 1000
 class MessagePing(Message):
     TYPE = P2P_MESSAGE_BASE + 1
 
+    __slots__ = Message.__slots__
+
 
 class MessagePong(Message):
     TYPE = P2P_MESSAGE_BASE + 2
 
+    __slots__ = Message.__slots__
+
 
 class MessageGetPeers(Message):
     TYPE = P2P_MESSAGE_BASE + 3
+
+    __slots__ = Message.__slots__
 
 
 class MessagePeers(Message):
@@ -333,6 +339,8 @@ class MessagePeers(Message):
 
 class MessageGetTasks(Message):
     TYPE = P2P_MESSAGE_BASE + 5
+
+    __slots__ = Message.__slots__
 
 
 class MessageTasks(Message):
@@ -366,6 +374,8 @@ class MessageRemoveTask(Message):
 class MessageGetResourcePeers(Message):
     """Request for resource peers"""
     TYPE = P2P_MESSAGE_BASE + 8
+
+    __slots__ = Message.__slots__
 
 
 class MessageResourcePeers(Message):
@@ -413,6 +423,8 @@ class MessageGossip(Message):
 class MessageStopGossip(Message):
     """Create stop gossip message"""
     TYPE = P2P_MESSAGE_BASE + 12
+
+    __slots__ = Message.__slots__
 
 
 class MessageLocRank(Message):
@@ -765,7 +777,7 @@ class MessageGetResource(Message):
 class MessageSubtaskResultAccepted(Message):
     TYPE = TASK_MSG_BASE + 10
 
-    __slots = [
+    __slots__ = [
         'subtask_id',
         'reward'
     ] + Message.__slots__
@@ -927,6 +939,8 @@ class MessageBeingMiddlemanAccepted(Message):
     """Create message with information that node accepted being a middleman"""
     TYPE = TASK_MSG_BASE + 19
 
+    __slots__ = Message.__slots__
+
 
 class MessageMiddlemanAccepted(Message):
     """Create message with information that this node accepted connection
@@ -934,12 +948,16 @@ class MessageMiddlemanAccepted(Message):
     """
     TYPE = TASK_MSG_BASE + 20
 
+    __slots__ = Message.__slots__
+
 
 class MessageMiddlemanReady(Message):
     """Create message with information that other node connected and
        middleman session may be started
     """
     TYPE = TASK_MSG_BASE + 21
+
+    __slots__ = Message.__slots__
 
 
 class MessageNatPunch(Message):
@@ -991,9 +1009,13 @@ class MessageNatPunchFailure(Message):
     """Create message that informs node about unsuccessful nat punch"""
     TYPE = TASK_MSG_BASE + 24
 
+    __slots__ = Message.__slots__
+
 
 class MessageWaitingForResults(Message):
     TYPE = TASK_MSG_BASE + 25
+
+    __slots__ = Message.__slots__
 
 
 class MessageCannotComputeTask(Message):
@@ -1100,15 +1122,21 @@ class MessageHasResource(AbstractResource):
     """Create message with information about having given resource"""
     TYPE = RESOURCE_MSG_BASE + 2
 
+    __slots__ = AbstractResource.__slots__
+
 
 class MessageWantsResource(AbstractResource):
     """Send information that node wants to receive given resource"""
     TYPE = RESOURCE_MSG_BASE + 3
 
+    __slots__ = AbstractResource.__slots__
+
 
 class MessagePullResource(AbstractResource):
     """Create message with information that given resource is needed"""
     TYPE = RESOURCE_MSG_BASE + 4
+
+    __slots__ = AbstractResource.__slots__
 
 
 class MessagePullAnswer(Message):

--- a/tests/golem/network/transport/test_message.py
+++ b/tests/golem/network/transport/test_message.py
@@ -11,6 +11,7 @@ import mock
 
 from golem.core.common import to_unicode
 from golem.network.transport import message
+from golem.network.transport.message import Message
 from golem.network.transport.tcpnetwork import BasicProtocol
 from golem.task.taskbase import ResultType
 from golem.testutils import PEP8MixIn
@@ -451,3 +452,12 @@ class TestMessages(unittest.TestCase, PEP8MixIn):
         with self.assertRaises(RuntimeError):
             message.init_messages()
         message.registered_message_types = copy_registered
+
+    def test_slots(self):
+        message.init_messages()
+
+        for _, cls in message.registered_message_types.items():
+            # only __slots__ can be present in objects
+            assert not hasattr(cls.__new__(cls), '__dict__')
+            # slots are properly set in class definition
+            assert len(cls.__slots__) >= len(Message.__slots__)

--- a/tests/golem/network/transport/test_message.py
+++ b/tests/golem/network/transport/test_message.py
@@ -456,7 +456,7 @@ class TestMessages(unittest.TestCase, PEP8MixIn):
     def test_slots(self):
         message.init_messages()
 
-        for _, cls in message.registered_message_types.items():
+        for cls in message.registered_message_types.values():
             # only __slots__ can be present in objects
             assert not hasattr(cls.__new__(cls), '__dict__')
             # slots are properly set in class definition


### PR DESCRIPTION
- `__slots__` are now required in `Message` subclasses
- unit test for presence of `__slots__` in `Message*`

Resolves #1607 