### PR TITLE
Drop the pyelliptic dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ peewee<2.11,>=2.8
 Pillow==4.2.1
 psutil==5.2.2
 pluggy==0.6.0
-pyelliptic==1.5.7
 coincurve>=5.0.1
 asn1crypto==0.22.0
 pyasn1==0.4.1


### PR DESCRIPTION
`pyelliptic` is only required by `golem-messages`.