### PR TITLE
Requestor-oriented stats #1492

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -1153,6 +1153,14 @@ class MonitoringPublisherService(Service):
             event='task_computer_snapshot',
             task_computer=self._task_server.task_computer,
         )
+        dispatcher.send(
+            signal='golem.monitor',
+            event='requestor_stats_snapshot',
+            current_stats=(self._task_server.task_manager
+                           .requestor_stats_manager.get_current_stats()),
+            finished_stats=(self._task_server.task_manager
+                            .requestor_stats_manager.get_finished_stats())
+        )
 
 
 class NetworkConnectionPublisherService(Service):

--- a/golem/monitor/model/statssnapshotmodel.py
+++ b/golem/monitor/model/statssnapshotmodel.py
@@ -1,3 +1,4 @@
+from golem.task.taskrequestorstats import CurrentStats, FinishedTasksStats
 from .modelbase import BasicModel
 
 
@@ -38,3 +39,32 @@ class ComputationTime(BasicModel):
         )
         self.success = success
         self.value = value
+
+class RequestorStatsModel(BasicModel):
+    # pylint: disable=too-many-instance-attributes,too-few-public-methods
+    def __init__(self, meta_data: BasicModel, current_stats: CurrentStats,
+                 finished_stats: FinishedTasksStats):
+        super().__init__("RequestorStats", meta_data.cliid, meta_data.sessid)
+
+        self.tasks_cnt = current_stats.tasks_cnt
+        self.finished_task_cnt = current_stats.finished_task_cnt
+        self.requested_subtasks_cnt = current_stats.requested_subtasks_cnt
+        self.collected_results_cnt = current_stats.collected_results_cnt
+        self.verified_results_cnt = current_stats.verified_results_cnt
+        self.timed_out_subtasks_cnt = current_stats.timed_out_subtasks_cnt
+        self.not_downloadable_subtasks_cnt = (current_stats
+                                              .not_downloadable_subtasks_cnt)
+        self.failed_subtasks_cnt = current_stats.failed_subtasks_cnt
+        self.work_offers_cnt = current_stats.work_offers_cnt
+
+        self.finished_ok_cnt = finished_stats.finished_ok.tasks_cnt
+        self.finished_ok_total_time = finished_stats.finished_ok.total_time
+
+        self.finished_with_failures_cnt = (finished_stats
+                                           .finished_with_failures.tasks_cnt)
+        self.finished_with_failures_total_time = (finished_stats
+                                                  .finished_with_failures
+                                                  .total_time)
+
+        self.failed_cnt = finished_stats.failed.tasks_cnt
+        self.failed_total_time = finished_stats.failed.total_time

--- a/golem/monitor/monitor.py
+++ b/golem/monitor/monitor.py
@@ -4,6 +4,7 @@ from pydispatch import dispatcher
 import threading
 import queue
 
+from golem.task.taskrequestorstats import CurrentStats, FinishedTasksStats
 from .model.nodemetadatamodel import NodeMetadataModel, NodeInfoModel
 from .model.loginlogoutmodel import LoginModel, LogoutModel
 from .model.taskcomputersnapshotmodel import TaskComputerSnapshotModel
@@ -168,6 +169,13 @@ class SystemMonitor(object):
 
     def on_task_computer_snapshot(self, task_computer):
         msg = TaskComputerSnapshotModel(self.meta_data, task_computer)
+        self.sender_thread.send(msg)
+
+    def on_requestor_stats_snapshot(self,
+                                    current_stats: CurrentStats,
+                                    finished_stats: FinishedTasksStats):
+        msg = statssnapshotmodel.RequestorStatsModel(
+            self.meta_data, current_stats, finished_stats)
         self.sender_thread.send(msg)
 
     def on_payment(self, addr, value):

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -13,7 +13,7 @@ from golem.manager.nodestatesnapshot import LocalTaskStateSnapshot
 from golem.network.transport.tcpnetwork import SocketAddress
 from golem.resource.dirmanager import DirManager
 from golem.resource.hyperdrive.resourcesmanager import \
-    HyperdriveResourceManager  # noqa
+    HyperdriveResourceManager
 from golem.task.result.resultmanager import EncryptedResultPackageManager
 from golem.task.taskbase import TaskEventListener, Task, \
     ResourceType
@@ -838,6 +838,30 @@ class TaskManager(TaskEventListener):
     @handle_task_key_error
     def notice_task_updated(self, task_id, subtask_id=None, task_op=None,
                             persist=True):
+        """Called when a task is modified, saves the task and
+        propagates information
+
+        Whenever task is changed `notice_task_updated` should be called
+        to save the task - if the change is save-worthy, as specified
+        by the `persist` parameter - and propagate information about
+        changed task to other parts of the system.
+
+        Most of the calls are save-worthy, but a minority is not: for
+        instance when the work offer is received, the task does not
+        change so saving it does not make sense, but it still makes
+        sense to let other parts of the system know about the change.
+        Also, when a number of minor changes are always followed by a
+        major one, as it is with restarting a frame task, it does not
+        make sense to store all the partial changes, so only the
+        final one is considered save-worthy.
+
+        :param str task_id: id of the updated task
+        :param Optional[str] subtask_id: if the operation done on the
+          task is related to a subtask, id of that subtask
+        :param Optional[TaskOp] task_op: description of the performed
+          operation
+        :param bool persist: should the task be persisted now
+        """
         # self.save_state()
         if persist and self.task_persistence:
             self.dump_task(task_id)

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -19,6 +19,7 @@ from golem.task.taskbase import TaskEventListener, Task, \
     ResourceType
 
 from golem.task.taskkeeper import CompTaskKeeper, compute_subtask_value
+from golem.task.taskrequestorstats import RequestorTaskStatsManager
 
 from golem.task.taskstate import TaskState, TaskStatus, SubtaskStatus, \
     SubtaskState, TaskOp
@@ -104,6 +105,8 @@ class TaskManager(TaskEventListener):
             tasks_dir,
             persist=self.task_persistence,
         )
+
+        self.requestor_stats_manager = RequestorTaskStatsManager()
 
         if self.task_persistence:
             self.restore_tasks()

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -12,7 +12,8 @@ from golem.core.common import HandleKeyError, get_timestamp_utc, \
 from golem.manager.nodestatesnapshot import LocalTaskStateSnapshot
 from golem.network.transport.tcpnetwork import SocketAddress
 from golem.resource.dirmanager import DirManager
-from golem.resource.hyperdrive.resourcesmanager import HyperdriveResourceManager  # noqa
+from golem.resource.hyperdrive.resourcesmanager import \
+    HyperdriveResourceManager  # noqa
 from golem.task.result.resultmanager import EncryptedResultPackageManager
 from golem.task.taskbase import TaskEventListener, Task, \
     ResourceType
@@ -20,7 +21,7 @@ from golem.task.taskbase import TaskEventListener, Task, \
 from golem.task.taskkeeper import CompTaskKeeper, compute_subtask_value
 
 from golem.task.taskstate import TaskState, TaskStatus, SubtaskStatus, \
-    SubtaskState
+    SubtaskState, TaskOp
 
 logger = logging.getLogger(__name__)
 
@@ -164,6 +165,10 @@ class TaskManager(TaskEventListener):
         self.tasks[task.header.task_id] = task
         self.tasks_states[task.header.task_id] = ts
 
+        self.notice_task_updated(task.header.task_id,
+                                 task_op=TaskOp.TASK_CREATED,
+                                 persist=False)
+
     @handle_task_key_error
     def start_task(self, task_id):
         task = self.tasks[task_id]
@@ -180,7 +185,8 @@ class TaskManager(TaskEventListener):
         if self.task_persistence:
             self.dump_task(task.header.task_id)
             logger.info("Task %s added" % task.header.task_id)
-            self.notice_task_updated(task.header.task_id)
+        self.notice_task_updated(task.header.task_id,
+                                 task_op=TaskOp.TASK_STARTED)
 
     def _dump_filepath(self, task_id):
         return self.tasks_dir / ('%s.pickle' % (task_id,))
@@ -235,11 +241,8 @@ class TaskManager(TaskEventListener):
                     path.unlink()
 
             if task_id is not None:
-                dispatcher.send(
-                    signal='golem.taskmanager',
-                    event='task_status_updated',
-                    task_id=task_id
-                )
+                self.notice_task_updated(task_id, task_op=TaskOp.TASK_RESTORED,
+                                         persist=False)
 
     @handle_task_key_error
     def resources_send(self, task_id):
@@ -247,6 +250,24 @@ class TaskManager(TaskEventListener):
         self.tasks[task_id].task_status = TaskStatus.waiting
         self.notice_task_updated(task_id)
         logger.info("Resources for task {} sent".format(task_id))
