### PR TITLE
Buildbot scripts for mac including unit test

### DIFF
--- a/scripts/ci/.gitignore
+++ b/scripts/ci/.gitignore
@@ -1,0 +1,1 @@
+roles/geerlingguy.homebrew

--- a/scripts/ci/ansible.cfg
+++ b/scripts/ci/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+allow_world_readable_tmpfiles=true

--- a/scripts/ci/requirements.yml
+++ b/scripts/ci/requirements.yml
@@ -1,0 +1,3 @@
+---
+
+- name: "geerlingguy.homebrew"

--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
@@ -33,7 +33,7 @@ class StepsFactory(object):
     def git_step():
         return steps.Git(
             repourl='https://github.com/golemfactory/golem.git',
-            mode='full', method='fresh', branch='mwu/linux_unit_test')
+            mode='full', method='fresh')
 
     def venv_step(self):
         return steps.ShellCommand(
@@ -130,28 +130,24 @@ class StepsFactory(object):
         install_req_cmd = self.pip_command + ['install', '-r',
                                               'requirements-test.txt']
 
+        # Since test-daemons are running commands should not halt on failure.
         return steps.ShellSequence(
             name='run tests',
             commands=[
                 util.ShellArg(
                     logfile='install requirements',
-                    haltOnFailure=True,
+                    warnOnFailure=True,
                     command=install_req_cmd),
                 # TODO: move to requirements itself?
                 util.ShellArg(
                     logfile='install missing requirement',
-                    haltOnFailure=True,
-                    command=self.pip_command + ['install', 'pyasn1==0.2.3',
-                                                'codecov', 'pytest-cov']),
+                    warnOnFailure=True,
+                    command=self.pip_command + ['install', 'pyasn1==0.2.3']),
                 util.ShellArg(
                     logfile='prepare for test',
-                    haltOnFailure=True,
+                    warnOnFailure=True,
                     command=self.python_command + ['setup.py', 'develop']),
-                util.ShellArg(
-                    logfile='start hyperg',
-                    haltOnFailure=True,
-                    command=['scripts/test-daemon-start.sh']),
-                # TODO: add xml results
+                # TODO: add xml results ?
                 # TODO 2: add run slow
                 util.ShellArg(
                     logfile='run tests',

--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
@@ -8,6 +8,18 @@ class StepsFactory(object):
         'git+https://github.com/pyinstaller/pyinstaller.git',
     ]
 
+    # Basic Linux settings, override other platforms.
+    platform = 'linux'
+    venv_command = ['python3', '-m', 'venv']
+    python_command = ['.venv/bin/python']
+    pip_command = ['.venv/bin/pip']
+    venv_bin_path = util.Interpolate('%(prop:builddir)s/build/.venv/bin')
+    venv_path = util.Interpolate('%(prop:builddir)s/build/.venv')
+    requirements_files = ['requirements.txt']
+    pathsep = '/'
+    golem_package = 'dist/golem.tar.gz'
+    golem_package_extension = 'tar.gz'
+
     def build_factory(self):
         factory = util.BuildFactory()
         factory.addStep(self.git_step())
@@ -17,10 +29,11 @@ class StepsFactory(object):
         factory.addStep(self.file_upload_step())
         return factory
 
-    def git_step(self):
+    @staticmethod
+    def git_step():
         return steps.Git(
             repourl='https://github.com/golemfactory/golem.git',
-            mode='full', method='fresh')
+            mode='full', method='fresh', branch='mwu/linux_unit_test')
 
     def venv_step(self):
         return steps.ShellCommand(
@@ -59,12 +72,21 @@ class StepsFactory(object):
                 'LANG': 'en_US.UTF-8',  # required for readline
             })
 
