### PR TITLE
Show full traceback when [Task|Docker]Thread fails

### DIFF
--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -1,5 +1,6 @@
 import logging
 import os
+import traceback
 
 import requests
 from golem.docker.job import DockerJob
@@ -103,8 +104,9 @@ class DockerTaskThread(TaskThread):
                            format(self.time_to_compute))
             else:
                 self._fail(str(exc))
-        except Exception as exc:
-            self._fail(str(exc))
+        except Exception:
+            tb = ''.join(traceback.format_exc(limit=None))
+            self._fail(tb)
         finally:
             self._cleanup()
 

--- a/golem/task/taskthread.py
+++ b/golem/task/taskthread.py
@@ -1,6 +1,7 @@
 import logging
 import threading
 import time
+import traceback
 from threading import Lock, Thread
 
 import copy
@@ -96,7 +97,7 @@ class TaskThread(Thread):
         self.end_comp()
 
         logger.error("Task computing error: %s", exception)
-        logger.error("%r", exception.__traceback__)
+        logger.error("%r", traceback.format_tb(exception.__traceback__))
 
         self.error = True
         self.error_msg = str(exception)

--- a/golem/task/taskthread.py
+++ b/golem/task/taskthread.py
@@ -3,6 +3,7 @@ import logging
 import os
 import threading
 import time
+import traceback
 from threading import Thread, Lock
 
 
@@ -66,9 +67,10 @@ class TaskThread(Thread):
         logger.info("RUNNING ")
         try:
             self.__do_work()
-        except Exception as exc:
+        except Exception:
             logger.exception("__do_work failed")
-            self._fail(str(exc))
+            tb = ''.join(traceback.format_exc(limit=None))
+            self._fail(tb)
         else:
             self.task_computer.task_computed(self)
 

--- a/tests/golem/docker/test_docker_task_thread.py
+++ b/tests/golem/docker/test_docker_task_thread.py
@@ -1,15 +1,14 @@
 import time
 from threading import Thread
-
-from mock import Mock
+from unittest import TestCase
+from unittest.mock import Mock
 
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.docker.image import DockerImage
-from golem.docker.task_thread import DockerTaskThread
+from golem.docker.task_thread import DockerTaskThread, EXIT_CODE_MESSAGE
 from golem.task.taskcomputer import TaskComputer
 from golem.tools.ci import ci_skip
 from golem.tools.testwithdatabase import TestWithDatabase
-
 from .test_docker_job import TestDockerJob
 
 
@@ -68,3 +67,16 @@ class TestDockerTaskThread(TestDockerJob, TestWithDatabase):
                 ct = task_computer.counting_thread
 
             time.sleep(1)
+
+
+class TestExitCodeMessage(TestCase):
+
+    def test_exit_code_message(self):
+        exit_code = 1
+        message = DockerTaskThread._exit_code_message(exit_code)
+        assert message == EXIT_CODE_MESSAGE.format(exit_code)
+
+        exit_code = 137
+        message = DockerTaskThread._exit_code_message(exit_code)
+        assert message != EXIT_CODE_MESSAGE.format(exit_code)
+        assert "out-of-memory" in message

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -347,20 +347,20 @@ class TestTaskThread(DatabaseFixture):
         self.assertTrue(tc.counting_task)
 
     def test_fail(self):
-        first_error_msg = "First error message"
-        second_error_msg = "Second error message"
+        first_error = Exception("First error message")
+        second_error = Exception("Second error message")
 
         tt = self._new_task_thread(mock.Mock())
-        tt._fail(first_error_msg)
+        tt._fail(first_error)
 
         assert tt.error is True
         assert tt.done is True
-        assert tt.error_msg == first_error_msg
+        assert tt.error_msg == str(first_error)
 
-        tt._fail(second_error_msg)
+        tt._fail(second_error)
         assert tt.error is True
         assert tt.done is True
-        assert tt.error_msg == first_error_msg
+        assert tt.error_msg == str(first_error)
 
     def _new_task_thread(self, task_computer):
         files = self.additional_dir_content([0, [1], [1], [1], [1]])


### PR DESCRIPTION
Greatly improves debugging task thread fails.