### PR TITLE
IncomesKeeper shouldn't depend on PaymentProcessor

### DIFF
--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -58,12 +58,6 @@ class PaymentProcessor(LoopingCallService):
         self.load_from_db()
         super(PaymentProcessor, self).__init__(13)
 
-    def wait_until_synchronized(self) -> bool:
-        return self.__client.wait_until_synchronized()
-
-    def is_synchronized(self) -> bool:
-        return self.__client.is_synchronized()
-
     def eth_address(self, zpad=True):
         raw = keys.privtoaddr(self.__privkey)
         # TODO: Hack RPC client to allow using raw address.
@@ -328,20 +322,6 @@ class PaymentProcessor(LoopingCallService):
             return False
         return True
 
-    def get_incomes_from_block(self, block, address):
-        return self.__token.get_incomes_from_block(block, address)
-
-    def get_logs(self,
-                 from_block=None,
-                 to_block=None,
-                 address=None,
-                 topics=None):
-
-        return self.__client.get_logs(from_block=from_block,
-                                      to_block=to_block,
-                                      address=address,
-                                      topics=topics)
-
     def _run(self):
         if self._waiting_for_faucet:
             return
@@ -349,7 +329,7 @@ class PaymentProcessor(LoopingCallService):
         self._waiting_for_faucet = True
 
         try:
-            if self.is_synchronized() and \
+            if self.__token.is_synchronized() and \
                     self.get_ether_from_faucet() and \
                     self.get_gnt_from_faucet():
                 self.monitor_progress()
@@ -359,4 +339,3 @@ class PaymentProcessor(LoopingCallService):
 
     def stop(self):
         super(PaymentProcessor, self).stop()
-        self.__client._kill_node()

--- a/golem/ethereum/token.py
+++ b/golem/ethereum/token.py
@@ -103,6 +103,12 @@ class AbstractToken(object, metaclass=abc.ABCMeta):
         data = token_abi.encode_function_call('create', [])
         self._send_transaction(privkey, token_address, data, 90000)
 
+    def wait_until_synchronized(self) -> bool:
+        return self._client.wait_until_synchronized()
+
+    def is_synchronized(self) -> bool:
+        return self._client.is_synchronized()
+
     @abc.abstractmethod
     def get_balance(self, addr: str) -> int:
         pass

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -1,12 +1,10 @@
 import logging
-from time import sleep
 
 from ethereum.utils import privtoaddr
 
 from golem.ethereum import Client
 from golem.ethereum.paymentprocessor import PaymentProcessor
 from golem.ethereum.token import GNTWToken
-from golem.report import report_calls, Component
 from golem.transactions.ethereum.ethereumpaymentskeeper \
     import EthereumAddress
 from golem.transactions.ethereum.ethereumincomeskeeper \
@@ -40,31 +38,34 @@ class EthereumTransactionSystem(TransactionSystem):
 
         log.info("Node Ethereum address: " + self.get_payment_address())
 
-        client = Client(datadir, start_geth, start_port, address)
-        token = GNTWToken(client)
-        payment_processor = PaymentProcessor(
-            client=client,
+        self._client = Client(datadir, start_geth, start_port, address)
+        token = GNTWToken(self._client)
+        self.payment_processor = PaymentProcessor(
+            client=self._client,
             privkey=node_priv_key,
             token=token,
             faucet=True
         )
 
-        super(EthereumTransactionSystem, self).__init__(
+        super().__init__(
             incomes_keeper=EthereumIncomesKeeper(
-                payment_processor)
+                self.payment_processor.eth_address(),
+                token)
         )
 
-        self.incomes_keeper.start()
+        self.payment_processor.start()
 
     def stop(self):
-        self.incomes_keeper.stop()
+        if self.payment_processor.running:
+            self.payment_processor.stop()
+        self._client._kill_node()
 
     def add_payment_info(self, *args, **kwargs):
         payment = super(EthereumTransactionSystem, self).add_payment_info(
             *args,
             **kwargs
         )
-        self.incomes_keeper.processor.add(payment)
+        self.payment_processor.add(payment)
         return payment
 
     def get_payment_address(self):
@@ -72,21 +73,9 @@ class EthereumTransactionSystem(TransactionSystem):
         return self.__eth_addr.get_str_addr()
 
     def get_balance(self):
-        if not self.incomes_keeper.processor.balance_known():
+        if not self.payment_processor.balance_known():
             return None, None, None
-        gnt = self.incomes_keeper.processor.gnt_balance()
-        av_gnt = self.incomes_keeper.processor._gnt_available()
-        eth = self.incomes_keeper.processor.eth_balance()
+        gnt = self.payment_processor.gnt_balance()
+        av_gnt = self.payment_processor._gnt_available()
+        eth = self.payment_processor.eth_balance()
         return gnt, av_gnt, eth
-
-    @report_calls(Component.ethereum, 'sync')
-    def sync(self):
-        syncing = True
-        while syncing:
-            try:
-                syncing = self.incomes_keeper.processor.is_synchronized()
-            except Exception as e:
-                log.error("IPC error: {}".format(e))
-                syncing = False
-            else:
-                sleep(0.5)

--- a/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
+++ b/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
@@ -35,44 +35,6 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
                                      "Invalid Ethereum address constructed"):
             EthereumTransactionSystem(self.tempdir, PRIV_KEY)
 
