### PR TITLE
Task persistence fix: proper resource restore edge-case handling

### DIFF
--- a/golem/network/hyperdrive/client.py
+++ b/golem/network/hyperdrive/client.py
@@ -1,10 +1,10 @@
 import collections
 import json
 import logging
+from ipaddress import AddressValueError, ip_address
 
 import requests
-from copy import deepcopy
-from ipaddress import AddressValueError, ip_address
+from requests import HTTPError
 
 from golem.resource.client import IClient, ClientOptions
 
@@ -104,7 +104,14 @@ class HyperdriveClient(IClient):
                                  headers=self._headers,
                                  data=json.dumps(data),
                                  timeout=self.timeout)
-        response.raise_for_status()
+
+        try:
+            response.raise_for_status()
+        except HTTPError:
+            if response.text:
+                raise HTTPError('Hyperdrive HTTP {} error: {}'.format(
+                    response.status_code, response.text), response=response)
+            raise
 
         if response.content:
             return json.loads(response.content.decode('utf-8'))

--- a/golem/resource/base/resourcesmanager.py
+++ b/golem/resource/base/resourcesmanager.py
@@ -366,7 +366,8 @@ class AbstractResourceManager(IClientHandler, metaclass=abc.ABCMeta):
         if prefix and resources:
             logger.warning("Resource manager: Task {} already exists"
                            .format(task_id))
-            return files, resources[0].hash
+            resource = resources[0]
+            return resource.files, resource.hash
 
         if not files:
             raise RuntimeError("Empty input task resources")

--- a/golem/resource/hyperdrive/resourcesmanager.py
+++ b/golem/resource/hyperdrive/resourcesmanager.py
@@ -94,7 +94,7 @@ class HyperdriveResourceManager(ClientHandler, AbstractResourceManager):
                                         id=task_id,
                                         client_options=client_options,
                                         obj_id=str(uuid.uuid4()),
-                                        raise_exc=bool(resource_hash))
+                                        raise_exc=True)
 
         file_list = list(files.values())
         self._cache_response(file_list, response, task_id)


### PR DESCRIPTION
- fixes an edge case of re-adding resources to HyperG
- encapsulates HyperG daemon's error responses in `HTTPError`s