### PR TITLE
Move tokens implementations to its own file

### DIFF
--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -1,6 +1,4 @@
-import abc
 import calendar
-import json
 import logging
 import sys
 import time
@@ -8,8 +6,7 @@ from threading import Lock
 from time import sleep
 from typing import Any, List
 
-from ethereum import abi, utils, keys
-from ethereum.transactions import Transaction
+from ethereum import utils, keys
 from ethereum.utils import denoms
 from pydispatch import dispatcher
 
@@ -17,35 +14,9 @@ from golem.core.service import LoopingCallService
 from golem.ethereum import Client
 from golem.model import db, Payment, PaymentStatus
 from golem.utils import decode_hex, encode_hex
-from .contracts import TestGNT
-from .contracts import gntw
 from .node import tETH_faucet_donate
 
 log = logging.getLogger("golem.pay")
-
-
-def encode_payments(payments: List[Payment]):
-    paymap = {}
-    for p in payments:
-        if p.payee in paymap:
-            paymap[p.payee] += p.value
-        else:
-            paymap[p.payee] = p.value
-
-    args = []
-    value = 0
-    for to, v in paymap.items():
-        max_value = 2 ** 96
-        if v >= max_value:
-            raise ValueError("v should be less than {}".format(max_value))
-        value += v
-        v = utils.zpad(utils.int_to_big_endian(v), 12)
-        pair = v + to
-        if len(pair) != 32:
-            raise ValueError(
-                "Incorrect pair length: {}. Should be 32".format(len(pair)))
-        args.append(pair)
-    return args
 
 
 def get_timestamp() -> int:
@@ -53,316 +24,9 @@ def get_timestamp() -> int:
     return calendar.timegm(time.gmtime())
 
 
