### PR TITLE
ConcentService handle delay as timedelta

### DIFF
--- a/golem/network/concent/client.py
+++ b/golem/network/concent/client.py
@@ -186,7 +186,7 @@ class ConcentClientService(threading.Thread):
             constants.DEFAULT_MSG_LIFETIME
         )
         if delay is None:
-            delay = constants.MSG_DELAYS.get(msg_cls, 0)
+            delay = constants.MSG_DELAYS[msg_cls]
 
         req = ConcentRequest(key, msg, lifetime=lifetime)
         req.status = ConcentRequestStatus.Waiting

--- a/golem/network/concent/constants.py
+++ b/golem/network/concent/constants.py
@@ -1,3 +1,4 @@
+import collections
 import datetime
 
 from golem_messages import message
@@ -16,15 +17,17 @@ mtd = datetime.timedelta(minutes=0, seconds=10)
 mat = datetime.timedelta(minutes=2, seconds=15)
 
 
-# FIXME: value
 DEFAULT_MSG_LIFETIME = (3 * mmtt + 3 * mat)
 
 # Time to wait before sending a message
-MSG_DELAYS = {  # FIXME: values
-    message.ForceReportComputedTask: (2 * mmtt + mat)
-}
+MSG_DELAYS = collections.defaultdict(
+    lambda: datetime.timedelta(0),
+    {
+        message.ForceReportComputedTask: (2 * mmtt + mat)
+    },
+)
 
 # A valid period of time for sending a message
-MSG_LIFETIMES = {  # FIXME: values
+MSG_LIFETIMES = {
 
 }

--- a/tests/golem/network/concent/test_concent_client.py
+++ b/tests/golem/network/concent/test_concent_client.py
@@ -132,7 +132,7 @@ class TestConcentClientService(TestCase):
         self.concent_service.submit(
             'key',
             self.msg,
-            delay=60
+            delay=datetime.timedelta(seconds=60)
         )
 
         assert 'key' in self.concent_service._delayed
@@ -246,3 +246,22 @@ class TestConcentRequestStatus(TestCase):
         assert status.completed()
         assert not status.success()
         assert status.error()
+
+
+class ConcentCallLaterTestCase(TestCase):
+    def setUp(self):
+        node_keys = golem_messages.cryptography.ECCx(None)
+        self.concent_service = client.ConcentClientService(
+            signing_key=node_keys.raw_privkey,
+            public_key=node_keys.raw_pubkey,
+            enabled=True,
+        )
+        self.msg = message.ForceReportComputedTask()
+
+    def test_submit(self):
+        # Shouldn't fail
+        self.concent_service.submit(
+            'key',
+            self.msg,
+            datetime.timedelta(seconds=1)
+        )


### PR DESCRIPTION
Fixes `TypeError: unorderable types: datetime.timedelta() >= int()`