### PR TITLE
rinkeby.golem.network doesn't provide node list

### DIFF
--- a/golem/ethereum/node.py
+++ b/golem/ethereum/node.py
@@ -10,7 +10,6 @@ import threading
 import time
 from distutils.version import StrictVersion
 
-import requests
 from web3 import Web3, IPCProvider, HTTPProvider
 
 from golem.core.common import is_windows, DEVNULL, SUBPROCESS_STARTUP_INFO
@@ -22,8 +21,7 @@ from golem.utils import tee_target
 log = logging.getLogger('golem.ethereum')
 
 
-NODE_LIST_URL = 'https://rinkeby.golem.network'
-FALLBACK_NODE_LIST = [
+NODE_LIST = [
     'http://188.165.227.180:55555',
     'http://94.23.17.170:55555',
     'http://94.23.57.58:55555',
@@ -32,12 +30,7 @@ FALLBACK_NODE_LIST = [
 
 def get_public_nodes():
     """Returns public geth RPC addresses"""
-    try:
-        return requests.get(NODE_LIST_URL).json()
-    except Exception as exc:
-        log.error("Error downloading node list: %s", exc)
-
-    addr_list = FALLBACK_NODE_LIST[:]
+    addr_list = NODE_LIST[:]
     random.shuffle(addr_list)
     return addr_list
 

--- a/tests/golem/ethereum/test_ethereum_node.py
+++ b/tests/golem/ethereum/test_ethereum_node.py
@@ -8,7 +8,7 @@ from os import path
 from mock import patch, Mock
 
 from golem.ethereum.node import log, NodeProcess, \
-    FALLBACK_NODE_LIST, get_public_nodes
+    NODE_LIST, get_public_nodes
 from golem.testutils import PEP8MixIn, TempDirFixture
 from golem.tools.assertlogs import LogTestCase
 from golem.utils import encode_hex
@@ -79,21 +79,12 @@ class EthereumNodeTest(TempDirFixture, LogTestCase, PEP8MixIn):
 
 class TestPublicNodeList(unittest.TestCase):
 
-    def test_fetched_public_nodes(self):
-        class Wrapper:
-            @staticmethod
-            def json():
-                return FALLBACK_NODE_LIST
-
-        with patch('requests.get', lambda *_: Wrapper):
-            assert get_public_nodes() is FALLBACK_NODE_LIST
-
     def test_builtin_public_nodes(self):
         with patch('requests.get', lambda *_: None):
             public_nodes = get_public_nodes()
 
-        assert public_nodes is not FALLBACK_NODE_LIST
-        assert all(n in FALLBACK_NODE_LIST for n in public_nodes)
+        assert public_nodes is not NODE_LIST
+        assert all(n in NODE_LIST for n in public_nodes)
 
 
 class EthereumClientNodeTest(TempDirFixture):


### PR DESCRIPTION
Not trying to make empty requests may improve our situation with geth running out of file descriptors.