-class AbstractToken(object, metaclass=abc.ABCMeta):
-    """
-    This is a common interface for token transactions. It hides whether we're
-    using GNT or GNTW underneath.
-    """
-    def __init__(self, client: Client):
-        self._client = client
-
-    def _create_transaction(self,
-                            sender: str,
-                            token_address,
-                            data,
-                            gas: int) -> Transaction:
-        nonce = self._client.get_transaction_count(sender)
-        tx = Transaction(nonce,
-                         PaymentProcessor.GAS_PRICE,
-                         gas,
-                         to=token_address,
-                         value=0,
-                         data=data)
-        return tx
-
-    def _send_transaction(self,
-                          privkey: bytes,
-                          token_address,
-                          data,
-                          gas: int) -> Transaction:
-        tx = self._create_transaction(
-            '0x' + encode_hex(keys.privtoaddr(privkey)),
-            token_address,
-            data,
-            gas)
-        tx.sign(privkey)
-        self._client.send(tx)
-        return tx
-
-    def _get_balance(self, token_abi, token_address, addr: str) -> int:
-        data = token_abi.encode_function_call('balanceOf', [addr])
-        r = self._client.call(
-            _from='0x' + encode_hex(addr),
-            to='0x' + encode_hex(token_address),
-            data='0x' + encode_hex(data),
-            block='pending')
-        if r is None:
-            return None
-        return 0 if r == '0x' else int(r, 16)
-
-    def _request_from_faucet(self,
-                             token_abi,
-                             token_address,
-                             privkey: bytes) -> None:
-        data = token_abi.encode_function_call('create', [])
-        self._send_transaction(privkey, token_address, data, 90000)
-
-    @abc.abstractmethod
-    def get_balance(self, addr: str) -> int:
-        pass
-
-    @abc.abstractmethod
-    def batch_transfer(self,
-                       privkey: bytes,
-                       payments: List[Payment],
-                       closure_time: int) -> Transaction:
-        """
-        Takes a list of payments to be made and returns prepared transaction
-        for the batch payment. The transaction is not sent, but it is signed.
-        It may return None when it's unable to make transaction at the moment,
-        but this shouldn't be treated as an error. In case of GNTW sometimes
-        we need to do some preparations (like convertion from GNT) before
-        we can make a batch transfer.
-        """
-        pass
-
-    @abc.abstractmethod
-    def get_incomes_from_block(self, block: int, address) -> List[Any]:
-        pass
-
-
-class GNTToken(AbstractToken):
-    """
-    When the main token and the batchTransfer function are in the same contract.
-    Which is the case for tGNT in testnet and eventually (after migration)
-    will be the case for the new GNT in the mainnet as well.
-    """
-    TESTGNT_ADDR = decode_hex("7295bB8709EC1C22b758A8119A4214fFEd016323")
-
-    # keccak256(Transfer(address,address,uint256))
-    TRANSFER_EVENT_ID = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'  # noqa
-
-    def __init__(self, client: Client):
-        super().__init__(client)
-        self.__testGNT = abi.ContractTranslator(json.loads(TestGNT.ABI))
-
-    def get_balance(self, addr: str) -> int:
-        balance = self._get_balance(
-            self.__testGNT,
-            self.TESTGNT_ADDR,
-            decode_hex(addr))
-        if balance is not None:
-            log.info("TestGNT: {}".format(balance / denoms.ether))
-        return balance
-
-    def request_from_faucet(self, privkey: bytes) -> None:
-        self._request_from_faucet(self.__testGNT, self.TESTGNT_ADDR, privkey)
-
-    def batch_transfer(self,
-                       privkey: bytes,
-                       payments: List[Payment],
-                       closure_time: int) -> Transaction:
-        p = encode_payments(payments)
-        data = self.__testGNT.encode_function_call('batchTransfer', [p])
-        gas = PaymentProcessor.GAS_BATCH_PAYMENT_BASE + \
-            len(p) * PaymentProcessor.GAS_PER_PAYMENT
-        tx = self._create_transaction(
-            '0x' + encode_hex(keys.privtoaddr(privkey)),
-            self.TESTGNT_ADDR,
-            data,
-            gas)
-        tx.sign(privkey)
-        return tx
-
-    def get_incomes_from_block(self, block: int, address) -> List[Any]:
-        logs = self._client.get_logs(block,
-                                     block,
-                                     '0x' + encode_hex(self.TESTGNT_ADDR),
-                                     [self.TRANSFER_EVENT_ID, None, address])
-        if not logs:
-            return logs
-
-        res = []
-        for entry in logs:
-            if entry['topics'][2] != address:
-                raise Exception("Unexpected income event from {}"
-                                .format(entry['topics'][2]))
-
-            res.append({
-                'sender': entry['topics'][1],
-                'value': int(entry['data'], 16),
-            })
-        return res
-
-
-class GNTWToken(AbstractToken):
-    """
-    When batchTransfer function is in a different contract than the main token.
-    GNTW implementation specifically.
-    """
-    GNTW_ADDRESS = decode_hex("a8CD649dB30b963592D88FdE95fe6284d6224329")
-    TESTGNT_ADDRESS = decode_hex("2928aA793B79FCdb7b5B94f5d8419e0EE20AbDaF")
-    FAUCET_ADDRESS = decode_hex("36FeE1616A131E7382922475A1BA67F88F891f0d")
-
-    # keccak256(BatchTransfer(address,address,uint256,uint64))
-    TRANSFER_EVENT_ID = '0x24310ec9df46c171fe9c6d6fe25cac6781e7fa8f153f8f72ce63037a4b38c4b6'  # noqa
-
-    CREATE_PERSONAL_DEPOSIT_GAS = 320000
-    PROCESS_DEPOSIT_GAS = 110000
-    GNT_TRANSFER_GAS = 55000
-
-    def __init__(self, client: Client):
-        super().__init__(client)
-        self.__gntw = abi.ContractTranslator(
-            json.loads(gntw.GolemNetworkTokenWrapped.ABI))
-        self.__gnt = abi.ContractTranslator(
-            json.loads(gntw.GolemNetworkToken.ABI))
-        self.__faucet = abi.ContractTranslator(json.loads(gntw.Faucet.ABI))
-        self.__deposit_address = None
-        self.__deposit_address_created = False
-        self.__process_deposit_tx = None
-
-    def get_balance(self, addr: str) -> int:
-        gnt_balance = self._get_balance(self.__gnt, self.TESTGNT_ADDRESS, addr)
-        if gnt_balance is None:
-            return None
-
-        gntw_balance = self._get_balance(self.__gntw, self.GNTW_ADDRESS, addr)
-        if gntw_balance is None:
-            return None
-
-        log.info("TestGNT: {} GNTW: {}".format(
-            gnt_balance / denoms.ether,
-            gntw_balance / denoms.ether))
-        return gnt_balance + gntw_balance
-
-    def request_from_faucet(self, privkey: bytes) -> None:
-        self._request_from_faucet(self.__faucet, self.FAUCET_ADDRESS, privkey)
-
-    def batch_transfer(self,
-                       privkey: bytes,
-                       payments: List[Payment],
-                       closure_time: int) -> Transaction:
-        if self.__process_deposit_tx:
-            hstr = '0x' + encode_hex(self.__process_deposit_tx)
-            receipt = self._client.get_transaction_receipt(hstr)
-            if not receipt:
-                log.info("Waiting to process deposit")
-                return None
-            self.__process_deposit_tx = None
-
-        gntw_balance = self._get_balance(
-            self.__gntw,
-            self.GNTW_ADDRESS,
-            '0x' + encode_hex(keys.privtoaddr(privkey)))
-        if gntw_balance is None:
-            return None
-        total_value = sum([p.value for p in payments])
-        if gntw_balance < total_value:
-            log.info("Not enough GNTW, trying to convert GNT. "
-                     "GNTW: {}, total_value: {}"
-                     .format(gntw_balance, total_value))
-            self.__convert_gnt(privkey)
-            return None
-
-        p = encode_payments(payments)
-        data = self.__gntw.encode_function_call('batchTransfer',
-                                                [p, closure_time])
-        gas = PaymentProcessor.GAS_BATCH_PAYMENT_BASE + \
-            len(p) * PaymentProcessor.GAS_PER_PAYMENT
-        return self._create_transaction(privkey, self.GNTW_ADDRESS, data, gas)
-
-    def get_incomes_from_block(self, block: int, address) -> List[Any]:
-        logs = self._client.get_logs(block,
-                                     block,
-                                     '0x' + encode_hex(self.GNTW_ADDRESS),
-                                     [self.TRANSFER_EVENT_ID, None, address])
-        if not logs:
-            return logs
-
-        res = []
-        for entry in logs:
-            if entry['topics'][2] != address:
-                raise Exception("Unexpected income event from {}"
-                                .format(entry['topics'][2]))
-
-            res.append({
-                'sender': entry['topics'][1],
-                'value': int(entry['data'][:66], 16),
-            })
-        return res
-
-    def __get_deposit_address(self, privkey: bytes) -> bytes:
-        if not self.__deposit_address:
-            addr = keys.privtoaddr(privkey)
-            data = self.__gntw.encode_function_call(
-                'getPersonalDepositAddress',
-                [addr])
-            res = self._client.call(_from='0x' + encode_hex(addr),
-                                    to='0x' + encode_hex(self.GNTW_ADDRESS),
-                                    data='0x' + encode_hex(data),
-                                    block='pending')
-            if int(res, 16) != 0:
-                self.__deposit_address = decode_hex(res)[-20:]
-            elif not self.__deposit_address_created:
-                data = self.__gntw.encode_function_call(
-                    'createPersonalDepositAddress',
-                    [])
-                tx = self._send_transaction(privkey,
-                                            self.GNTW_ADDRESS,
-                                            data,
-                                            self.CREATE_PERSONAL_DEPOSIT_GAS)
-                log.info("Create personal deposit address tx: {}"
-                         .format(encode_hex(tx.hash)))
-                self.__deposit_address_created = True
-        return self.__deposit_address
-
-    def __convert_gnt(self, privkey: bytes) -> None:
-        gnt_balance = self._get_balance(
-            self.__gnt,
-            self.TESTGNT_ADDRESS,
-            '0x' + encode_hex(keys.privtoaddr(privkey)))
-        if gnt_balance is None:
-            return
-
-        log.info("Converting {} GNT to GNTW".format(gnt_balance))
-        pda = self.__get_deposit_address(privkey)
-        if not pda:
-            log.info("Not converting until deposit address is known")
-            return
-
-        data = self.__gnt.encode_function_call(
-            'transfer',
-            [self.__deposit_address, gnt_balance])
-        tx = self._send_transaction(privkey,
-                                    self.TESTGNT_ADDRESS,
-                                    data,
-                                    self.GNT_TRANSFER_GAS)
-        log.info("Transfer GNT to personal deposit tx: {}"
-                 .format(encode_hex(tx.hash)))
-
-        data = self.__gntw.encode_function_call('processDeposit', [])
-        tx = self._send_transaction(privkey,
-                                    self.GNTW_ADDRESS,
-                                    data,
-                                    self.PROCESS_DEPOSIT_GAS)
-        self.__process_deposit_tx = tx.hash
-        log.info("Process deposit tx: {}".format(encode_hex(tx.hash)))
-
-
 class PaymentProcessor(LoopingCallService):
     # Default deadline in seconds for new payments.
     DEFAULT_DEADLINE = 10 * 60
