### PR TITLE
Hotfix for resource peers (0.10.1)

### DIFF
--- a/golem/network/hyperdrive/client.py
+++ b/golem/network/hyperdrive/client.py
@@ -11,12 +11,17 @@ from golem.resource.client import IClient, ClientOptions
 log = logging.getLogger(__name__)
 
 
+DEFAULT_HYPERDRIVE_PORT = 3282
+DEFAULT_HYPERDRIVE_RPC_PORT = 3292
+
+
 class HyperdriveClient(IClient):
 
     CLIENT_ID = 'hyperg'
     VERSION = 1.1
 
-    def __init__(self, port=3292, host='localhost', timeout=None):
+    def __init__(self, port=DEFAULT_HYPERDRIVE_RPC_PORT,
+                 host='localhost', timeout=None):
         super(HyperdriveClient, self).__init__()
 
         # API destination address

--- a/golem/resource/resourcehandshake.py
+++ b/golem/resource/resourcehandshake.py
@@ -251,7 +251,8 @@ class ResourceHandshakeSessionMixin:
             entry, self.NONCE_TASK,
             success=lambda res, files, _: self._nonce_downloaded(key_id, files),
             error=lambda exc, *_: self._handshake_error(key_id, exc),
-            client_options=self.task_server.get_download_options(key_id)
+            client_options=self.task_server.get_download_options(key_id,
+                                                                 self.address)
         )
 
     def _nonce_downloaded(self, key_id, files):

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -14,6 +14,7 @@ from requests import HTTPError
 
 from golem import model
 from golem.clientconfigdescriptor import ClientConfigDescriptor
+from golem.network.hyperdrive.client import DEFAULT_HYPERDRIVE_PORT
 from golem.network.transport.network import ProtocolFactory, SessionFactory
 from golem.network.transport.tcpnetwork import TCPNetwork, TCPConnectInfo, SocketAddress, FilesProtocol
 from golem.network.transport.tcpserver import PendingConnectionsServer, PenConnStatus
@@ -106,10 +107,16 @@ class TaskResourcesMixin(object):
         logger.error("Cannot restore task '%s' resources: %r", task_id, error)
         self.task_manager.delete_task(task_id)
 
-    def get_download_options(self, key_id):
+    def get_download_options(self, key_id, address=None):
         resource_manager = self._get_resource_manager()
-        peer = self.get_resource_peer(key_id)
-        peers = [peer] if peer else []
+        peers = []
+
+        if address:
+            peers.append({'TCP': [address, DEFAULT_HYPERDRIVE_PORT]})
+        else:
+            peer = self.get_resource_peer(key_id)
+            if peer:
+                peers.append(peer)
         return resource_manager.build_client_options(peers=peers)
 
     def get_share_options(self, task_id, key_id):

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -574,7 +574,8 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
         secret = msg.secret
         multihash = msg.multihash
         subtask_id = msg.subtask_id
-        client_options = self.task_server.get_download_options(self.key_id)
+        client_options = self.task_server.get_download_options(self.key_id,
+                                                               self.address)
 
         task_id = self.task_manager.subtask2task_mapping.get(subtask_id, None)
         task = self.task_manager.tasks.get(task_id, None)
@@ -666,10 +667,8 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
         resource_manager = self.task_server.client.resource_server.resource_manager  # noqa
         resources = resource_manager.from_wire(msg.resources)
 
-        # Prefer known client options to ones provided in the message
-        client_options = self.task_server.get_download_options(self.key_id)
-        if not (client_options.options and client_options.options.get('peers')):
-            client_options = msg.options
+        client_options = self.task_server.get_download_options(self.key_id,
+                                                               self.address)
 
         self.task_computer.wait_for_resources(self.task_id, resources)
         self.task_server.pull_resources(self.task_id, resources,

--- a/tests/golem/resource/test_resourcehandshake.py
+++ b/tests/golem/resource/test_resourcehandshake.py
@@ -604,6 +604,7 @@ class MockTaskSession(ResourceHandshakeSessionMixin):
         self.successful_uploads = successful_uploads
 
         self.key_id = str(uuid.uuid4())
+        self.address = '1.2.3.4'
         self.data_dir = data_dir
         self.task_server = Mock(
             client=Mock(datadir=data_dir),

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -572,9 +572,9 @@ class TestTaskSession(LogTestCase, testutils.TempDirFixture,
         assert task_server.pull_resources.called
         assert isinstance(call_options['client_options'], Mock)
 
-        # Use remote options when local ones are not available
-        task_server.get_download_options.return_value = ClientOptions(client,
-                                                                      version)
+        # Use download options built by TaskServer
+        task_server.get_download_options.return_value = client_options
+
         self.task_session.task_server.pull_resources.reset_mock()
         self.task_session._react_to_resource_list(msg)
         call_options = task_server.pull_resources.call_args[1]


### PR DESCRIPTION
- this is a 0.10.0 hotfix only (no protocol version changes), for `develop` see https://github.com/golemfactory/golem/pull/1768
- resource peer addresses are always passed to hyperg
- addresses are built by the local node (unlike https://github.com/golemfactory/golem/pull/1768)
