### PR TITLE
Try harder to fix machine when regenerate-certs fails

### DIFF
--- a/golem/docker/manager.py
+++ b/golem/docker/manager.py
@@ -408,8 +408,29 @@ class DockerManager(DockerConfigManager):
                 try:
                     self.command('regenerate_certs', self.docker_machine)
                 except subprocess.CalledProcessError as e:
-                    logger.warning("DockerMachine: failed to env the VM: %s", e)
-                    logger.debug("DockerMachine_output: %s", e.output)
+                    logger.warning("DockerMachine:"
+                                   " failed to env the VM: %s -- %s",
+                                   e, e.output)
+                else:
+                    return self._set_docker_machine_env(retried=True)
+
+                try:
+                    self.command('start', self.docker_machine)
+                except subprocess.CalledProcessError as e:
+                    logger.warning("DockerMachine:"
+                                   " failed to restart the VM: %s -- %s",
+                                   e, e.output)
+                else:
+                    return self._set_docker_machine_env(retried=True)
+
+                try:
+                    self.command('rm', self.docker_machine)
+                    self.command('create', self.docker_machine)
+                except subprocess.CalledProcessError as e:
+                    logger.warning("DockerMachine:"
+                                   " failed to re-create the VM: %s -- %s",
+                                   e, e.output)
+
                 return self._set_docker_machine_env(retried=True)
             typical_solution_s = """It seems there is a  problem with your Docker installation.
 Ensure that you try the following before reporting an issue:

--- a/golem/docker/manager.py
+++ b/golem/docker/manager.py
@@ -424,8 +424,9 @@ class DockerManager(DockerConfigManager):
                     return self._set_docker_machine_env(retried=True)
 
                 try:
-                    if self.hypervisor.remove(self.docker_machine):
-                        self.hypervisor.create(self.docker_machine)
+                    if self.hypervisor:
+                        if self.hypervisor.remove(self.docker_machine):
+                            self.hypervisor.create(self.docker_machine)
                 except subprocess.CalledProcessError as e:
                     logger.warning("DockerMachine:"
                                    " failed to re-create the VM: %s -- %s",

--- a/golem/docker/manager.py
+++ b/golem/docker/manager.py
@@ -424,8 +424,8 @@ class DockerManager(DockerConfigManager):
                     return self._set_docker_machine_env(retried=True)
 
                 try:
-                    self.command('rm', self.docker_machine)
-                    self.command('create', self.docker_machine)
+                    if self.hypervisor.remove(self.docker_machine):
+                        self.hypervisor.create(self.docker_machine)
                 except subprocess.CalledProcessError as e:
                     logger.warning("DockerMachine:"
                                    " failed to re-create the VM: %s -- %s",

--- a/tests/golem/docker/test_docker_manager.py
+++ b/tests/golem/docker/test_docker_manager.py
@@ -6,7 +6,6 @@ import sys
 from contextlib import contextmanager
 from subprocess import CalledProcessError
 
-
 from golem.docker.manager import DockerManager, FALLBACK_DOCKER_MACHINE_NAME, \
                                  VirtualBoxHypervisor, XhyveHypervisor, \
                                  Hypervisor, logger
@@ -571,7 +570,6 @@ class TestDockerManager(unittest.TestCase):
             if key != 'start':
                 raise_process_exception('error')
             return key
-
 
         with mock.patch.dict('os.environ', environ):
             dmm._set_docker_machine_env()

--- a/tests/golem/docker/test_docker_manager.py
+++ b/tests/golem/docker/test_docker_manager.py
@@ -1,12 +1,11 @@
 import json
 import os
 import unittest
+from unittest import mock
 import sys
 from contextlib import contextmanager
-import subprocess
 from subprocess import CalledProcessError
 
-import mock
 
 from golem.docker.manager import DockerManager, FALLBACK_DOCKER_MACHINE_NAME, \
                                  VirtualBoxHypervisor, XhyveHypervisor, \
@@ -560,12 +559,19 @@ class TestDockerManager(unittest.TestCase):
 
     def test_set_docker_machine_env(self):
         dmm = MockDockerManager()
+        dmm.hypervisor = mock.MagicMock()
         environ = dict()
 
         def raise_on_env(key, *args, **kwargs):
             if key == 'env':
                 raise_process_exception('error')
             return key
+
+        def raise_not_start(key, *args, **kwargs):
+            if key != 'start':
+                raise_process_exception('error')
+            return key
+
 
         with mock.patch.dict('os.environ', environ):
             dmm._set_docker_machine_env()
@@ -577,6 +583,10 @@ class TestDockerManager(unittest.TestCase):
                     dmm._set_docker_machine_env()
 
             with mock.patch.object(dmm, 'command', side_effect=raise_on_env):
+                with self.assertRaises(CalledProcessError):
+                    dmm._set_docker_machine_env()
+
+            with mock.patch.object(dmm, 'command', side_effect=raise_not_start):
                 with self.assertRaises(CalledProcessError):
                     dmm._set_docker_machine_env()
 


### PR DESCRIPTION
Resolves #1629 

When regenerate certs fails on the docker machine also try to:
- Restart
- Delete and create

before giving the critical error, making the application unusable.