### PR TITLE
use pyelliptic compatible with openssl 1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ peewee>=2.8.1
 Pillow==4.2.1
 psutil==5.2.1
 pycodestyle
-pyelliptic==1.5.7
+-e git://github.com/etam/pyelliptic.git@make_compatible_with_openssl1_1#egg=pyelliptic
 coincurve>=5.0.1
 asn1crypto==0.22.0
 pysha3>=1.0.2


### PR DESCRIPTION
pyelliptic is officially deprecated https://github.com/yann2192/pyelliptic/issues/50 and we want to replace it (#1217). Until then, a patched version is required.