+    @staticmethod
+    def taskcollector_step():
+        return steps.ShellCommand(
+            name='build taskcollector',
+            haltOnFailure=True,
+            command=['make', '-C', 'apps/rendering/resources/taskcollector'],
+        )
+
     def create_binaries_step(self):
         return steps.ShellCommand(
             name='create binaries',
             haltOnFailure=True,
             command=self.python_command + ['setup.py', 'pyinstaller',
-                     '--package-path', self.golem_package],
+                                           '--package-path',
+                                           self.golem_package],
             env={
                 'PATH': [self.venv_bin_path, '${PATH}'],
                 'VIRTUAL_ENV': self.venv_path,
@@ -91,8 +113,18 @@ class StepsFactory(object):
         factory.addStep(self.git_step())
         factory.addStep(self.venv_step())
         factory.addStep(self.requirements_step())
+        factory.addStep(self.taskcollector_step())
+        factory.addStep(self.daemon_start_step())
         factory.addStep(self.test_step())
+        factory.addStep(self.daemon_stop_step())
         return factory
+
+    @staticmethod
+    def daemon_start_step():
+        return steps.ShellCommand(
+            name='start hyperg',
+            haltOnFailure=True,
+            command=['scripts/test-daemon-start.sh'])
 
     def test_step(self):
         install_req_cmd = self.pip_command + ['install', '-r',
@@ -132,11 +164,14 @@ class StepsFactory(object):
                     logfile='handle coverage',
                     warnOnFailure=True,
                     command=self.python_command + ['-m', 'codecov']),
-                util.ShellArg(
-                    logfile='stop hyperg',
-                    haltOnFailure=True,
-                    command=['scripts/test-daemon-stop.sh']),
             ])
+
+    @staticmethod
+    def daemon_stop_step():
+        return steps.ShellCommand(
+            name='stop hyperg',
+            haltOnFailure=True,
+            command=['scripts/test-daemon-stop.sh'])
 
 
 class WindowsStepsFactory(StepsFactory):
@@ -192,40 +227,29 @@ class WindowsStepsFactory(StepsFactory):
             })
 
 
-class PosixStepsFactory(StepsFactory):
-    venv_command = ['python3', '-m', 'venv']
-    python_command = ['.venv/bin/python']
-    pip_command = ['.venv/bin/pip']
-    venv_bin_path = util.Interpolate('%(prop:builddir)s/build/.venv/bin')
-    venv_path = util.Interpolate('%(prop:builddir)s/build/.venv')
-    requirements_files = ['requirements.txt']
-    pathsep = '/'
-    golem_package = 'dist/golem.tar.gz'
-    golem_package_extension = 'tar.gz'
+class LinuxStepsFactory(StepsFactory):
+    pass
 
 
-class LinuxStepsFactory(PosixStepsFactory):
-    platform = 'linux'
-
-
-class MacOsStepsFactory(PosixStepsFactory):
+class MacOsStepsFactory(StepsFactory):
     platform = 'macOS'
 
 
 builders = [
-    util.BuilderConfig(name="unittest_macOS",
-        workernames=["macOS"],
-        factory=LinuxStepsFactory().test_factory()),
-    util.BuilderConfig(name="buildpackage_macOS",
-        workernames=["macOS"],
-        factory=MacOsStepsFactory().build_factory()),
-    util.BuilderConfig(name="unittest_linux",
-        workernames=["linux"],
-        factory=LinuxStepsFactory().test_factory()),
-    util.BuilderConfig(name="buildpackage_linux",
-        workernames=["linux"],
-        factory=LinuxStepsFactory().build_factory()),
+    util.BuilderConfig(name="unittest_macOS", workernames=["macOS"],
+                       factory=LinuxStepsFactory().test_factory(),
+                       env={
+                           'TRAVIS': 'TRUE',
+                           # required for mkdir, ioreg, rm and cat
+                           'PATH': ['/usr/sbin/', '/bin/', '${PATH}'],
+                       }),
+    util.BuilderConfig(name="buildpackage_macOS", workernames=["macOS"],
+                       factory=MacOsStepsFactory().build_factory()),
+    util.BuilderConfig(name="unittest_linux", workernames=["linux"],
+                       factory=LinuxStepsFactory().test_factory()),
+    util.BuilderConfig(name="buildpackage_linux", workernames=["linux"],
+                       factory=LinuxStepsFactory().build_factory()),
     util.BuilderConfig(name="buildpackage_windows",
-        workernames=["windows_server_2016"],
-        factory=WindowsStepsFactory().build_factory()),
+                       workernames=["windows_server_2016"],
+                       factory=WindowsStepsFactory().build_factory()),
 ]

