### PR TITLE
async_run: increase thread pool size

### DIFF
--- a/golem/core/async.py
+++ b/golem/core/async.py
@@ -4,14 +4,27 @@ from twisted.internet import threads
 log = logging.getLogger(__name__)
 
 
+THREAD_POOL_SIZE = 30
+
+
 class AsyncRequest(object):
 
     """ Deferred job descriptor """
+    initialized = False
 
     def __init__(self, method, *args, **kwargs):
         self.method = method
         self.args = args or []
         self.kwargs = kwargs or {}
+
+        if not AsyncRequest.initialized:
+            AsyncRequest.initialized = True
+            self.increase_thread_pool_size()
+
+    @classmethod
+    def increase_thread_pool_size(cls):
+        from twisted.internet import reactor
+        reactor.suggestThreadPoolSize(THREAD_POOL_SIZE)
 
 
 def async_run(deferred_call, success=None, error=None):

--- a/tests/golem/resource/test_resourceclient.py
+++ b/tests/golem/resource/test_resourceclient.py
@@ -1,9 +1,9 @@
 import time
 import unittest
 import uuid
+from unittest.mock import Mock
 
 import twisted
-from mock import Mock
 
 from golem.core.async import AsyncRequest, async_run
 from golem.resource.client import ClientHandler, ClientCommands, ClientError, \
@@ -113,7 +113,25 @@ class TestClientOptions(unittest.TestCase):
         assert isinstance(filtered, ClientOptions)
 
 
-class TestAsyncRequest(TestWithReactor):
+@unittest.mock.patch('twisted.internet.reactor', create=True)
+class TestAsyncRequest(unittest.TestCase):
+
+    def test_initialization(self, reactor):
+        AsyncRequest.initialized = False
+        request = AsyncRequest(lambda x: x)
+        assert AsyncRequest.initialized
+
+        assert request.args == []
+        assert request.kwargs == {}
+        assert reactor.suggestThreadPoolSize.call_count == 1
+
+        request = AsyncRequest(lambda x: x, "arg", kwarg="kwarg")
+        assert request.args == ("arg",)
+        assert request.kwargs == {"kwarg": "kwarg"}
+        assert reactor.suggestThreadPoolSize.call_count == 1
+
+
+class TestAsyncRun(TestWithReactor):
 
     def test_callbacks(self):
         done = [False]


### PR DESCRIPTION
Return threads to the pool as soon as possible. Under heavy load (many hyperg download requests), the pool may be exhausted quickly.

