### PR TITLE
Message history fix: database locking

### DIFF
--- a/golem/network/history.py
+++ b/golem/network/history.py
@@ -98,13 +98,13 @@ class MessageHistoryService(IService, threading.Thread):
 
         return list(result)
 
-    def add(self, msg: NetworkMessage) -> None:
+    def add(self, msg_dict: dict) -> None:
         """
-        Appends the message to the save queue.
-        :param msg:
+        Appends the dict message representation to the save queue.
+        :param msg_dict:
         """
-        if msg:
-            self._save_queue.put(msg)
+        if msg_dict:
+            self._save_queue.put(msg_dict)
 
     def add_sync(self, msg: NetworkMessage) -> None:
         """
@@ -198,7 +198,8 @@ class MessageHistoryService(IService, threading.Thread):
 
         # Save messages
         try:
-            msg = self._save_queue.get(True, self._queue_timeout)
+            msg_dict = self._save_queue.get(True, self._queue_timeout)
+            msg = NetworkMessage(**msg_dict)
         except queue.Empty:
             pass
         else:
@@ -229,13 +230,13 @@ class IMessageHistoryProvider(ABC):
     @abstractmethod
     def message_to_model(self, msg: 'golem_messages.message.Message',
                          local_role: Actor,
-                         remote_role: Actor) -> NetworkMessage:
+                         remote_role: Actor) -> dict:
         """
         Convert a message to its database model representation.
         :param msg: Session message
         :param local_role: Local node's role in computation
         :param remote_role: Remote node's role in computation
-        :return:
+        :return: Dict representation of NetworkMessage
         """
 
 ##############

--- a/golem/network/history.py
+++ b/golem/network/history.py
@@ -232,7 +232,16 @@ class IMessageHistoryProvider(ABC):
                          local_role: Actor,
                          remote_role: Actor) -> dict:
         """
-        Convert a message to its database model representation.
+        Converts a message to its database model dictionary representation.
+
+        MessageHistoryService operates in a separate thread, whereas peewee
+        models are created on per-connection (here: per-thread) basis. If
+        MessageHistoryService used objects created in another thread, it would
+        lock the database for that thread.
+
+        The returned dict representation is used for creating NetworkMessage
+        models in MessageHistoryService thread.
+
         :param msg: Session message
         :param local_role: Local node's role in computation
         :param remote_role: Remote node's role in computation

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -13,7 +13,7 @@ from golem.core.simpleserializer import CBORSerializer
 from golem.core.variables import PROTOCOL_CONST
 from golem.decorators import log_error
 from golem.docker.environment import DockerEnvironment
-from golem.model import Payment, Actor, NetworkMessage
+from golem.model import Payment, Actor
 from golem.model import db
 from golem.network.concent.client import ConcentRequest
 from golem.network.history import IMessageHistoryProvider, provider_history
@@ -192,7 +192,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
         if subtask and not task:
             task = self._subtask_to_task(subtask, local_role)
 
-        return NetworkMessage(
+        return dict(
             task=task,
             subtask=subtask,
             node=self.key_id,


### PR DESCRIPTION
`NetworkMessage` objects created in threads other than `MessageHistoryService`'s may cause a database lock-up.