### PR TITLE
Refactor ethereumincomeskeeper a bit

### DIFF
--- a/golem/ethereum/client.py
+++ b/golem/ethereum/client.py
@@ -167,7 +167,7 @@ class Client(object):
         obj = {
             'fromBlock': from_block,
             'toBlock': to_block,
-            'address': Client.__add_padding(address),
+            'address': address,
             'topics': topics
         }
         return self.web3.eth.filter(obj).filter_id
@@ -210,8 +210,7 @@ class Client(object):
         """
         for i in range(len(topics)):
             topics[i] = Client.__add_padding(topics[i])
-        filter_id = self.new_filter(from_block, to_block,
-                                    Client.__add_padding(address), topics)
+        filter_id = self.new_filter(from_block, to_block, address, topics)
         return self.web3.eth.getFilterLogs(filter_id)
 
     @staticmethod


### PR DESCRIPTION
1. Moved magic constant `LOG_ID` to the payment processor - it's related to the token implementation so it belongs there, closer to the actual token logic.
2. Created `get_incomes_from_block` for `ethereumincomeskeeper` for easier communication - in particular it shouldn't know about the above mentioned `LOG_ID`
3. If I understand correctly I also fixed potential vulnerability since `address` was not passed in the `get_logs` method, meaning we were listening to all `Transfer` events, not only generated from `GNT` contract.