### PR TITLE
Round robin over all seeds

### DIFF
--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -97,6 +97,7 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):
         self.free_peers = []  # peers to which we're not connected
         self.resource_peers = {}
         self.seeds = set()
+        self.used_seeds = set()
 
         self._peer_lock = Lock()
 
@@ -140,7 +141,8 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):
         if not self.connect_to_known_hosts:
             return
 
-        for ip_address, port in random.sample(self.seeds, k=len(self.seeds)):
+        for _ in range(len(self.seeds)):
+            ip_address, port = self._get_next_random_seed()
             try:
                 socket_address = tcpnetwork.SocketAddress(ip_address, port)
                 self.connect(socket_address)
@@ -1023,6 +1025,15 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):
                 )
                 continue
             self.seeds.add((ip_address, port))
+
+    def _get_next_random_seed(self):
+        # this loop won't execute more than twice
+        while True:
+            for seed in random.sample(self.seeds, k=len(self.seeds)):
+                if seed not in self.used_seeds:
+                    self.used_seeds.add(seed)
+                    return seed
+            self.used_seeds = set()
 
     def __remove_sessions_to_end_from_peer_keeper(self):
         for node in self.peer_keeper.sessions_to_end:

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -406,3 +406,14 @@ class TestP2PService(testutils.DatabaseFixture):
         self.service.peers = {'peer_id': mock.Mock()}
         self.service.disconnect()
         assert self.service.peers['peer_id'].dropped.called
+
+    def test_round_robin_seeds(self):
+        SEEDS_NUM = 10
+        seeds = set()
+        for i in range(SEEDS_NUM):
+            seeds.add(('127.0.0.1', i+1))
+        self.service.seeds = seeds.copy()
+        for i in range(SEEDS_NUM):
+            seed = self.service._get_next_random_seed()
+            seeds.remove(seed)
+        assert len(seeds) == 0

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -416,4 +416,4 @@ class TestP2PService(testutils.DatabaseFixture):
         for i in range(SEEDS_NUM):
             seed = self.service._get_next_random_seed()
             seeds.remove(seed)
-        assert len(seeds) == 0
+        assert not seeds


### PR DESCRIPTION
This means that we will try to connect to all seeds before attempting to reconnect with previous seed.
This helps in a scenario where our seed nodes are using different protocol ids (e.g. protocol got updated and we would like to support both versions until next release) and we would like to eventually connect to the one with compatible protocol with ours. Because until now if we were unlucky it could take some longer period of time.