### PR TITLE
Remove sender node details from incomes

### DIFF
--- a/golem/model.py
+++ b/golem/model.py
@@ -40,7 +40,7 @@ db = GolemSqliteDatabase(None, threadlocals=True,
 
 class Database:
     # Database user schema version, bump to recreate the database
-    SCHEMA_VERSION = 10
+    SCHEMA_VERSION = 11
 
     def __init__(self, datadir):
         # TODO: Global database is bad idea. Check peewee for other solutions.
@@ -254,13 +254,9 @@ class Payment(BaseModel):
                 self.processed_ts
             )
 
-    def get_sender_node(self) -> Optional[Node]:
-        return self.details.node_info
-
 
 class ExpectedIncome(BaseModel):
     sender_node = CharField()
-    sender_node_details = NodeField()
     subtask = CharField()
     value = BigIntegerField()
     accepted_ts = IntegerField(null=True)
@@ -268,9 +264,6 @@ class ExpectedIncome(BaseModel):
     def __repr__(self):
         return "<ExpectedIncome: {!r} v:{:.3f}>"\
             .format(self.subtask, self.value)
-
-    def get_sender_node(self):
-        return self.sender_node_details
 
 
 class Income(BaseModel):

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -288,7 +288,6 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
             if self.client.transaction_system:
                 self.client.transaction_system.incomes_keeper.expect(
                     sender_node_id=owner_key_id,
-                    p2p_node=owner,
                     subtask_id=subtask_id,
                     value=value,
                 )

--- a/golem/transactions/incomeskeeper.py
+++ b/golem/transactions/incomeskeeper.py
@@ -89,7 +89,7 @@ class IncomesKeeper(object):
                 db_income.transaction
             )
 
-    def expect(self, sender_node_id, p2p_node, subtask_id, value):
+    def expect(self, sender_node_id, subtask_id, value):
         logger.debug(
             "expect(%r, %r, %r)",
             sender_node_id,
@@ -98,7 +98,6 @@ class IncomesKeeper(object):
         )
         return ExpectedIncome.create(
             sender_node=sender_node_id,
-            sender_node_details=p2p_node,
             subtask=subtask_id,
             value=value
         )

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -196,7 +196,6 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
             sender_node_id="key",
             subtask_id="xyzxyz",
             value=1,
-            p2p_node=n,
         )
 
         with self.assertLogs(logger, level='WARNING'):
@@ -213,7 +212,6 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
         ts.task_manager.comp_task_keeper.receive_subtask(ctd)
         model.ExpectedIncome.create(
             sender_node="key",
-            sender_node_details=None,
             task=ctd['task_id'],
             subtask=ctd['subtask_id'],
             value=1

--- a/tests/golem/transactions/test_incomeskeeper.py
+++ b/tests/golem/transactions/test_incomeskeeper.py
@@ -39,7 +39,6 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
         self.incomes_keeper.expect(
             sender_node_id=sender_node_id,
             subtask_id=subtask_id,
-            p2p_node=Node(),
             value=value
         )
         with db.atomic():
@@ -96,7 +95,6 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
 
         expected_income = self.incomes_keeper.expect(
             sender_node_id=sender_node_id,
-            p2p_node=Node(),
             subtask_id=subtask_id,
             value=value
         )


### PR DESCRIPTION
It's no longer needed anywhere.