### PR TITLE
Fixes issue #856

### DIFF
--- a/tests/golem/core/test_hostaddress.py
+++ b/tests/golem/core/test_hostaddress.py
@@ -44,7 +44,8 @@ def is_ip_address(address):
     except (ValueError, AddressValueError):
         try:
             # Check for local scope prefix and designator
-            ip_address(s.split('%')[0])
+            s = s.split('%')
+            ip_address(s[0])
             return (s[0][:4].lower().startswith('fe80'))
         except (ValueError, AddressValueError):
             pass
@@ -67,6 +68,11 @@ class TestIPAddresses(unittest.TestCase):
         if addresses:
             for address in addresses:
                 self.assertTrue(is_ip_address(address), "Incorrect IP address: {}".format(address))
+                self.assertTrue(ip_address_private('fe80::71a3:2b00:ddd3:753f%16'))
+        self.assertTrue(is_ip_address('fe80::71a3:2b00:ddd3:753f'))
+        self.assertTrue(is_ip_address('2001:db8::1000'))
+        self.assertTrue(is_ip_address('FE80::71a3:2b00:ddd3:753f%166')
+        self.assertFalse(is_ip_address('de80::71a3:2b00:ddd3:753f%143'))
 
 
 class TestHostAddress(unittest.TestCase):

--- a/tests/golem/core/test_hostaddress.py
+++ b/tests/golem/core/test_hostaddress.py
@@ -69,10 +69,10 @@ class TestIPAddresses(unittest.TestCase):
             for address in addresses:
                 self.assertTrue(is_ip_address(address), "Incorrect IP address: {}".format(address))
                 self.assertTrue(ip_address_private('fe80::71a3:2b00:ddd3:753f%16'))
-        self.assertTrue(is_ip_address('fe80::71a3:2b00:ddd3:753f'))
-        self.assertTrue(is_ip_address('2001:db8::1000'))
-        self.assertTrue(is_ip_address('FE80::71a3:2b00:ddd3:753f%166')
-        self.assertFalse(is_ip_address('de80::71a3:2b00:ddd3:753f%143'))
+        self.assertTrue(is_ip_address('fe80::71a3:2b00:ddd3:753f'), "Failed basic IPV6 test")
+        self.assertTrue(is_ip_address('2001:db8::1000'), "Failed abbreviated IPV6 address")
+        self.assertTrue(is_ip_address('FE80::71a3:2b00:ddd3:753f%166'), "Failed IPV6 with local scope test")
+        self.assertFalse(is_ip_address('de80::71a3:2b00:ddd3:753f%143'), "Failed to reject IPV6 address with local scope, wrong prefix")
 
 
 class TestHostAddress(unittest.TestCase):

--- a/tests/golem/core/test_hostaddress.py
+++ b/tests/golem/core/test_hostaddress.py
@@ -38,9 +38,16 @@ def is_ip_address(address):
     from ipaddress import ip_address, AddressValueError
     try:
         # will raise error in case of incorrect address
-        ip_address(str(address))
+        s = str(address)
+        ip_address(s)
         return True
     except (ValueError, AddressValueError):
+        try:
+            # Check for local scope prefix and designator
+            ip_address(s.split('%')[0])
+            return (s[0][:4].lower().startswith('fe80'))
+        except (ValueError, AddressValueError):
+            pass
         return False
 
 


### PR DESCRIPTION
The ipaddress module doesn't appear to support the local scope addressing.  As elsewhere in the code, this considers only the address itself, ignoring anything at or beyond the '%'.  Also checks the convention for local-only addresses of using the 'fe80' prefix.