### PR TITLE
Income query fix

### DIFF
--- a/golem/transactions/incomeskeeper.py
+++ b/golem/transactions/incomeskeeper.py
@@ -112,20 +112,24 @@ class IncomesKeeper(object):
 
     def get_list_of_all_incomes(self):
         # TODO: pagination
-        return (
-            ExpectedIncome.select(
-                ExpectedIncome.sender_node,
-                ExpectedIncome.task,
-                ExpectedIncome.subtask,
-                peewee.SQL("NULL as 'transaction'"),
-                peewee.SQL("NULL as 'block_number'"),
-                ExpectedIncome.value
-            ) | Income.select(
-                Income.sender_node,
-                Income.task,
-                Income.subtask,
-                Income.transaction,
-                Income.block_number,
-                Income.value
-            )
-        ).select().execute()
+        union = ExpectedIncome.select(
+            ExpectedIncome.created_date,
+            ExpectedIncome.sender_node,
+            ExpectedIncome.task,
+            ExpectedIncome.subtask,
+            peewee.SQL("NULL as 'transaction'"),
+            peewee.SQL("NULL as 'block_number'"),
+            ExpectedIncome.value
+        ) | Income.select(
+            Income.created_date,
+            Income.sender_node,
+            Income.task,
+            Income.subtask,
+            Income.transaction,
+            Income.block_number,
+            Income.value
+        )
+
+        # Usage of .c : http://docs.peewee-orm.com/en/latest/peewee
+        # /querying.html#using-subqueries
+        return union.order_by(union.c.created_date.desc()).execute()

--- a/golem/transactions/incomeskeeper.py
+++ b/golem/transactions/incomeskeeper.py
@@ -113,10 +113,19 @@ class IncomesKeeper(object):
     def get_list_of_all_incomes(self):
         # TODO: pagination
         return (
-            ExpectedIncome.select(ExpectedIncome, Income)
-            .join(Income, peewee.JOIN_LEFT_OUTER, on=(
-                (ExpectedIncome.subtask == Income.subtask) &
-                (ExpectedIncome.sender_node == Income.sender_node)
-            ))
-            .order_by(ExpectedIncome.created_date.desc())
-        )
+            ExpectedIncome.select(
+                ExpectedIncome.sender_node,
+                ExpectedIncome.task,
+                ExpectedIncome.subtask,
+                peewee.SQL("NULL as 'transaction'"),
+                peewee.SQL("NULL as 'block_number'"),
+                ExpectedIncome.value
+            ) | Income.select(
+                Income.sender_node,
+                Income.task,
+                Income.subtask,
+                Income.transaction,
+                Income.block_number,
+                Income.value
+            )
+        ).select().execute()

--- a/golem/transactions/transactionsystem.py
+++ b/golem/transactions/transactionsystem.py
@@ -65,7 +65,7 @@ class TransactionSystem(object):
         incomes = self.incomes_keeper.get_list_of_all_incomes()
 
         def item(o):
-            status = PaymentStatus.confirmed if o.income.transaction \
+            status = PaymentStatus.confirmed if o.transaction \
                 else PaymentStatus.awaiting
 
             return {
@@ -74,8 +74,8 @@ class TransactionSystem(object):
                 "payer": to_unicode(o.sender_node),
                 "value": to_unicode(o.value),
                 "status": to_unicode(status.name),
-                "block_number": to_unicode(o.income.block_number),
-                "transaction": to_unicode(o.income.transaction),
+                "block_number": to_unicode(o.block_number),
+                "transaction": to_unicode(o.transaction),
                 "created": datetime_to_timestamp(o.created_date),
                 "modified": datetime_to_timestamp(o.modified_date)
             }


### PR DESCRIPTION
Previous query tried to join `ExpectedIncome`s with `Income`s without the knowledge that `ExpectedIncome`s are removed when a matching `Income` is detected.