### PR TITLE
Task persistence: fixes, sharing restored task resources with HyperG

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -476,7 +476,6 @@ class Client(HardwarePresetsMixin):
         def add_task(result):
             task_state = task_manager.tasks_states[task_id]
             task_state.resource_hash = result[1]
-            self.task_server.task_manager.notify_update_task(task_id)
 
             request = AsyncRequest(task_manager.start_task, task_id)
             async_run(request, None, error)

--- a/golem/client.py
+++ b/golem/client.py
@@ -329,6 +329,7 @@ class Client(HardwarePresetsMixin):
             self.resource_server = BaseResourceServer(resource_manager,
                                                       dir_manager,
                                                       self.keys_auth, self)
+            self.task_server.restore_task_resources()
 
         def connect(ports):
             p2p_port, task_port = ports
@@ -472,7 +473,11 @@ class Client(HardwarePresetsMixin):
         options = resource_manager.build_client_options()
         files = task.get_resources(None, ResourceType.HASHES)
 
-        def add_task(_):
+        def add_task(result):
+            task_state = task_manager.tasks_states[task_id]
+            task_state.resource_hash = result[1]
+            self.task_server.task_manager.notify_update_task(task_id)
+
             request = AsyncRequest(task_manager.start_task, task_id)
             async_run(request, None, error)
 

--- a/golem/client.py
+++ b/golem/client.py
@@ -329,7 +329,7 @@ class Client(HardwarePresetsMixin):
             self.resource_server = BaseResourceServer(resource_manager,
                                                       dir_manager,
                                                       self.keys_auth, self)
-            self.task_server.restore_task_resources()
+            self.task_server.restore_resources()
 
         def connect(ports):
             p2p_port, task_port = ports

--- a/golem/network/hyperdrive/client.py
+++ b/golem/network/hyperdrive/client.py
@@ -58,6 +58,14 @@ class HyperdriveClient(IClient):
         )
         return response['hash']
 
+    def restore(self, multihash, **kwargs):
+        response = self._request(
+            command='upload',
+            id=kwargs.get('id'),
+            hash=multihash
+        )
+        return response['hash']
+
     def get_file(self, multihash, client_options=None, **kwargs):
         filepath = kwargs.pop('filepath')
         peers = None

--- a/golem/resource/base/resourcesmanager.py
+++ b/golem/resource/base/resourcesmanager.py
@@ -340,14 +340,19 @@ class AbstractResourceManager(IClientHandler, metaclass=abc.ABCMeta):
                                     client=client,
                                     client_options=client_options)
 
-    def add_task(self, files, task_id,
-                 client=None, client_options=None):
+    def add_task(self, files, task_id, resource_hash=None,
+                 client=None, client_options=None, async=True):
 
-        request = AsyncRequest(self._add_task, files, task_id,
-                               client=client, client_options=client_options)
-        return async_run(request)
+        args = (files, task_id)
+        kwargs = dict(resource_hash=resource_hash, client=client,
+                      client_options=client_options)
 
