### PR TITLE
Make Client depends on web3 and manage NodeProcess explicitly

### DIFF
--- a/golem/ethereum/client.py
+++ b/golem/ethereum/client.py
@@ -5,7 +5,6 @@ import rlp
 from ethereum.utils import zpad
 
 from golem.core.common import get_timestamp_utc
-from .node import NodeProcess
 
 log = logging.getLogger('golem.ethereum')
 
@@ -13,32 +12,15 @@ log = logging.getLogger('golem.ethereum')
 class Client(object):
     """ RPC interface client for Ethereum node."""
 
-    node = None
-
     SYNC_CHECK_INTERVAL = 10
 
-    def __init__(self, datadir, start_node=False, start_port=None,
-                 address=None):
-        if not Client.node:
-            Client.node = NodeProcess(datadir, address, start_node)
-        if not Client.node.is_running():
-            Client.node.start(start_port)
-        self.web3 = Client.node.web3
+    def __init__(self, web3):
+        self.web3 = web3
         # Set fake default account.
         self.web3.eth.defaultAccount = '\xff' * 20
         self._last_sync_check = time.time()
         self._sync = False
         self._temp_sync = False
-
-    @staticmethod
-    def _kill_node():
-        """
-        Stop node if is running
-        """
-        # FIXME: Keeping the node as a static object might not be the best.
-        if Client.node:
-            Client.node.stop()
-            Client.node = None
 
     def get_peer_count(self):
         """

--- a/golem/ethereum/smartcontractinterface.py
+++ b/golem/ethereum/smartcontractinterface.py
@@ -5,8 +5,8 @@ from .token import GNTWToken
 
 
 class SmartContractInterface(object):
-    def __init__(self, datadir, start_geth, start_port, address):
-        self._geth_client = Client(datadir, start_geth, start_port, address)
+    def __init__(self, web3):
+        self._geth_client = Client(web3)
         self._token = GNTWToken(self._geth_client)
         self.GAS_PRICE = self._token.GAS_PRICE
         self.GAS_PER_PAYMENT = self._token.GAS_PER_PAYMENT
@@ -44,9 +44,6 @@ class SmartContractInterface(object):
 
     def request_gnt_from_faucet(self, privkey: bytes) -> None:
         self._token.request_from_faucet(privkey)
-
-    def stop(self) -> None:
-        self._geth_client._kill_node()
 
     def wait_until_synchronized(self) -> bool:
         return self._geth_client.wait_until_synchronized()

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -2,6 +2,7 @@ import logging
 
 from ethereum.utils import privtoaddr
 
+from golem.ethereum.node import NodeProcess
 from golem.ethereum.smartcontractinterface import SmartContractInterface
 from golem.ethereum.paymentprocessor import PaymentProcessor
 from golem.transactions.ethereum.ethereumpaymentskeeper \
@@ -37,11 +38,9 @@ class EthereumTransactionSystem(TransactionSystem):
 
         log.info("Node Ethereum address: " + self.get_payment_address())
 
-        self._sci = SmartContractInterface(
-            datadir,
-            start_geth,
-            start_port,
-            address)
+        self._node = NodeProcess(datadir, start_geth, address)
+        self._node.start(start_port)
+        self._sci = SmartContractInterface(self._node.web3)
         self.payment_processor = PaymentProcessor(
             privkey=node_priv_key,
             sci=self._sci,
@@ -59,7 +58,7 @@ class EthereumTransactionSystem(TransactionSystem):
     def stop(self):
         if self.payment_processor.running:
             self.payment_processor.stop()
-        self._sci.stop()
+        self._node.stop()
 
     def add_payment_info(self, *args, **kwargs):
         payment = super(EthereumTransactionSystem, self).add_payment_info(

--- a/tests/golem/ethereum/test_ethereum_client.py
+++ b/tests/golem/ethereum/test_ethereum_client.py
@@ -1,105 +1,22 @@
-import logging
 import time
 from unittest import mock
 
-from ethereum.transactions import Transaction
-from ethereum.utils import zpad
-
 from golem.ethereum import Client
 from golem.testutils import TempDirFixture
-from golem.utils import encode_hex
 
 SYNC_TEST_INTERVAL = 0.01
-
-
-class EthereumClientNodeTest(TempDirFixture):
-    def setUp(self):
-        super().setUp()
-        # Show information about Ethereum node starting and terminating.
-        logging.basicConfig(level=logging.INFO)
-        self.client = Client(self.tempdir, start_node=True)
-
-    def tearDown(self):
-        self.client._kill_node()
-        super().tearDown()
-
-    def test_client(self):
-        client = self.client
-        p = client.get_peer_count()
-        assert type(p) is int
-        s = client.is_syncing()
-        assert type(s) is bool
-        addr = b'FakeEthereumAddress!'
-        assert len(addr) == 20
-        hex_addr = '0x' + encode_hex(addr)
-        c = client.get_transaction_count(hex_addr)
-        assert type(c) is int
-        assert c == 0
-        b = client.get_balance(hex_addr)
-        assert b == 0
-
-        eth = client.web3.eth
-        with mock.patch.object(eth, 'getBalance', side_effect=ValueError):
-            b = client.get_balance(hex_addr)
-        assert b is None
-
-    def test_send_raw_transaction(self):
-        client = self.client
-        with self.assertRaises(ValueError):
-            client.send("fake data")
-        client.node.stop()
-
-    def test_send_transaction(self):
-        client = self.client
-        addr = b'\xff' * 20
-        priv = b'\xee' * 32
-        tx = Transaction(1, 20 * 10**9, 21000, to=addr, value=0, data=b'')
-        tx.sign(priv)
-        with self.assertRaisesRegex(ValueError, "[Ii]nsufficient funds"):
-            client.send(tx)
-
-    def test_start_terminate(self):
-        client = self.client
-        assert client.node.is_running()
-        client.node.stop()
-        assert not client.node.is_running()
-
-    def test_get_logs(self):
-        addr = encode_hex(zpad(b'deadbeef', 32))
-        log_id = encode_hex(zpad(b'beefbeef', 32))
-        client = self.client
-        logs = client.get_logs(from_block='latest', to_block='latest',
-                               topics=[log_id, addr])
-        assert logs == []
-
-    def test_filters(self):
-        """ Test creating filter and getting logs """
-        client = self.client
-        filter_id = client.new_filter()
-        assert type(filter_id) is str
-        # Filter id is hex encoded 256-bit integer.
-        assert filter_id.startswith('0x')
-        number = int(filter_id, 16)
-        assert 0 < number < 2**256
-
-        entries = client.get_filter_changes(filter_id)
-        assert not entries
 
 
 class EthereumClientTest(TempDirFixture):
     def setUp(self):
         super().setUp()
-        self.client = Client(self.tempdir, start_node=False)
-        self.client.web3 = mock.Mock()
-
-    def tearDown(self):
-        self.client._kill_node()
-        super().tearDown()
+        self.web3 = mock.Mock()
+        self.client = Client(self.web3)
 
     def check_synchronized(self):
         assert not self.client.is_synchronized()
-        self.client.web3.net.peerCount = 1
-        self.client.web3.eth.syncing = {
+        self.web3.net.peerCount = 1
+        self.web3.eth.syncing = {
             "currentBlock": 1,
             "highestBlock": 1,
         }
@@ -116,8 +33,8 @@ class EthereumClientTest(TempDirFixture):
 
     def test_wait_until_synchronized(self):
         Client.SYNC_CHECK_INTERVAL = SYNC_TEST_INTERVAL
-        self.client.web3.net.peerCount = 1
-        self.client.web3.eth.syncing = {
+        self.web3.net.peerCount = 1
+        self.web3.eth.syncing = {
             "currentBlock": 1,
             "highestBlock": 1,
         }
@@ -136,21 +53,21 @@ class EthereumClientTest(TempDirFixture):
                         (65, syncing_status),
                         (65, False))
 
-        self.client.web3.eth.syncing = {
+        self.web3.eth.syncing = {
             'currentBlock': 123,
             'highestBlock': 1234,
         }
-        self.client.web3.eth.getBlock.return_value = {"timestamp": time.time()}
+        self.web3.eth.getBlock.return_value = {"timestamp": time.time()}
 
         for c in combinations:
             print("Subtest {}".format(c))
             # Allow reseting the status.
             time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
-            self.client.web3.net.peerCount = 0
+            self.web3.net.peerCount = 0
             self.assertFalse(self.client.is_synchronized())
             time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
-            self.client.web3.net.peerCount = c[0]
-            self.client.web3.eth.syncing = c[1]
+            self.web3.net.peerCount = c[0]
+            self.web3.eth.syncing = c[1]
             # First time is always no.a
             self.assertFalse(self.client.is_synchronized())
             time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
@@ -171,35 +88,35 @@ class EthereumClientTest(TempDirFixture):
             'highestBlock': '0x1',
         }
 
-        self.client.web3.net.peerCount = 1
-        self.client.web3.eth.syncing = synced_status
+        self.web3.net.peerCount = 1
+        self.web3.eth.syncing = synced_status
         self.assertFalse(self.client.is_synchronized())
         time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
-        self.client.web3.net.peerCount = 1
-        self.client.web3.eth.syncing = syncing_status
+        self.web3.net.peerCount = 1
+        self.web3.eth.syncing = syncing_status
         self.assertFalse(self.client.is_synchronized())
         time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
         self.assertFalse(self.client.is_synchronized())
 
-        self.client.web3.net.peerCount = 1
-        self.client.web3.eth.syncing = synced_status
+        self.web3.net.peerCount = 1
+        self.web3.eth.syncing = synced_status
         self.assertFalse(self.client.is_synchronized())
         time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
         self.assertFalse(self.client.is_synchronized())
         time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
         self.assertTrue(self.client.is_synchronized())
         time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
-        self.client.web3.net.peerCount = 0
-        self.client.web3.eth.syncing = synced_status
+        self.web3.net.peerCount = 0
+        self.web3.eth.syncing = synced_status
         self.assertFalse(self.client.is_synchronized())
         time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
-        self.client.web3.net.peerCount = 2
-        self.client.web3.eth.syncing = synced_status
+        self.web3.net.peerCount = 2
+        self.web3.eth.syncing = synced_status
         self.assertFalse(self.client.is_synchronized())
         time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
         self.assertTrue(self.client.is_synchronized())
         time.sleep(1.5 * Client.SYNC_CHECK_INTERVAL)
-        self.client.web3.net.peerCount = 2
-        self.client.web3.eth.syncing = syncing_status
+        self.web3.net.peerCount = 2
+        self.web3.eth.syncing = syncing_status
         self.assertFalse(self.client.is_synchronized())
         Client.SYNC_CHECK_INTERVAL = tmp

--- a/tests/golem/ethereum/test_ethereum_node.py
+++ b/tests/golem/ethereum/test_ethereum_node.py
@@ -1,18 +1,18 @@
+import logging
 import unittest
 from distutils.version import StrictVersion
+from ethereum.transactions import Transaction
+from ethereum.utils import zpad
 from os import path
 
 from mock import patch, Mock
 
+from golem.ethereum import Client
 from golem.ethereum.node import log, NodeProcess, \
     FALLBACK_NODE_LIST, get_public_nodes
 from golem.testutils import PEP8MixIn, TempDirFixture
 from golem.tools.assertlogs import LogTestCase
-
-
-class MockPopen(Mock):
-    def communicate(self):
-        return "Version: 1.6.2", Mock()
+from golem.utils import encode_hex
 
 
 class EthereumNodeTest(TempDirFixture, LogTestCase, PEP8MixIn):
@@ -94,3 +94,72 @@ class TestPublicNodeList(unittest.TestCase):
 
         assert public_nodes is not FALLBACK_NODE_LIST
         assert all(n in FALLBACK_NODE_LIST for n in public_nodes)
+
+
+class EthereumClientNodeTest(TempDirFixture):
+    def setUp(self):
+        super().setUp()
+        # Show information about Ethereum node starting and terminating.
+        logging.basicConfig(level=logging.INFO)
+        self.node = NodeProcess(self.tempdir, start_node=True)
+        self.node.start()
+        self.client = Client(self.node.web3)
+
+    def tearDown(self):
+        self.node.stop()
+        super().tearDown()
+
+    def test_client(self):
+        client = self.client
+        p = client.get_peer_count()
+        assert type(p) is int
+        s = client.is_syncing()
+        assert type(s) is bool
+        addr = b'FakeEthereumAddress!'
+        assert len(addr) == 20
+        hex_addr = '0x' + encode_hex(addr)
+        c = client.get_transaction_count(hex_addr)
+        assert type(c) is int
+        assert c == 0
+        b = client.get_balance(hex_addr)
+        assert b == 0
+
+        eth = client.web3.eth
+        with patch.object(eth, 'getBalance', side_effect=ValueError):
+            b = client.get_balance(hex_addr)
+        assert b is None
+
+    def test_send_raw_transaction(self):
+        client = self.client
+        with self.assertRaises(ValueError):
+            client.send("fake data")
+
+    def test_send_transaction(self):
+        client = self.client
+        addr = b'\xff' * 20
+        priv = b'\xee' * 32
+        tx = Transaction(1, 20 * 10**9, 21000, to=addr, value=0, data=b'')
+        tx.sign(priv)
+        with self.assertRaisesRegex(ValueError, "[Ii]nsufficient funds"):
+            client.send(tx)
+
+    def test_get_logs(self):
+        addr = encode_hex(zpad(b'deadbeef', 32))
+        log_id = encode_hex(zpad(b'beefbeef', 32))
+        client = self.client
+        logs = client.get_logs(from_block='latest', to_block='latest',
+                               topics=[log_id, addr])
+        assert logs == []
+
+    def test_filters(self):
+        """ Test creating filter and getting logs """
+        client = self.client
+        filter_id = client.new_filter()
+        assert type(filter_id) is str
+        # Filter id is hex encoded 256-bit integer.
+        assert filter_id.startswith('0x')
+        number = int(filter_id, 16)
+        assert 0 < number < 2**256
+
+        entries = client.get_filter_changes(filter_id)
+        assert not entries

--- a/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
+++ b/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
@@ -61,14 +61,13 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
             mock_is_service_running.return_value = False
             e = EthereumTransactionSystem(self.tempdir, PRIV_KEY)
             assert e.payment_processor._loopingCall.start.called
-            assert e._sci._geth_client.node.start.called
+            assert e._node.start.called
 
             mock_is_service_running.return_value = False
             e.stop()
-            assert e._sci._geth_client.node is None
+            assert e._node.stop.called
             assert not e.payment_processor._loopingCall.stop.called
 
             mock_is_service_running.return_value = True
             e.stop()
-            assert e._sci._geth_client.node is None
             assert e.payment_processor._loopingCall.stop.called


### PR DESCRIPTION
Minimal dependencies, smartContractInterface doesn't need to know whether the web3 provider is remote or local. 