### PR TITLE
Suppress error messages by delaying DoWorkService.start

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -146,6 +146,7 @@ class Client(HardwarePresetsMixin):
                 self,
                 int(self.config_desc.network_check_interval)),
             MessageHistoryService(),
+            DoWorkService(self),
         ]
 
         clean_resources_older_than = \
@@ -276,10 +277,6 @@ class Client(HardwarePresetsMixin):
                 self.keys_auth,
                 connect_to_known_hosts=self.connect_to_known_hosts
             )
-
-            do_work_service = DoWorkService(self)
-            do_work_service.start()
-            self._services.append(do_work_service)
 
         if not self.task_server:
             self.task_server = TaskServer(


### PR DESCRIPTION
`DoWorkService` is started prior to creating all objects for `P2PService`, causing unnecessary error messages to show (mainly on Windows).