-    def _add_task(self, files, task_id,
+        if async:
+            request = AsyncRequest(self._add_task, *args, **kwargs)
+            return async_run(request)
+        return self._add_task(*args, **kwargs)
+
+    def _add_task(self, files, task_id, resource_hash=None,
                   client=None, client_options=None):
 
         if self.storage.cache.get_prefix(task_id):
@@ -364,13 +369,13 @@ class AbstractResourceManager(IClientHandler, metaclass=abc.ABCMeta):
 
         self.storage.cache.set_prefix(task_id, prefix)
         return self.add_files(files, task_id,
+                              resource_hash=resource_hash,
                               absolute_path=True,
                               client=client,
                               client_options=client_options)
 
-    def add_files(self, files, task_id,
-                  absolute_path=False, client=None,
-                  client_options=None):
+    def add_files(self, files, task_id, resource_hash=None,
+                  absolute_path=False, client=None, client_options=None):
 
         if files:
             client = client or self.new_client()

--- a/golem/resource/base/resourcesmanager.py
+++ b/golem/resource/base/resourcesmanager.py
@@ -363,10 +363,10 @@ class AbstractResourceManager(IClientHandler, metaclass=abc.ABCMeta):
             prefix = common_dir(files)
 
         self.storage.cache.set_prefix(task_id, prefix)
-        self.add_files(files, task_id,
-                       absolute_path=True,
-                       client=client,
-                       client_options=client_options)
+        return self.add_files(files, task_id,
+                              absolute_path=True,
+                              client=client,
+                              client_options=client_options)
 
     def add_files(self, files, task_id,
                   absolute_path=False, client=None,

--- a/golem/resource/client.py
+++ b/golem/resource/client.py
@@ -97,6 +97,7 @@ class ClientCommands(Enum):
     add = 0
     get = 1
     id = 2
+    restore = 3
 
 
 class ClientError(Exception):

--- a/golem/resource/hyperdrive/resourcesmanager.py
+++ b/golem/resource/hyperdrive/resourcesmanager.py
@@ -75,7 +75,7 @@ class HyperdriveResourceManager(ClientHandler, AbstractResourceManager):
     def _add_files(self, files, task_id, resource_hash=None,
                    client=None, client_options=None):
 
-        if not all(os.path.exists(f) for f in files.keys()):
+        if not all(os.path.exists(f) for f in files):
             logger.error("Resource manager: missing files (task: %r)", task_id)
             return
 

--- a/golem/resource/hyperdrive/resourcesmanager.py
+++ b/golem/resource/hyperdrive/resourcesmanager.py
@@ -75,8 +75,12 @@ class HyperdriveResourceManager(ClientHandler, AbstractResourceManager):
     def _add_files(self, files, task_id, resource_hash=None,
                    client=None, client_options=None):
 
-        if not all(os.path.exists(f) for f in files):
-            logger.error("Resource manager: missing files (task: %r)", task_id)
+        checked = {f: os.path.exists(f) for f in files}
+
+        if not all(checked.values()):
+            missing = [f for f, exists in files.items() if not exists]
+            logger.error("Resource manager: missing files (task: %r):\n%s",
+                         task_id, missing)
             return
 
         client = client or self.new_client()

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -349,7 +349,7 @@ class TaskManager(TaskEventListener):
     def get_tasks_headers(self):
         ret = []
         for tid, task in self.tasks.items():
-            status = self.tasks_states.get(tid).status
+            status = self.tasks_states[tid].status
             if task.needs_computation() and status in self.activeStatus:
                 ret.append(task.header)
 

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -210,7 +210,7 @@ class TaskManager(TaskEventListener):
             filepath.unlink()
             logger.debug('TASK DUMP with id %s REMOVED from %r',
                          task_id, filepath)
-        except OSError as e:
+        except (FileNotFoundError, OSError) as e:
             logger.warning("Couldn't remove dump file: %s - %s", e)
 
     def restore_tasks(self) -> None:
@@ -224,6 +224,8 @@ class TaskManager(TaskEventListener):
             with path.open('rb') as f:
                 try:
                     task, state = pickle.load(f)
+                    task.register_listener(self)
+
                     self.tasks[task.header.task_id] = task
                     self.tasks_states[task.header.task_id] = state
 

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -542,7 +542,6 @@ class TaskManager(TaskEventListener):
 
     @handle_task_key_error
     def restart_task(self, task_id):
-        logger.info("Restarting task %s", task_id)
         self.dir_manager.clear_temporary(task_id)
         task = self.tasks[task_id]
 
@@ -558,6 +557,7 @@ class TaskManager(TaskEventListener):
 
         task.header.signature = self.sign_task_header(task.header)
 
+        logger.info("Task %s restarted", task_id)
         self.notice_task_updated(task_id)
 
     @handle_subtask_key_error

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -208,7 +208,7 @@ class TaskManager(TaskEventListener):
             logger.debug('TASK DUMP with id %s REMOVED from %r',
                          task_id, filepath)
         except (FileNotFoundError, OSError) as e:
-            logger.warning("Couldn't remove dump file: %s - %s", e)
+            logger.warning("Couldn't remove dump file: %s - %s", filepath, e)
 
     def restore_tasks(self) -> None:
         logger.debug('SEARCHING FOR TASKS TO RESTORE')

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -68,7 +68,9 @@ class TaskResourcesMixin(object):
         if not self.task_manager.task_persistence:
             return
 
-        for task_id, task_state in self.task_manager.tasks_states.items():
+        states = dict(self.task_manager.tasks_states)
+
+        for task_id, task_state in states.items():
             task = self.task_manager.tasks[task_id]
             files = task.get_resources(None, ResourceType.HASHES)
 

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -71,7 +71,7 @@ class TaskResourcesMixin(object):
             task = tasks[task_id]
             files = task.get_resources(None, ResourceType.HASHES)
 
-            logger.warning("Restoring task resources: %r", task_id)
+            logger.info("Restoring task resources: %r", task_id)
             self._restore_resources(files, task_id,
                                     resource_hash=task_state.resource_hash)
 
@@ -90,6 +90,7 @@ class TaskResourcesMixin(object):
             if resource_hash:
                 return self._restore_resources(files, task_id)
             logger.error("Cannot restore resources for task: %r", task_id)
+            self.task_manager.delete_task(task_id)
         else:
             task_state = self.task_manager.tasks_states[task_id]
             task_state.resource_hash = resource_hash

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -73,8 +73,7 @@ class TaskResourcesMixin(object):
             files = task.get_resources(None, ResourceType.HASHES)
 
             logger.info("Restoring task resources: %r", task_id)
-            self._restore_resources(files, task_id,
-                                    resource_hash=task_state.resource_hash)
+            self._restore_resources(files, task_id, task_state.resource_hash)
 
     def _restore_resources(self,
                            files: Iterable[str],
@@ -84,9 +83,11 @@ class TaskResourcesMixin(object):
         resource_manager = self._get_resource_manager()
 
         try:
-            _, resource_hash = resource_manager.add_files(
-                files, task_id,
-                resource_hash=resource_hash
+            _, resource_hash = resource_manager.add_task(
+                files,
+                task_id,
+                resource_hash=resource_hash,
+                async=False
             )
         except ConnectionError:
             logger.error("Cannot restore resources for task: %r", task_id)

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -13,6 +13,7 @@ class TaskState(object):
         self.outputs = []
         self.total_subtasks = 0
         self.subtask_states = {}
+        self.resource_hash = None
 
         self.extra_data = {}
 

--- a/tests/golem/network/hyperdrive/test_hyperdrive_client.py
+++ b/tests/golem/network/hyperdrive/test_hyperdrive_client.py
@@ -52,6 +52,14 @@ class TestHyperdriveClient(unittest.TestCase):
                                return_value=self.response):
             assert client.add(self.response['files']) == self.response['hash']
 
+    def test_restore(self):
+        client = HyperdriveClient()
+
+        with mock.patch.object(HyperdriveClient, '_request',
+                               return_value=self.response):
+            assert client.restore(self.response['files']) == \
+                   self.response['hash']
+
     def test_get_file(self):
         client = HyperdriveClient()
         multihash = str(uuid.uuid4())

--- a/tests/golem/resource/hyperdrive/test_hyperdrive_resourcemanager.py
+++ b/tests/golem/resource/hyperdrive/test_hyperdrive_resourcemanager.py
@@ -1,7 +1,7 @@
 import os
 import uuid
 from unittest import skipIf, TestCase
-from unittest.mock import Mock
+from unittest.mock import Mock, ANY
 
 from pathlib import Path
 from requests import ConnectionError
@@ -85,16 +85,26 @@ class TestHyperdriveResourceManager(TempDirFixture):
     def test_add_files_empty_resource_hash(self):
         self.resource_manager._add_files(self.files, self.task_id,
                                          resource_hash=None)
-        assert self.handle_retries.called
-        command = self.handle_retries.call_args[0][1]
-        assert command == self.resource_manager.commands.add
+
+        self.handle_retries.assert_called_once_with(
+            ANY, self.resource_manager.commands.add, ANY,
+            client_options=None,
+            id=ANY,
+            obj_id=ANY,
+            raise_exc=False
+        )
 
     def test_add_files_with_resource_hash(self):
         self.resource_manager._add_files(self.files, self.task_id,
                                          resource_hash=str(uuid.uuid4()))
-        assert self.handle_retries.called
-        command = self.handle_retries.call_args[0][1]
-        assert command == self.resource_manager.commands.restore
+
+        self.handle_retries.assert_called_once_with(
+            ANY, self.resource_manager.commands.restore, ANY,
+            client_options=None,
+            id=ANY,
+            obj_id=ANY,
+            raise_exc=True
+        )
 
 
 @skipIf(not running(), "Hyperdrive daemon isn't running")

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -518,7 +518,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             self.tm.add_new_task(t)
             self.tm.start_task(t.header.task_id)
             self.tm.resources_send("xyz")
-            self.assertEqual(listener_mock.call_count, 2)
+            self.assertEqual(listener_mock.call_count, 3)
         finally:
             dispatcher.disconnect(listener, signal='golem.taskmanager')
 
@@ -676,7 +676,8 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             p2p_prv_port=40102, p2p_pub_port=40102
         )
         task = Task(TaskHeader("node", "task_id", "1.2.3.4", 1234,
-                               "key_id", "environment", task_owner=node), '', Mock())
+                               "key_id", "environment", task_owner=node), '',
+                    TaskDefinition())
 
         self.tm.keys_auth = EllipticalKeysAuth(self.path)
         self.tm.add_new_task(task)

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -540,7 +540,6 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             self.tm.get_next_subtask("ABC", "ABC", "abc", 1000, 10, 5, 10, 2, "10.10.10.10")
             time.sleep(0.1)
             self.tm.check_timeouts()
