### PR TITLE
Convert price from UI to an int, not float

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -571,7 +571,7 @@ class CoreTaskBuilder(TaskBuilder):
     def build_full_definition(cls, task_type: CoreTaskTypeInfo, dictionary):
         definition = cls.build_minimal_definition(task_type, dictionary)
         definition.task_name = dictionary['name']
-        definition.max_price = float(dictionary['bid']) * denoms.ether
+        definition.max_price = int(float(dictionary['bid']) * denoms.ether)
 
         definition.full_task_timeout = string_to_timeout(
             dictionary['timeout'])

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -1,5 +1,6 @@
 import abc
 import copy
+import decimal
 import golem_messages.message
 import logging
 import os
@@ -571,7 +572,8 @@ class CoreTaskBuilder(TaskBuilder):
     def build_full_definition(cls, task_type: CoreTaskTypeInfo, dictionary):
         definition = cls.build_minimal_definition(task_type, dictionary)
         definition.task_name = dictionary['name']
-        definition.max_price = int(float(dictionary['bid']) * denoms.ether)
+        definition.max_price = \
+            int(decimal.Decimal(dictionary['bid']) * denoms.ether)
 
         definition.full_task_timeout = string_to_timeout(
             dictionary['timeout'])

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -62,11 +62,11 @@ class TaskHeader(object):
                  resource_size=0,
                  estimated_memory=0,
                  min_version=APP_VERSION,
-                 max_price=0.0,
+                 max_price: int=0,
                  docker_images=None,
                  signature=None):
         """
-        :param float max_price: maximum price that this (requestor) node may
+        :param int max_price: maximum price that this (requestor) node may
         pay for an hour of computation
         :param docker_images: docker image specification
         """

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -66,7 +66,7 @@ class TaskHeader(object):
                  docker_images=None,
                  signature=None):
         """
-        :param int max_price: maximum price that this (requestor) node may
+        :param max_price: maximum price that this (requestor) node may
         pay for an hour of computation
         :param docker_images: docker image specification
         """

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -17,7 +17,7 @@ from .taskbase import TaskHeader
 logger = logging.getLogger('golem.task.taskkeeper')
 
 
-def compute_subtask_value(price, computation_time):
+def compute_subtask_value(price: int, computation_time: int):
     """
     Don't use math.ceil (this is general advice, not specific to the case here)
     >>> math.ceil(10 ** 18 / 6)


### PR DESCRIPTION
We should prefer integers everywhere where possible over floats.