### PR TITLE
Copy resource file to blender working dir

### DIFF
--- a/apps/blender/task/verifier.py
+++ b/apps/blender/task/verifier.py
@@ -6,6 +6,7 @@ import posixpath
 from collections import Callable
 from threading import Lock
 from functools import partial
+from shutil import copy
 
 from apps.rendering.task.verifier import FrameRenderingVerifier
 from apps.blender.resources.cropgenerator import generate_crops
@@ -177,13 +178,16 @@ class BlenderVerifier(FrameRenderingVerifier):
 
         output_dir = os.path.join(work_dir, "output")
         logs_dir = os.path.join(work_dir, "logs")
+        resource_dir = os.path.join(work_dir, "resources")
 
+        if not os.path.exists(resource_dir):
+                os.mkdir(resource_dir)
         if not os.path.exists(logs_dir):
             os.mkdir(logs_dir)
         if not os.path.exists(output_dir):
             os.mkdir(output_dir)
 
-        resource_path = os.path.dirname(self.current_results_file)
+        copy(self.current_results_file, resource_dir)
 
         params = dict()
 
@@ -206,7 +210,7 @@ class BlenderVerifier(FrameRenderingVerifier):
             src_code = ""
 
         with DockerJob(di, src_code, params,
-                       resource_path, work_dir, output_dir,
+                       resource_dir, work_dir, output_dir,
                        host_config=None) as job:
             job.start()
             was_failure = job.wait()

--- a/tests/apps/blender/task/test_blenderverifier.py
+++ b/tests/apps/blender/task/test_blenderverifier.py
@@ -63,6 +63,7 @@ class TestBlenderVerifier(LogTestCase, PEP8MixIn, TempDirFixture):
         verify_ctx = VerificationContext([[75, 34]], 0, self.tempdir)
         crop_path = os.path.join(self.tempdir, str(0))
         bv.current_results_file = os.path.join(self.tempdir, "none.png")
+        open(bv.current_results_file, mode='a').close()
         if not os.path.exists(crop_path):
             os.mkdir(crop_path)
         with self.assertLogs(logger, level="INFO") as logs:


### PR DESCRIPTION
Looks like that either mounting directory with resource files or even mounting single file, can result in race condition when preview and verificator want to use same file in exact same moment. The only solution i can see is to copy subtask to verificator working dir, so it can have its own copy of it.

Fix this:
https://github.com/golemfactory/golem/issues/2020

Signed-off-by: Lukasz Foniok <lukaszfoniok@gmail.com>