### PR TITLE
Use pending block for transaction count

### DIFF
--- a/golem/ethereum/client.py
+++ b/golem/ethereum/client.py
@@ -62,12 +62,15 @@ class Client(object):
 
     def get_transaction_count(self, address):
         """
-        Returns the number of transactions
-        that have been sent from account
+        Returns the number of transactions that have been sent from account.
+        Use `pending` block to account the transactions that haven't been mined
+        yet. Otherwise it would be problematic to send more than one transaction
+        in less than ~15 seconds span.
         :param address: account address
         :return: number of transactions
         """
-        return self.web3.eth.getTransactionCount(Client.__add_padding(address))
+        return self.web3.eth.getTransactionCount(Client.__add_padding(address),
+                                                 'pending')
 
     def send(self, transaction):
         """


### PR DESCRIPTION
It may happen we will try to send more than one transaction before a block is mined in which case we will use incorrect nonce for all of them except the first one.
Currently it may happen for example when we are requesting GNT from the faucet - we do it every 13 seconds or so by sending a transaction to the faucet and since the time between mined block is slightly higher it may happen those transactions will share nonce.