### PR TITLE
Avoid operations on floats

### DIFF
--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -18,6 +18,13 @@ logger = logging.getLogger('golem.task.taskkeeper')
 
 
 def compute_subtask_value(price, computation_time):
+    """
+    Don't use math.ceil (this is general advice, not specific to the case here)
+    >>> math.ceil(10 ** 18 / 6)
+    166666666666666656
+    >>> (10 ** 18 + 5) // 6
+    166666666666666667
+    """
     return (price * computation_time + 3599) // 3600
 
 

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -18,8 +18,7 @@ logger = logging.getLogger('golem.task.taskkeeper')
 
 
 def compute_subtask_value(price, computation_time):
-    value = int(math.ceil(price * computation_time / 3600))
-    return value
+    return (price * computation_time + 3599) // 3600
 
 
 class CompTaskInfo:


### PR DESCRIPTION
Because floats are evil.
```
>>> math.ceil(10 ** 18 * 600 / 3600)
166666666666666656
>>> (10 ** 18 * 600 + 3599) // 3600
166666666666666667
```