### PR TITLE
Throttle the rate of message.SetTaskSession

### DIFF
--- a/golem/core/collections.py
+++ b/golem/core/collections.py
@@ -1,0 +1,13 @@
+from collections import OrderedDict
+
+
+class SizedOrderedDict(OrderedDict):
+
+    def __init__(self, max_len, **kwds):
+        self.__max_len = max_len
+        super().__init__(**kwds)
+
+    def __setitem__(self, key, value):
+        if self.__max_len and len(self) == self.__max_len:
+            self.popitem(last=False)  # FIFO
+        OrderedDict.__setitem__(self, key, value)

--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -235,13 +235,13 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):
         now = time.time()
 
         if now - self.last_peers_request > PEERS_INTERVAL:
-            self.last_peers_request = time.time()
+            self.last_peers_request = now
             self.__sync_free_peers()
             self.__sync_peer_keeper()
             self.__send_get_peers()
 
         if now - self.last_forward_request > FORWARD_INTERVAL:
-            self.last_forward_request = time.time()
+            self.last_forward_request = now
             self._sync_forward_requests()
 
         self.__remove_old_peers()

--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -785,7 +785,7 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):
         distances = sorted(
             (key_distance(key_id, peer.key_id), peer)
             for peer in list(self.peers.values())
-            if peer.key_id != node_info.key
+            if peer.key_id != node_info.key and peer.verified
         )
 
         for _, peer in distances[:FORWARD_NEIGHBORS_COUNT]:

--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -782,8 +782,8 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):
                 super_node_info
             )
             msg_snd = True
-            logger.warning("Forwarding task session request: {} -> {} to {}"
-                           .format(node_info.key, key_id, peer.key_id))
+            logger.debug("Forwarding task session request: {} -> {} to {}"
+                         .format(node_info.key, key_id, peer.key_id))
 
         if msg_snd and node_info.key == self.node.key:
             self.task_server.add_forwarded_session_request(key_id, conn_id)

--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -782,13 +782,14 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):
             return
 
         msg_snd = False
+
+        peers = list(self.peers.values())  # may change during iteration
         distances = sorted(
-            (key_distance(key_id, peer.key_id), peer)
-            for peer in list(self.peers.values())
-            if peer.key_id != node_info.key and peer.verified
+            (p for p in peers if p.key_id != node_info.key and p.verified),
+            key=lambda p: key_distance(key_id, p.key_id)
         )
 
-        for _, peer in distances[:FORWARD_NEIGHBORS_COUNT]:
+        for peer in distances[:FORWARD_NEIGHBORS_COUNT]:
             self.task_server.task_connections_helper.forward_queue_put(
                 peer, key_id, node_info, conn_id, super_node_info
             )

--- a/golem/network/p2p/peerkeeper.py
+++ b/golem/network/p2p/peerkeeper.py
@@ -231,6 +231,10 @@ def node_id_distance(node_info, key_num):
     return int(node_info.key, 16) ^ key_num
 
 
+def key_distance(key, second_key):
+    return int(key, 16) ^ int(second_key, 16)
+
+
 class KBucket(object):
     """
     K-bucket for keeping information about peers from a given distance range

--- a/golem/network/p2p/peersession.py
+++ b/golem/network/p2p/peersession.py
@@ -290,6 +290,8 @@ class PeerSession(BasicSafeSession):
         :param uuid conn_id: connection id for reference
         :param Node|None super_node_info: information about known supernode
         """