-            assert t2.task_status == TaskStatus.waiting
             assert self.tm.tasks_states["abc"].status == TaskStatus.waiting
             assert self.tm.tasks_states["abc"].subtask_states["aabbcc"].subtask_status == SubtaskStatus.failure
         # Task with task and subtask timeout
@@ -551,7 +550,6 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             self.tm.get_next_subtask("ABC", "ABC", "qwe", 1000, 10, 5, 10, 2, "10.10.10.10")
             time.sleep(0.1)
             self.tm.check_timeouts()
-            assert t3.task_status == TaskStatus.timeout
             assert self.tm.tasks_states["qwe"].status == TaskStatus.timeout
             assert self.tm.tasks_states["qwe"].subtask_states["qwerty"].subtask_status == SubtaskStatus.failure
 
@@ -580,7 +578,6 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
         with self.assertNoLogs(logger, level="WARNING"):
             self.tm.restart_task("xyz")
 
-        assert self.tm.tasks["xyz"].task_status == TaskStatus.restarted
         assert self.tm.tasks_states["xyz"].status == TaskStatus.restarted
 
         with patch('golem.task.taskbase.Task.needs_computation', return_value=True):
@@ -591,7 +588,6 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             with self.assertNoLogs(logger, level="WARNING"):
                 self.tm.restart_task("xyz")
 
