### PR TITLE
CLI macOS fix + cleanup

### DIFF
--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -8,6 +8,7 @@ import sys
 import pytz
 
 from golem.core import simpleenv
+from golem.core.variables import REACTOR_THREAD_POOL_SIZE
 
 TIMEOUT_FORMAT = '{}:{:0=2d}:{:0=2d}'
 DEVNULL = open(os.devnull, 'wb')
@@ -244,3 +245,17 @@ def get_cpu_count():
     if is_osx():
         return min(cpu_count(), MAX_CPU_MACOS)    # xhyve limitation
     return cpu_count()  # No limitatons on Linux
+
+
+def install_reactor():
+
+    if is_windows():
+        from twisted.internet import iocpreactor
+        iocpreactor.install()
+    elif is_osx():
+        from twisted.internet import kqreactor
+        kqreactor.install()
+
+    from twisted.internet import reactor
+    reactor.suggestThreadPoolSize(REACTOR_THREAD_POOL_SIZE)
+    return reactor

--- a/golem/interface/client/account.py
+++ b/golem/interface/client/account.py
@@ -4,13 +4,11 @@ from ethereum.utils import denoms
 
 from golem.core.deferred import sync_wait
 from golem.interface.command import command, group
-# For type annotations:
-from golem.client import Client  # pylint: disable=unused-import
 
 
 @group(help="Manage account")
 class Account:
-    client = None  # type: Client
+    client = None  # type: 'golem.rpc.session.Client'
 
     @command(help="Display account & financial info")
     def info(self) -> Dict[str, Any]:

--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -4,14 +4,10 @@ from uuid import uuid4
 
 from apps.appsmanager import AppsManager
 from apps.core.task.coretaskstate import TaskDefinition
-
 from golem.core.deferred import sync_wait
-from golem.interface.command import doc, group, command, Argument, CommandResult
 from golem.interface.client.logic import AppLogic
+from golem.interface.command import doc, group, command, Argument, CommandResult
 from golem.resource.dirmanager import DirManager
-
-# For type annotations:
-from golem.client import Client  # pylint: disable=unused-import
 
 
 class CommandAppLogic(AppLogic):
@@ -36,7 +32,7 @@ class CommandAppLogic(AppLogic):
 @group(help="Manage tasks")
 class Tasks:
 
-    client = None  # type: Client
+    client = None  # type: 'golem.rpc.session.Client'
 
     task_table_headers = ['id', 'remaining', 'subtasks', 'status', 'completion']
     subtask_table_headers = ['node', 'id', 'remaining', 'status', 'completion']

--- a/golemapp.py
+++ b/golemapp.py
@@ -6,7 +6,8 @@ import click
 from ethereum import slogging
 
 import golem
-from golem.core.variables import PROTOCOL_CONST, REACTOR_THREAD_POOL_SIZE
+from golem.core.common import install_reactor
+from golem.core.variables import PROTOCOL_CONST
 from golem.node import OptNode
 
 
@@ -115,21 +116,6 @@ def start(payments, monitor, datadir, node_address, rpc_address, peer,
 def delete_reactor():
     if 'twisted.internet.reactor' in sys.modules:
         del sys.modules['twisted.internet.reactor']
-
-
-def install_reactor():
-    from golem.core.common import is_osx, is_windows
-
-    if is_windows():
-        from twisted.internet import iocpreactor
-        iocpreactor.install()
-    elif is_osx():
-        from twisted.internet import kqreactor
-        kqreactor.install()
-
-    from twisted.internet import reactor
-    reactor.suggestThreadPoolSize(REACTOR_THREAD_POOL_SIZE)
-    return reactor
 
 
 def start_crossbar_worker(module):

--- a/golemcli.py
+++ b/golemcli.py
@@ -3,7 +3,7 @@
 import argparse
 import sys
 
-from golem.core.common import config_logging
+from golem.core.common import config_logging, install_reactor
 from golem.interface.cli import CLI
 from golem.interface.client import debug
 from golem.interface.client.account import Account
@@ -58,6 +58,7 @@ def start():
         cli = CLI(main_parser=parser, main_parser_options=flag_options)
 
     # run the cli
+    install_reactor()
     ws_cli = WebSocketCLI(cli, host=parsed.address, port=parsed.port)
     ws_cli.execute(forwarded, interactive=interactive)
 

--- a/tests/golem/interface/test_golemcli.py
+++ b/tests/golem/interface/test_golemcli.py
@@ -1,19 +1,15 @@
-import unittest
-
 import sys
-from mock import patch
+import unittest
+from unittest.mock import patch
 
 from golemcli import start
 
 
-def _nop(*a, **kw):
-    pass
-
-
 class TestGolemCLI(unittest.TestCase):
 
-    @patch('golem.interface.websockets.WebSocketCLI.execute', side_effect=_nop)
-    @patch('golem.core.common.config_logging', side_effect=_nop)
+    @patch('golemcli.install_reactor')
+    @patch('golem.interface.websockets.WebSocketCLI.execute')
+    @patch('golem.core.common.config_logging')
     def test_golem_cli(self, *_):
 
         with patch.object(sys, 'argv', ["program"]):


### PR DESCRIPTION
- remove the heavy `golem.client.Client` import from `golem.interface.client.*` 
- explicitly install the platform-specific reactor in `golemcli.py`

Resolves #1998