### PR TITLE
Extract token logic into a separate class

### DIFF
--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -1,8 +1,11 @@
+import abc
 import json
 import logging
 import sys
 import time
+from threading import Lock
 from time import sleep
+from typing import Any, List
 
 from ethereum import abi, utils, keys
 from ethereum.transactions import Transaction
@@ -18,10 +21,8 @@ from .node import tETH_faucet_donate
 
 log = logging.getLogger("golem.pay")
 
-gnt_contract = abi.ContractTranslator(json.loads(TestGNT.ABI))
 
-
-def _encode_payments(payments):
+def encode_payments(payments: List[Payment]):
     paymap = {}
     for p in payments:
         if p.payee in paymap:
@@ -42,7 +43,147 @@ def _encode_payments(payments):
             raise ValueError(
                 "Incorrect pair length: {}. Should be 32".format(len(pair)))
         args.append(pair)
-    return args, value
+    return args
+
+
+class AbstractToken(object, metaclass=abc.ABCMeta):
+    """
+    This is a common interface for token transactions. It hides whether we're
+    using GNT or GNTW underneath.
+    """
+    def __init__(self, client: Client):
+        self._client = client
+
+    def _create_transaction(self,
+                            sender: str,
+                            token_address,
+                            data,
+                            gas: int) -> Transaction:
+        nonce = self._client.get_transaction_count(sender)
+        tx = Transaction(nonce,
+                         PaymentProcessor.GAS_PRICE,
+                         gas,
+                         to=token_address,
+                         value=0,
+                         data=data)
+        return tx
+
+    def _send_transaction(self,
+                          privkey: bytes,
+                          token_address,
+                          data,
+                          gas: int) -> Transaction:
+        tx = self._create_transaction(
+            '0x' + encode_hex(keys.privtoaddr(privkey)),
+            token_address,
+            data,
+            gas)
+        tx.sign(privkey)
+        self._client.send(tx)
+        return tx
+
+    def _get_balance(self, token_abi, token_address, addr: str) -> int:
+        data = token_abi.encode_function_call('balanceOf', [addr])
+        r = self._client.call(
+            _from='0x' + encode_hex(addr),
+            to='0x' + encode_hex(token_address),
+            data='0x' + encode_hex(data),
+            block='pending')
+        if r is None:
+            return None
+        return 0 if r == '0x' else int(r, 16)
+
+    def _request_from_faucet(self,
+                             token_abi,
+                             token_address,
+                             privkey: bytes) -> None:
+        data = token_abi.encode_function_call('create', [])
+        self._send_transaction(privkey, token_address, data, 90000)
+
+    @abc.abstractmethod
+    def get_balance(self, addr: str) -> int:
+        pass
+
+    @abc.abstractmethod
+    def batch_transfer(self,
+                       privkey: bytes,
+                       payments: List[Payment]) -> Transaction:
+        """
+        Takes a list of payments to be made and returns prepared transaction
+        for the batch payment. The transaction is not sent, but it is signed.
+        It may return None when it's unable to make transaction at the moment,
+        but this shouldn't be treated as an error. In case of GNTW sometimes
+        we need to do some preparations (like convertion from GNT) before
+        we can make a batch transfer.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_incomes_from_block(self, block: int, address) -> List[Any]:
+        pass
+
+
+class GNTToken(AbstractToken):
+    """
+    When the main token and the batchTransfer function are in the same contract.
+    Which is the case for tGNT in testnet and eventually (after migration)
+    will be the case for the new GNT in the mainnet as well.
+    """
+    TESTGNT_ADDR = decode_hex("7295bB8709EC1C22b758A8119A4214fFEd016323")
+
+    # keccak256(Transfer(address,address,uint256))
+    TRANSFER_EVENT_ID = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'  # noqa
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.__testGNT = abi.ContractTranslator(json.loads(TestGNT.ABI))
+
+    def get_balance(self, addr: str) -> int:
+        balance = self._get_balance(
+            self.__testGNT,
+            self.TESTGNT_ADDR,
+            decode_hex(addr))
+        if balance is not None:
+            log.info("TestGNT: {}".format(balance / denoms.ether))
+        return balance
+
+    def request_from_faucet(self, privkey: bytes) -> None:
+        self._request_from_faucet(self.__testGNT, self.TESTGNT_ADDR, privkey)
+
+    def batch_transfer(self,
+                       privkey: bytes,
+                       payments: List[Payment]) -> Transaction:
+        p = encode_payments(payments)
+        data = self.__testGNT.encode_function_call('batchTransfer', [p])
+        gas = PaymentProcessor.GAS_BATCH_PAYMENT_BASE + \
+            len(p) * PaymentProcessor.GAS_PER_PAYMENT
+        tx = self._create_transaction(
+            '0x' + encode_hex(keys.privtoaddr(privkey)),
+            self.TESTGNT_ADDR,
+            data,
+            gas)
+        tx.sign(privkey)
+        return tx
+
+    def get_incomes_from_block(self, block: int, address) -> List[Any]:
+        logs = self._client.get_logs(block,
+                                     block,
+                                     '0x' + encode_hex(self.TESTGNT_ADDR),
+                                     [self.TRANSFER_EVENT_ID, None, address])
+        if not logs:
+            return logs
+
+        res = []
+        for entry in logs:
+            if entry['topics'][2] != address:
+                raise Exception("Unexpected income event from {}"
+                                .format(entry['topics'][2]))
+
+            res.append({
+                'sender': entry['topics'][1],
+                'value': int(entry['data'], 16),
+            })
+        return res
 
 
 class PaymentProcessor(LoopingCallService):
@@ -62,17 +203,17 @@ class PaymentProcessor(LoopingCallService):
     # Time required to reset the current balance when errors occur
     BALANCE_RESET_TIMEOUT = 30
 
-    TESTGNT_ADDR = decode_hex("7295bB8709EC1C22b758A8119A4214fFEd016323")
-
     SYNC_CHECK_INTERVAL = 10
 
     # Minimal number of confirmations before we treat transactions as done
     REQUIRED_CONFIRMATIONS = 12
 
-    # keccak256(Transfer(address,address,uint256))
-    LOG_ID = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'  # noqa
-
-    def __init__(self, client: Client, privkey, faucet=False) -> None:
+    def __init__(self,
+                 client: Client,
+                 privkey,
+                 faucet=False,
+                 token_factory=GNTToken) -> None:
+        self.__token = token_factory(client)
         self.__client = client
         self.__privkey = privkey
         self.__eth_balance = None
@@ -81,13 +222,13 @@ class PaymentProcessor(LoopingCallService):
         self.__gnt_reserved = 0
         self.__eth_update_ts = 0
         self.__gnt_update_ts = 0
+        self._awaiting_lock = Lock()
         self._awaiting = []  # type: List[Any] # Awaiting individual payments
         self._inprogress = {}  # type: Dict[Any,Any] # Sent transactions.
         self.__last_sync_check = time.time()
         self.__sync = False
         self.__temp_sync = False
         self.__faucet = faucet
-        self.__testGNT = abi.ContractTranslator(json.loads(TestGNT.ABI))
         self._waiting_for_faucet = False
         self.deadline = sys.maxsize
         self.load_from_db()
@@ -110,7 +251,6 @@ class PaymentProcessor(LoopingCallService):
 
     def is_synchronized(self):
         """ Checks if the Ethereum node is in sync with the network."""
-
         if time.time() - self.__last_sync_check <= self.SYNC_CHECK_INTERVAL:
             # When checking again within 10 s return previous status.
             # This also handles geth issue where synchronization starts after
@@ -174,19 +314,8 @@ class PaymentProcessor(LoopingCallService):
 
     def gnt_balance(self, refresh=False):
         if self.__gnt_balance is None or refresh:
-            addr = keys.privtoaddr(self.__privkey)
-            data = self.__testGNT.encode('balanceOf', (addr,))
-            r = self.__client.call(_from='0x' + encode_hex(addr),
-                                   to='0x' + encode_hex(self.TESTGNT_ADDR),
-                                   data='0x' + encode_hex(data),
-                                   block='pending')
-            if r is None:
-                gnt_balance = None
-            else:
-                gnt_balance = 0 if r == '0x' else int(r, 16)
-
+            gnt_balance = self.__token.get_balance(self.eth_address(zpad=False))
             self._update_gnt_balance(gnt_balance)
-            log.info("GNT: {}".format(self.__gnt_balance / denoms.ether))
         return self.__gnt_balance
 
     def _update_eth_balance(self, eth_balance):
@@ -259,43 +388,52 @@ class PaymentProcessor(LoopingCallService):
             log.warning("Low GNT: {:.6f}".format(av_gnt / denoms.ether))
             return False
 
-        self._awaiting.append(payment)
+        with self._awaiting_lock:
+            self._awaiting.append(payment)
+            # TODO: Optimize by checking the time once per service update.
+            new_deadline = int(time.time()) + deadline
+            if new_deadline < self.deadline:
+                self.deadline = new_deadline
+
         self.__gnt_reserved += payment.value
         self.__eth_reserved += self.ETH_PER_PAYMENT
-
-        # Set new deadline if not set already or shorter than the current one.
-        # TODO: Optimize by checking the time once per service update.
-        new_deadline = int(time.time()) + deadline
-        if new_deadline < self.deadline:
-            self.deadline = new_deadline
 
         log.info("GNT: available {:.6f}, reserved {:.6f}".format(
             av_gnt / denoms.ether, self.__gnt_reserved / denoms.ether))
         return True
 
     def sendout(self):
-        if not self._awaiting:
+        with self._awaiting_lock:
+            if not self._awaiting:
+                return False
+
+            now = int(time.time())
+            if self.deadline > now:
+                log.info("Next sendout in {} s".format(self.deadline - now))
+                return False
+
+            payments = self._awaiting
+            self._awaiting = []
+
+        tx = self.__token.batch_transfer(self.__privkey, payments)
+        if not tx:
+            with self._awaiting_lock:
+                payments.extend(self._awaiting)
+                self._awaiting = payments
             return False
 
-        now = int(time.time())
-        if self.deadline > now:
-            log.info("Next sendout in {} s".format(self.deadline - now))
-            return False
-
-        payments = self._awaiting  # FIXME: Should this list be synchronized?
-        self._awaiting = []
-        self.deadline = sys.maxsize
-        addr = self.eth_address(zpad=False)
-        nonce = self.__client.get_transaction_count(addr)
-        p, value = _encode_payments(payments)
-        data = gnt_contract.encode('batchTransfer', [p])
-        gas = self.GAS_BATCH_PAYMENT_BASE + len(p) * self.GAS_PER_PAYMENT
-        tx = Transaction(nonce, self.GAS_PRICE, gas, to=self.TESTGNT_ADDR,
-                         value=0, data=data)
         tx.sign(self.__privkey)
+        value = sum([p.value for p in payments])
         h = tx.hash
         log.info("Batch payments: {:.6}, value: {:.6f}"
                  .format(encode_hex(h), value / denoms.ether))
+
+        # If awaiting payments are not empty it means a new payment has been
+        # added between clearing the awaiting list and here. In that case
+        # we shouldn't update the deadline to sys.maxsize.
+        with self._awaiting_lock:
+            if not self._awaiting:
+                self.deadline = sys.maxsize
 
         # Firstly write transaction hash to database. We need the hash to be
         # remembered before sending the transaction to the Ethereum node in
@@ -408,36 +546,13 @@ class PaymentProcessor(LoopingCallService):
 
     def get_gnt_from_faucet(self):
         if self.__faucet and self.gnt_balance(True) < 100 * denoms.ether:
-            log.info("Requesting tGNT")
-            addr = self.eth_address(zpad=False)
-            nonce = self.__client.get_transaction_count(addr)
-            data = self.__testGNT.encode_function_call('create', ())
-            tx = Transaction(nonce, self.GAS_PRICE, 90000, to=self.TESTGNT_ADDR,
-                             value=0, data=data)
-            tx.sign(self.__privkey)
-            self.__client.send(tx)
+            log.info("Requesting GNT from faucet")
+            self.__token.request_from_faucet(self.__privkey)
             return False
         return True
 
     def get_incomes_from_block(self, block, address):
-        logs = self.get_logs(block,
-                             block,
-                             '0x' + encode_hex(self.TESTGNT_ADDR),
-                             [self.LOG_ID, None, address])
-        if not logs:
-            return logs
-
-        res = []
-        for entry in logs:
-            if entry['topics'][2] != address:
-                raise Exception("Unexpected income event from {}"
-                    .format(entry['topics'][2]))
-
-            res.append({
-                'sender': entry['topics'][1],
-                'value': int(entry['data'], 16),
-            })
-        return res
+        return self.__token.get_incomes_from_block(block, address)
 
     def get_logs(self,
                  from_block=None,

--- a/tests/golem/transactions/ethereum/test_paymentprocessor.py
+++ b/tests/golem/transactions/ethereum/test_paymentprocessor.py
@@ -17,7 +17,8 @@ from twisted.internet.task import Clock
 from golem.ethereum import Client
 from golem.ethereum.contracts import TestGNT
 from golem.ethereum.node import Faucet
-from golem.ethereum.paymentprocessor import PaymentProcessor
+from golem.ethereum.paymentprocessor import \
+    PaymentProcessor, GNTToken, encode_payments
 from golem.model import Payment, PaymentStatus
 from golem.testutils import DatabaseFixture
 from golem.utils import encode_hex, decode_hex
@@ -493,7 +494,7 @@ class PaymentProcessorFunctionalTest(DatabaseFixture):
         print('gnt_addr %s', gnt_addr)
         self.state.mine()
         self.gnt = tester.ABIContract(self.state, TEST_GNT_ABI, gnt_addr)
-        PaymentProcessor.TESTGNT_ADDR = decode_hex(gnt_addr)
+        GNTToken.TESTGNT_ADDR = decode_hex(gnt_addr)
         self.privkey = tester.k1
         self.client = mock.MagicMock(spec=Client)
         self.client.get_peer_count.return_value = 0
@@ -663,28 +664,150 @@ class PaymentProcessorFunctionalTest(DatabaseFixture):
         assert self.pp._balance_value(None, now - dt) == 0
         assert self.pp._balance_value(None, now) is None
 
+
+def make_awaiting_payment():
+    p = mock.Mock()
+    p.status = PaymentStatus.awaiting
+    p.payee = urandom(20)
+    p.value = random.randint(1, 10)
+    p.subtask = '123'
+    return p
+
+
+class InteractionWithTokenTest(DatabaseFixture):
+
+    def setUp(self):
+        DatabaseFixture.setUp(self)
+        self.token = mock.Mock()
+        self.privkey = urandom(32)
+        self.client = mock.Mock()
+
+        def token_factory(*_):
+            return self.token
+
+        self.pp = PaymentProcessor(self.client,
+                                   self.privkey,
+                                   token_factory=token_factory)
+
+    def test_faucet(self):
+        self.pp._PaymentProcessor__faucet = True
+
+        self.token.get_balance.return_value = 1000 * denoms.ether
+        self.assertTrue(self.pp.get_gnt_from_faucet())
+        self.token.request_from_faucet.assert_not_called()
+
+        self.token.get_balance.return_value = 0
+        self.assertFalse(self.pp.get_gnt_from_faucet())
+        self.token.request_from_faucet.assert_called_with(self.privkey)
+
+    def test_batch_transfer(self):
+        self.pp.deadline = time.time() - 1
+        self.token.batch_transfer.return_value = None
+        self.assertFalse(self.pp.sendout())
+
+        p1 = make_awaiting_payment()
+        p2 = make_awaiting_payment()
+        self.client.get_balance.return_value = denoms.ether
+        self.token.get_balance.return_value = 1000 * denoms.ether
+        self.pp.add(p1)
+        self.pp.add(p2)
+        tx = mock.Mock()
+        tx_hash = '0xdead'
+        tx.hash = decode_hex(tx_hash)
+        self.client.send.return_value = tx_hash
+        self.token.batch_transfer.return_value = tx
+        self.assertTrue(self.pp.sendout())
+        self.client.send.assert_called_with(tx)
+
     def test_get_incomes_from_block(self):
         block_number = 1
         receiver_address = '0xbadcode'
         some_address = '0xdeadbeef'
 
-        self.client.get_logs.return_value = []
-        assert not self.pp.get_incomes_from_block(block_number,
-                                                  receiver_address)
+        expected_incomes = [{'sender': some_address, 'value': 1}]
+        self.token.get_incomes_from_block.return_value = expected_incomes
+        incomes = self.pp.get_incomes_from_block(block_number, receiver_address)
+        self.assertEqual(expected_incomes, incomes)
 
-        topics = [self.pp.LOG_ID, None, receiver_address]
+
+class GNTTokenTest(unittest.TestCase):
+    def setUp(self):
+        self.client = mock.Mock()
+        self.privkey = urandom(32)
+        self.addr = '0x' + encode_hex(privtoaddr(self.privkey))
+        self.token = GNTToken(self.client)
+
+    def test_get_balance(self):
+        abi = mock.Mock()
+        self.token._GNTToken__testGNT = abi
+        encoded_data = 'dada'
+        abi.encode_function_call.return_value = encoded_data
+
+        self.client.call.return_value = None
+        self.assertEqual(None, self.token.get_balance(self.addr))
+        abi.encode_function_call.assert_called_with(
+            'balanceOf',
+            [privtoaddr(self.privkey)])
+        self.client.call.assert_called_with(
+            _from=mock.ANY,
+            to='0x' + encode_hex(self.token.TESTGNT_ADDR),
+            data='0x' + encode_hex(encoded_data),
+            block='pending')
+
+        self.client.call.return_value = '0x'
+        self.assertEqual(0, self.token.get_balance(self.addr))
+
+        self.client.call.return_value = '0xf'
+        self.assertEqual(15, self.token.get_balance(self.addr))
+
+    def test_batches(self):
+        p1 = make_awaiting_payment()
+        p2 = make_awaiting_payment()
+        p3 = make_awaiting_payment()
+
+        nonce = 0
+        self.client.get_transaction_count.return_value = nonce
+
+        abi = mock.Mock()
+        self.token._GNTToken__testGNT = abi
+        encoded_data = 'dada'
+        abi.encode_function_call.return_value = encoded_data
+
+        tx = self.token.batch_transfer(self.privkey, [p1, p2, p3])
+        self.assertEqual(nonce, tx.nonce)
+        self.assertEqual(self.token.TESTGNT_ADDR, tx.to)
+        self.assertEqual(0, tx.value)
+        expected_gas = PaymentProcessor.GAS_BATCH_PAYMENT_BASE + \
+            3 * PaymentProcessor.GAS_PER_PAYMENT
+        self.assertEqual(expected_gas, tx.startgas)
+        self.assertEqual(encoded_data, tx.data)
+        abi.encode_function_call.assert_called_with(
+            'batchTransfer',
+            [encode_payments([p1, p2, p3])])
+
+    def test_get_incomes_from_block(self):
+        block_number = 1
+        receiver_address = '0xbadcode'
+        some_address = '0xdeadbeef'
+
+        self.client.get_logs.return_value = None
+        incomes = self.token.get_incomes_from_block(block_number,
+                                                    receiver_address)
+        self.assertEqual(None, incomes)
+
+        topics = [self.token.TRANSFER_EVENT_ID, None, receiver_address]
         self.client.get_logs.assert_called_with(
-            address='0x' + encode_hex(self.pp.TESTGNT_ADDR),
-            from_block=block_number,
-            to_block=block_number,
-            topics=topics)
+            block_number,
+            block_number,
+            '0x' + encode_hex(self.token.TESTGNT_ADDR),
+            topics)
 
         self.client.get_logs.return_value = [{
             'topics': ['0x0', some_address, receiver_address],
             'data': '0xf',
         }]
-        incomes = self.pp.get_incomes_from_block(block_number,
-                                                 receiver_address)
-        assert len(incomes) == 1
-        assert incomes[0]['sender'] == some_address
-        assert incomes[0]['value'] == 15
+        incomes = self.token.get_incomes_from_block(block_number,
+                                                    receiver_address)
+        self.assertEqual(1, len(incomes))
+        self.assertEqual(some_address, incomes[0]['sender'])
+        self.assertEqual(15, incomes[0]['value'])


### PR DESCRIPTION
Abstract all the token related logic into its own class. This way `paymentprocessor` doesn't need to know anything about the details of the token implementation. 
It makes the code clearer.
It makes testing easier.
It makes migrating to GNTW easier.
The world is a better place.

This PR doesn't include any functional changes (except for making `self._awaiting` thread safe), so it's relatively safe.