-
-    # Gas price: 20 gwei, Homestead suggested gas price.
-    GAS_PRICE = 20 * 10 ** 9
-
-    # Total gas for a batchTransfer is BASE + len(payments) * PER_PAYMENT
-    GAS_PER_PAYMENT = 30000
-    ETH_PER_PAYMENT = GAS_PRICE * GAS_PER_PAYMENT
-    # tx: 21000, balance substract: 5000, arithmetics < 800
-    GAS_BATCH_PAYMENT_BASE = 21000 + 800 + 5000
-    ETH_BATCH_PAYMENT_BASE = GAS_PRICE * GAS_BATCH_PAYMENT_BASE
 
     # Time required to reset the current balance when errors occur
     BALANCE_RESET_TIMEOUT = 30
@@ -377,9 +41,12 @@ class PaymentProcessor(LoopingCallService):
     def __init__(self,
                  client: Client,
                  privkey,
-                 faucet=False,
-                 token_factory=GNTToken) -> None:
-        self.__token = token_factory(client)
+                 token,
+                 faucet=False) -> None:
+        self.__token = token
+        self.ETH_PER_PAYMENT = token.GAS_PRICE * token.GAS_PER_PAYMENT
+        self.ETH_BATCH_PAYMENT_BASE = \
+            token.GAS_PRICE * token.GAS_BATCH_PAYMENT_BASE
         self.__client = client
         self.__privkey = privkey
         self.__eth_balance = None
@@ -675,7 +342,7 @@ class PaymentProcessor(LoopingCallService):
                 continue
 
             gas_used = receipt['gasUsed']
-            total_fee = gas_used * self.GAS_PRICE
+            total_fee = gas_used * self.__token.GAS_PRICE
             fee = total_fee // len(payments)
             log.info("Confirmed {:.6}: block {} ({}), gas {}, fee {}"
                      .format(hstr, block_hash, block_number, gas_used, fee))

