### PR TITLE
Pass payment timestamp in SubtaskResultAccepted message

### DIFF
--- a/golem/model.py
+++ b/golem/model.py
@@ -29,7 +29,7 @@ db = SqliteDatabase(None, threadlocals=True,
 
 class Database:
     # Database user schema version, bump to recreate the database
-    SCHEMA_VERSION = 7
+    SCHEMA_VERSION = 8
 
     def __init__(self, datadir):
         # TODO: Global database is bad idea. Check peewee for other solutions.
@@ -247,6 +247,7 @@ class ExpectedIncome(BaseModel):
     task = CharField()
     subtask = CharField()
     value = BigIntegerField()
+    accepted_ts = IntegerField(null=True)
 
     def __repr__(self):
         return "<ExpectedIncome: {!r} v:{:.3f}>"\

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -299,8 +299,10 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
             self._reject_subtask_result(subtask_id)
             return
 
-        self.task_server.accept_result(subtask_id, self.result_owner)
-        self.send(message.SubtaskResultAccepted(subtask_id=subtask_id))
+        payment = self.task_server.accept_result(subtask_id, self.result_owner)
+        self.send(message.SubtaskResultAccepted(
+            subtask_id=subtask_id,
+            payment_ts=payment.processed_ts))
 
     @log_error()
     def inform_worker_about_payment(self, payment):
@@ -655,7 +657,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
 
     @history.provider_history
     def _react_to_subtask_result_accepted(self, msg):
-        self.task_server.subtask_accepted(msg.subtask_id)
+        self.task_server.subtask_accepted(msg.subtask_id, msg.payment_ts)
         self.dropped()
 
     @history.provider_history

--- a/golem/transactions/incomeskeeper.py
+++ b/golem/transactions/incomeskeeper.py
@@ -110,6 +110,18 @@ class IncomesKeeper(object):
             value=value
         )
 
+    def update_awaiting(self, subtask_id, accepted_ts):
+        try:
+            # FIXME: query by (sender_id, subtask_id)
+            income = ExpectedIncome.get(subtask=subtask_id)
+        except ExpectedIncome.DoesNotExist:
+            logger.error(
+                "ExpectedIncome.DoesNotExist subtask_id: %r",
+                subtask_id)
+            return
+        income.accepted_ts = accepted_ts
+        income.save()
+
     def get_list_of_all_incomes(self):
         # TODO: pagination
         union = ExpectedIncome.select(


### PR DESCRIPTION
When `batchTransfer` happens it should cover all incomes where `accepted_ts <= closure_time`, thus we should store accepted_ts in ExpectedIncome.