### PR TITLE
All requirements in .txt files

### DIFF
--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,1 +1,1 @@
-git+https://github.com/pyinstaller/pyinstaller.git
+pyinstaller

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -1,0 +1,1 @@
+git+https://github.com/pyinstaller/pyinstaller.git

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,3 +5,5 @@ pytest-cov
 codecov
 flake8
 factory-boy==2.9.2
+# Required by buildbots to run unit test
+pyasn1==0.2.3

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -3,3 +3,5 @@ pywin32
 vboxapi
 pyvbox
 pyreadline
+# Fixed on buildbots, TODO: test and make issue?
+pyethash==0.1.23

--- a/requirements-winpackager.txt
+++ b/requirements-winpackager.txt
@@ -1,9 +1,0 @@
-# This file is used in windows packaging procedure: https://github.com/golemfactory/golem/wiki/Installation-Packaging-Win
-vboxapi
-git+https://github.com/pyinstaller/pyinstaller.git
-
-https://github.com/golemfactory/golem/wiki/wheels/OpenEXR-1.3.0-cp35-cp35m-win_amd64.whl
-https://github.com/golemfactory/golem/wiki/wheels/pyethash-0.1.23-cp35-cp35m-win_amd64.whl
-https://github.com/golemfactory/golem/wiki/wheels/secp256k1-0.13.2-cp35-cp35m-win_amd64.whl
-https://github.com/golemfactory/golem/wiki/wheels/devp2p-0.8.0-py2.py3-none-any.whl
--r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,8 +36,6 @@ pydispatcher
 Crypto
 scrypt
 packaging
-# GitPython < 2.1.8 has problems with latest git version
-GitPython>=2.1.8
 semantic_version
 pyOpenSSL==17.1.0
 requests==2.13.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,6 +36,8 @@ pydispatcher
 Crypto
 scrypt
 packaging
+# GitPython < 2.1.8 has problems with latest git version
+GitPython>=2.1.8
 semantic_version
 pyOpenSSL==17.1.0
 requests==2.13.0


### PR DESCRIPTION
Put all requirements in `requirements.txt` files.
- No more manual requirements installed on buildbot
- Removed `-winpackager`
- Added more generic `-build`

Requires buildbot to be updated when this PR hits develop.