### PR TITLE
Proper detection whether a connection is incoming or outgoing

### DIFF
--- a/golem/network/transport/network.py
+++ b/golem/network/transport/network.py
@@ -24,6 +24,7 @@ class SessionFactory(object):
     def get_session(self, conn):
         return self.session_class(conn)
 
+
 class IncomingSessionFactoryWrapper(object):
     def __init__(self, session_factory):
         self.session_factory = session_factory
@@ -33,6 +34,7 @@ class IncomingSessionFactoryWrapper(object):
         session.conn_type = Session.CONN_TYPE_SERVER
         return session
 
+
 class OutgoingSessionFactoryWrapper(object):
     def __init__(self, session_factory):
         self.session_factory = session_factory
@@ -41,6 +43,7 @@ class OutgoingSessionFactoryWrapper(object):
         session = self.session_factory.get_session(conn)
         session.conn_type = Session.CONN_TYPE_CLIENT
         return session
+
 
 class ProtocolFactory(Factory):
     def __init__(self, protocol_class, server=None, session_factory=None):
@@ -53,6 +56,7 @@ class ProtocolFactory(Factory):
         protocol.set_session_factory(self.session_factory)
         return protocol
 
+
 class IncomingProtocolFactoryWrapper(Factory):
     def __init__(self, protocol_factory):
         self.protocol_factory = protocol_factory
@@ -64,6 +68,7 @@ class IncomingProtocolFactoryWrapper(Factory):
         protocol.set_session_factory(self.session_factory)
         return protocol
 
+
 class OutgoingProtocolFactoryWrapper(Factory):
     def __init__(self, protocol_factory):
         self.protocol_factory = protocol_factory
@@ -74,6 +79,7 @@ class OutgoingProtocolFactoryWrapper(Factory):
         protocol = self.protocol_factory.buildProtocol(addr)
         protocol.set_session_factory(self.session_factory)
         return protocol
+
 
 class SessionProtocol(Protocol):
     def __init__(self):

--- a/golem/network/transport/network.py
+++ b/golem/network/transport/network.py
@@ -17,13 +17,30 @@ class Network(object, metaclass=abc.ABCMeta):
         return
 
 
-class SessionFactory(Factory):
+class SessionFactory(object):
     def __init__(self, session_class):
         self.session_class = session_class
 
     def get_session(self, conn):
         return self.session_class(conn)
 
+class IncomingSessionFactoryWrapper(object):
+    def __init__(self, session_factory):
+        self.session_factory = session_factory
+
+    def get_session(self, conn):
+        session = self.session_factory.get_session(conn)
+        session.conn_type = Session.CONN_TYPE_SERVER
+        return session
+
+class OutgoingSessionFactoryWrapper(object):
+    def __init__(self, session_factory):
+        self.session_factory = session_factory
+
+    def get_session(self, conn):
+        session = self.session_factory.get_session(conn)
+        session.conn_type = Session.CONN_TYPE_CLIENT
+        return session
 
 class ProtocolFactory(Factory):
     def __init__(self, protocol_class, server=None, session_factory=None):
@@ -36,6 +53,27 @@ class ProtocolFactory(Factory):
         protocol.set_session_factory(self.session_factory)
         return protocol
 
+class IncomingProtocolFactoryWrapper(Factory):
+    def __init__(self, protocol_factory):
+        self.protocol_factory = protocol_factory
+        self.session_factory = IncomingSessionFactoryWrapper(
+            protocol_factory.session_factory)
+
+    def buildProtocol(self, addr):
+        protocol = self.protocol_factory.buildProtocol(addr)
+        protocol.set_session_factory(self.session_factory)
+        return protocol
+
+class OutgoingProtocolFactoryWrapper(Factory):
+    def __init__(self, protocol_factory):
+        self.protocol_factory = protocol_factory
+        self.session_factory = OutgoingSessionFactoryWrapper(
+            protocol_factory.session_factory)
+
+    def buildProtocol(self, addr):
+        protocol = self.protocol_factory.buildProtocol(addr)
+        protocol.set_session_factory(self.session_factory)
+        return protocol
 
 class SessionProtocol(Protocol):
     def __init__(self):
@@ -61,10 +99,6 @@ class SessionProtocol(Protocol):
 
         Protocol.connectionMade(self)
         self.session = self.session_factory.get_session(self)
-        if isinstance(self.transport, Client):
-            self.session.conn_type = Session.CONN_TYPE_CLIENT
-        elif isinstance(self.transport, Server):
-            self.session.conn_type = Session.CONN_TYPE_SERVER
 
     def connectionLost(self, reason=connectionDone):
         del self.session

--- a/golem/network/transport/tcpnetwork.py
+++ b/golem/network/transport/tcpnetwork.py
@@ -9,8 +9,8 @@ from threading import Lock
 
 from golem.core.hostaddress import get_host_addresses
 from twisted.internet.defer import maybeDeferred
-from twisted.internet.endpoints import TCP4ServerEndpoint, TCP4ClientEndpoint, TCP6ServerEndpoint, \
-    TCP6ClientEndpoint
+from twisted.internet.endpoints import TCP4ServerEndpoint, TCP4ClientEndpoint, \
+    TCP6ServerEndpoint, TCP6ClientEndpoint
 from twisted.internet.interfaces import IPullProducer
 from twisted.internet.protocol import connectionDone
 from zope.interface import implements, implementer
@@ -20,7 +20,8 @@ from ipaddress import IPv6Address, IPv4Address, ip_address, AddressValueError
 from golem.core.databuffer import DataBuffer
 from golem.core.variables import LONG_STANDARD_SIZE, BUFF_SIZE, MIN_PORT, MAX_PORT
 from golem_messages.message import Message
-from .network import Network, SessionProtocol
+from .network import Network, SessionProtocol, IncomingProtocolFactoryWrapper, \
+    OutgoingProtocolFactoryWrapper
 
 logger = logging.getLogger(__name__)
 
@@ -230,7 +231,10 @@ class TCPNetwork(Network):
         """
         from twisted.internet import reactor
         self.reactor = reactor
-        self.protocol_factory = protocol_factory
+        self.incoming_protocol_factory = IncomingProtocolFactoryWrapper(
+            protocol_factory)
+        self.outgoing_protocol_factory = OutgoingProtocolFactoryWrapper(
+            protocol_factory)
         self.use_ipv6 = use_ipv6
         self.timeout = timeout
         self.active_listeners = {}
@@ -326,7 +330,7 @@ class TCPNetwork(Network):
         else:
             endpoint = TCP4ClientEndpoint(self.reactor, address, port, self.timeout)
 
-        defer = endpoint.connect(self.protocol_factory)
+        defer = endpoint.connect(self.outgoing_protocol_factory)
 
         defer.addCallback(self.__connection_established, established_callback, **kwargs)
         defer.addErrback(self.__connection_failure, failure_callback, **kwargs)
@@ -361,7 +365,7 @@ class TCPNetwork(Network):
         else:
             ep = TCP4ServerEndpoint(self.reactor, port)
 
-        defer = ep.listen(self.protocol_factory)
+        defer = ep.listen(self.incoming_protocol_factory)
 
         defer.addCallback(self.__listening_established, established_callback, **kwargs)
         defer.addErrback(self.__listening_failure, port, max_port, established_callback, failure_callback, **kwargs)


### PR DESCRIPTION
The check against Client/Server instances was a quick hack in order to avoid all this boilerplate. Turns out on Windows they use different implementation that don't share common interface, thus it doesn't work. 
Boilerplate code it is.