+
+    def got_wants_to_compute(self, task_id: str, key_id: str,
+                             node_name: str):
+        """
+        Updates number of offers to compute task.
+
+        For statistical purposes only, real processing of the offer is done
+        elsewhere. Silently ignores wrong task ids.
+
+        :param str task_id: id of the task in the offer
+        :param key_id: id of the node offering computations
+        :param node_name: name of the node offering computations
+        :return: Nothing
+        :rtype: None
+        """
+        if task_id in self.tasks:
+            self.notice_task_updated(task_id,
+                                     task_op=TaskOp.WORK_OFFER_RECEIVED)
 
     def get_next_subtask(
             self, node_id, node_name, task_id, estimated_performance, price,
@@ -345,14 +366,16 @@ class TaskManager(TaskEventListener):
         self.__add_subtask_to_tasks_states(
             node_name, node_id, price, ctd, address,
         )
-        self.notice_task_updated(task_id)
+        self.notice_task_updated(task_id,
+                                 subtask_id=ctd['subtask_id'],
+                                 task_op=TaskOp.SUBTASK_ASSIGNED)
         return ctd, False, extra_data.should_wait
 
     def get_tasks_headers(self):
         ret = []
         for tid, task in self.tasks.items():
             if task.needs_computation() and \
-                    task.task_status in self.activeStatus:
+                            task.task_status in self.activeStatus:
                 ret.append(task.header)
 
         return ret
@@ -420,7 +443,9 @@ class TaskManager(TaskEventListener):
         if not SubtaskStatus.is_computed(subtask_status):
             logger.warning("Result for subtask {} when subtask state is {}"
                            .format(subtask_id, subtask_status))
-            self.notice_task_updated(task_id)
+            self.notice_task_updated(task_id,
+                                     subtask_id=subtask_id,
+                                     task_op=TaskOp.UNEXPECTED_SUBTASK_RECEIVED)
             return False
 
         self.tasks[task_id].computation_finished(
@@ -437,8 +462,14 @@ class TaskManager(TaskEventListener):
         if not self.tasks[task_id].verify_subtask(subtask_id):
             logger.debug("Subtask {} not accepted\n".format(subtask_id))
             ss.subtask_status = SubtaskStatus.failure
-            self.notice_task_updated(task_id)
+            self.notice_task_updated(task_id,
+                                     subtask_id=subtask_id,
+                                     task_op=TaskOp.SUBTASK_NOT_ACCEPTED)
             return False
+
+        self.notice_task_updated(task_id,
+                                 subtask_id=subtask_id,
+                                 task_op=TaskOp.SUBTASK_FINISHED)
 
         if self.tasks_states[task_id].status in self.activeStatus:
             if not self.tasks[task_id].finished_computation():
@@ -447,9 +478,10 @@ class TaskManager(TaskEventListener):
                 if self.tasks[task_id].verify_task():
                     logger.debug("Task {} accepted".format(task_id))
                     self.tasks_states[task_id].status = TaskStatus.finished
+                    self.notice_task_updated(task_id,
+                                             task_op=TaskOp.TASK_FINISHED)
                 else:
                     logger.debug("Task {} not accepted".format(task_id))
-        self.notice_task_updated(task_id)
         return True
 
     @handle_subtask_key_error
@@ -462,7 +494,9 @@ class TaskManager(TaskEventListener):
         if not SubtaskStatus.is_computed(subtask_status):
             logger.warning("Result for subtask {} when subtask state is {}"
                            .format(subtask_id, subtask_status))
-            self.notice_task_updated(task_id)
+            self.notice_task_updated(task_id,
+                                     subtask_id=subtask_id,
+                                     task_op=TaskOp.UNEXPECTED_SUBTASK_RECEIVED)
             return False
 
         self.tasks[task_id].computation_failed(subtask_id)
@@ -472,7 +506,9 @@ class TaskManager(TaskEventListener):
         ss.subtask_status = SubtaskStatus.failure
         ss.stderr = str(err)
 
-        self.notice_task_updated(task_id)
+        self.notice_task_updated(task_id,
+                                 subtask_id=subtask_id,
+                                 task_op=TaskOp.SUBTASK_FAILED)
         return True
 
     def task_result_incoming(self, subtask_id):
@@ -487,7 +523,10 @@ class TaskManager(TaskEventListener):
                 task.result_incoming(subtask_id)
                 states.subtask_status = SubtaskStatus.downloading
 
-                self.notify_update_task(task_id)
+                self.notice_task_updated(
+                    task_id,
+                    subtask_id=subtask_id,
+                    task_op=TaskOp.SUBTASK_RESULT_DOWNLOADING)
             else:
                 logger.error("Unknown task id: {}".format(task_id))
         else:
@@ -506,7 +545,8 @@ class TaskManager(TaskEventListener):
                 logger.info("Task {} dies".format(th.task_id))
                 t.task_status = TaskStatus.timeout
                 self.tasks_states[th.task_id].status = TaskStatus.timeout
-                self.notice_task_updated(th.task_id)
+                self.notice_task_updated(th.task_id,
+                                         task_op=TaskOp.TASK_TIMEOUT)
             ts = self.tasks_states[th.task_id]
             for s in list(ts.subtask_states.values()):
                 if SubtaskStatus.is_computed(s.subtask_status):
@@ -516,7 +556,9 @@ class TaskManager(TaskEventListener):
                         nodes_with_timeouts.append(s.computer.node_id)
                         t.computation_failed(s.subtask_id)
                         s.stderr = "[GOLEM] Timeout"
-                        self.notice_task_updated(th.task_id)
+                        self.notice_task_updated(th.task_id,
+                                                 subtask_id=s.subtask_id,
+                                                 task_op=TaskOp.SUBTASK_TIMEOUT)
         return nodes_with_timeouts
 
     def get_progresses(self):
@@ -560,7 +602,7 @@ class TaskManager(TaskEventListener):
 
         task.header.signature = self.sign_task_header(task.header)
 
-        self.notice_task_updated(task_id)
+        self.notice_task_updated(task_id, task_op=TaskOp.TASK_RESTARTED)
 
     @handle_subtask_key_error
     def restart_subtask(self, subtask_id):
@@ -572,7 +614,9 @@ class TaskManager(TaskEventListener):
         subtask_state.subtask_status = SubtaskStatus.restarted
         subtask_state.stderr = "[GOLEM] Restarted"
 
-        self.notice_task_updated(task_id)
+        self.notice_task_updated(task_id,
+                                 subtask_id=subtask_id,
+                                 task_op=TaskOp.SUBTASK_RESTARTED)
 
     @handle_task_key_error
     def restart_frame_subtasks(self, task_id, frame):
@@ -588,9 +632,14 @@ class TaskManager(TaskEventListener):
             subtask_state = task_state.subtask_states[subtask_id]
             subtask_state.subtask_status = SubtaskStatus.restarted
             subtask_state.stderr = "[GOLEM] Restarted"
+            self.notice_task_updated(task_id,
+                                     subtask_id=subtask_id,
+                                     task_op=TaskOp.SUBTASK_RESTARTED,
+                                     persist=False)
 
         task.status = TaskStatus.computing
-        self.notice_task_updated(task_id)
+        self.notice_task_updated(task_id,
+                                 task_op=TaskOp.FRAME_SUBTASK_RESTARTED)
 
     @handle_task_key_error
     def abort_task(self, task_id):
@@ -601,7 +650,7 @@ class TaskManager(TaskEventListener):
             del self.subtask2task_mapping[sub.subtask_id]
         self.tasks_states[task_id].subtask_states.clear()
 
-        self.notice_task_updated(task_id)
+        self.notice_task_updated(task_id, task_op=TaskOp.TASK_ABORTED)
 
     @handle_task_key_error
     def get_output_states(self, task_id):
@@ -784,12 +833,16 @@ class TaskManager(TaskEventListener):
         self.notice_task_updated(task_id)
 
     @handle_task_key_error
-    def notice_task_updated(self, task_id):
+    def notice_task_updated(self, task_id, subtask_id=None, task_op=None,
+                            persist=True):
         # self.save_state()
-        if self.task_persistence:
+        if persist and self.task_persistence:
             self.dump_task(task_id)
         dispatcher.send(
             signal='golem.taskmanager',
             event='task_status_updated',
             task_id=task_id,
+            task_state=self.tasks_states.get(task_id),
+            subtask_id=subtask_id,
+            task_op=task_op,
         )

--- a/golem/task/taskrequestorstats.py
+++ b/golem/task/taskrequestorstats.py
@@ -1,0 +1,530 @@
+import logging
+import time
+from collections import defaultdict
+from typing import (  # pylint: disable=unused-import
+    NamedTuple, List, Optional, DefaultDict)
+
+from pydispatch import dispatcher
+
+from golem.task.taskstate import TaskOp, SubtaskStatus, TaskStatus, TaskState
+
+
+__all__ = ['RequestorTaskStatsManager']
+
+logger = logging.getLogger(__name__)
+
+
+TaskMsg = NamedTuple("TaskMsg", [("ts", float), ("op", TaskOp)])
+
+
+class SubtaskInfo:  # pylint: disable=too-few-public-methods
+    def __init__(self):
+        self.latest_status = SubtaskStatus.starting
+        self.messages = []
+
+
+class TaskInfo:
+    """Stores information about events related to the task.
+
+    Stores information about events that were related to a single task and
+    processes those information to get statistical information. It is probably
+    only useful for :py:class:`RequestorTaskStats` objects which fill instances
+    of this class with information.
+    """
+
+    def __init__(self):
+        self.latest_status = TaskStatus.notStarted  # type: TaskStatus
+        self._want_to_compute_count = 0
+        self.messages = []  # type: List[TaskMsg]
+        self.subtasks = defaultdict(
+            SubtaskInfo)  # type: DefaultDict[str, SubtaskInfo]
+
+    def got_want_to_compute(self):
+        """Makes note of a received work offer"""
+        self._want_to_compute_count += 1
+
+    def got_task_message(self, msg: TaskMsg, latest_status: TaskStatus):
+        """Stores information from task level message"""
+        self.messages.append(msg)
+        self.latest_status = latest_status
+
+    def got_subtask_message(self, subtask_id: str, msg: TaskMsg,
+                            latest_status: SubtaskStatus):
+        """Stores information from subtask level message"""
+        self.subtasks[subtask_id].latest_status = latest_status
+        self.subtasks[subtask_id].messages.append(msg)
+
+    def subtask_count(self) -> int:
+        """Number of subtasks of this task"""
+        return len(self.subtasks.keys())
+
+    def collected_results_count(self) -> int:
+        """Returns number of successfully received results
+
+        This is just a sum of verified and not accepted counts. That does not
+        take "unexpected" results into account, that is results received
+        which were not previously requested.
+        """
+        return (self.verified_results_count() +
+                self.not_accepted_results_count())
+
+    def verified_results_count(self) -> int:
+        """Number of verified results of the subtasks for self task
+
+        This is equal to the number of subtasks with the latest state
+        ``SubtaskStatus.finished``.
+        """
+        cnt = 0
+        for st in self.subtasks.values():
+            if st.latest_status == SubtaskStatus.finished:
+                cnt += 1
+        return cnt
+
+    def _subtasks_count_specific_task_ops(self, op: TaskOp):
+        cnt = 0
+        for st in self.subtasks.values():
+            for msg in st.messages:
+                if msg.op == op:
+                    cnt += 1
+        return cnt
+
+    def not_accepted_results_count(self) -> int:
+        """Number of times a subtask failed verification"""
+        return self._subtasks_count_specific_task_ops(
+            TaskOp.SUBTASK_NOT_ACCEPTED)
+
+    def timeout_count(self) -> int:
+        """Number of times a subtask has not beed finished in time"""
+        return self._subtasks_count_specific_task_ops(
+            TaskOp.SUBTASK_TIMEOUT)
+
+    def failed_count(self) -> int:
+        """Number of subtasks that failed on computing side"""
+        return self._subtasks_count_specific_task_ops(
+            TaskOp.SUBTASK_FAILED)
+
+    def not_downloaded_count(self) -> int:
+        """Returns # of subtasks that were reported as computed but their
+        results were never downloaded
+
+        Note that if executed for a task that is still in progress this will
+        also include subtasks that are actively sending results at the moment
+        of a call.
+        """
+        cnt = 0
+        for st in self.subtasks.values():
+            download_in_progress = False
+            for msg in st.messages:
+                if msg.op == TaskOp.SUBTASK_RESULT_DOWNLOADING:
+                    download_in_progress = True
+                elif msg.op in [TaskOp.SUBTASK_FINISHED,
+                                TaskOp.SUBTASK_NOT_ACCEPTED]:
+                    download_in_progress = False
+            if download_in_progress:
+                cnt += 1
+        return cnt
+
+    def total_time(self) -> float:
+        """Returns total time in seconds spent on the task
+
+        It is calculated as a wall time between ``TASK_CREATED`` and one of
+        ``TASK_FINISHED``, ``TASK_NOT_ACCEPTED`` and ``TASK_TIMEOUT`` messages.
+        If the task is in progress then current time is taken instead of the
+        latter. Note that the time spent paused is also included in the total
+        time.
+        """
+        start_time = 0.0
+        finish_time = 0.0
+
+        if not self.is_completed():
+            finish_time = time.time()
+
+        for msg in reversed(self.messages):
+            if (msg.op in [TaskOp.TASK_CREATED, TaskOp.TASK_RESTORED]
+                    and not start_time):
+                start_time = msg.ts
+            elif (msg.op in [TaskOp.TASK_FINISHED, TaskOp.TASK_NOT_ACCEPTED,
+                             TaskOp.TASK_ABORTED, TaskOp.TASK_TIMEOUT]
+                  and not finish_time):
+                finish_time = msg.ts
+
+        assert finish_time >= start_time
+        return finish_time - start_time
+
+    def had_failures_or_timeouts(self) -> bool:
+        """Were there any failures or timeouts during computation
+
+        Both failure to calculate (SUBTASK_FAILED) and failure to verify
+        (SUBTASK_NOT_ACCEPTED) are considered failures in this method.
+        """
+        for msg in self.messages:
+            if msg.op in [TaskOp.TASK_NOT_ACCEPTED,
+                          TaskOp.TASK_TIMEOUT]:
+                return True
+        for st in self.subtasks.values():
+            for msg in st.messages:
+                if msg.op in [TaskOp.SUBTASK_FAILED,
+                              TaskOp.SUBTASK_NOT_ACCEPTED,
+                              TaskOp.SUBTASK_TIMEOUT]:
+                    return True
+        return False
+
+    def is_completed(self) -> bool:
+        """Has the task already been completed
+
+        In other words, is its latest status in the list of finished.
+        """
+        return self.latest_status in [TaskStatus.finished,
+                                      TaskStatus.aborted,
+                                      TaskStatus.timeout]
+
+    def has_task_failed(self) -> bool:
+        """Had the task failed
+
+        If true it means that the whole task failed which is different
+        from subtasks failing, which are reported via
+        ``had_failures_or_timeouts()``
+        """
+        return self.latest_status in [TaskStatus.aborted, TaskStatus.timeout]
+
+    def want_to_compute_count(self) -> int:
+        """How many computation offers were received for this task"""
+        return self._want_to_compute_count
+
+    def in_progress_subtasks_count(self) -> int:
+        """How many subtasks of this task are still being computed
+
+        No tasks are considered to be in progress if the whole task has
+        been completed, even if their individual statuses show
+        otherwise.
+        """
+        if self.is_completed():
+            return 0
+
+        cnt = 0
+        for st in self.subtasks.values():
+            if st.latest_status in [SubtaskStatus.finished,
+                                    SubtaskStatus.failure]:
+                continue
+            in_progress = False
+            for msg in st.messages:
+                if msg.op == TaskOp.SUBTASK_ASSIGNED:
+                    in_progress = True
+                elif msg.op in [TaskOp.SUBTASK_TIMEOUT,
+                                TaskOp.SUBTASK_FINISHED,
+                                TaskOp.SUBTASK_FAILED,
+                                TaskOp.SUBTASK_NOT_ACCEPTED]:
+                    in_progress = False
+            if in_progress:
+                cnt += 1
+        return cnt
+
+
+TaskStats = NamedTuple("TaskStats", [("finished", bool),
+                                     ("total_time", float),
+                                     ("task_failed", bool),
+                                     ("had_failures", bool),
+                                     ("work_offers_cnt", int),
+                                     ("requested_subtasks_cnt", int),
+                                     ("collected_results_cnt", int),
+                                     ("verified_results_cnt", int),
+                                     ("timed_out_subtasks_cnt", int),
+                                     ("not_downloaded_subtasks_cnt", int),
+                                     ("failed_subtasks_cnt", int)])
+TaskStats.__doc__ = """Information about a single task requested by this node
+
+Names of fields are mostly self-explanatory.
+``not_downloaded_subtasks_cnt`` is the number of tasks that were
+announced as done by the computing node but were not received.
+"""
+
+EMPTY_TASK_STATS = TaskStats(False, 0.0, False, False, 0, 0, 0, 0, 0, 0, 0)
+
+CurrentStats = NamedTuple("CurrentStats", [
+    ("tasks_cnt", int),
+    ("finished_task_cnt", int),
+    ("requested_subtasks_cnt", int),
+    ("collected_results_cnt", int),
+    ("verified_results_cnt", int),
+    ("timed_out_subtasks_cnt", int),
+    ("not_downloadable_subtasks_cnt", int),
+    ("failed_subtasks_cnt", int),
+    ("work_offers_cnt", int)])
+
+EMPTY_CURRENT_STATS = CurrentStats(0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+
+def update_current_stats_with_task(
+        current: CurrentStats,
+        old: Optional[TaskStats],
+        new: TaskStats) -> CurrentStats:
+    """Returns new :py:class:`CurrentStats` instance with changes
+    between ``old`` and ``new`` incorporated into ``current``
+
+    The ``not_downloadable_subtasks_cnt`` is only updated for tasks
+    that are finished. Since it includes tasks that are downloaded at
+    a time of a call, it would be misleading to update it earlier.
+
+    Note that ``current`` is a tuple and can't be updated in place so
+    a brand new one is returned.
+    """
+    is_new_task = old is None
+    if old is None:
+        old = EMPTY_TASK_STATS
+    return CurrentStats(
+        tasks_cnt=current.tasks_cnt + (1 if is_new_task else 0),
+        finished_task_cnt=(current.finished_task_cnt
+                           - (1 if old.finished else 0)
+                           + (1 if new.finished else 0)),
+        requested_subtasks_cnt=(current.requested_subtasks_cnt
+                                - old.requested_subtasks_cnt
+                                + new.requested_subtasks_cnt),
+        collected_results_cnt=(current.collected_results_cnt
+                               - old.collected_results_cnt
+                               + new.collected_results_cnt),
+        verified_results_cnt=(current.verified_results_cnt
+                              - old.verified_results_cnt
+                              + new.verified_results_cnt),
+        timed_out_subtasks_cnt=(current.timed_out_subtasks_cnt
+                                - old.timed_out_subtasks_cnt
+                                + new.timed_out_subtasks_cnt),
+        not_downloadable_subtasks_cnt=(
+            current.not_downloadable_subtasks_cnt
+            - (old.not_downloaded_subtasks_cnt if old.finished else 0)
+            + (new.not_downloaded_subtasks_cnt if new.finished else 0)),
+        failed_subtasks_cnt=(current.failed_subtasks_cnt
+                             - old.failed_subtasks_cnt
+                             + new.failed_subtasks_cnt),
+        work_offers_cnt=(current.work_offers_cnt
+                         - old.work_offers_cnt
+                         + new.work_offers_cnt)
+    )
+
+
+FinishedTasksSummary = NamedTuple("FinishedTaskSummary", [
+    ("tasks_cnt", int),
+    ("total_time", float)])
+
+EMPTY_FINISHED_SUMMARY = FinishedTasksSummary(0, 0.0)
+
+FinishedTasksStats = NamedTuple("FinishedTasksStats", [
+    ("finished_ok", FinishedTasksSummary),
+    ("finished_with_failures", FinishedTasksSummary),
+    ("failed", FinishedTasksSummary)])
+
+EMPTY_FINISHED_STATS = FinishedTasksStats(
+    EMPTY_FINISHED_SUMMARY,
+    EMPTY_FINISHED_SUMMARY,
+    EMPTY_FINISHED_SUMMARY)
+
+
+def update_finished_stats_with_task(
+        finished: FinishedTasksStats,
+        old: Optional[TaskStats],
+        new: TaskStats) -> FinishedTasksStats:
+    mid = finished
+    if old and old.finished:
+        if old.task_failed:
+            mid = finished._replace(
+                failed=FinishedTasksSummary(
+                    tasks_cnt=finished.failed.tasks_cnt - 1,
+                    total_time=finished.failed.total_time - old.total_time))
+        elif old.had_failures:
+            mid = finished._replace(
+                finished_with_failures=FinishedTasksSummary(
+                    tasks_cnt=finished.finished_with_failures.tasks_cnt - 1,
+                    total_time=(finished.finished_with_failures.total_time
+                                - old.total_time)))
+        else:
+            mid = finished._replace(
+                finished_ok=FinishedTasksSummary(
+                    tasks_cnt=finished.finished_ok.tasks_cnt - 1,
+                    total_time=(finished.finished_ok.total_time
+                                - old.total_time)))
+    ret = mid
+    if new.finished:
+        if new.task_failed:
+            ret = mid._replace(
+                failed=FinishedTasksSummary(
+                    tasks_cnt=mid.failed.tasks_cnt + 1,
+                    total_time=mid.failed.total_time + new.total_time))
+        elif new.had_failures:
+            ret = mid._replace(
+                finished_with_failures=FinishedTasksSummary(
+                    tasks_cnt=mid.finished_with_failures.tasks_cnt + 1,
+                    total_time=(mid.finished_with_failures.total_time
+                                + new.total_time)))
+        else:
+            ret = mid._replace(
+                finished_ok=FinishedTasksSummary(
+                    tasks_cnt=mid.finished_ok.tasks_cnt + 1,
+                    total_time=mid.finished_ok.total_time + new.total_time))
+    return ret
+
+
+class RequestorTaskStats:
+    """Collects statistics about our tasks.
+
+    :py:class:`RequestorTaskStats` collects information about tasks requested
+    by the user via ``on_message`` method and has two methods,
+    :py:meth:`get_current_stats` and :py:meth:`get_finished_stats`, that are
+    used for extracting information from it.
+    """
+
+    # Ops that result in storing of task level information
+    TASK_LEVEL_OPS = [TaskOp.TASK_STARTED, TaskOp.TASK_FINISHED,
+                      TaskOp.TASK_NOT_ACCEPTED, TaskOp.TASK_TIMEOUT,
+                      TaskOp.TASK_RESTARTED, TaskOp.TASK_ABORTED,
+                      TaskOp.TASK_CREATED, TaskOp.TASK_RESTORED]
+
+    # Ops that result in storing of subtask level information; subtask_id needs
+    # to be set for those
+    SUBTASK_LEVEL_OPS = [TaskOp.SUBTASK_ASSIGNED,
+                         TaskOp.SUBTASK_RESULT_DOWNLOADING,
+                         TaskOp.SUBTASK_NOT_ACCEPTED,
+                         TaskOp.SUBTASK_FINISHED,
+                         TaskOp.SUBTASK_FAILED,
+                         TaskOp.SUBTASK_TIMEOUT,
+                         TaskOp.SUBTASK_RESTARTED]
+
+    # Ops that are not really interesting, for statistics anyway
+    UNNOTEWORTHY_OPS = [TaskOp.FRAME_SUBTASK_RESTARTED,
+                        TaskOp.UNEXPECTED_SUBTASK_RECEIVED]
+
+    def __init__(self):
+        self.tasks = defaultdict(
+            TaskInfo)  # type: DefaultDict[str, TaskInfo]
+        self.stats = EMPTY_CURRENT_STATS
+        self.finished_stats = EMPTY_FINISHED_STATS
+
+    def on_message(self,
+                   task_id: str,
+                   task_state: TaskState,
+                   task_op: TaskOp,
+                   subtask_id: Optional[str] = None) -> None:
+        """Updates stats according to the received information."""
+
+        old_task_stats = None
+        if task_id in self.tasks:
+            old_task_stats = self.get_task_stats(task_id)
+
+        if task_op == TaskOp.WORK_OFFER_RECEIVED:
+            self.tasks[task_id].got_want_to_compute()
+
+        elif task_op == TaskOp.TASK_RESTORED:
+            the_time = time.time()
+            msg1 = TaskMsg(ts=the_time, op=TaskOp.SUBTASK_RESTARTED)
+            msg2 = TaskMsg(ts=the_time, op=TaskOp.SUBTASK_ASSIGNED)
+            for s_id in task_state.subtask_states.keys():
+                subtask_status = (task_state.subtask_states[s_id]
+                                  .subtask_status)
+                self.tasks[task_id].got_subtask_message(
+                    s_id,
+                    msg1,
+                    subtask_status)
+                if subtask_status in [SubtaskStatus.starting,
+                                      SubtaskStatus.downloading]:
+                    self.tasks[task_id].got_subtask_message(
+                        s_id,
+                        msg2,
+                        subtask_status)
+
+            msg = TaskMsg(ts=the_time, op=TaskOp.TASK_RESTORED)
+            self.tasks[task_id].got_task_message(msg, task_state.status)
+
+        elif task_op in self.TASK_LEVEL_OPS:
+            self.tasks[task_id].got_task_message(
+                TaskMsg(ts=time.time(), op=task_op),
+                task_state.status)
+
+        elif task_op in self.SUBTASK_LEVEL_OPS:
+            assert subtask_id
+            self.tasks[task_id].got_subtask_message(
+                subtask_id,
+                TaskMsg(ts=time.time(), op=task_op),
+                task_state.subtask_states[subtask_id].subtask_status)
+
+        elif task_op in self.UNNOTEWORTHY_OPS:
+            # these are not interesting and are not stored
+            pass
+
+        else:
+            # Unknown task_op, log problem
+            logger.info("Unknown TaskOp {}".format(task_op.name))
+
+        if task_id in self.tasks:
+            new_task_stats = self.get_task_stats(task_id)
+            self.stats = update_current_stats_with_task(
+                self.stats, old_task_stats, new_task_stats)
+            self.finished_stats = update_finished_stats_with_task(
+                self.finished_stats, old_task_stats, new_task_stats)
+
+    def is_task_finished(self, task_id: str) -> bool:
+        """Returns True for a known, completed task"""
+        ti = self.tasks.get(task_id)
+        return bool(ti and ti.is_completed())
+
+    def get_task_stats(self, task_id: str) -> TaskStats:
+        """Returns statistical information about a single task
+
+        It is best to call it on a finished task, as all the values
+        will then be final. It will work on the task in progress, but
+        some fields like ``not_downloaded_subtasks_cnt`` can decrease.
+        """
+        ti = self.tasks[task_id]  # type: TaskInfo
+        return TaskStats(
+            finished=ti.is_completed(),
+            task_failed=ti.has_task_failed(),
+            total_time=ti.total_time(),
+            had_failures=ti.had_failures_or_timeouts(),
+            work_offers_cnt=ti.want_to_compute_count(),
+            requested_subtasks_cnt=ti.subtask_count(),
+            collected_results_cnt=ti.collected_results_count(),
+            verified_results_cnt=ti.verified_results_count(),
+            timed_out_subtasks_cnt=ti.timeout_count(),
+            not_downloaded_subtasks_cnt=ti.not_downloaded_count(),
+            failed_subtasks_cnt=ti.failed_count())
+
+    def get_current_stats(self) -> CurrentStats:
+        """Returns information about current state of requested tasks."""
+        return self.stats
+
+    def get_finished_stats(self) -> FinishedTasksStats:
+        """Returns stats about tasks that had been finished."""
+        return self.finished_stats
+
+
+class RequestorTaskStatsManager:
+    """Connects :py:class:`RequestorTaskStats` to pydispatcher.
+
+    It learns about changes to the tasks via ``pydispatcher``
+    signal ``golem.taskmanager`` with event ``task_status_updated``. This signal
+    is normally emitted by :py:meth:`TaskManager.notice_task_updated` method.
+    """
+    def __init__(self):
+        self.requestor_stats = RequestorTaskStats()
+        dispatcher.connect(self.cb_message,
+                           signal="golem.taskmanager",
+                           sender=dispatcher.Any)
+
+    def cb_message(self,  # pylint: disable=too-many-arguments
+                   sender: str,  # pylint: disable=unused-argument
+                   signal: str,  # pylint: disable=unused-argument
+                   event: Optional[str],
+                   task_id: str,
+                   task_state: TaskState,
+                   subtask_id: Optional[str] = None,
+                   task_op: Optional[TaskOp] = None):
+        """A callback for ``pydispatcher`` messages about tasks"""
+        if event != 'task_status_updated' or not task_id or not task_op:
+            return
+        self.requestor_stats.on_message(task_id, task_state,
+                                        task_op, subtask_id)
+
+    def get_current_stats(self) -> CurrentStats:
+        """See :py:meth:`RequestorTaskStats.get_current_stats`"""
+        return self.requestor_stats.get_current_stats()
+
+    def get_finished_stats(self) -> FinishedTasksStats:
+        """See :py:meth:`RequestorTaskStats.get_finished_stats`"""
+        return self.requestor_stats.get_finished_stats()

--- a/golem/task/taskrequestorstats.py
+++ b/golem/task/taskrequestorstats.py
@@ -253,6 +253,11 @@ CurrentStats = NamedTuple("CurrentStats", [
     ("not_downloadable_subtasks_cnt", int),
     ("failed_subtasks_cnt", int),
     ("work_offers_cnt", int)])
+CurrentStats.__doc__ = """Statistics about a set of tasks
+
+Intended to be used as a summary of information from a set of
+`TaskStats`, this is periodically sent to the monitor.
+"""
 
 EMPTY_CURRENT_STATS = CurrentStats(0, 0, 0, 0, 0, 0, 0, 0, 0)
 
@@ -314,7 +319,7 @@ FinishedTasksStats = NamedTuple("FinishedTasksStats", [
     ("finished_ok", FinishedTasksSummary),
     ("finished_with_failures", FinishedTasksSummary),
     ("failed", FinishedTasksSummary)])
-FinishedTasksSummary.__doc__ = """Statisitics about tasks that are done
+FinishedTasksSummary.__doc__ = """Statisitics about finished tasks
 
 Divided into groups depending on the level of success: `finished_ok`
 are tasks that were verified ok and had no problems along the way,
@@ -424,7 +429,7 @@ class RequestorTaskStats:
 
         elif task_op == TaskOp.TASK_RESTORED:
             if task_state.status in TASK_COMPLETED_STATUSES:
-                logger.info("Skipping completed task {}".format(task_id))
+                logger.debug("Skipping completed task %r", task_id)
             else:
                 the_time = time.time()
                 msg1 = TaskMsg(ts=the_time, op=TaskOp.SUBTASK_RESTARTED)
@@ -464,7 +469,7 @@ class RequestorTaskStats:
 
         else:
             # Unknown task_op, log problem
-            logger.info("Unknown TaskOp {}".format(task_op.name))
+            logger.debug("Unknown TaskOp %r", task_op.name)
 
         if task_id in self.tasks:
             new_task_stats = self.get_task_stats(task_id)

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -23,6 +23,9 @@ from golem.resource.resourcehandshake import ResourceHandshakeSessionMixin
 from golem.task.taskbase import ResultType, ResourceType
 from golem.transactions.ethereum.ethereumpaymentskeeper import EthAccountInfo
 
+# For type annotations:
+from golem.task.taskmanager import TaskManager  # pylint: disable=unused-import
+
 logger = logging.getLogger(__name__)
 
 
@@ -67,7 +70,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
         BasicSafeSession.__init__(self, conn)
         ResourceHandshakeSessionMixin.__init__(self)
         self.task_server = self.conn.server
-        self.task_manager = self.task_server.task_manager
+        self.task_manager = self.task_server.task_manager  # type: TaskManager
         self.task_computer = self.task_server.task_computer
         self.concent_service = self.task_server.client.concent_service
         self.task_id = None  # current task id
@@ -412,6 +415,8 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
     #########################
 
     def _react_to_want_to_compute_task(self, msg):
+        self.task_manager.got_wants_to_compute(msg.task_id, self.key_id,
+                                               msg.node_name)
         if self.task_server.should_accept_provider(self.key_id):
 
             if self._handshake_required(self.key_id):

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from golem.core.common import to_unicode
 
 
@@ -104,3 +106,24 @@ class TaskTestStatus(object):
     started = 'Started'
     success = 'Success'
     error = 'Error'
+
+
+class TaskOp(Enum):
+    WORK_OFFER_RECEIVED = 0
+    TASK_CREATED = 1
+    TASK_STARTED = 2
+    SUBTASK_ASSIGNED = 3
+    SUBTASK_RESULT_DOWNLOADING = 4
+    UNEXPECTED_SUBTASK_RECEIVED = 5
+    SUBTASK_NOT_ACCEPTED = 6
+    SUBTASK_FINISHED = 7
+    SUBTASK_FAILED = 8
+    TASK_FINISHED = 9
+    TASK_NOT_ACCEPTED = 10
+    TASK_TIMEOUT = 11
+    SUBTASK_TIMEOUT = 12
+    TASK_RESTARTED = 13
+    SUBTASK_RESTARTED = 14
+    FRAME_SUBTASK_RESTARTED = 15
+    TASK_ABORTED = 16
+    TASK_RESTORED = 17

--- a/tests/golem/monitor/test_monitor.py
+++ b/tests/golem/monitor/test_monitor.py
@@ -7,6 +7,8 @@ from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.monitor.model.nodemetadatamodel import NodeMetadataModel
 from golem.monitor.monitor import SystemMonitor
 from golem.monitorconfig import MONITOR_CONFIG
+from golem.task.taskrequestorstats import CurrentStats, FinishedTasksStats, \
+    EMPTY_FINISHED_SUMMARY
 
 
 class TestSystemMonitor(TestCase, testutils.PEP8MixIn):
@@ -28,6 +30,11 @@ class TestSystemMonitor(TestCase, testutils.PEP8MixIn):
         monitor.on_income("different address", 319031904194810)
         monitor.on_peer_snapshot([{"node_id": "firt node", "port": 19301},
                                   {"node_id": "second node", "port": 3193}])
+        monitor.on_requestor_stats_snapshot(CurrentStats(1,0,1,0,0,0,0,0,1),
+                                            FinishedTasksStats(
+                                                EMPTY_FINISHED_SUMMARY,
+                                                EMPTY_FINISHED_SUMMARY,
+                                                EMPTY_FINISHED_SUMMARY))
         ccd = ClientConfigDescriptor()
         ccd.node_name = "new node name"
         nmm = NodeMetadataModel("CLIID", "SESSID", "win32", "1.3", ccd)

--- a/tests/golem/task/test_taskrequestorstats.py
+++ b/tests/golem/task/test_taskrequestorstats.py
@@ -79,8 +79,8 @@ class TestTaskInfo(TestCase, testutils.PEP8MixIn):
                          "No results should have had problems w/download yet")
 
         self.assertGreaterEqual(ti.total_time(), 1.0,
-                           "Total time should be larger than 1.0 at this point "
-                           "since the task is not finished yet")
+                                "Total time should be larger than 1.0 at this "
+                                "point since the task is not finished yet")
         self.assertFalse(ti.had_failures_or_timeouts(),
                          "No timeouts nor failures expected so far")
         self.assertFalse(ti.is_completed(),
@@ -617,6 +617,18 @@ class TestRequestorTaskStats(LogTestCase):
             rs.on_message("task1", tstate, TaskOp.UNEXPECTED_SUBTASK_RECEIVED)
 
             assert any("Unknown TaskOp" in l for l in log.output)
+
+    def test_restore_finished_task(self):
+        # finished task should be skipped during restore so it does not
+        # clutter statistics
+        rs = RequestorTaskStats()
+        tstate = TaskState()
+        tstate.status = TaskStatus.timeout
+        tstate.time_started = 0.0
+
+        with self.assertLogs(logger, level="INFO") as log:
+            rs.on_message("task1", tstate, TaskOp.TASK_RESTORED)
+            assert any("Skipping completed task" in l for l in log.output)
 
 
 class TestRequestorTaskStatsManager(TestCase):

--- a/tests/golem/task/test_taskrequestorstats.py
+++ b/tests/golem/task/test_taskrequestorstats.py
@@ -78,7 +78,7 @@ class TestTaskInfo(TestCase, testutils.PEP8MixIn):
         self.assertEqual(ti.not_downloaded_count(), 0,
                          "No results should have had problems w/download yet")
 
-        self.assertGreater(ti.total_time(), 1.0,
+        self.assertGreaterEqual(ti.total_time(), 1.0,
                            "Total time should be larger than 1.0 at this point "
                            "since the task is not finished yet")
         self.assertFalse(ti.had_failures_or_timeouts(),
@@ -258,7 +258,7 @@ class TestTaskInfo(TestCase, testutils.PEP8MixIn):
 
 class TestRequestorTaskStats(LogTestCase):
     def compare_task_stats(self, ts1, ts2):
-        self.assertGreater(ts1.total_time, ts2.total_time)
+        self.assertGreaterEqual(ts1.total_time, ts2.total_time)
         self.assertEqual(ts1.finished, ts2.finished)
         self.assertEqual(ts1.task_failed, ts2.task_failed)
         self.assertEqual(ts1.had_failures, ts2.had_failures)
@@ -568,7 +568,7 @@ class TestRequestorTaskStats(LogTestCase):
                              FinishedTasksSummary(0, 0.0),
                              FinishedTasksSummary(0, 0.0),
                              FinishedTasksSummary(1, ftime2)))
-        self.assertGreater(ftime2, ftime1, "Time should not go back")
+        self.assertGreaterEqual(ftime2, ftime1, "Time should not go back")
 
         # and get it back to a good shape, create a subtask, fail it
         # and test then
@@ -589,7 +589,7 @@ class TestRequestorTaskStats(LogTestCase):
                              FinishedTasksSummary(0, 0.0),
                              FinishedTasksSummary(1, ftime3),
                              FinishedTasksSummary(0, 0.0)))