--- a/golem/ethereum/token.py
+++ b/golem/ethereum/token.py
@@ -1,0 +1,346 @@
+import abc
+import json
+import logging
+from typing import List, Any
+
+from ethereum import abi, utils, keys
+from ethereum.transactions import Transaction
+from ethereum.utils import denoms
+
+from golem.ethereum import Client
+from golem.model import Payment
+from golem.utils import decode_hex, encode_hex
+from .contracts import TestGNT
+from .contracts import gntw
+
+logger = logging.getLogger("golem.token")
+
+
+def encode_payments(payments: List[Payment]):
+    paymap = {}
+    for p in payments:
+        if p.payee in paymap:
+            paymap[p.payee] += p.value
+        else:
+            paymap[p.payee] = p.value
+
+    args = []
+    value = 0
+    for to, v in paymap.items():
+        max_value = 2 ** 96
+        if v >= max_value:
+            raise ValueError("v should be less than {}".format(max_value))
+        value += v
+        v = utils.zpad(utils.int_to_big_endian(v), 12)
+        pair = v + to
+        if len(pair) != 32:
+            raise ValueError(
+                "Incorrect pair length: {}. Should be 32".format(len(pair)))
+        args.append(pair)
+    return args
+
+
+class AbstractToken(object, metaclass=abc.ABCMeta):
+    """
+    This is a common interface for token transactions. It hides whether we're
+    using GNT or GNTW underneath.
+    """
+
+    # Gas price: 20 gwei, Homestead suggested gas price.
+    GAS_PRICE = 20 * 10 ** 9
+
+    # Total gas for a batchTransfer is BASE + len(payments) * PER_PAYMENT
+    GAS_PER_PAYMENT = 30000
+    # tx: 21000, balance substract: 5000, arithmetics < 800
+    GAS_BATCH_PAYMENT_BASE = 21000 + 800 + 5000
+
+    def __init__(self, client: Client):
+        self._client = client
+
+    def _create_transaction(self,
+                            sender: str,
+                            token_address,
+                            data,
+                            gas: int) -> Transaction:
+        nonce = self._client.get_transaction_count(sender)
+        tx = Transaction(nonce,
+                         self.GAS_PRICE,
+                         gas,
+                         to=token_address,
+                         value=0,
+                         data=data)
+        return tx
+
+    def _send_transaction(self,
+                          privkey: bytes,
+                          token_address,
+                          data,
+                          gas: int) -> Transaction:
+        tx = self._create_transaction(
+            '0x' + encode_hex(keys.privtoaddr(privkey)),
+            token_address,
+            data,
+            gas)
+        tx.sign(privkey)
+        self._client.send(tx)
+        return tx
+
+    def _get_balance(self, token_abi, token_address, addr: str) -> int:
+        data = token_abi.encode_function_call('balanceOf', [addr])
+        r = self._client.call(
+            _from='0x' + encode_hex(addr),
+            to='0x' + encode_hex(token_address),
+            data='0x' + encode_hex(data),
+            block='pending')
+        if r is None:
+            return None
+        return 0 if r == '0x' else int(r, 16)
+
+    def _request_from_faucet(self,
+                             token_abi,
+                             token_address,
+                             privkey: bytes) -> None:
+        data = token_abi.encode_function_call('create', [])
+        self._send_transaction(privkey, token_address, data, 90000)
+
+    @abc.abstractmethod
+    def get_balance(self, addr: str) -> int:
+        pass
+
+    @abc.abstractmethod
+    def batch_transfer(self,
+                       privkey: bytes,
+                       payments: List[Payment],
+                       closure_time: int) -> Transaction:
+        """
+        Takes a list of payments to be made and returns prepared transaction
+        for the batch payment. The transaction is not sent, but it is signed.
+        It may return None when it's unable to make transaction at the moment,
+        but this shouldn't be treated as an error. In case of GNTW sometimes
+        we need to do some preparations (like convertion from GNT) before
+        we can make a batch transfer.
+        """
+        pass
+
+    @abc.abstractmethod
+    def get_incomes_from_block(self, block: int, address) -> List[Any]:
+        pass
+
+
+class GNTToken(AbstractToken):
+    """
+    When the main token and the batchTransfer function are in the same contract.
+    Which is the case for tGNT in testnet and eventually (after migration)
+    will be the case for the new GNT in the mainnet as well.
+    """
+    TESTGNT_ADDR = decode_hex("7295bB8709EC1C22b758A8119A4214fFEd016323")
+
+    # keccak256(Transfer(address,address,uint256))
+    TRANSFER_EVENT_ID = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef'  # noqa
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.__testGNT = abi.ContractTranslator(json.loads(TestGNT.ABI))
+
+    def get_balance(self, addr: str) -> int:
+        balance = self._get_balance(
+            self.__testGNT,
+            self.TESTGNT_ADDR,
+            decode_hex(addr))
+        if balance is not None:
+            logger.info("TestGNT: {}".format(balance / denoms.ether))
+        return balance
+
+    def request_from_faucet(self, privkey: bytes) -> None:
+        self._request_from_faucet(self.__testGNT, self.TESTGNT_ADDR, privkey)
+
+    def batch_transfer(self,
+                       privkey: bytes,
+                       payments: List[Payment],
+                       closure_time: int) -> Transaction:
+        p = encode_payments(payments)
+        data = self.__testGNT.encode_function_call('batchTransfer', [p])
+        gas = self.GAS_BATCH_PAYMENT_BASE + len(p) * self.GAS_PER_PAYMENT
+        tx = self._create_transaction(
+            '0x' + encode_hex(keys.privtoaddr(privkey)),
+            self.TESTGNT_ADDR,
+            data,
+            gas)
+        tx.sign(privkey)
+        return tx
+
+    def get_incomes_from_block(self, block: int, address) -> List[Any]:
+        logs = self._client.get_logs(block,
+                                     block,
+                                     '0x' + encode_hex(self.TESTGNT_ADDR),
+                                     [self.TRANSFER_EVENT_ID, None, address])
+        if not logs:
+            return logs
+
+        res = []
+        for entry in logs:
+            if entry['topics'][2] != address:
+                raise Exception("Unexpected income event from {}"
+                                .format(entry['topics'][2]))
+
+            res.append({
+                'sender': entry['topics'][1],
+                'value': int(entry['data'], 16),
+            })
+        return res
+
+
+class GNTWToken(AbstractToken):
+    """
+    When batchTransfer function is in a different contract than the main token.
+    GNTW implementation specifically.
+    """
+    GNTW_ADDRESS = decode_hex("a8CD649dB30b963592D88FdE95fe6284d6224329")
+    TESTGNT_ADDRESS = decode_hex("2928aA793B79FCdb7b5B94f5d8419e0EE20AbDaF")
+    FAUCET_ADDRESS = decode_hex("36FeE1616A131E7382922475A1BA67F88F891f0d")
+
+    # keccak256(BatchTransfer(address,address,uint256,uint64))
+    TRANSFER_EVENT_ID = '0x24310ec9df46c171fe9c6d6fe25cac6781e7fa8f153f8f72ce63037a4b38c4b6'  # noqa
+
+    CREATE_PERSONAL_DEPOSIT_GAS = 320000
+    PROCESS_DEPOSIT_GAS = 110000
+    GNT_TRANSFER_GAS = 55000
+
+    def __init__(self, client: Client):
+        super().__init__(client)
+        self.__gntw = abi.ContractTranslator(
+            json.loads(gntw.GolemNetworkTokenWrapped.ABI))
+        self.__gnt = abi.ContractTranslator(
+            json.loads(gntw.GolemNetworkToken.ABI))
+        self.__faucet = abi.ContractTranslator(json.loads(gntw.Faucet.ABI))
+        self.__deposit_address = None
+        self.__deposit_address_created = False
+        self.__process_deposit_tx = None
+
+    def get_balance(self, addr: str) -> int:
+        gnt_balance = self._get_balance(
+            self.__gnt, self.TESTGNT_ADDRESS, decode_hex(addr))
+        if gnt_balance is None:
+            return None
+
+        gntw_balance = self._get_balance(
+            self.__gntw, self.GNTW_ADDRESS, decode_hex(addr))
+        if gntw_balance is None:
+            return None
+
+        logger.info("TestGNT: {} GNTW: {}".format(
+            gnt_balance / denoms.ether,
+            gntw_balance / denoms.ether))
+        return gnt_balance + gntw_balance
+
+    def request_from_faucet(self, privkey: bytes) -> None:
+        self._request_from_faucet(self.__faucet, self.FAUCET_ADDRESS, privkey)
+
+    def batch_transfer(self,
+                       privkey: bytes,
+                       payments: List[Payment],
+                       closure_time: int) -> Transaction:
+        if self.__process_deposit_tx:
+            hstr = '0x' + encode_hex(self.__process_deposit_tx)
+            receipt = self._client.get_transaction_receipt(hstr)
+            if not receipt:
+                logger.info("Waiting to process deposit")
+                return None
+            self.__process_deposit_tx = None
+
+        gntw_balance = self._get_balance(
+            self.__gntw,
+            self.GNTW_ADDRESS,
+            '0x' + encode_hex(keys.privtoaddr(privkey)))
+        if gntw_balance is None:
+            return None
+        total_value = sum([p.value for p in payments])
+        if gntw_balance < total_value:
+            logger.info("Not enough GNTW, trying to convert GNT. "
+                        "GNTW: {}, total_value: {}"
+                        .format(gntw_balance, total_value))
+            self.__convert_gnt(privkey)
+            return None
+
+        p = encode_payments(payments)
+        data = self.__gntw.encode_function_call('batchTransfer',
+                                                [p, closure_time])
+        gas = self.GAS_BATCH_PAYMENT_BASE + len(p) * self.GAS_PER_PAYMENT
+        return self._create_transaction(privkey, self.GNTW_ADDRESS, data, gas)
+
+    def get_incomes_from_block(self, block: int, address) -> List[Any]:
+        logs = self._client.get_logs(block,
+                                     block,
+                                     '0x' + encode_hex(self.GNTW_ADDRESS),
+                                     [self.TRANSFER_EVENT_ID, None, address])
+        if not logs:
+            return logs
+
+        res = []
+        for entry in logs:
+            if entry['topics'][2] != address:
+                raise Exception("Unexpected income event from {}"
+                                .format(entry['topics'][2]))
+
+            res.append({
+                'sender': entry['topics'][1],
+                'value': int(entry['data'][:66], 16),
+            })
+        return res
+
+    def __get_deposit_address(self, privkey: bytes) -> bytes:
+        if not self.__deposit_address:
+            addr = keys.privtoaddr(privkey)
+            data = self.__gntw.encode_function_call(
+                'getPersonalDepositAddress',
+                [addr])
+            res = self._client.call(_from='0x' + encode_hex(addr),
+                                    to='0x' + encode_hex(self.GNTW_ADDRESS),
+                                    data='0x' + encode_hex(data),
+                                    block='pending')
+            if int(res, 16) != 0:
+                self.__deposit_address = decode_hex(res)[-20:]
+            elif not self.__deposit_address_created:
+                data = self.__gntw.encode_function_call(
+                    'createPersonalDepositAddress',
+                    [])
+                tx = self._send_transaction(privkey,
+                                            self.GNTW_ADDRESS,
+                                            data,
+                                            self.CREATE_PERSONAL_DEPOSIT_GAS)
+                logger.info("Create personal deposit address tx: {}"
+                            .format(encode_hex(tx.hash)))
+                self.__deposit_address_created = True
+        return self.__deposit_address
+
+    def __convert_gnt(self, privkey: bytes) -> None:
+        gnt_balance = self._get_balance(
+            self.__gnt,
+            self.TESTGNT_ADDRESS,
+            '0x' + encode_hex(keys.privtoaddr(privkey)))
+        if gnt_balance is None:
+            return
+
+        logger.info("Converting {} GNT to GNTW".format(gnt_balance))
+        pda = self.__get_deposit_address(privkey)
+        if not pda:
+            logger.info("Not converting until deposit address is known")
+            return
+
+        data = self.__gnt.encode_function_call(
+            'transfer',
+            [self.__deposit_address, gnt_balance])
+        tx = self._send_transaction(privkey,
+                                    self.TESTGNT_ADDRESS,
+                                    data,
+                                    self.GNT_TRANSFER_GAS)
+        logger.info("Transfer GNT to personal deposit tx: {}"
+                    .format(encode_hex(tx.hash)))
+
+        data = self.__gntw.encode_function_call('processDeposit', [])
+        tx = self._send_transaction(privkey,
+                                    self.GNTW_ADDRESS,
+                                    data,
+                                    self.PROCESS_DEPOSIT_GAS)
+        self.__process_deposit_tx = tx.hash
+        logger.info("Process deposit tx: {}".format(encode_hex(tx.hash)))

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -5,6 +5,7 @@ from ethereum.utils import privtoaddr
 
 from golem.ethereum import Client
 from golem.ethereum.paymentprocessor import PaymentProcessor