-            assert self.tm.tasks["xyz"].task_status == TaskStatus.restarted
             assert self.tm.tasks_states["xyz"].status == TaskStatus.restarted
             self.assertEqual(len(self.tm.tasks_states["xyz"].subtask_states), 2)
             for ss in list(self.tm.tasks_states["xyz"].subtask_states.values()):
@@ -606,7 +602,6 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
         with self.assertNoLogs(logger, level="WARNING"):
             self.tm.abort_task("xyz")
 
-        assert self.tm.tasks["xyz"].task_status == TaskStatus.aborted
         assert self.tm.tasks_states["xyz"].status == TaskStatus.aborted
 
     @patch('golem.network.p2p.node.Node.collect_network_info')

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -903,7 +903,7 @@ class TestRestoreResources(TestWithKeysAuth, LogTestCase,
 
     @staticmethod
     def _create_tasks(task_server, count):
-        for i in range(count):
+        for _ in range(count):
             task_id = str(uuid.uuid4())
             task_server.task_manager.tasks[task_id] = Mock()
             task_server.task_manager.tasks_states[task_id] = TaskState()

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -908,15 +908,9 @@ class TestRestoreResources(TestWithKeysAuth, LogTestCase,
             task_server.task_manager.tasks[task_id] = Mock()
             task_server.task_manager.tasks_states[task_id] = TaskState()
 
-    @staticmethod
-    def _build_raise(cls):
-        def _raise(*_a, **_kw):
-            raise cls()
-        return Mock(side_effect=_raise)
-
     def test_without_tasks(self):
         with patch.object(self.resource_manager, 'add_task',
-                          side_effect=self._build_raise(ConnectionError)):
+                          side_effect=ConnectionError):
             self.ts.restore_resources()
             assert not self.resource_manager.add_task.called
             assert not self.ts.task_manager.delete_task.called
@@ -926,7 +920,7 @@ class TestRestoreResources(TestWithKeysAuth, LogTestCase,
         self._create_tasks(self.ts, self.task_count)
 
         with patch.object(self.resource_manager, 'add_task',
-                          side_effect=self._build_raise(ConnectionError)):
+                          side_effect=ConnectionError):
             self.ts.restore_resources()
             assert self.resource_manager.add_task.call_count == self.task_count
             assert self.ts.task_manager.delete_task.call_count == \
@@ -937,7 +931,7 @@ class TestRestoreResources(TestWithKeysAuth, LogTestCase,
         self._create_tasks(self.ts, self.task_count)
 
         with patch.object(self.resource_manager, 'add_task',
-                          side_effect=self._build_raise(HTTPError)):
+                          side_effect=HTTPError):
             self.ts.restore_resources()
             assert self.resource_manager.add_task.call_count == self.task_count
             assert self.ts.task_manager.delete_task.call_count == \
@@ -950,7 +944,7 @@ class TestRestoreResources(TestWithKeysAuth, LogTestCase,
             state.resource_hash = str(uuid.uuid4())
 
         with patch.object(self.resource_manager, 'add_task',
-                          side_effect=self._build_raise(HTTPError)):
+                          side_effect=HTTPError):
             self.ts.restore_resources()
             assert self.resource_manager.add_task.call_count == \
                 self.task_count * 2

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1,4 +1,3 @@
-from copy import copy
 import datetime
 import os
 import time
@@ -29,7 +28,6 @@ from golem.resource.dirmanager import DirManager
 from golem.resource.resourceserver import ResourceServer
 from golem.rpc.mapping.rpceventnames import UI, Environment
 from golem.task.taskbase import Task, TaskHeader, ResourceType
-from golem.task.taskcomputer import TaskComputer
 from golem.task.taskserver import TaskServer
 from golem.task.taskstate import TaskState
 from golem.tools.assertlogs import LogTestCase
@@ -38,7 +36,6 @@ from golem.tools.testwithdatabase import TestWithDatabase
 from golem.tools.testwithreactor import TestWithReactor
 from golem.utils import decode_hex, encode_hex
 from golem.core.variables import APP_VERSION
-from apps.appsmanager import AppsManager
 
 
 def mock_async_run(req, success, error):
@@ -708,6 +705,7 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
 
         c.resource_server = Mock()
         c.task_server.task_manager.start_task = Mock()
+        c.task_server.task_manager.dump_task = Mock()
         c.task_server.task_manager.listen_address = '127.0.0.1'
         c.task_server.task_manager.listen_port = 40103
         c.keys_auth = Mock()
@@ -725,7 +723,7 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         assert not c.task_server.task_manager.start_task.called
 
         deferred = Deferred()
-        deferred.callback(True)
+        deferred.callback((['file_1', 'file_2'], 'hash'))
         c.task_server.task_manager.tasks.pop(task.header.task_id, None)
 
         c.resource_server.add_task.called = False

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1,14 +1,16 @@
 import datetime
 import os
 import time
-import unittest
 import uuid
-
+from unittest import TestCase
 from unittest.mock import Mock, MagicMock, patch
+
 from twisted.internet.defer import Deferred
 
 from freezegun import freeze_time
 
+from apps.dummy.task.dummytask import DummyTask
+from apps.dummy.task.dummytaskstate import DummyTaskDefinition
 from golem import testutils
 from golem.client import Client, ClientTaskComputerEventListener, \
     DoWorkService, MonitoringPublisherService, \
@@ -19,6 +21,7 @@ from golem.core.common import timestamp_to_datetime, timeout_to_string
 from golem.core.deferred import sync_wait
 from golem.core.keysauth import EllipticalKeysAuth
 from golem.core.simpleserializer import DictSerializer
+from golem.core.variables import APP_VERSION
 from golem.environments.environment import Environment as DefaultEnvironment
 from golem.model import Payment, PaymentStatus, ExpectedIncome
 from golem.network.p2p.node import Node
@@ -27,7 +30,7 @@ from golem.report import StatusPublisher
 from golem.resource.dirmanager import DirManager
 from golem.resource.resourceserver import ResourceServer
 from golem.rpc.mapping.rpceventnames import UI, Environment
-from golem.task.taskbase import Task, TaskHeader, ResourceType
+from golem.task.taskbase import Task, ResourceType
 from golem.task.taskserver import TaskServer
 from golem.task.taskstate import TaskState
 from golem.tools.assertlogs import LogTestCase
@@ -35,7 +38,6 @@ from golem.tools.testdirfixture import TestDirFixture
 from golem.tools.testwithdatabase import TestWithDatabase
 from golem.tools.testwithreactor import TestWithReactor
 from golem.utils import decode_hex, encode_hex
-from golem.core.variables import APP_VERSION
 
 
 def mock_async_run(req, success, error):
@@ -196,10 +198,8 @@ class TestClient(TestWithDatabase, TestWithReactor):
         self.assertIsInstance(payment_address, str)
         self.assertTrue(len(payment_address) > 0)
 
-    @patch(
-        'golem.transactions.ethereum.ethereumtransactionsystem.'
-        'EthereumTransactionSystem.sync'
-    )
+    @patch('golem.transactions.ethereum.ethereumtransactionsystem.'
+           'EthereumTransactionSystem.sync')
     def test_sync(self, *_):
         self.client = Client(
             datadir=self.path,
@@ -381,10 +381,11 @@ class TestClient(TestWithDatabase, TestWithReactor):
         assert len(presets) == 1
         assert presets.get("Preset1") is None
 
+    @patch('golem.environments.environmentsmanager.'
+           'EnvironmentsManager.load_config')
     @patch('golem.client.SystemMonitor')
     @patch('golem.client.P2PService.connect_to_network')
-    @patch('golem.environments.environmentsmanager.EnvironmentsManager.load_config')
-    def test_start_stop(self, load_config, connect_to_network, *_):
+    def test_start_stop(self, connect_to_network, *_):
         self.client = Client(
             datadir=self.path,
             transaction_system=False,
@@ -468,7 +469,7 @@ class TestMonitoringPublisherService(TestWithReactor):
     def test_run(self, send, log):
         task_server = Mock()
         task_server.task_keeper = Mock()
-        task_server.task_keeper.get_all_tasks = lambda: list()
+        task_server.task_keeper.get_all_tasks.return_value = list()
         task_server.task_keeper.supported_tasks = list()
         task_server.task_computer.stats = dict()
 
@@ -486,9 +487,7 @@ class TestNetworkConnectionPublisherService(TestWithReactor):
     def test_run(self, log):
         c = Mock()
 
-        service = NetworkConnectionPublisherService(
-            c,
-            interval_seconds=1)
+        service = NetworkConnectionPublisherService(c, interval_seconds=1)
         service._run()
 
         assert not log.debug.called
@@ -841,7 +840,6 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         assert result > 100.0
         assert benchmark_manager.run_benchmark.call_count == 2
 
-
     @patch("golem.task.benchmarkmanager.BenchmarkRunner")
     def test_run_benchmarks(self, br_mock, *_):
         benchmark_manager = self.client.task_server.benchmark_manager
@@ -905,19 +903,12 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         c.config_changed()
         rpc_session.publish.assert_called_with(Environment.evt_opts_changed)
 
-    @patch.multiple(Task, __abstractmethods__=frozenset())
     def test_create_task(self, *_):
+        t = DummyTask(total_tasks=10, node_name="node_name",
+                      task_definition=DummyTaskDefinition())
+
         c = self.client
         c.enqueue_new_task = Mock()
-
-        # create a task
-        t = Task(TaskHeader("node_name", "task_id",
-                            "10.10.10.10", 123,
-                            "owner_id", "DEFAULT"),
-                 src_code="print('hello')",
-                 task_definition=Mock())
-
-
         c.create_task(DictSerializer.dump(t))
         self.assertTrue(c.enqueue_new_task.called)
 
@@ -1049,9 +1040,8 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         return session
 
 
-class TestEventListener(unittest.TestCase):
+class TestEventListener(TestCase):
     def test_task_computer_event_listener(self):
-
         client = Mock()
         listener = ClientTaskComputerEventListener(client)
 
@@ -1062,7 +1052,7 @@ class TestEventListener(unittest.TestCase):
         client.lock_config.assert_called_with(False)
 
 
-class TestClientPEP8(unittest.TestCase, testutils.PEP8MixIn):
+class TestClientPEP8(TestCase, testutils.PEP8MixIn):
     PEP8_FILES = [
         "golem/client.py",
     ]


### PR DESCRIPTION
- registers a task event listener in unplicked tasks
- restores the `TaskManager.subtask2task_mapping` for unplicked tasks
- restores / adds resources to HyperG for unplicked tasks
- stores information on shared resource hash in `TaskState`
- removes the redundant `Task.task_status` property