### PR TITLE
Always add payments to paymentprocessor

### DIFF
--- a/tests/golem/ethereum/test_paymentprocessor_eth.py
+++ b/tests/golem/ethereum/test_paymentprocessor_eth.py
@@ -67,7 +67,7 @@ class TestPaymentProcessorWithDB(testutils.DatabaseFixture):
             payee=payee,
             value=value
         )
-        self.assertTrue(self.payment_processor.add(payment))
+        self.payment_processor.add(payment)
 
         self.payment_processor._awaiting = []
         self.payment_processor.load_from_db()


### PR DESCRIPTION
Currently when adding payments we check for available balance and don't append the payments if we're short on funds. And this way we only re-add the payments on client restart, during the `load_from_db` phase.
Instead we could always add payments to paymentprocessor and only do `batchTransfer` for those we can afford. This way if new funds come in, we will detect that and process pending payments. Resovles #1680
Also `processed_ts` is important to be set during the `add` call, so we can pass this value in `SubtaskResultAccepted` message to the provider.