### PR TITLE
Scipy hook for PyInstaller

### DIFF
--- a/scripts/pyinstaller/hooks/hook-scipy.py
+++ b/scripts/pyinstaller/hooks/hook-scipy.py
@@ -1,0 +1,3 @@
+from PyInstaller.utils.hooks import collect_submodules
+
+hiddenimports = collect_submodules('scipy')


### PR DESCRIPTION
Searches for and embeds scipy libraries (required on mac OS).