+from golem.ethereum.token import GNTToken
 from golem.report import report_calls, Component
 from golem.transactions.ethereum.ethereumpaymentskeeper \
     import EthereumAddress
@@ -38,9 +39,12 @@ class EthereumTransactionSystem(TransactionSystem):
 
         log.info("Node Ethereum address: " + self.get_payment_address())
 
+        client = Client(datadir, port, start_geth)
+        token = GNTToken(client)
         payment_processor = PaymentProcessor(
-            client=Client(datadir, port, start_geth),
+            client=client,
             privkey=node_priv_key,
+            token=token,
             faucet=True
         )
 

--- a/loggingconfig.py
+++ b/loggingconfig.py
@@ -78,6 +78,10 @@ LOGGING = {
             'level': 'INFO',
             'propagate': True,
         },
+        'golem.token': {
+            'level': 'INFO',
+            'propagate': True,
+        },
         'twisted': {
             'level': 'INFO',
             'propagate': True,

--- a/tests/golem/ethereum/test_paymentprocessor_eth.py
+++ b/tests/golem/ethereum/test_paymentprocessor_eth.py
@@ -11,6 +11,14 @@ from golem.ethereum import paymentprocessor
 from golem.utils import encode_hex
 
 
+def mock_token():
+    token = mock.Mock()
+    token.GAS_PRICE = 0
+    token.GAS_PER_PAYMENT = 0
+    token.GAS_BATCH_PAYMENT_BASE = 0
+    return token
+
+
 class TestPaymentProcessor(unittest.TestCase):
     def setUp(self):
         privkey = (b'!\xcd!^\xfe#\x82-#!Z]b\xb4\x8ce[\n\xfbN\x18V\x8c\x1dA'
@@ -18,7 +26,8 @@ class TestPaymentProcessor(unittest.TestCase):
         with mock.patch("golem.ethereum.paymentprocessor.PaymentProcessor.load_from_db"):  # noqa
             self.payment_processor = paymentprocessor.PaymentProcessor(
                 client=mock.MagicMock(),
-                privkey=privkey
+                privkey=privkey,
+                token=mock_token()
             )
 
     def test_eth_address(self):
@@ -41,7 +50,8 @@ class TestPaymentProcessorWithDB(testutils.DatabaseFixture):
         client = mock.MagicMock()
         self.payment_processor = paymentprocessor.PaymentProcessor(
             client=client,
-            privkey=privkey
+            privkey=privkey,
+            token=mock_token()
         )
 
     @mock.patch("golem.ethereum.paymentprocessor.PaymentProcessor.eth_balance", return_value=2**100)  # noqa

--- a/tests/golem/transactions/ethereum/test_token.py
+++ b/tests/golem/transactions/ethereum/test_token.py
@@ -1,0 +1,291 @@
+import json
+import mock
+import unittest
+from os import urandom
+
+from ethereum.utils import privtoaddr
+
+from golem.ethereum.token import GNTToken, GNTWToken, encode_payments
+from golem.utils import decode_hex, encode_hex
+
+
+def mock_payment(value: int=1):
+    p = mock.Mock()
+    p.value = value
+    p.payee = urandom(20)
+    return p
+
+
+class GNTTokenTest(unittest.TestCase):
+    def setUp(self):
+        self.client = mock.Mock()
+        self.privkey = urandom(32)
+        self.addr = '0x' + encode_hex(privtoaddr(self.privkey))
+        self.token = GNTToken(self.client)
+
+    def test_get_balance(self):
+        abi = mock.Mock()
+        self.token._GNTToken__testGNT = abi
+        encoded_data = 'dada'
+        abi.encode_function_call.return_value = encoded_data
+
+        self.client.call.return_value = None
+        self.assertEqual(None, self.token.get_balance(self.addr))
+        abi.encode_function_call.assert_called_with(
+            'balanceOf',
+            [privtoaddr(self.privkey)])
+        self.client.call.assert_called_with(
+            _from=mock.ANY,
+            to='0x' + encode_hex(self.token.TESTGNT_ADDR),
+            data='0x' + encode_hex(encoded_data),
+            block='pending')
+
+        self.client.call.return_value = '0x'
+        self.assertEqual(0, self.token.get_balance(self.addr))
+
+        self.client.call.return_value = '0xf'
+        self.assertEqual(15, self.token.get_balance(self.addr))
+
+    def test_batches(self):
+        p1 = mock_payment()
+        p2 = mock_payment()
+        p3 = mock_payment()
+
+        nonce = 0
+        self.client.get_transaction_count.return_value = nonce
+
+        abi = mock.Mock()
+        self.token._GNTToken__testGNT = abi
+        encoded_data = 'dada'
+        abi.encode_function_call.return_value = encoded_data
+
+        tx = self.token.batch_transfer(self.privkey, [p1, p2, p3], 0)
+        self.assertEqual(nonce, tx.nonce)
+        self.assertEqual(self.token.TESTGNT_ADDR, tx.to)
+        self.assertEqual(0, tx.value)
+        expected_gas = self.token.GAS_BATCH_PAYMENT_BASE + \
+            3 * self.token.GAS_PER_PAYMENT
+        self.assertEqual(expected_gas, tx.startgas)
+        self.assertEqual(encoded_data, tx.data)
+        abi.encode_function_call.assert_called_with(
+            'batchTransfer',
+            [encode_payments([p1, p2, p3])])
+
+    def test_get_incomes_from_block(self):
+        block_number = 1
+        receiver_address = '0xbadcode'
+        some_address = '0xdeadbeef'
+
+        self.client.get_logs.return_value = None
+        incomes = self.token.get_incomes_from_block(block_number,
+                                                    receiver_address)
+        self.assertEqual(None, incomes)
+
+        topics = [self.token.TRANSFER_EVENT_ID, None, receiver_address]
+        self.client.get_logs.assert_called_with(
+            block_number,
+            block_number,
+            '0x' + encode_hex(self.token.TESTGNT_ADDR),
+            topics)
+
+        self.client.get_logs.return_value = [{
+            'topics': ['0x0', some_address, receiver_address],
+            'data': '0xf',
+        }]
+        incomes = self.token.get_incomes_from_block(block_number,
+                                                    receiver_address)
+        self.assertEqual(1, len(incomes))
+        self.assertEqual(some_address, incomes[0]['sender'])
+        self.assertEqual(15, incomes[0]['value'])
+
+
+def abi_encoder(function_name, args):
+    def bytes2hex(elem):
+        if isinstance(elem, bytes):
+            return encode_hex(elem)
+        if isinstance(elem, list):
+            for i, e in enumerate(elem):
+                elem[i] = bytes2hex(e)
+        return elem
+
+    args = bytes2hex(args.copy())
+    res = json.dumps({'function_name': function_name, 'args': args})
+    return res
+
+
+class GNTWTokenTest(unittest.TestCase):
+    def setUp(self):
+        self.client = mock.Mock()
+        self.privkey = urandom(32)
+        self.addr = '0x' + encode_hex(privtoaddr(self.privkey))
+        self.token = GNTWToken(self.client)
+
+        gnt_abi = mock.Mock()
+        gnt_abi.encode_function_call.side_effect = abi_encoder
+        self.token._GNTWToken__gnt = gnt_abi
+
+        gntw_abi = mock.Mock()
+        gntw_abi.encode_function_call.side_effect = abi_encoder
+        self.token._GNTWToken__gntw = gntw_abi
+
+        self.balances = {
+            'gnt': None,
+            'gntw': None,
+        }
+
+        self.pda = bytearray(32)
+        self.pda_create_called = False
+
+        def client_call(_from, to, data, block):
+            self.assertEqual('pending', block)
+            token_addr = decode_hex(to)
+            data = json.loads(decode_hex(data).decode())
+            if data['function_name'] == 'balanceOf':
+                self.assertEqual(1, len(data['args']))
+
+                if privtoaddr(self.privkey) == decode_hex(data['args'][0]):
+                    if token_addr == self.token.TESTGNT_ADDRESS:
+                        return self.balances['gnt']
+                    if token_addr == self.token.GNTW_ADDRESS:
+                        return self.balances['gntw']
+
+                raise Exception('Unknown balance')
+
+            if data['function_name'] == 'getPersonalDepositAddress':
+                self.assertEqual(self.token.GNTW_ADDRESS, token_addr)
+                self.assertEqual(1, len(data['args']))
+                self.assertEqual(
+                    privtoaddr(self.privkey),
+                    decode_hex(data['args'][0]))
+                return '0x' + encode_hex(self.pda)
+
+            raise Exception('Unknown call {}'.format(data['function_name']))
+
+        self.nonce = 0
+        self.process_deposit_called = False
+        self.transfer_called = False
+
+        def client_send(tx):
+            token_addr = tx.to
+            data = json.loads(tx.data)
+            self.assertEqual(self.nonce, tx.nonce)
+            self.nonce += 1
+            if data['function_name'] == 'createPersonalDepositAddress':
+                self.assertEqual(self.token.GNTW_ADDRESS, token_addr)
+                self.assertEqual(0, len(data['args']))
+                self.assertEqual(
+                    self.token.CREATE_PERSONAL_DEPOSIT_GAS,
+                    tx.startgas)
+                self.pda_create_called = True
+                return '0x' + encode_hex(urandom(32))
+
+            if data['function_name'] == 'transfer':
+                self.assertEqual(self.token.TESTGNT_ADDRESS, token_addr)
+                self.assertEqual(2, len(data['args']))
+                self.assertEqual(encode_hex(self.pda[-20:]), data['args'][0])
+                self.assertEqual(int(self.balances['gnt'], 16), data['args'][1])
+                self.transfer_called = True
+                return '0x' + encode_hex(urandom(32))
+
+            if data['function_name'] == 'processDeposit':
+                self.assertEqual(self.token.GNTW_ADDRESS, token_addr)
+                self.assertEqual(0, len(data['args']))
+                self.process_deposit_called = True
+                return '0x' + encode_hex(urandom(32))
+
+            raise Exception('Unknown send {}'.format(data['function_name']))
+
+        self.client.call.side_effect = client_call
+        self.client.send.side_effect = client_send
+        self.client.get_transaction_count.side_effect = lambda *_: self.nonce
+
+    def test_get_balance(self):
+        self.assertEqual(None, self.token.get_balance(self.addr))
+
+        self.balances['gnt'] = '0x'
+        self.assertEqual(None, self.token.get_balance(self.addr))
+
+        self.balances['gntw'] = '0x'
+        self.assertEqual(0, self.token.get_balance(self.addr))
+
+        self.balances['gnt'] = '0xf'
+        self.assertEqual(15, self.token.get_balance(self.addr))
+
+        self.balances['gntw'] = '0xa'
+        self.assertEqual(25, self.token.get_balance(self.addr))
+
+    def test_batches_enough_gntw(self):
+        p1 = mock_payment(1)
+        p2 = mock_payment(2)
+        p3 = mock_payment(3)
+
+        self.balances['gnt'] = '0x0'
+        self.balances['gntw'] = '0xf'
+
+        closure_time = 0
+        tx = self.token.batch_transfer(self.privkey, [p1, p2, p3], closure_time)
+        self.assertEqual(self.nonce, tx.nonce)
+        self.assertEqual(self.token.GNTW_ADDRESS, tx.to)
+        self.assertEqual(0, tx.value)
+        expected_gas = self.token.GAS_BATCH_PAYMENT_BASE + \
+            3 * self.token.GAS_PER_PAYMENT
+        self.assertEqual(expected_gas, tx.startgas)
+        expected_data = abi_encoder(
+            'batchTransfer',
+            [encode_payments([p1, p2, p3]), closure_time])
+        self.assertEqual(expected_data, tx.data)
+
+    def test_batches_gnt_convertion(self):
+        p1 = mock_payment()
+
+        self.balances['gnt'] = '0x10'
+        self.balances['gntw'] = '0x0'
+
+        # Will need to convert GNT to GNTW
+        closure_time = 0
+        tx = self.token.batch_transfer(self.privkey, [p1], closure_time)
+        self.assertEqual(None, tx)
+        # Created personal deposit
+        self.assertTrue(self.pda_create_called)
+        self.pda_create_called = False
+        # Waiting for personal deposit tx to be mined
+        tx = self.token.batch_transfer(self.privkey, [p1], closure_time)
+        self.assertEqual(None, tx)
+        self.assertFalse(self.pda_create_called)
+        self.assertFalse(self.transfer_called)
+        self.assertFalse(self.process_deposit_called)
+        # Personal deposit tx mined, sending and processing deposit
+        self.pda = urandom(32)
+        tx = self.token.batch_transfer(self.privkey, [p1], closure_time)
+        self.assertEqual(None, tx)
+        # 2 transactions to convert GNT to GNTW
+        self.assertEqual(3, self.nonce)
+        self.assertTrue(self.transfer_called)
+        self.assertTrue(self.process_deposit_called)
+
+    def test_get_incomes_from_block(self):
+        block_number = 1
+        receiver_address = '0xbadcode'
+        some_address = '0xdeadbeef'
+
+        self.client.get_logs.return_value = None
+        incomes = self.token.get_incomes_from_block(block_number,
+                                                    receiver_address)
+        self.assertEqual(None, incomes)
+
+        topics = [self.token.TRANSFER_EVENT_ID, None, receiver_address]
+        self.client.get_logs.assert_called_with(
+            block_number,
+            block_number,
+            '0x' + encode_hex(self.token.GNTW_ADDRESS),
+            topics)
+
+        self.client.get_logs.return_value = [{
+            'topics': ['0x0', some_address, receiver_address],
+            'data': '0xf',
+        }]
+        incomes = self.token.get_incomes_from_block(block_number,
+                                                    receiver_address)
+        self.assertEqual(1, len(incomes))
+        self.assertEqual(some_address, incomes[0]['sender'])
+        self.assertEqual(15, incomes[0]['value'])


### PR DESCRIPTION
Same for tests. Also make `PaymentProcessor` take an instance of the token instead of a factory method - other modules will use the same instance.