-        self.assertGreater(ftime3, ftime2, "Time should not go back")
+        self.assertGreaterEqual(ftime3, ftime2, "Time should not go back")
 
         # fail it again, just for fun (and coverage)
         ts1.status = TaskStatus.aborted
@@ -602,7 +602,7 @@ class TestRequestorTaskStats(LogTestCase):
                              FinishedTasksSummary(0, 0.0),
                              FinishedTasksSummary(0, 0.0),
                              FinishedTasksSummary(1, ftime4)))
-        self.assertGreater(ftime4, ftime3, "Time should not go back")
+        self.assertGreaterEqual(ftime4, ftime3, "Time should not go back")
 
     def test_unknown_task_op(self):
         # for that we need to remove one of the known ops from the list
@@ -720,7 +720,7 @@ class TestRequestorTaskStatsManager(TestCase):
                          CurrentStats(1, 1, 1, 1, 1, 0, 0, 0, 1))
         # duration of the task is unknown hence the complex compare
         self.assertEqual(rtsm.get_finished_stats()[0][0], 1)
-        self.assertGreater(rtsm.get_finished_stats()[0][1], 0)
+        self.assertGreaterEqual(rtsm.get_finished_stats()[0][1], 0.0)
         self.assertEqual(
             rtsm.get_finished_stats()[1], FinishedTasksSummary(0, 0.0))
         self.assertEqual(

--- a/tests/golem/task/test_taskrequestorstats.py
+++ b/tests/golem/task/test_taskrequestorstats.py
@@ -1,0 +1,739 @@
+from unittest import TestCase
+
+from pydispatch import dispatcher
+
+from golem import testutils
+from golem.task.taskrequestorstats import TaskInfo, TaskMsg, \
+    RequestorTaskStats, logger, CurrentStats, TaskStats, EMPTY_TASK_STATS, \
+    FinishedTasksStats, FinishedTasksSummary, RequestorTaskStatsManager, \
+    EMPTY_CURRENT_STATS, EMPTY_FINISHED_STATS
+from golem.task.taskstate import TaskStatus, TaskOp, SubtaskStatus, TaskState, \
+    SubtaskState
+from golem.tools.assertlogs import LogTestCase
+
+
+class TestTaskInfo(TestCase, testutils.PEP8MixIn):
+    PEP8_FILES = [
+        'golem/task/taskrequestorstats.py',
+        'tests/golem/task/test_taskrequestorstats.py'
+    ]
+
+    def test_taskinfo_creation(self):
+        # A new TaskInfo is created, it should have the status of type
+        # TaskStatus.notStarted, no subtasks, and no offers of computaion
+        # received
+        ti = TaskInfo()
+        self.assertIsNotNone(ti, "TaskInfo() returned None")
+        self.assertEqual(ti.latest_status, TaskStatus.notStarted,
+                         "Newly created TaskInfo should have"
+                         "TaskStatus.notStarted status")
+        self.assertEqual(ti.subtask_count(), 0,
+                         "Newly created TaskInfo should have no subtasks")
+        self.assertEqual(ti.want_to_compute_count(), 0,
+                         "Newly created TaskInfo should have not received any "
+                         "want to compute offers yet")
+
+    def test_task_with_one_subtask(self):
+        # Create a TaskInfo instance and let it know the task has been created
+        ti = TaskInfo()
+        tm = TaskMsg(ts=1.0, op=TaskOp.TASK_CREATED)
+        ti.got_task_message(tm, TaskStatus.waiting)
+
+        # latest_status got updated
+        self.assertEqual(ti.latest_status, TaskStatus.waiting,
+                         "TaskInfo should store the latest status supplied")
+        # still no computing offers nor subtasks
+        self.assertEqual(ti.subtask_count(), 0,
+                         "TaskInfo should have no subtasks at this point")
+        self.assertEqual(ti.want_to_compute_count(), 0,
+                         "TaskInfo should have not received any want to "
+                         "compute offers yet")
+
+        # start the task
+        tm = TaskMsg(ts=1.5, op=TaskOp.TASK_STARTED)
+        ti.got_task_message(tm, TaskStatus.starting)
+
+        # send a want to compute
+        ti.got_want_to_compute()
+
+        self.assertEqual(ti.want_to_compute_count(), 1,
+                         "TaskInfo should have received one want to compute "
+                         "offer already")
+
+        # Create a subtask
+        tm = TaskMsg(ts=2.0, op=TaskOp.SUBTASK_ASSIGNED)
+        ti.got_subtask_message("st1", tm, SubtaskStatus.starting)
+
+        # And make sure all the values are as expected
+        self.assertEqual(ti.subtask_count(), 1,
+                         "TaskInfo should have one subtask at this point")
+        self.assertEqual(ti.collected_results_count(), 0,
+                         "No results should have been collected yet")
+        self.assertEqual(ti.verified_results_count(), 0,
+                         "No results should have been verified yet")
+        self.assertEqual(ti.not_accepted_results_count(), 0,
+                         "No results should have been not accepted yet")
+        self.assertEqual(ti.timeout_count(), 0,
+                         "No results should have timed out yet")
+        self.assertEqual(ti.not_downloaded_count(), 0,
+                         "No results should have had problems w/download yet")
+
+        self.assertGreater(ti.total_time(), 1.0,
+                           "Total time should be larger than 1.0 at this point "
+                           "since the task is not finished yet")
+        self.assertFalse(ti.had_failures_or_timeouts(),
+                         "No timeouts nor failures expected so far")
+        self.assertFalse(ti.is_completed(),
+                         "Task should not be considered done")
+        self.assertEqual(ti.in_progress_subtasks_count(), 1,
+                         "One subtask should be in progress")
+
+        # Finish the subtask - download the results
+        tm = TaskMsg(ts=3.0, op=TaskOp.SUBTASK_RESULT_DOWNLOADING)
+        ti.got_subtask_message("st1", tm, SubtaskStatus.downloading)
+
+        # make sure the task is still considered active at this point
+        self.assertEqual(ti.in_progress_subtasks_count(), 1,
+                         "One subtask should still be in progress")
+        # but the results are not downloaded
+        self.assertEqual(ti.not_downloaded_count(), 1,
+                         "Results of one subtask are being downloaded now")
+
+        tm = TaskMsg(ts=4.0, op=TaskOp.SUBTASK_FINISHED)
+        ti.got_subtask_message("st1", tm, SubtaskStatus.finished)
+
+        # subtask should no longer be in progress
+        self.assertEqual(ti.in_progress_subtasks_count(), 0,
+                         "No subtasks should be in progress")
+        # but it should be there anyway
+        self.assertEqual(ti.subtask_count(), 1,
+                         "TaskInfo should have one subtask at this point")
+        # and the task should not be finished
+        self.assertFalse(ti.is_completed(),
+                         "Task should not be considered done")
+        # we should have one subtask collected & verified, no subtasks
+        # not accepted nor timeouts
+        self.assertEqual(ti.collected_results_count(), 1,
+                         "One result should have been collected already")
+        self.assertEqual(ti.verified_results_count(), 1,
+                         "One result should have been verified already")
+        self.assertEqual(ti.not_accepted_results_count(), 0,
+                         "No results should have been not accepted yet")
+        self.assertEqual(ti.timeout_count(), 0,
+                         "No results should have timed out yet")
+        self.assertEqual(ti.not_downloaded_count(), 0,
+                         "No results should have had problems w/download yet")
+
+        # finally, finish the task
+        tm = TaskMsg(ts=5.0, op=TaskOp.TASK_FINISHED)
+        ti.got_task_message(tm, TaskStatus.finished)
+
+        # the task should now be finished
+        self.assertTrue(ti.is_completed(),
+                        "Task should be considered done now")
+        self.assertEqual(ti.total_time(), 4.0,
+                         "Total time should equal 4.0 at this point")
+
+    @staticmethod
+    def _create_task_with_single_subtask(subtask_name="st1"):
+        ti = TaskInfo()
+        tm = TaskMsg(ts=1.0, op=TaskOp.TASK_CREATED)
+        ti.got_task_message(tm, TaskStatus.waiting)
+        tm = TaskMsg(ts=2.0, op=TaskOp.SUBTASK_ASSIGNED)
+        ti.got_subtask_message(subtask_name, tm, SubtaskStatus.starting)
+        return ti
+
+    def test_task_with_two_subtasks(self):
+        # Create a task with a single subtask
+        ti = self._create_task_with_single_subtask()
+
+        # Create another subtask...
+        tm = TaskMsg(ts=3.0, op=TaskOp.SUBTASK_ASSIGNED)
+        ti.got_subtask_message("st2", tm, SubtaskStatus.starting)
+
+        self.assertEqual(ti.subtask_count(), 2,
+                         "TaskInfo should have two subtasks at this point")
+        self.assertEqual(ti.in_progress_subtasks_count(), 2,
+                         "Both subtasks should be in progress")
+
+        # And finish the first subtask created...
+        tm = TaskMsg(ts=4.0, op=TaskOp.SUBTASK_RESULT_DOWNLOADING)
+        ti.got_subtask_message("st1", tm, SubtaskStatus.downloading)
+        tm = TaskMsg(ts=5.0, op=TaskOp.SUBTASK_FINISHED)
+        ti.got_subtask_message("st1", tm, SubtaskStatus.finished)
+
+        # we still have one task in progress, and no downloads in progress
+        self.assertEqual(ti.in_progress_subtasks_count(), 1,
+                         "One subtask should still be in progress")
+        self.assertEqual(ti.not_downloaded_count(), 0,
+                         "No downloads should be in progress")
+        # and still two subtasks...
+        self.assertEqual(ti.subtask_count(), 2,
+                         "TaskInfo should still have two subtasks at "
+                         "this point")
+
+        # finish the only remaining subtask
+        tm = TaskMsg(ts=6.0, op=TaskOp.SUBTASK_RESULT_DOWNLOADING)
+        ti.got_subtask_message("st2", tm, SubtaskStatus.downloading)
+        tm = TaskMsg(ts=7.0, op=TaskOp.SUBTASK_FINISHED)
+        ti.got_subtask_message("st2", tm, SubtaskStatus.finished)
+
+        self.assertEqual(ti.in_progress_subtasks_count(), 0,
+                         "One subtask should still be in progress")
+        self.assertEqual(ti.not_downloaded_count(), 0,
+                         "No downloads should be in progress")
+        self.assertEqual(ti.subtask_count(), 2,
+                         "TaskInfo should still have two subtasks at "
+                         "this point")
+        self.assertFalse(ti.had_failures_or_timeouts(),
+                         "Everything wenth smoothly so no failures were "
+                         "expected")
+        self.assertEqual(ti.verified_results_count(), 2,
+                         "Both result should have been verified already")
+
+    def test_task_with_various_problems(self):
+        # Create a task with a single subtask
+        ti = self._create_task_with_single_subtask()
+
+        # time out the subtask...
+        tm = TaskMsg(ts=3.0, op=TaskOp.SUBTASK_TIMEOUT)
+        ti.got_subtask_message("st1", tm, SubtaskStatus.failure)
+
+        self.assertEqual(ti.in_progress_subtasks_count(), 0,
+                         "No subtasks should be in progress")
+        self.assertEqual(ti.timeout_count(), 1,
+                         "One subtask should have timed out")
+        self.assertTrue(ti.had_failures_or_timeouts(),
+                        "One subtask should have timed out")
+
+        # create another task w/subtask and make it not pass verification
+        ti = self._create_task_with_single_subtask()
+        tm = TaskMsg(ts=3.0, op=TaskOp.SUBTASK_NOT_ACCEPTED)
+        ti.got_subtask_message("st1", tm, SubtaskStatus.failure)
+
+        self.assertEqual(ti.in_progress_subtasks_count(), 0,
+                         "No subtasks should be in progress")
+        self.assertEqual(ti.not_accepted_results_count(), 1,
+                         "One subtask should have not been accepted")
+        self.assertTrue(ti.had_failures_or_timeouts(),
+                        "One subtask should have not been accepted")
+
+        # and yet another that will fail on the other side
+        ti = self._create_task_with_single_subtask()
+        tm = TaskMsg(ts=3.0, op=TaskOp.SUBTASK_FAILED)
+        ti.got_subtask_message("st1", tm, SubtaskStatus.failure)
+        self.assertEqual(ti.in_progress_subtasks_count(), 0,
+                         "No subtasks should be in progress")
+        self.assertTrue(ti.had_failures_or_timeouts(),
+                        "One subtask should have failed")
+
+        # and a task that will time out without subtasks finished
+        ti = self._create_task_with_single_subtask()
+        tm = TaskMsg(ts=3.0, op=TaskOp.TASK_TIMEOUT)
+        ti.got_task_message(tm, TaskStatus.timeout)
+        self.assertEqual(ti.in_progress_subtasks_count(), 0,
+                         "No subtasks should be in progress")
+        self.assertTrue(ti.had_failures_or_timeouts(),
+                        "Whole task should have failed")
+
+    def test_strange_case(self):
+        """An unlikely scenario, but technically not impossible.
+
+        We create a task with a subtask, then we fail the subtask and restart
+        it later on. Then we check if it is considered in progress. To be
+        honest it's just for coverage.
+        """
+        ti = self._create_task_with_single_subtask()
+        tm = TaskMsg(ts=3.0, op=TaskOp.SUBTASK_TIMEOUT)
+        ti.got_subtask_message("st1", tm, SubtaskStatus.failure)
+
+        tm = TaskMsg(ts=4.0, op=TaskOp.SUBTASK_RESTARTED)
+        ti.got_subtask_message("st1", tm, SubtaskStatus.restarted)
+
+        self.assertEqual(ti.in_progress_subtasks_count(), 0,
+                         "No subtasks should be in progress")
+        self.assertTrue(ti.had_failures_or_timeouts(),
+                        "One subtask should have failed")
+
+
+class TestRequestorTaskStats(LogTestCase):
+    def compare_task_stats(self, ts1, ts2):
+        self.assertGreater(ts1.total_time, ts2.total_time)
+        self.assertEqual(ts1.finished, ts2.finished)
+        self.assertEqual(ts1.task_failed, ts2.task_failed)
+        self.assertEqual(ts1.had_failures, ts2.had_failures)
+        self.assertEqual(ts1.work_offers_cnt, ts2.work_offers_cnt)
+        self.assertEqual(ts1.requested_subtasks_cnt, ts2.requested_subtasks_cnt)
+        self.assertEqual(ts1.collected_results_cnt, ts2.collected_results_cnt)
+        self.assertEqual(ts1.verified_results_cnt, ts2.verified_results_cnt)
+        self.assertEqual(ts1.timed_out_subtasks_cnt, ts2.timed_out_subtasks_cnt)
+        self.assertEqual(ts1.not_downloaded_subtasks_cnt,
+                         ts2.not_downloaded_subtasks_cnt)
+        self.assertEqual(ts1.failed_subtasks_cnt, ts2.failed_subtasks_cnt)
+
+    def test_stats_collection(self):
+        rs = RequestorTaskStats()
+
+        # create a task
+        tstate = TaskState()
+        tstate.status = TaskStatus.notStarted
+        tstate.time_started = 0.0
+        rs.on_message("task1", tstate, TaskOp.TASK_CREATED, None)
+
+        # is it finished?
+        self.assertFalse(rs.is_task_finished("task1"),
+                         "task1 should be in progress")
+        # are the stats as expected?
+        task1_ts = rs.get_task_stats("task1")
+        self.compare_task_stats(task1_ts, EMPTY_TASK_STATS)
+
+        # what about the current stats?
+        cs = rs.get_current_stats()
+        self.assertEqual(cs, CurrentStats(1, 0, 0, 0, 0, 0, 0, 0, 0),
+                         "There should be one task only with no information "
+                         "about any subtasks")
+
+        # start the task
+        tstate.status = TaskStatus.waiting
+        rs.on_message("task1", tstate, TaskOp.TASK_STARTED)
+        # still one task, no finished ones and no subtasks at all
+        self.assertEqual(cs, CurrentStats(1, 0, 0, 0, 0, 0, 0, 0, 0),
+                         "There should be one task only with no information "
+                         "about any subtasks")
+
+        # receive work offer
+        rs.on_message("task1", tstate, TaskOp.WORK_OFFER_RECEIVED)
+        # which does not mean that a subtask is in progress
+        cs = rs.get_current_stats()
+        self.assertEqual(cs, CurrentStats(1, 0, 0, 0, 0, 0, 0, 0, 1),
+                         "Got work offer now")
+
+        # add a subtask
+        tstate.subtask_states["st1"] = SubtaskState()
+        sst = tstate.subtask_states["st1"]  # type: SubtaskState
+        sst.subtask_status = SubtaskStatus.starting
+        rs.on_message("task1", tstate, TaskOp.SUBTASK_ASSIGNED, "st1")
+        # a subtask in progress
+        cs = rs.get_current_stats()
+        self.assertEqual(cs, CurrentStats(1, 0, 1, 0, 0, 0, 0, 0, 1),
+                         "One subtask was requested so far, otherwise there "
+                         "should be no changes to stats")
+
+        # download results of that subtask
+        sst.subtask_status = SubtaskStatus.downloading
+        rs.on_message("task1", tstate, TaskOp.SUBTASK_RESULT_DOWNLOADING, "st1")
+        # still subtask in progress
+        cs = rs.get_current_stats()
+        self.assertEqual(cs, CurrentStats(1, 0, 1, 0, 0, 0, 0, 0, 1),
+                         "One subtask is still in progress, and even though "
+                         "its results are being downloaded it's not shown "
+                         "in the stats")
+
+        # and finish the subtask now
+        sst.subtask_status = SubtaskStatus.finished
+        rs.on_message("task1", tstate, TaskOp.SUBTASK_FINISHED, "st1")
+        # no subtask in progress but task is still not finished
+        cs = rs.get_current_stats()
+        self.assertEqual(cs, CurrentStats(1, 0, 1, 1, 1, 0, 0, 0, 1),
+                         "Sole subtask was finished which means its results "
+                         "were collected and verified")
+
+        # send an unexpected subtask
+        rs.on_message("task1", tstate, TaskOp.UNEXPECTED_SUBTASK_RECEIVED)
+        cs = rs.get_current_stats()
+        self.assertEqual(cs, CurrentStats(1, 0, 1, 1, 1, 0, 0, 0, 1),
+                         "Unexpected subtask have no influence on stats")
+
+        # finish the task now
+        tstate.status = TaskStatus.finished
+        rs.on_message("task1", tstate, TaskOp.TASK_FINISHED)
+        # no subtasks in progress, task finished
+        cs = rs.get_current_stats()
+        self.assertEqual(cs, CurrentStats(1, 1, 1, 1, 1, 0, 0, 0, 1),
+                         "The only task is now finished")
+        self.assertTrue(rs.is_task_finished("task1"),
+                        "A task should be finished now")
+
+    @staticmethod
+    def create_task_and_taskstate(rs, name):
+        tstate = TaskState()
+        tstate.status = TaskStatus.notStarted
+        tstate.time_started = 0.0
+        rs.on_message(name, tstate, TaskOp.TASK_CREATED)
+        tstate.status = TaskStatus.waiting
+        rs.on_message(name, tstate, TaskOp.TASK_STARTED)
+        rs.on_message(name, tstate, TaskOp.WORK_OFFER_RECEIVED)
+        return tstate
+
+    @staticmethod
+    def add_subtask(rs, task, tstate, subtask):
+        tstate.subtask_states[subtask] = SubtaskState()
+        sst = tstate.subtask_states[subtask]
+        sst.subtask_status = SubtaskStatus.starting
+        rs.on_message(task, tstate, TaskOp.SUBTASK_ASSIGNED, subtask)
+
+    @staticmethod
+    def finish_subtask(rs, task, tstate, subtask):
+        sst = tstate.subtask_states[subtask]
+        sst.subtask_status = SubtaskStatus.downloading
+        rs.on_message(task, tstate, TaskOp.SUBTASK_RESULT_DOWNLOADING,
+                      subtask)
+        sst.subtask_status = SubtaskStatus.finished
+        rs.on_message(task, tstate, TaskOp.SUBTASK_FINISHED, subtask)
+
+    @staticmethod
+    def finish_task(rs, task, tstate):
+        tstate.status = TaskStatus.finished
+        rs.on_message(task, tstate, TaskOp.TASK_FINISHED)
+
+    def test_multiple_tasks(self):
+        rs = RequestorTaskStats()
+
+        # create a task
+        ts1 = self.create_task_and_taskstate(rs, "task1")
+        # add two subtasks
+        self.add_subtask(rs, "task1", ts1, "st1.1")
+        self.add_subtask(rs, "task1", ts1, "st1.2")
+        # and another task
+        ts2 = self.create_task_and_taskstate(rs, "task2")
+        self.add_subtask(rs, "task2", ts2, "st2.1")
+
+        # check the stats now:
+        # both tasks are not finished
+        self.assertFalse(rs.is_task_finished("task1"), "task1 is still active")
+        self.assertFalse(rs.is_task_finished("task2"), "task2 is still active")
+        # current stats show 2 tasks, no finished tasks, 3 subtasks in progress
+        self.assertEqual(rs.get_current_stats(),
+                         CurrentStats(2, 0, 3, 0, 0, 0, 0, 0, 2),
+                         "Two tasks should be in progress, with 3 subtasks "
+                         "requested")
+
+        # finish one of the subtasks of the first task
+        self.finish_subtask(rs, "task1", ts1, "st1.1")
+        self.assertFalse(rs.is_task_finished("task1"), "task1 is still active")
+        self.assertFalse(rs.is_task_finished("task2"), "task2 is still active")
+        # current stats show 2 tasks, no finished tasks, 2 subtasks in progress
+        self.assertEqual(rs.get_current_stats(),
+                         CurrentStats(2, 0, 3, 1, 1, 0, 0, 0, 2),
+                         "Two tasks should be in progress, with 3 subtasks; "
+                         "one subtask should be collected and verified")
+
+        # finish task2
+        self.finish_subtask(rs, "task2", ts2, "st2.1")
+        self.assertFalse(rs.is_task_finished("task1"), "task1 is still active")
+        self.assertFalse(rs.is_task_finished("task2"), "task2 is still active")
+        self.assertEqual(rs.get_current_stats(),
+                         CurrentStats(2, 0, 3, 2, 2, 0, 0, 0, 2),
+                         "Two tasks should be in progress, with 3 subtasks; "
+                         "two of the subtasks should be collected and verified")
+        self.finish_task(rs, "task2", ts2)
+        self.assertFalse(rs.is_task_finished("task1"), "task1 is still active")
+        self.assertTrue(rs.is_task_finished("task2"), "task2 is finished")
+        self.assertEqual(rs.get_current_stats(),
+                         CurrentStats(2, 1, 3, 2, 2, 0, 0, 0, 2),
+                         "One task should be in progress, with 1 subtask "
+                         "running and 2 finished")
+
+        # add a restored task with 2 subtasks
+        ts3 = TaskState()
+        ts3.status = TaskStatus.notStarted
+        ts3.time_started = 0.0
+        ts3.subtask_states["st3.1"] = SubtaskState()
+        ts3.subtask_states["st3.1"].subtask_status = SubtaskStatus.starting
+        ts3.subtask_states["st3.2"] = SubtaskState()
+        ts3.subtask_states["st3.2"].subtask_status = SubtaskStatus.starting
+        rs.on_message("task3", ts3, TaskOp.TASK_RESTORED)
+
+        self.assertFalse(rs.is_task_finished("task1"), "task1 is still active")
+        self.assertTrue(rs.is_task_finished("task2"), "task2 is finished")
+        self.assertFalse(rs.is_task_finished("task3"), "task3 is still active")
+        self.assertEqual(rs.get_current_stats(),
+                         CurrentStats(3, 1, 5, 2, 2, 0, 0, 0, 2),
+                         "2 tasks should be in progress, with 5 subtasks "
+                         "(2 of them are finished)")
+
+        # close the remaining tasks
+        self.finish_subtask(rs, "task1", ts1, "st1.2")
+        self.finish_task(rs, "task1", ts1)
+        self.finish_subtask(rs, "task3", ts3, "st3.2")
+        self.finish_subtask(rs, "task3", ts3, "st3.1")
+        self.finish_task(rs, "task3", ts3)
+
+        self.assertEqual(rs.get_current_stats(),
+                         CurrentStats(3, 3, 5, 5, 5, 0, 0, 0, 2),
+                         "No tasks should be in progress, with all 5 subtasks "
+                         "collected and verified")
+
+    def test_tasks_with_errors(self):
+        rs = RequestorTaskStats()
+        ts1 = self.create_task_and_taskstate(rs, "task1")
+        self.add_subtask(rs, "task1", ts1, "st1.1")
+        self.add_subtask(rs, "task1", ts1, "st1.2")
+        self.add_subtask(rs, "task1", ts1, "st1.3")
+        self.add_subtask(rs, "task1", ts1, "st1.4")
+
+        # verification failure for st1.1
+        ts1.subtask_states["st1.1"].subtask_status = SubtaskStatus.downloading
+        rs.on_message("task1", ts1, TaskOp.SUBTASK_RESULT_DOWNLOADING, "st1.1")
+        ts1.subtask_states["st1.1"].subtask_status = SubtaskStatus.failure
+        rs.on_message("task1", ts1, TaskOp.SUBTASK_NOT_ACCEPTED, "st1.1")
+
+        stats1 = rs.get_task_stats("task1")
+        # Is in progress, have failed subtasks, 1 work offer, 4
+        # requested subtasks, 1 collected result, no verified results,
+        # no timed out subtasks, no problems with download
+        self.compare_task_stats(stats1,
+                                TaskStats(False, 0.0, False, True,
+                                          1, 4, 1, 0, 0, 0, 0))
+
+        # timeout for st1.2
+        ts1.subtask_states["st1.2"].subtask_status = SubtaskStatus.failure
+        rs.on_message("task1", ts1, TaskOp.SUBTASK_TIMEOUT, "st1.2")
+        # 1 timed out subtask, no other differences
+        stats2 = rs.get_task_stats("task1")
+        self.compare_task_stats(stats2,
+                                TaskStats(False, 0.0, False, True,
+                                          1, 4, 1, 0, 1, 0, 0))
+        self.assertEqual(rs.get_current_stats(),
+                         CurrentStats(1, 0, 4, 1, 0, 1, 0, 0, 1),
+                         "1 task should be in progress with 2 subtasks, one of "
+                         "them with timeout")
+
+        # remote failure for st1.3
+        ts1.subtask_states["st1.3"].subtask_status = SubtaskStatus.failure
+        rs.on_message("task1", ts1, TaskOp.SUBTASK_FAILED, "st1.3")
+        # no changes here, but the count of subtasks in progress decreases
+        stats3 = rs.get_task_stats("task1")
+        self.compare_task_stats(stats3,
+                                TaskStats(False, 0.0, False, True,
+                                          1, 4, 1, 0, 1, 0, 1))
+        self.assertEqual(rs.get_current_stats(),
+                         CurrentStats(1, 0, 4, 1, 0, 1, 0, 1, 1),
+                         "1 task should be in progress with 1 subtask still "
+                         "running; we have one failed subtask")
+
+        # download error for st1.4
+        ts1.subtask_states["st1.4"].subtask_status = SubtaskStatus.downloading
+        rs.on_message("task1", ts1, TaskOp.SUBTASK_RESULT_DOWNLOADING, "st1.4")
+        # one task not downloaded
+        stats4 = rs.get_task_stats("task1")
+        self.compare_task_stats(stats4,
+                                TaskStats(False, 0.0, False, True,
+                                          1, 4, 1, 0, 1, 1, 1))
+        # st1.4 may finish downloading later as the task is still in
+        # progress, so we still consider st1.4 to be in progress
+        self.assertEqual(rs.get_current_stats(),
+                         CurrentStats(1, 0, 4, 1, 0, 1, 0, 1, 1),
+                         "1 task should be in progress with 1 subtask")
+
+        # and it should stay as download error after the task is finished
+        ts1.status = TaskStatus.timeout
+        rs.on_message("task1", ts1, TaskOp.TASK_TIMEOUT)
+        stats5 = rs.get_task_stats("task1")
+        self.compare_task_stats(stats5,
+                                TaskStats(True, 0.0, True, True,
+                                          1, 4, 1, 0, 1, 1, 1))
+        # the task is finished so st1.4 won't ever finish downloading
+        # so it is not in progress anymore
+        self.assertEqual(rs.get_current_stats(),
+                         CurrentStats(1, 1, 4, 1, 0, 1, 1, 1, 1),
+                         "1 task should be finished")
+
+    def test_resurrected_tasks(self):
+        """This should probably not happen in practice, but let's test
+        tasks that are finished and then modified.
+        """
+        rs = RequestorTaskStats()
+        ts1 = self.create_task_and_taskstate(rs, "task1")
+        self.add_subtask(rs, "task1", ts1, "st1.1")
+        self.finish_subtask(rs, "task1", ts1, "st1.1")
+        self.finish_task(rs, "task1", ts1)
+
+        fstats1 = rs.get_finished_stats()
+        ftime1 = fstats1.finished_ok.total_time
+        self.assertEqual(fstats1,
+                         FinishedTasksStats(
+                             FinishedTasksSummary(1, ftime1),
+                             FinishedTasksSummary(0, 0.0),
+                             FinishedTasksSummary(0, 0.0)))
+
+        # zombies! let's change the status to failed task
+        ts1.status = TaskStatus.timeout
+        rs.on_message("task1", ts1, TaskOp.TASK_TIMEOUT)
+
+        fstats2 = rs.get_finished_stats()
+        ftime2 = fstats2.failed.total_time
+        self.assertEqual(fstats2,
+                         FinishedTasksStats(
+                             FinishedTasksSummary(0, 0.0),
+                             FinishedTasksSummary(0, 0.0),
+                             FinishedTasksSummary(1, ftime2)))
+        self.assertGreater(ftime2, ftime1, "Time should not go back")
+
+        # and get it back to a good shape, create a subtask, fail it
+        # and test then
+        ts1.status = TaskStatus.waiting
+        rs.on_message("task1", ts1, TaskOp.TASK_RESTARTED)
+        self.add_subtask(rs, "task1", ts1, "st1.2")
+        sst = ts1.subtask_states["st1.2"]
+        sst.subtask_status = SubtaskStatus.downloading
+        rs.on_message("task1", ts1, TaskOp.SUBTASK_RESULT_DOWNLOADING, "st1.2")
+        sst.subtask_status = SubtaskStatus.failure
+        rs.on_message("task1", ts1, TaskOp.SUBTASK_NOT_ACCEPTED, "st1.2")
+        self.finish_task(rs, "task1", ts1)
+
+        fstats3 = rs.get_finished_stats()
+        ftime3 = fstats3.finished_with_failures.total_time
+        self.assertEqual(fstats3,
+                         FinishedTasksStats(
+                             FinishedTasksSummary(0, 0.0),
+                             FinishedTasksSummary(1, ftime3),
+                             FinishedTasksSummary(0, 0.0)))
+        self.assertGreater(ftime3, ftime2, "Time should not go back")
+
+        # fail it again, just for fun (and coverage)
+        ts1.status = TaskStatus.aborted
+        rs.on_message("task1", ts1, TaskOp.TASK_ABORTED)
+
+        fstats4 = rs.get_finished_stats()
+        ftime4 = fstats4.failed.total_time
+        self.assertEqual(fstats4,
+                         FinishedTasksStats(
+                             FinishedTasksSummary(0, 0.0),
+                             FinishedTasksSummary(0, 0.0),
+                             FinishedTasksSummary(1, ftime4)))
+        self.assertGreater(ftime4, ftime3, "Time should not go back")
+
+    def test_unknown_task_op(self):
+        # for that we need to remove one of the known ops from the list
+        rs = RequestorTaskStats()
+        rs.UNNOTEWORTHY_OPS = []
+
+        tstate = TaskState()
+        tstate.status = TaskStatus.notStarted
+        tstate.time_started = 0.0
+
+        with self.assertLogs(logger, level="INFO") as log:
+            rs.on_message("task1", tstate, TaskOp.UNEXPECTED_SUBTASK_RECEIVED)
+
+            assert any("Unknown TaskOp" in l for l in log.output)
+
+
+class TestRequestorTaskStatsManager(TestCase):
+    def test_empty_stats(self):
+        rtsm = RequestorTaskStatsManager()
+        self.assertEqual(rtsm.get_current_stats(), EMPTY_CURRENT_STATS)
+        self.assertEqual(rtsm.get_finished_stats(), EMPTY_FINISHED_STATS)
+
+    def test_single_task(self):
+        # Just a single task, created with one subtask and finished
+        # afterwards
+        rtsm = RequestorTaskStatsManager()
+
+        tstate = TaskState()
+        tstate.status = TaskStatus.notStarted
+        tstate.time_started = 0.0
+
+        dispatcher.send(
+            signal='golem.taskmanager',
+            event='task_status_updated',
+            task_id="task1",
+            task_state=tstate,
+            subtask_id=None,
+            task_op=TaskOp.TASK_CREATED)
+
+        # task created
+        self.assertEqual(rtsm.get_current_stats(),
+                         CurrentStats(1, 0, 0, 0, 0, 0, 0, 0, 0))
+        self.assertEqual(rtsm.get_finished_stats(), EMPTY_FINISHED_STATS)
+
+        tstate.status = TaskStatus.waiting
+        dispatcher.send(
+            signal='golem.taskmanager',
+            event='task_status_updated',
+            task_id="task1",
+            task_state=tstate,
+            subtask_id=None,
+            task_op=TaskOp.TASK_STARTED)
+        dispatcher.send(
+            signal='golem.taskmanager',
+            event='task_status_updated',
+            task_id="task1",
+            task_state=tstate,
+            subtask_id=None,
+            task_op=TaskOp.WORK_OFFER_RECEIVED)
+
+        # work offer received, but nothing more changed
+        self.assertEqual(rtsm.get_current_stats(),
+                         CurrentStats(1, 0, 0, 0, 0, 0, 0, 0, 1))
+        self.assertEqual(rtsm.get_finished_stats(), EMPTY_FINISHED_STATS)
+
+        tstate.subtask_states["st1.1"] = SubtaskState()
+        tstate.subtask_states["st1.1"].subtask_status = SubtaskStatus.starting
+        dispatcher.send(
+            signal='golem.taskmanager',
+            event='task_status_updated',
+            task_id="task1",
+            task_state=tstate,
+            subtask_id="st1.1",
+            task_op=TaskOp.SUBTASK_ASSIGNED)
+
+        # assigned subtask reflected in stats
+        self.assertEqual(rtsm.get_current_stats(),
+                         CurrentStats(1, 0, 1, 0, 0, 0, 0, 0, 1))
+        self.assertEqual(rtsm.get_finished_stats(), EMPTY_FINISHED_STATS)
+
+        tstate.subtask_states["st1.1"].subtask_status = (
+            SubtaskStatus.downloading)
+        dispatcher.send(
+            signal='golem.taskmanager',
+            event='task_status_updated',
+            task_id="task1",
+            task_state=tstate,
+            subtask_id="st1.1",
+            task_op=TaskOp.SUBTASK_RESULT_DOWNLOADING)
+        tstate.subtask_states["st1.1"].subtask_status = SubtaskStatus.finished
+        dispatcher.send(
+            signal='golem.taskmanager',
+            event='task_status_updated',
+            task_id="task1",
+            task_state=tstate,
+            subtask_id="st1.1",
+            task_op=TaskOp.SUBTASK_FINISHED)
+
+        # subtask finished and verified ok
+        self.assertEqual(rtsm.get_current_stats(),
+                         CurrentStats(1, 0, 1, 1, 1, 0, 0, 0, 1))
+        self.assertEqual(rtsm.get_finished_stats(), EMPTY_FINISHED_STATS)
+
+        tstate.status = TaskStatus.finished
+        dispatcher.send(
+            signal='golem.taskmanager',
+            event='task_status_updated',
+            task_id="task1",
+            task_state=tstate,
+            subtask_id=None,
+            task_op=TaskOp.TASK_FINISHED)
+
+        # task done
+        self.assertEqual(rtsm.get_current_stats(),
+                         CurrentStats(1, 1, 1, 1, 1, 0, 0, 0, 1))
+        # duration of the task is unknown hence the complex compare
+        self.assertEqual(rtsm.get_finished_stats()[0][0], 1)
+        self.assertGreater(rtsm.get_finished_stats()[0][1], 0)
+        self.assertEqual(
+            rtsm.get_finished_stats()[1], FinishedTasksSummary(0, 0.0))
+        self.assertEqual(
+            rtsm.get_finished_stats()[2], FinishedTasksSummary(0, 0.0))
+
+    def test_bad_message(self):
+        # mostly for coverage, message without all necessary fields
+        # should not cause exception nor change statistics
+        rtsm = RequestorTaskStatsManager()
+        dispatcher.send(
+            signal='golem.taskmanager',
+            event='task_status_updated',
+            task_id=None,
+            task_state=TaskState())
+        self.assertEqual(rtsm.get_current_stats(), EMPTY_CURRENT_STATS)
+        self.assertEqual(rtsm.get_finished_stats(), EMPTY_FINISHED_STATS)

--- a/tests/golem/task/test_taskrequestorstats.py
+++ b/tests/golem/task/test_taskrequestorstats.py
@@ -613,7 +613,7 @@ class TestRequestorTaskStats(LogTestCase):
         tstate.status = TaskStatus.notStarted
         tstate.time_started = 0.0
 
-        with self.assertLogs(logger, level="INFO") as log:
+        with self.assertLogs(logger, level="DEBUG") as log:
             rs.on_message("task1", tstate, TaskOp.UNEXPECTED_SUBTASK_RECEIVED)
 
             assert any("Unknown TaskOp" in l for l in log.output)
@@ -626,7 +626,7 @@ class TestRequestorTaskStats(LogTestCase):
         tstate.status = TaskStatus.timeout
         tstate.time_started = 0.0
 
-        with self.assertLogs(logger, level="INFO") as log:
+        with self.assertLogs(logger, level="DEBUG") as log:
             rs.on_message("task1", tstate, TaskOp.TASK_RESTORED)
             assert any("Skipping completed task" in l for l in log.output)
 

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -481,7 +481,7 @@ class TestMonitoringPublisherService(TestWithReactor):
         service._run()
 
         assert not log.debug.called
-        assert send.call_count == 2
+        assert send.call_count == 3
 
 
 class TestNetworkConnectionPublisherService(TestWithReactor):


### PR DESCRIPTION
Statistics about requested tasks are gathered using pydispatch signals sent from `TaskManager` objects. They are transmitted to the monitor in `MonitoringPublisherService`'s `_run` method. The statistics are collected per-session and are not stored on application's exit.