### PR TITLE
Fix path on windows for lux verification

### DIFF
--- a/apps/lux/task/luxrendertask.py
+++ b/apps/lux/task/luxrendertask.py
@@ -2,6 +2,7 @@ import glob
 import logging
 import math
 import os
+from pathlib import Path
 import random
 import shutil
 from collections import OrderedDict
@@ -449,7 +450,8 @@ class LuxTask(renderingtask.RenderingTask):
         with open(script_file) as f:
             src_code = f.read()
 
-        extra_data = {'output_flm': self.output_file, 'flm_files': files}
+        extra_data = {'output_flm': Path(self.output_file).as_posix(),
+                      'flm_files': files}
         ctd = self._new_compute_task_def(hash=self.header.task_id,
                                          extra_data=extra_data,
                                          perf_index=0)

--- a/tests/apps/lux/task/test_luxrendertask.py
+++ b/tests/apps/lux/task/test_luxrendertask.py
@@ -116,7 +116,8 @@ class TestLuxRenderTask(TempDirFixture, LogTestCase, PEP8MixIn):
         ctd = luxtask.query_extra_data_for_final_flm()
         self.assertIsInstance(ctd, ComputeTaskDef)
         assert ctd['src_code'] is not None
-        assert ctd['extra_data']['output_flm'] == luxtask.output_file
+        assert ctd['extra_data']['output_flm'] == \
+               Path(luxtask.output_file).as_posix()
         assert set(ctd['extra_data']['flm_files']) == {"xxyyzzfile", "abcdfile"}
 
     def test_remove_from_preview(self):


### PR DESCRIPTION
Previously if requestor was using Windows then output_file was in windows path format, eg. "C:\\Users\\bla\\result", but the script that was cutting this path to basename was in Docker and expected posix path. It was not able to parse path correctly so path like "/golem/output/C:\\Users\\bla\\result.flm" was generated instead of "/golem/output/result.flm"