### PR TITLE
RPC router shutdown method changed

### DIFF
--- a/golem/rpc/router.py
+++ b/golem/rpc/router.py
@@ -74,6 +74,11 @@ class CrossbarRouter(object):
     def _build_config(address, serializers, allowed_origins='*', realm='golem', enable_webstatus=False):
         return {
             'version': 2,
+            'controller': {
+                'options': {
+                    'shutdown': ['shutdown_on_shutdown_requested']
+                }
+            },
             'workers': [{
                 'type': 'router',
                 'options': {


### PR DESCRIPTION
Replaces #1582.

RPC router will shut down only when requested. Currently, rare ping timeouts cause clients to disconnect and in turn, the router shuts down.