### PR TITLE
Make PaymentProcessor use latest SmartContractInterface

### DIFF
--- a/golem/ethereum/gntconverter.py
+++ b/golem/ethereum/gntconverter.py
@@ -1,0 +1,82 @@
+import logging
+
+from ethereum.utils import denoms
+
+log = logging.getLogger("golem.gnt_converter")
+
+
+class GNTConverter:
+    REQUIRED_CONFS = 2
+
+    def __init__(self, sci):
+        self._sci = sci
+        self._deposit_address = None
+        self._tx_hash = None
+        self._amount_to_convert = None
+
+    def convert(self, amount: int):
+        if self.is_converting():
+            # This isn't a technical restriction but rather a simplification
+            # for our use case
+            raise Exception('Can process only single conversion at once')
+
+        self._amount_to_convert = amount
+        self._update_personal_deposit_address()
+
+    def is_converting(self):
+        if self._awaiting_transaction():
+            return True
+
+        if not self._amount_to_convert:
+            return False
+
+        if self._update_personal_deposit_address():
+            return True
+
+        if self._sci.get_gnt_balance(self._deposit_address):
+            self._tx_hash = self._sci.process_personal_deposit_slot()
+            self._amount_to_convert = None
+            log.info('Processing personal deposit slot %r', self._tx_hash)
+            return True
+
+        self._tx_hash = self._sci.transfer_gnt(
+            self._deposit_address,
+            self._amount_to_convert,
+        )
+        log.info(
+            'Converting %r GNT %r',
+            self._amount_to_convert / denoms.ether,
+            self._tx_hash,
+        )
+
+        return True
+
+    def _update_personal_deposit_address(self) -> bool:
+        if self._deposit_address is not None:
+            return False
+
+        self._deposit_address = self._sci.get_personal_deposit_slot()
+        if self._deposit_address and int(self._deposit_address, 16) == 0:
+            self._deposit_address = None
+
+        if self._deposit_address is None:
+            self._tx_hash = self._sci.create_personal_deposit_slot()
+            log.info('Creating personal deposit slot %r', self._tx_hash)
+            return True
+        return False
+
+    def _awaiting_transaction(self) -> bool:
+        if self._tx_hash is None:
+            return False
+        receipt = self._sci.get_transaction_receipt(self._tx_hash)
+        if not receipt:
+            return True
+
+        current_block = self._sci.get_block_number()
+        block_number = receipt['blockNumber']
+        if current_block < block_number + self.REQUIRED_CONFS:
+            return True
+        if receipt['status'] == '0x0':
+            log.warning('Unsuccessful transaction %r', self._tx_hash)
+        self._tx_hash = None
+        return False

--- a/golem/transactions/ethereum/ethereumincomeskeeper.py
+++ b/golem/transactions/ethereum/ethereumincomeskeeper.py
@@ -13,15 +13,14 @@ class EthereumIncomesKeeper(IncomesKeeper):
     BLOCK_NUMBER_DB_KEY = 'eth_incomes_keeper_block_number'
     BLOCK_NUMBER_BUFFER = 10
 
