### PR TITLE
Ignore geth errors when updating balances

### DIFF
--- a/tests/golem/transactions/ethereum/test_paymentprocessor.py
+++ b/tests/golem/transactions/ethereum/test_paymentprocessor.py
@@ -663,17 +663,6 @@ class PaymentProcessorFunctionalTest(DatabaseFixture):
         assert self.pp.monitor_progress.called
         assert self.pp.sendout.called
 
-    def test_balance_value(self):
-        now = time.time()
-        dt = self.pp.BALANCE_RESET_TIMEOUT * 2
-        valid_value = 10 * denoms.ether
-
-        assert self.pp._balance_value(valid_value, 0) is valid_value
-        assert self.pp._balance_value(valid_value, now + 10) is valid_value
-        assert self.pp._balance_value(None, 0) == 0
-        assert self.pp._balance_value(None, now - dt) == 0
-        assert self.pp._balance_value(None, now) is None
-
 
 def make_awaiting_payment(value=None, ts=None):
     p = mock.Mock()


### PR DESCRIPTION
I say we just ignore if we failed to refresh the balances from geth. Keep using previously known values do nothing about this, they will get updated eventually.
And the two cases to consider here:
1. We think we have less money then we do - user is able to do less, which is safe, maybe a little bit annoying, but the balance will get updated eventually
2. We think we have more money then we do - user could take advantage of that and submit tasks and whatnot for which they can't pay for. This doesn't really change anything since it was the case before anyway (user has the access to the private key, so they can control the wallet without our knowledge, we need to guard ourselves against that anyway). For better experience of honest users we could inform them that we have troubles retrieving their current balance, so they might either wait or check on 3rd party (eg etherscan) what's their balance.
  
Resolves #1769