### PR TITLE
Message history fix: message.TaskToCompute and NetworkMessage constraints

### DIFF
--- a/golem/model.py
+++ b/golem/model.py
@@ -433,9 +433,9 @@ class NetworkMessage(BaseModel):
     # The node on the other side of the communication.
     # It can be a receiver or a sender, depending on local_role,
     # remote_role and msg_cls.
-    node = CharField()
-    task = CharField(null=False, index=True)
-    subtask = CharField(index=True)
+    node = CharField(null=False)
+    task = CharField(null=True, index=True)
+    subtask = CharField(null=True, index=True)
 
     msg_date = DateTimeField(null=False)
     msg_cls = CharField(null=False)

--- a/golem/network/history.py
+++ b/golem/network/history.py
@@ -8,7 +8,7 @@ from functools import reduce, wraps
 from typing import List
 
 from peewee import (PeeweeException, DataError, ProgrammingError,
-                    NotSupportedError, Field)
+                    NotSupportedError, Field, IntegrityError)
 
 from golem.core.service import IService
 from golem.model import NetworkMessage, Actor
@@ -124,13 +124,14 @@ class MessageHistoryService(IService):
         try:
             msg = NetworkMessage(**msg_dict)
             msg.save()
-        except (DataError, ProgrammingError, NotSupportedError) as exc:
+        except (DataError, ProgrammingError, NotSupportedError,
+                TypeError, IntegrityError) as exc:
             # Unrecoverable error
             logger.error("Cannot save message '%s' to database: %r",
-                         msg.msg_cls, exc)
+                         msg_dict.get('msg_cls'), exc)
         except PeeweeException:
             # Temporary error
-            logger.debug("Message '%s' save queued", msg.msg_cls)
+            logger.warning("Message '%s' save queued", msg_dict.get('msg_cls'))
             self._save_queue.put(msg_dict)
 
     def remove(self, task: str, **properties) -> None:
@@ -155,15 +156,16 @@ class MessageHistoryService(IService):
             NetworkMessage.delete() \
                 .where(reduce(operator.and_, clauses)) \
                 .execute()
-        except (DataError, ProgrammingError, NotSupportedError) as exc:
+        except (DataError, ProgrammingError, NotSupportedError,
+                TypeError, IntegrityError) as exc:
             # Unrecoverable error
             logger.error("Cannot remove task messages from the database: "
                          "(task: '%s', parameters: %r): %r",
                          task, properties, exc)
         except PeeweeException:
             # Temporary error
-            logger.debug("Task %s (%r) message removal queued",
-                         task, properties)
+            logger.warning("Task %s (%r) message removal queued",
+                           task, properties)
             self._remove_queue.put((task, properties))
 
     @staticmethod

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -186,11 +186,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
     ###################################
 
     def message_to_model(self, msg, local_role, remote_role):
-        task = getattr(msg, 'task_id', None)
-        subtask = getattr(msg, 'subtask_id', None)
-
-        if subtask and not task:
-            task = self._subtask_to_task(subtask, local_role)
+        task, subtask = self._task_subtask_from_message(msg, local_role)
 
         return dict(
             task=task,
@@ -201,7 +197,22 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
             msg_data=msg.raw,
             local_role=local_role,
             remote_role=remote_role,
-        ) if task else None
+        )
+
+    def _task_subtask_from_message(self, msg, local_role):
+        task, subtask = None, None
+
+        if isinstance(msg, message.TaskToCompute):
+            definition = msg.compute_task_def
+            if isinstance(definition, dict):
+                task = definition.get('task_id')
+                subtask = definition.get('subtask_id')
+        else:
+            task = getattr(msg, 'task_id', None)
+            subtask = getattr(msg, 'subtask_id', None)
+            task = task or self._subtask_to_task(subtask, local_role)
+
+        return task, subtask
 
     def _subtask_to_task(self, sid, local_role):
         if not self.task_manager:

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -204,7 +204,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
 
         if isinstance(msg, message.TaskToCompute):
             definition = msg.compute_task_def
-            if isinstance(definition, dict):
+            if definition:
                 task = definition.get('task_id')
                 subtask = definition.get('subtask_id')
         else:


### PR DESCRIPTION
Subtask to task mapping does not exist when receiving a `TaskToCompute` message.

Additionally, try to save all (annotated) messages retrieved from the network. Constraint check may fail on save and will be logged.