### PR TITLE
Require specific version of golem-messages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -50,4 +50,4 @@ numpy==1.13.1
 scipy
 pyssim
 enforce==0.3.4
--e git://github.com/golemfactory/golem-messages.git#egg=golem_messages
+-e git://github.com/golemfactory/golem-messages.git@cfdb067c715ffd27489c746ce4892f3f6faff321#egg=golem_messages


### PR DESCRIPTION
Without this:
* Things will break unexpectedly
* It will be hard to reproduce old bugs (how would you know which version was used in the past)