-    def __init__(self, eth_address: str, sci) -> None:
-        self.__eth_address = eth_address
+    def __init__(self, sci) -> None:
         self.__sci = sci
 
         values = GenericKeyValue.select().where(
             GenericKeyValue.key == self.BLOCK_NUMBER_DB_KEY)
         from_block = int(values.get().value) if values.count() == 1 else 0
         self.__sci.subscribe_to_incoming_batch_transfers(
-            eth_address,
+            self.__sci.get_eth_address(),
             from_block,
             self._on_batch_event,
             self.REQUIRED_CONFS,

--- a/loggingconfig.py
+++ b/loggingconfig.py
@@ -78,6 +78,10 @@ LOGGING = {
             'level': 'INFO',
             'propagate': True,
         },
+        'golem.gnt_converter': {
+            'level': 'INFO',
+            'propagate': True,
+        },
         'golem.ethereum': {
             'level': 'INFO',
             'propagate': True,

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,4 +48,4 @@ pyssim
 enforce==0.3.4
 miniupnpc<2.1,>=2.0
 Golem-Messages==1.7.0
--e git://github.com/golemfactory/golem-smart-contracts-interface.git@8ab8dbbbd689fb5ba04914de5ec317607fd95fc9#egg=golem_sci
+-e git://github.com/golemfactory/golem-smart-contracts-interface.git@333c6c02281c5c6372e59caababee72d653a0e42#egg=golem_sci

--- a/tests/golem/ethereum/test_gntconverter.py
+++ b/tests/golem/ethereum/test_gntconverter.py
@@ -1,0 +1,89 @@
+import unittest
+import unittest.mock as mock
+
+from golem.ethereum.gntconverter import GNTConverter
+
+
+class GNTConverterTest(unittest.TestCase):
+    def setUp(self):
+        self.sci = mock.Mock()
+        self.sci.get_personal_deposit_slot.return_value = None
+        self.converter = GNTConverter(self.sci)
+
+    def test_flow(self):
+        assert not self.converter.is_converting()
+
+        receipts = {
+        }
+        self.sci.get_transaction_receipt.side_effect = \
+            lambda tx_hash: receipts[tx_hash]
+        block_number = 333
+        self.sci.get_block_number.return_value = block_number
+        gnt_amount = 123
+
+        # create personal deposit slot
+        cpds_tx_hash = '0xdead'
+        self.sci.create_personal_deposit_slot.return_value = cpds_tx_hash
+        self.converter.convert(gnt_amount)
+        self.sci.get_personal_deposit_slot.assert_called_once_with()
+        self.sci.create_personal_deposit_slot.assert_called_once_with()
+
+        receipts[cpds_tx_hash] = {'blockNumber': block_number}
+        assert self.converter.is_converting()
+        self.sci.get_transaction_receipt.assert_called_once_with(cpds_tx_hash)
+        self.sci.get_transaction_receipt.reset_mock()
+
+        # create personal deposit slot mined, transfer GNT
+        receipts[cpds_tx_hash] = {
+            'blockNumber': block_number - GNTConverter.REQUIRED_CONFS,
+            'status': '0x1',
+        }
+        pda = '0xdddd'
+        self.sci.get_personal_deposit_slot.return_value = pda
+        transfer_tx_hash = '0xbeef'
+        self.sci.transfer_gnt.return_value = transfer_tx_hash
+        self.sci.get_gnt_balance.return_value = 0
+        assert self.converter.is_converting()
+        self.sci.get_transaction_receipt.assert_called_once_with(cpds_tx_hash)
+        self.sci.transfer_gnt.assert_called_once_with(pda, gnt_amount)
+        self.sci.get_transaction_receipt.reset_mock()
+
+        receipts[transfer_tx_hash] = {'blockNumber': block_number}
+        assert self.converter.is_converting()
+        self.sci.get_transaction_receipt.assert_called_once_with(
+            transfer_tx_hash,
+        )
+        self.sci.get_transaction_receipt.reset_mock()
+
+        # transfer GNT mined, process personal deposit
+        receipts[transfer_tx_hash] = {
+            'blockNumber': block_number - GNTConverter.REQUIRED_CONFS,
+            'status': '0x1',
+        }
+        self.sci.get_gnt_balance.return_value = gnt_amount
+        process_pd_tx_hash = '0xbad'
+        self.sci.process_personal_deposit_slot.return_value = process_pd_tx_hash
+        assert self.converter.is_converting()
+        self.sci.get_transaction_receipt.assert_called_once_with(
+            transfer_tx_hash,
+        )
+        self.sci.get_transaction_receipt.reset_mock()
+        self.sci.process_personal_deposit_slot.assert_called_once_with()
+
+        receipts[process_pd_tx_hash] = {'blockNumber': block_number}
+        assert self.converter.is_converting()
+        self.sci.get_transaction_receipt.assert_called_once_with(
+            process_pd_tx_hash,
+        )
+        self.sci.get_transaction_receipt.reset_mock()
+
+        # process personal deposit mined, conversion done
+        receipts[process_pd_tx_hash] = {
+            'blockNumber': block_number - GNTConverter.REQUIRED_CONFS,
+            'status': '0x1',
+        }
+        assert not self.converter.is_converting()
+        self.sci.get_transaction_receipt.assert_called_once_with(
+            process_pd_tx_hash,
+        )
+        self.sci.get_transaction_receipt.reset_mock()

--- a/tests/golem/ethereum/test_paymentprocessor_eth.py
+++ b/tests/golem/ethereum/test_paymentprocessor_eth.py
@@ -1,6 +1,5 @@
 import os
 import random
-import unittest
 import uuid
 
 import mock
@@ -19,35 +18,11 @@ def mock_sci():
     return sci
 
 
-class TestPaymentProcessor(unittest.TestCase):
-    def setUp(self):
-        privkey = (b'!\xcd!^\xfe#\x82-#!Z]b\xb4\x8ce[\n\xfbN\x18V\x8c\x1dA'
-                   b'\xea\x8c\xe8ZO\xc9\xdb')
-        with mock.patch("golem.ethereum.paymentprocessor.PaymentProcessor.load_from_db"):  # noqa
-            self.payment_processor = paymentprocessor.PaymentProcessor(
-                privkey=privkey,
-                sci=mock_sci()
-            )
-
-    def test_eth_address(self):
-        # Test with zpad
-        expected = ('0x000000000000000000000000e1ad9e38fc4bf20e5'
-                    'd4847e00e8a05170c87913f')
-        self.assertEqual(expected, self.payment_processor.eth_address())
-
-        # Test without zpad
-        expected = '0xe1ad9e38fc4bf20e5d4847e00e8a05170c87913f'
-        result = self.payment_processor.eth_address(zpad=False)
-        self.assertEqual(expected, result)
-
-
 class TestPaymentProcessorWithDB(testutils.DatabaseFixture):
     def setUp(self):
         super(TestPaymentProcessorWithDB, self).setUp()
         random.seed()
-        privkey = os.urandom(32)
         self.payment_processor = paymentprocessor.PaymentProcessor(
-            privkey=privkey,
             sci=mock_sci()
         )
 
@@ -73,19 +48,19 @@ class TestPaymentProcessorWithDB(testutils.DatabaseFixture):
 
         # Sent payments
         self.assertEqual({}, self.payment_processor._inprogress)
-        tx_hash = os.urandom(32)
+        tx_hash = '0x' + encode_hex(os.urandom(32))
         sent_payment = model.Payment.create(
             subtask='sent' + str(uuid.uuid4()),
             payee=payee,
             value=value,
-            details=model.PaymentDetails(tx=encode_hex(tx_hash)),
+            details=model.PaymentDetails(tx=tx_hash[2:]),
             status=model.PaymentStatus.sent
         )
         sent_payment2 = model.Payment.create(
             subtask='sent2' + str(uuid.uuid4()),
             payee=payee,
             value=value,
-            details=model.PaymentDetails(tx=encode_hex(tx_hash)),
+            details=model.PaymentDetails(tx=tx_hash[2:]),
             status=model.PaymentStatus.sent
         )
         self.payment_processor.load_from_db()

--- a/tests/golem/transactions/ethereum/test_ethereumincomeskeeper.py
+++ b/tests/golem/transactions/ethereum/test_ethereumincomeskeeper.py
@@ -24,7 +24,8 @@ class TestEthereumIncomesKeeper(testutils.DatabaseFixture, testutils.PEP8MixIn):
         super().setUp()
         self.sci = mock.Mock()
         self.eth_address = get_receiver_id()
-        self.instance = EthereumIncomesKeeper(self.eth_address, self.sci)
+        self.sci.get_eth_address.return_value = self.eth_address
+        self.instance = EthereumIncomesKeeper(self.sci)
 
     def test_start_stop(self):
         self.sci.subscribe_to_incoming_batch_transfers.assert_called_once_with(
@@ -39,7 +40,7 @@ class TestEthereumIncomesKeeper(testutils.DatabaseFixture, testutils.PEP8MixIn):
         self.instance.stop()
 
         self.sci.reset_mock()
-        instance = EthereumIncomesKeeper(self.eth_address, self.sci)
+        instance = EthereumIncomesKeeper(self.sci)
         self.sci.subscribe_to_incoming_batch_transfers.assert_called_once_with(
             self.eth_address,
             block_number - (instance.REQUIRED_CONFS +


### PR DESCRIPTION
In particular SmartContractInterface is just a simple interface without any hidden logic like GNT to GNTW conversion, so this has been moved to `GNTConverter`.
Also we don't need to pass private key to PaymentProcessor anymore.
And some other minor clean ups, like consistent types for transaction hashes or simplified interfaces.