-    @patch('golem.ethereum.paymentprocessor.PaymentProcessor.start')
-    @patch('golem.transactions.ethereum.ethereumtransactionsystem.sleep')
-    def test_sync(self, sleep, *_):
-        switch_value = [True]
-
-        def false():
-            return False
-
-        def switch(*_):
-            switch_value[0] = not switch_value[0]
-            return not switch_value[0]
-
-        def error(*_):
-            raise Exception
-
-        e = EthereumTransactionSystem(self.tempdir, PRIV_KEY)
-
-        sleep.call_count = 0
-        with patch(
-                'golem.ethereum.paymentprocessor.PaymentProcessor.is_synchronized',
-                side_effect=false):
-            e.sync()
-            assert sleep.call_count == 1
-
-        sleep.call_count = 0
-        with patch(
-                'golem.ethereum.paymentprocessor.PaymentProcessor.is_synchronized',
-                side_effect=switch):
-            e.sync()
-            assert sleep.call_count == 2
-
-        sleep.call_count = 0
-        with patch(
-                'golem.ethereum.paymentprocessor.PaymentProcessor.is_synchronized',
-                side_effect=error):
-            e.sync()
-            assert sleep.call_count == 0
-
     def test_get_balance(self):
         e = EthereumTransactionSystem(self.tempdir, PRIV_KEY)
         assert e.get_balance() == (None, None, None)
@@ -96,21 +58,15 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
 
             mock_is_service_running.return_value = False
             e = EthereumTransactionSystem(self.tempdir, PRIV_KEY)
-            assert e.incomes_keeper.processor. \
-                _loopingCall.start.called
-            assert e.incomes_keeper.processor \
-                ._PaymentProcessor__client.node.start.called
+            assert e.payment_processor._loopingCall.start.called
+            assert e._client.node.start.called
 
             mock_is_service_running.return_value = False
             e.stop()
-            assert not e.incomes_keeper.processor. \
-                _PaymentProcessor__client.node.stop.called
-            assert not e.incomes_keeper.processor. \
-                _loopingCall.stop.called
+            assert e._client.node is None
+            assert not e.payment_processor._loopingCall.stop.called
 
             mock_is_service_running.return_value = True
             e.stop()
-            assert e.incomes_keeper.processor. \
-                _PaymentProcessor__client.node is None
-            assert e.incomes_keeper.processor. \
-                _loopingCall.stop.called
+            assert e._client.node is None
+            assert e.payment_processor._loopingCall.stop.called

--- a/tests/golem/transactions/ethereum/test_paymentprocessor.py
+++ b/tests/golem/transactions/ethereum/test_paymentprocessor.py
@@ -732,14 +732,3 @@ class InteractionWithTokenTest(DatabaseFixture):
                 [p5],
                 10)
             self.token.batch_transfer.reset_mock()
-
-
-    def test_get_incomes_from_block(self):
-        block_number = 1
-        receiver_address = '0xbadcode'
-        some_address = '0xdeadbeef'
-
-        expected_incomes = [{'sender': some_address, 'value': 1}]
-        self.token.get_incomes_from_block.return_value = expected_incomes
-        incomes = self.pp.get_incomes_from_block(block_number, receiver_address)
-        self.assertEqual(expected_incomes, incomes)


### PR DESCRIPTION
Because it just doesn't make sense to make outgoing payments through a class that is responsible for incomes.
IncomesKeeper only needs an access to the token, not the whole PaymentProcessor.