--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/builders.py
@@ -213,6 +213,9 @@ class MacOsStepsFactory(PosixStepsFactory):
 
 
 builders = [
+    util.BuilderConfig(name="unittest_macOS",
+        workernames=["macOS"],
+        factory=LinuxStepsFactory().test_factory()),
     util.BuilderConfig(name="buildpackage_macOS",
         workernames=["macOS"],
         factory=MacOsStepsFactory().build_factory()),

--- a/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/schedulers.py
+++ b/scripts/ci/roles/buildbot-master/files/src/golem_buildbot/schedulers.py
@@ -15,6 +15,7 @@ schedulers = [
         name='force',
         builderNames=[
             'buildpackage_macOS',
+            'unittest_macOS',
             'unittest_linux',
             'buildpackage_linux',
             'buildpackage_windows',

--- a/scripts/ci/roles/buildbot-worker-mac/README.md
+++ b/scripts/ci/roles/buildbot-worker-mac/README.md
@@ -2,7 +2,7 @@
 
 Install all dependencies for the golem project unit test.
 
-Steps to install TRAVIS tests
+## Steps to install TRAVIS tests
 
 - Get mac in cloud
 - Login via VNC
@@ -15,22 +15,8 @@ Steps to install TRAVIS tests
 - Install roles `cd scripts/ci; ansible-galaxy install -r requirements.yml ./roles/` 
 - Run playbook
 - Click install command line tools on remote machine (check if needed)
-- 
+- Wait for the script to finish, everything should be set now. 
 
 
-Required before running ALL tests:
-- clean osx 10.10
-- xcode 7.2.1
-- enable ssh for admin user
-- as running admin user
- - `$ sudo chown -R $(whoami):admin /usr/local`
- - `$ sudo xcode-select --install`
- - `$ sudo xcode-select -switch /`
-
-
-
-
-
-export TRAVIS=true
-
- https://superuser.com/questions/318809/linux-os-x-tar-incompatibility-tarballs-created-on-os-x-give-errors-when-unt
+## Running ALL tests:
+TODO: POC and add to installers

--- a/scripts/ci/roles/buildbot-worker-mac/README.md
+++ b/scripts/ci/roles/buildbot-worker-mac/README.md
@@ -2,7 +2,23 @@
 
 Install all dependencies for the golem project unit test.
 
-Required before running:
+Steps to install TRAVIS tests
+
+- Get mac in cloud
+- Login via VNC
+- Enable SSH
+- `ssh-copy-id` to the server
+- Set become password in vault
+- Update static host for this mac
+- Update buildbot-master firewall rules to allow the new mac
+
+- Install roles `cd scripts/ci; ansible-galaxy install -r requirements.yml ./roles/` 
+- Run playbook
+- Click install command line tools on remote machine (check if needed)
+- 
+
+
+Required before running ALL tests:
 - clean osx 10.10
 - xcode 7.2.1
 - enable ssh for admin user

--- a/scripts/ci/roles/buildbot-worker-mac/README.md
+++ b/scripts/ci/roles/buildbot-worker-mac/README.md
@@ -1,0 +1,20 @@
+# Buildbot mac worker role
+
+Install all dependencies for the golem project unit test.
+
+Required before running:
+- clean osx 10.10
+- xcode 7.2.1
+- enable ssh for admin user
+- as running admin user
+ - `$ sudo chown -R $(whoami):admin /usr/local`
+ - `$ sudo xcode-select --install`
+ - `$ sudo xcode-select -switch /`
+
+
+
+
+
+export TRAVIS=true
+
+ https://superuser.com/questions/318809/linux-os-x-tar-incompatibility-tarballs-created-on-os-x-give-errors-when-unt

--- a/scripts/ci/roles/buildbot-worker-mac/files/network.golem.buildbot-worker.plist
+++ b/scripts/ci/roles/buildbot-worker-mac/files/network.golem.buildbot-worker.plist
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+  <dict>
+    <key>StandardOutPath</key>
+    <string>twistd.log</string>
+    <key>StandardErrorPath</key>
+    <string>twistd-err.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+      <key>PATH</key>
+      <string>/Users/buildbot-worker/.venv/bin:/usr/local/bin/:/usr/bin/</string>
+      <key>TRAVIS</key>
+      <string>true</string>
+    </dict>
+    <key>GroupName</key>
+    <string>daemon</string>
+    <key>KeepAlive</key>
+    <dict>
+      <key>SuccessfulExit</key>
+      <false/>
+    </dict>
+    <key>Label</key>
+    <string>network.golem.buildbot-worker</string>
+    <key>ProgramArguments</key>
+    <array>
+      <string>/Users/buildbot-worker/.venv/bin/buildbot-worker</string>
+      <string>start</string>
+      <string>--nodaemon</string>
+    </array>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>UserName</key>
+    <string>buildbot-worker</string>
+    <key>WorkingDirectory</key>
+    <string>/Users/buildbot-worker/worker/</string>
+  </dict>
+</plist>

--- a/scripts/ci/roles/buildbot-worker-mac/handlers/main.yml
+++ b/scripts/ci/roles/buildbot-worker-mac/handlers/main.yml
@@ -1,0 +1,3 @@
+- name: load buildbot worker service
+  become: yes
+  command: launchctl load /Library/LaunchDaemons/network.golem.buildbot-worker.plist

--- a/scripts/ci/roles/buildbot-worker-mac/meta/main.yml
+++ b/scripts/ci/roles/buildbot-worker-mac/meta/main.yml
@@ -1,0 +1,3 @@
+---
+
+- geerlingguy.homebrew

--- a/scripts/ci/roles/buildbot-worker-mac/meta/main.yml
+++ b/scripts/ci/roles/buildbot-worker-mac/meta/main.yml
@@ -1,3 +1,4 @@
 ---
 
+dependencies:
 - geerlingguy.homebrew

--- a/scripts/ci/roles/buildbot-worker-mac/tasks/main.yml
+++ b/scripts/ci/roles/buildbot-worker-mac/tasks/main.yml
@@ -3,19 +3,14 @@
     name: site_settings
 
 
-# - local_action:
-#     module: ec2_instance_facts
-#     filters:
-#       "tag:role": buildbot-master
-#   register: master_instances
-#   become: no
-
 - name: add user buildbot worker
   become: yes
   user:
     name: buildbot-worker
     home: /Users/buildbot-worker
 
+
+#install geth
 - name: add geth repo
   become_user: buildbot-worker
   homebrew_tap:
@@ -32,10 +27,8 @@
     - libtool
     - libffi
     - gmp
-#
-#
-# install taskcollector
-#
+
+
 # install hyperg
 - name: install tar
   become_user: buildbot-worker
@@ -44,10 +37,7 @@
     options:
       - with-default-names
 
-# TODO: Link gtar to replace tar
-# - name: link tar
-#   command: "brew link --overwrite gnu-tar"
-
+# Link gtar to replace tar
 - lineinfile:
     create: yes
     path: ~/.bashrc
@@ -59,12 +49,11 @@
     dest: /usr/local/share
     state: directory
 
-
 - name: download hyperg
   become: yes
   unarchive:
     remote_src: yes
-    src: https://github.com/mfranciszkiewicz/golem-hyperdrive/releases/download/v0.2.1/hyperg_0.2.1_darwin-x64.tar.gz
+    src: https://github.com/mfranciszkiewicz/golem-hyperdrive/releases/download/v0.2.3/hyperg_0.2.3_darwin-x64.tar.gz
     dest: /usr/local/share/
   creates: /usr/local/share/hyperg
 
@@ -90,7 +79,7 @@
     - ipfs
 
 
-- name: install buildbot and its requirements
+- name: install buildbot venv
   become_user: buildbot-worker
   pip:
     name: virtualenv
@@ -104,14 +93,13 @@
     virtualenv: /Users/buildbot-worker/.venv
 
 # # TODO: master address will not be updated once configuration is generated
-# # TODO: Set master hostname to be dynamic
 - name: initialized workspace for the worker
   become_user: buildbot-worker
   become: yes
   command:
     /Users/buildbot-worker/.venv/bin/buildbot-worker create-worker
       /Users/buildbot-worker/worker
-      ec2-54-89-173-235.compute-1.amazonaws.com
+      {{hostvars[groups['master'][0]]['ec2_public_ip_address']}}
       macOS
       {{site_settings.worker_pass}}
     creates=/Users/buildbot-worker/worker/

--- a/scripts/ci/roles/buildbot-worker-mac/tasks/main.yml
+++ b/scripts/ci/roles/buildbot-worker-mac/tasks/main.yml
@@ -11,6 +11,7 @@
 #   become: no
 
 - name: add user buildbot worker
+  become: yes
   user:
     name: buildbot-worker
     home: /Users/buildbot-worker
@@ -31,19 +32,26 @@
     - libtool
     - libffi
     - gmp
-
-
-# TODO: install taskcollector
-
+#
+#
+# install taskcollector
+#
 # install hyperg
 - name: install tar
   become_user: buildbot-worker
   homebrew:
     name: gnu-tar
+    options:
+      - with-default-names
 
 # TODO: Link gtar to replace tar
 # - name: link tar
 #   command: "brew link --overwrite gnu-tar"
+
+- lineinfile:
+    create: yes
+    path: ~/.bashrc
+    line: export PATH=/usr/local/bin:$PATH
 
 - name: Prepare hyperg directory
   become: yes
@@ -75,6 +83,7 @@
   homebrew:
     name: "{{ item }}"
   with_items:
+    - python
     - python3
     - openexr
     - freeimage
@@ -82,7 +91,7 @@
 
 
 - name: install buildbot and its requirements
-  become: yes
+  become_user: buildbot-worker
   pip:
     name: virtualenv
 
@@ -94,8 +103,8 @@
     name: buildbot-worker
     virtualenv: /Users/buildbot-worker/.venv
 
-
-# # NOTE: master address will not be updated once configuration is generated
+# # TODO: master address will not be updated once configuration is generated
+# # TODO: Set master hostname to be dynamic
 - name: initialized workspace for the worker
   become_user: buildbot-worker
   become: yes
@@ -113,7 +122,7 @@
   copy:
     src: network.golem.buildbot-worker.plist
     dest: /Library/LaunchDaemons/network.golem.buildbot-worker.plist
-
+  notify: load buildbot worker service
 
 - name: remove wrong python3, should use /usr/local/bin/
   become_user: buildbot-worker

--- a/scripts/ci/roles/buildbot-worker-mac/tasks/main.yml
+++ b/scripts/ci/roles/buildbot-worker-mac/tasks/main.yml
@@ -1,0 +1,123 @@
+- include_vars:
+    file: site_settings.yml
+    name: site_settings
+
+
+# - local_action:
+#     module: ec2_instance_facts
+#     filters:
+#       "tag:role": buildbot-master
+#   register: master_instances
+#   become: no
+
+- name: add user buildbot worker
+  user:
+    name: buildbot-worker
+    home: /Users/buildbot-worker
+
+- name: add geth repo
+  become_user: buildbot-worker
+  homebrew_tap:
+    name: ethereum/ethereum
+
+- name: install geth and dependencies
+  become_user: buildbot-worker
+  homebrew:
+    name: "{{ item }}"
+  with_items:
+    - ethereum
+    - automake
+    - pkg-config
+    - libtool
+    - libffi
+    - gmp
+
+
+# TODO: install taskcollector
+
+# install hyperg
+- name: install tar
+  become_user: buildbot-worker
+  homebrew:
+    name: gnu-tar
+
+# TODO: Link gtar to replace tar
+# - name: link tar
+#   command: "brew link --overwrite gnu-tar"
+
+- name: Prepare hyperg directory
+  become: yes
+  file:
+    dest: /usr/local/share
+    state: directory
+
+
+- name: download hyperg
+  become: yes
+  unarchive:
+    remote_src: yes
+    src: https://github.com/mfranciszkiewicz/golem-hyperdrive/releases/download/v0.2.1/hyperg_0.2.1_darwin-x64.tar.gz
+    dest: /usr/local/share/
+  creates: /usr/local/share/hyperg
+
+
+- name: Link hyperg
+  file:
+    src: /usr/local/share/hyperg/hyperg
+    dest: /usr/local/bin/hyperg
+    state: link
+
+
+# install pythons
+- name: install python and deps
+  become_user: buildbot-worker
+  become: yes
+  homebrew:
+    name: "{{ item }}"
+  with_items:
+    - python3
+    - openexr
+    - freeimage
+    - ipfs
+
+
+- name: install buildbot and its requirements
+  become: yes
+  pip:
+    name: virtualenv
+
+
+- name: install buildbot and its requirements
+  become_user: buildbot-worker
+  become: yes
+  pip:
+    name: buildbot-worker
+    virtualenv: /Users/buildbot-worker/.venv
+
+
+# # NOTE: master address will not be updated once configuration is generated
+- name: initialized workspace for the worker
+  become_user: buildbot-worker
+  become: yes
+  command:
+    /Users/buildbot-worker/.venv/bin/buildbot-worker create-worker
+      /Users/buildbot-worker/worker
+      ec2-54-89-173-235.compute-1.amazonaws.com
+      macOS
+      {{site_settings.worker_pass}}
+    creates=/Users/buildbot-worker/worker/
+
+
+- name: copy the launchdaemon file
+  become: yes
+  copy:
+    src: network.golem.buildbot-worker.plist
+    dest: /Library/LaunchDaemons/network.golem.buildbot-worker.plist
+
+
+- name: remove wrong python3, should use /usr/local/bin/
+  become_user: buildbot-worker
+  become: yes
+  file:
+    dest: /Users/buildbot-worker/.venv/bin/python3
+    state: absent

--- a/scripts/ci/site.yml
+++ b/scripts/ci/site.yml
@@ -12,6 +12,7 @@
     - buildbot-master
     - webserver
 
+
 - hosts: linux_worker
   remote_user: ubuntu
   become: yes
@@ -41,3 +42,9 @@
     - setup:
   roles:
     - buildbot-worker-windows
+
+
+- hosts: mac_worker
+  connection: local
+  roles:
+    - buildbot-worker-mac

--- a/scripts/ci/site.yml
+++ b/scripts/ci/site.yml
@@ -22,8 +22,14 @@
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
       changed_when: False
     - setup:
+   roles:
+     - buildbot-worker-linux
+
+
+- hosts: mac_worker
+  remote_user: admin
   roles:
-    - buildbot-worker-linux
+    - buildbot-worker-mac
 
 - hosts: windows_worker
   gather_facts: False

--- a/scripts/ci/site.yml
+++ b/scripts/ci/site.yml
@@ -22,8 +22,8 @@
       raw: test -e /usr/bin/python || (apt -y update && apt install -y python-minimal)
       changed_when: False
     - setup:
-   roles:
-     - buildbot-worker-linux
+  roles:
+    - buildbot-worker-linux
 
 
 - hosts: windows_worker

--- a/scripts/ci/site.yml
+++ b/scripts/ci/site.yml
@@ -26,11 +26,6 @@
      - buildbot-worker-linux
 
 
-- hosts: mac_worker
-  remote_user: admin
-  roles:
-    - buildbot-worker-mac
-
 - hosts: windows_worker
   gather_facts: False
   pre_tasks:
@@ -51,6 +46,6 @@
 
 
 - hosts: mac_worker
-  connection: local
+  remote_user: admin
   roles:
     - buildbot-worker-mac


### PR DESCRIPTION
Another step as part of #1400

Requires #1455  to be merged first

Added:
- mac role to install buildbot dependencies
- buildbot as a mac service with automatic startup
- added unit tests to macOS config.

Requires testing on the final platform we pick for running mac builders.