### PR TITLE
fix requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,8 @@ peewee>=2.8.1
 Pillow==4.2.1
 psutil==5.2.2
 pluggy==0.6.0
-pyelliptic==1.5.7
+# pyelliptic==1.5.9
+git+https://github.com/mfranciszkiewicz/pyelliptic.git@openssl_1_1#egg=pyelliptic
 coincurve>=5.0.1
 asn1crypto==0.22.0
 pyasn1==0.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
---extra-index-url https://builds.golem.network
+# --extra-index-url https://builds.golem.network
 setuptools>=36.0.1
 appdirs>=1.4
 click>=4.0
@@ -49,5 +49,5 @@ scipy==0.19.1
 pyssim
 enforce==0.3.4
 miniupnpc<2.1,>=2.0
-Golem-Messages==1.6.1
--e git://github.com/golemfactory/golem-smart-contracts-interface.git@f844eb827074d7a7278982e1c07dc167eb2bcad3#egg=golem_sci
+git+https://github.com/golemfactory/golem-messages@v1.6.1#egg=golem-messages
+git+https://github.com/golemfactory/golem-smart-contracts-interface.git@f844eb827074d7a7278982e1c07dc167eb2bcad3#egg=golem_sci


### PR DESCRIPTION
`pip install -r requirements.txt` fails w/ pip@9.0.1, with this patch applied it works again.