### PR TITLE
Remove the ipaddress dependency (provided by Python 3.3+)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,6 @@ setuptools==34.3.3
 appdirs>=1.4
 click>=4.0
 docker-py==1.7.2
-ipaddress>=1.0.18
 netifaces==0.10.4
 peewee>=2.8.1
 Pillow==4.2.1


### PR DESCRIPTION
- `ipaddress` is provided by Python 3.3
- `ipaddress==1.0.18` is still installed by crossbar