+        logger.debug('Forwarding session request: %s -> %s to %s',
+                     node_info.key, key_id, self.key_id)
         self.send(
             message.SetTaskSession(
                 key_id=key_id,

--- a/golem/task/taskconnectionshelper.py
+++ b/golem/task/taskconnectionshelper.py
@@ -17,20 +17,21 @@ class TaskConnectionsHelper(object):
         self.remove_old_interval = REMOVE_OLD_INTERVAL  # How often should be information about old connections cleared
         self.conn_to_start = {}  # information about connection requests with this node
 
-    def is_new_conn_request(self, conn_id, key_id, node_info, super_node_info):
+    def is_new_conn_request(self, key_id, node_info, super_node_info):
         """ Check whether request for start connection with given conn_id has occurred before
         (in a latest remove_old_interval)
-        :param conn_id: connection id
         :param key_id: public key of a node that is asked to start task session with node from node info
         :param Node node_info: node that asks for a task connection to be started with him
         :param Node|None super_node_info: supernode that may help to mediate in a connection
         :return bool: return False if connection with given id is known, True otherwise
         """
-        if conn_id in self.conn_to_set:
+        id_tuple = key_id, node_info.key
+        if id_tuple in self.conn_to_set:
             return False
-        else:
-            self.conn_to_set[conn_id] = (key_id, weakref.ref(node_info), super_node_info, time.time())
-            return True
+
+        self.conn_to_set[id_tuple] = (key_id, weakref.ref(node_info),
+                                      super_node_info, time.time())
+        return True
 
     def want_to_start(self, conn_id, node_info, super_node_info):
         """ Process request to start task session from this node to a node from node_info. If it's a first request
@@ -51,11 +52,11 @@ class TaskConnectionsHelper(object):
             return
         self.last_remove_old = cur_time
         self.conn_to_set = dict([
-            y_z for y_z in list(self.conn_to_set.items())
+            y_z for y_z in self.conn_to_set.items()
             if cur_time - y_z[1][3] < self.remove_old_interval
         ])
         self.conn_to_start = dict([
-            y_z1 for y_z1 in list(self.conn_to_start.items())
+            y_z1 for y_z1 in self.conn_to_start.items()
             if cur_time - y_z1[1][2] < self.remove_old_interval
         ])
 

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -285,16 +285,19 @@ class TestP2PService(testutils.DatabaseFixture):
         def true_method(*args) -> bool:
             return True
 
-        key_id = str(uuid.uuid4())
-        conn_id = str(uuid.uuid4())
-        peer_id = str(uuid.uuid4())
+        def gen_uuid():
+            return str(uuid.uuid4()).replace('-', '')
+
+        key_id = gen_uuid()
+        conn_id = gen_uuid()
+        peer_id = gen_uuid()
 
         node_info = mock.MagicMock()
         node_info.key = key_id
         node_info.is_super_node = true_method
 
         peer = mock.MagicMock()
-        peer.key_id = str(uuid.uuid4())
+        peer.key_id = gen_uuid()
 
         self.service.peers[peer_id] = peer
         self.service.node = node_info

--- a/tests/golem/task/test_taskconnectionhelper.py
+++ b/tests/golem/task/test_taskconnectionhelper.py
@@ -1,5 +1,6 @@
 import unittest
 import time
+import uuid
 
 from mock import MagicMock
 
@@ -7,7 +8,9 @@ from golem.task.taskconnectionshelper import TaskConnectionsHelper
 
 
 class MockNodeInfo(object):
-    pass
+
+    def __init__(self):
+        self.key = str(uuid.uuid4())
 
 
 class TestTaskConnectionsHelper(unittest.TestCase):
@@ -20,20 +23,23 @@ class TestTaskConnectionsHelper(unittest.TestCase):
         nodeinfo1 = MockNodeInfo()
         nodeinfo3 = MockNodeInfo()
         tch = TaskConnectionsHelper()
-        self.assertTrue(tch.is_new_conn_request("abc", "ABC", nodeinfo, "supernodeinfo"))
-        self.assertTrue(tch.is_new_conn_request("def", "ABC", nodeinfo, "supernodeinfo"))
-        self.assertFalse(tch.is_new_conn_request("abc", "ABC", nodeinfo, "supernodeinfo"))
-        self.assertFalse(tch.is_new_conn_request("abc", "DEF", nodeinfo1, "supernodeinfo2"))
-        self.assertFalse(tch.is_new_conn_request("def", "DEF", nodeinfo3, "supernodeinfo3"))
-        data = tch.conn_to_set.get("abc")
+        self.assertTrue(tch.is_new_conn_request("ABC", nodeinfo,
+                                                "supernodeinfo"))
+        self.assertFalse(tch.is_new_conn_request("ABC", nodeinfo,
+                                                 "supernodeinfo"))
+        self.assertTrue(tch.is_new_conn_request("DEF", nodeinfo1,
+                                                "supernodeinfo2"))
+        self.assertTrue(tch.is_new_conn_request("DEF", nodeinfo3,
+                                                "supernodeinfo3"))
+        data = tch.conn_to_set.get(("ABC", nodeinfo.key))
         self.assertEqual(data[0], "ABC")
         self.assertEqual(data[1](), nodeinfo)
         self.assertEqual(data[2], "supernodeinfo")
         self.assertLessEqual(data[3], time.time())
-        data = tch.conn_to_set.get("def")
-        self.assertEqual(data[0], "ABC")
-        self.assertEqual(data[1](), nodeinfo)
-        self.assertEqual(data[2], "supernodeinfo")
+        data = tch.conn_to_set.get(("DEF", nodeinfo1.key))
+        self.assertEqual(data[0], "DEF")
+        self.assertEqual(data[1](), nodeinfo1)
+        self.assertEqual(data[2], "supernodeinfo2")
         self.assertLessEqual(data[3], time.time())
 
     def test_want_to_start(self):
@@ -65,11 +71,11 @@ class TestTaskConnectionsHelper(unittest.TestCase):
         self.assertEqual(len(tch.conn_to_start), 0)
         tch.want_to_start("abc", nodeinfo, "supernodeinfo")
         tch.want_to_start("def", nodeinfo1, "supernodeinfo1")
-        tch.is_new_conn_request("ABC", "ABCK", nodeinfo, "supernodeinfo")
-        tch.is_new_conn_request("DEF", "DEFK", nodeinfo1, "supernodeinfo1")
+        tch.is_new_conn_request("ABCK", nodeinfo, "supernodeinfo")
+        tch.is_new_conn_request("DEFK", nodeinfo1, "supernodeinfo1")
         time.sleep(2)
         tch.want_to_start("ghi", nodeinfo1, "supernodeinfo1")
-        tch.is_new_conn_request("GHI", "GHIK", nodeinfo2, "supernodeinfo2")
+        tch.is_new_conn_request("GHIK", nodeinfo2, "supernodeinfo2")
         self.assertEqual(len(tch.conn_to_start), 3)
         self.assertEqual(len(tch.conn_to_set), 3)
         tch.sync()
@@ -79,7 +85,7 @@ class TestTaskConnectionsHelper(unittest.TestCase):
         self.assertEqual(data[0], nodeinfo1)
         self.assertEqual(data[1], "supernodeinfo1")
         self.assertLessEqual(data[2], time.time())
-        data = tch.conn_to_set["GHI"]
+        data = tch.conn_to_set[("GHIK", nodeinfo2.key)]
         self.assertEqual(data[0], "GHIK")
         self.assertEqual(data[1](), nodeinfo2)
         self.assertEqual(data[2], "supernodeinfo2")

--- a/tests/golem/task/test_taskconnectionhelper.py
+++ b/tests/golem/task/test_taskconnectionhelper.py
@@ -23,24 +23,23 @@ class TestTaskConnectionsHelper(unittest.TestCase):
         nodeinfo1 = MockNodeInfo()
         nodeinfo3 = MockNodeInfo()
         tch = TaskConnectionsHelper()
+
         self.assertTrue(tch.is_new_conn_request("ABC", nodeinfo,
                                                 "supernodeinfo"))
         self.assertFalse(tch.is_new_conn_request("ABC", nodeinfo,
                                                  "supernodeinfo"))
+
+        timestamp = tch.conn_to_set.get(("ABC", nodeinfo.key))
+        self.assertLessEqual(timestamp, time.time())
+
         self.assertTrue(tch.is_new_conn_request("DEF", nodeinfo1,
                                                 "supernodeinfo2"))
+
+        timestamp = tch.conn_to_set.get(("ABC", nodeinfo.key))
+        self.assertLessEqual(timestamp, time.time())
+
         self.assertTrue(tch.is_new_conn_request("DEF", nodeinfo3,
                                                 "supernodeinfo3"))
-        data = tch.conn_to_set.get(("ABC", nodeinfo.key))
-        self.assertEqual(data[0], "ABC")
-        self.assertEqual(data[1](), nodeinfo)
-        self.assertEqual(data[2], "supernodeinfo")
-        self.assertLessEqual(data[3], time.time())
-        data = tch.conn_to_set.get(("DEF", nodeinfo1.key))
-        self.assertEqual(data[0], "DEF")
-        self.assertEqual(data[1](), nodeinfo1)
-        self.assertEqual(data[2], "supernodeinfo2")
-        self.assertLessEqual(data[3], time.time())
 
     def test_want_to_start(self):
         nodeinfo = MockNodeInfo()
@@ -85,11 +84,8 @@ class TestTaskConnectionsHelper(unittest.TestCase):
         self.assertEqual(data[0], nodeinfo1)
         self.assertEqual(data[1], "supernodeinfo1")
         self.assertLessEqual(data[2], time.time())
-        data = tch.conn_to_set[("GHIK", nodeinfo2.key)]
-        self.assertEqual(data[0], "GHIK")
-        self.assertEqual(data[1](), nodeinfo2)
-        self.assertEqual(data[2], "supernodeinfo2")
-        self.assertLessEqual(data[3], time.time())
+        timestamp = tch.conn_to_set[("GHIK", nodeinfo2.key)]
+        self.assertLessEqual(timestamp, time.time())
         time.sleep(1.5)
         tch.sync()
         self.assertEqual(len(tch.conn_to_start), 0)


### PR DESCRIPTION
Handling and forwarding excessive amounts of `message.SetTaskSession` may lock the event loop and lead to undesired delays in message processing, e.g. WebSocket ping timeouts.

- limits the number of recipients to 3 neighbors nearest to the target node
- forwarded session requests are queued and sent in batches of 12 every 2 seconds
  