### PR TITLE
Stop using reward field in SubtaskResultAccepted message

### DIFF
--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -491,7 +491,7 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
                 expected_income.sender_node,
                 self.max_trust)
 
-    def subtask_accepted(self, subtask_id, reward):
+    def subtask_accepted(self, subtask_id):
         logger.debug("Subtask {} result accepted".format(subtask_id))
         self.task_result_sent(subtask_id)
 

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -674,7 +674,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
 
     @history.provider_history
     def _react_to_subtask_result_accepted(self, msg):
-        self.task_server.subtask_accepted(msg.subtask_id, msg.reward)
+        self.task_server.subtask_accepted(msg.subtask_id)
         self.dropped()
 
     @history.provider_history


### PR DESCRIPTION
It's not (and won't be) used