### PR TITLE
Fixed: restartable MessageHistoryService

### DIFF
--- a/golem/network/history.py
+++ b/golem/network/history.py
@@ -73,11 +73,13 @@ class MessageHistoryService(IService):
         )
 
     def start(self) -> None:
-        if not self.running:
-            self._stop_event.clear()
-            self._queue_timeout = self.QUEUE_TIMEOUT
-            self._thread = threading.Thread(target=self.run, daemon=True)
-            self._thread.start()
+        if self.running:
+            return
+
+        self._stop_event.clear()
+        self._queue_timeout = self.QUEUE_TIMEOUT
+        self._thread = threading.Thread(target=self.run, daemon=True)
+        self._thread.start()
 
     def stop(self) -> None:
         """

--- a/golem/network/history.py
+++ b/golem/network/history.py
@@ -58,7 +58,7 @@ class MessageHistoryService(IService, threading.Thread):
         """
         Thread activity method.
         """
-        while not self._stop_event.isSet():
+        while not self._stop_event.is_set():
             self._loop()
 
     @property
@@ -74,6 +74,7 @@ class MessageHistoryService(IService, threading.Thread):
 
     def start(self) -> None:
         if not self.running:
+            self._stop_event.clear()
             self._queue_timeout = self.QUEUE_TIMEOUT
             threading.Thread.__init__(self, daemon=True)
             threading.Thread.start(self)

--- a/tests/golem/network/test_history.py
+++ b/tests/golem/network/test_history.py
@@ -139,21 +139,21 @@ class TestMessageHistoryService(DatabaseFixture):
         assert not self.service.running
         self.service.start()
         assert self.service.running
-        self.service.join(1.)
+        self.service._thread.join(1.)
         self.service.stop()
         assert not self.service.running
 
         assert self.service._loop.called
 
-    @patch('threading.Thread.start')
-    def test_multiple_starts(self, start):
+    @patch('threading.Thread')
+    def test_multiple_starts(self, *_):
         self.service.start()
-        assert start.called
+        assert self.service._thread.start.called
 
-        start.reset_mock()
-        self.service._started = Mock(is_set=Mock(return_value=True))
+        self.service._thread.reset_mock()
+        self.service._thread.is_alive.return_value = True
         self.service.start()
-        assert not start.called
+        assert not self.service._thread.start.called
 
     def test_sweep(self):
         msgs = [

--- a/tests/golem/network/test_history.py
+++ b/tests/golem/network/test_history.py
@@ -184,7 +184,7 @@ class TestMessageHistoryService(DatabaseFixture):
         self.service._sweep()
         assert message_count() == 2
 
-    def test_loop_sweep(self, *_):
+    def test_loop_sweep(self):
         self.service._sweep = Mock()
         self.service._queue_timeout = 0.1
 


### PR DESCRIPTION
`Service`s can be restarted via `Client.pause/resume`. It was not possible with `MessageHistoryService`, which was derived from `threading.Thread`.