### PR TITLE
Task result packaging and SHA1

### DIFF
--- a/golem/core/simplehash.py
+++ b/golem/core/simplehash.py
@@ -48,11 +48,12 @@ class SimpleHash(object):
         return cls.base64_encode(cls.hash(data))
 
     @classmethod
-    def hash_file_base64(cls, filename, block_size=2 ** 20):
-        """Return sha1 of data from given file encoded with base64
+    def hash_file(cls, filename, block_size=2 ** 20):
+        """Return sha1 of data from given file
         :param str filename: name of a file that should be read
-        :param int block_size: *Default: 2**20* data will be read from file in chunks of this size
-        :return str: base64 encoded sha1 of data from file <filename>
+        :param int block_size: *Default: 2**20* data will be read from file in
+        chunks of this size
+        :return bytes: bytes of data from file <filename>
         """
         with open(filename, "rb") as f:
             sha = hashlib.sha1()
@@ -63,7 +64,17 @@ class SimpleHash(object):
                     break
                 sha.update(data)
 
-            return cls.base64_encode(sha.digest())
+            return sha.digest()
+
+    @classmethod
+    def hash_file_base64(cls, filename, block_size=2 ** 20):
+        """Return sha1 of data from given file encoded with base64
+        :param str filename: name of a file that should be read
+        :param int block_size: *Default: 2**20* data will be read from file in
+        chunks of this size
+        :return str: base64 encoded sha1 of data from file <filename>
+        """
+        return cls.base64_encode(cls.hash_file(filename, block_size))
 
     @classmethod
     def hash_object(cls):

--- a/golem/network/concent/helpers.py
+++ b/golem/network/concent/helpers.py
@@ -8,7 +8,6 @@ import time
 from golem_messages import exceptions as msg_exceptions
 from golem_messages import message
 from twisted.internet import defer
-from twisted.internet import reactor
 from twisted.internet import threads
 
 from golem.network import history
@@ -44,6 +43,10 @@ def compute_result_hash(task_result):
 
 
 def deferred_compute_result_hash(task_result):
+    # Import reactor only when it is necessary;
+    # otherwise process-wide signal handlers may be installed
+    from twisted.internet import reactor
+
     if reactor.running:
         execute = threads.deferToThread
     else:

--- a/golem/task/result/resultmanager.py
+++ b/golem/task/result/resultmanager.py
@@ -76,17 +76,18 @@ class EncryptedResultPackageManager(TaskResultPackageManager):
             os.remove(file_path)
 
         packager = self.package_class(key_or_secret)
-        path = packager.create(file_path,
-                               node=node,
-                               task_result=task_result)
+        path, sha1 = packager.create(file_path,
+                                     node=node,
+                                     task_result=task_result)
 
         self.resource_manager.add_file(path, task_id)
         for resource in self.resource_manager.get_resources(task_id):
             if file_name in resource.files:
-                return resource.hash, file_path
+                return resource.hash, file_path, sha1
 
         if os.path.exists(path):
-            raise EnvironmentError("Error creating package: 'add' command failed")
+            raise EnvironmentError("Error creating package: "
+                                   "'add' command failed")
         raise Exception("Error creating package: file not found")
 
     def extract(self, path, output_dir=None, key_or_secret=None, **kwargs):

--- a/golem/task/result/resultpackage.py
+++ b/golem/task/result/resultpackage.py
@@ -1,8 +1,9 @@
-import abc
 import binascii
-import os
 import uuid
 import zipfile
+
+import abc
+import os
 
 from golem.core.fileencrypt import AESFileEncryptor
 from golem.core.simplehash import SimpleHash
@@ -108,9 +109,9 @@ class EncryptingPackager(Packager):
 
         output_dir = os.path.dirname(output_path)
         pkg_file_path = os.path.join(output_dir, str(uuid.uuid4()) + ".pkg")
-        out_file_path = super(EncryptingPackager, self).create(pkg_file_path,
-                                                               disk_files=disk_files,
-                                                               cbor_files=cbor_files)
+        out_file_path = super().create(pkg_file_path,
+                                       disk_files=disk_files,
+                                       cbor_files=cbor_files)
 
         self.encryptor_class.encrypt(out_file_path,
                                      output_path,
@@ -159,10 +160,6 @@ class EncryptingTaskResultPackager(EncryptingPackager):
     descriptor_file_name = '.package_desc'
     result_file_name = '.result_cbor'
 
-    def __init__(self, key_or_secret):
-        self.parent = super(EncryptingTaskResultPackager, self)
-        self.parent.__init__(key_or_secret)
-
     def create(self, output_path,
                disk_files=None, cbor_files=None,
                node=None, task_result=None, **kwargs):
@@ -174,13 +171,13 @@ class EncryptingTaskResultPackager(EncryptingPackager):
         descriptor = TaskResultDescriptor(node, task_result)
         cbor_files.append((self.descriptor_file_name, descriptor))
 
-        return self.parent.create(output_path,
-                                  disk_files=disk_files,
-                                  cbor_files=cbor_files)
+        return super().create(output_path,
+                              disk_files=disk_files,
+                              cbor_files=cbor_files)
 
     def extract(self, input_path, output_dir=None, **kwargs):
 
-        files, files_dir = self.parent.extract(input_path, output_dir=output_dir)
+        files, files_dir = super().extract(input_path, output_dir=output_dir)
         descriptor_path = os.path.join(files_dir, self.descriptor_file_name)
 
         try:
@@ -189,7 +186,7 @@ class EncryptingTaskResultPackager(EncryptingPackager):
             os.remove(descriptor_path)
 
         except Exception as e:
-            raise ValueError('Invalid package descriptor %r' % e.message)
+            raise ValueError('Invalid package descriptor {}'.format(e))
 
         if self.descriptor_file_name in files:
             files.remove(self.descriptor_file_name)
@@ -218,7 +215,8 @@ class EncryptingTaskResultPackager(EncryptingPackager):
         elif result.result_type == ResultType.FILES:
             disk_files.extend(result.result)
         else:
-            raise ValueError("Invalid result type {}".format(result.result_type))
+            raise ValueError("Invalid result type {}"
+                             .format(result.result_type))
 
         return disk_files, cbor_files
 

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -280,8 +280,6 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
         if 'data' not in result or 'result_type' not in result:
             raise AttributeError("Wrong result format")
 
-        Trust.REQUESTED.increase(owner_key_id)
-
         if subtask_id not in self.results_to_send:
             value = self.task_manager.comp_task_keeper.get_value(
                 task_id, computing_time)
@@ -296,19 +294,34 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
             delay_time = 0.0
             last_sending_trial = 0
 
-            self.results_to_send[subtask_id] = WaitingTaskResult(
-                task_id, subtask_id, result['data'], result['result_type'],
-                computing_time, last_sending_trial, delay_time, owner_address,
-                owner_port, owner_key_id, owner)
+            wtr = WaitingTaskResult(task_id, subtask_id, result['data'],
+                                    result['result_type'], computing_time,
+                                    last_sending_trial, delay_time,
+                                    owner_address, owner_port, owner_key_id,
+                                    owner)
+
+            self.create_and_set_result_package(wtr)
+            self.results_to_send[subtask_id] = wtr
+
+            Trust.REQUESTED.increase(owner_key_id)
         else:
             raise RuntimeError("Incorrect subtask_id: {}".format(subtask_id))
 
         return True
 
+    def create_and_set_result_package(self, wtr):
+        task_result_manager = self.task_manager.task_result_manager
+
+        wtr.result_secret = task_result_manager.gen_secret()
+        result = task_result_manager.create(self.node, wtr, wtr.result_secret)
+        wtr.result_hash, wtr.result_path, wtr.package_sha1 = result
+
     def send_task_failed(self, subtask_id, task_id, err_msg, owner_address,
                          owner_port, owner_key_id, owner, node_name):
-        Trust.REQUESTED.decrease(owner_key_id)
+
         if subtask_id not in self.failures_to_send:
+            Trust.REQUESTED.decrease(owner_key_id)
+
             self.failures_to_send[subtask_id] = WaitingTaskFailure(
                 task_id, subtask_id, err_msg, owner_address, owner_port,
                 owner_key_id, owner)
@@ -951,9 +964,11 @@ class TaskServer(PendingConnectionsServer, TaskResourcesMixin):
 
 
 class WaitingTaskResult(object):
-    def __init__(self, task_id, subtask_id, result, result_type,
-                 computing_time, last_sending_trial, delay_time, owner_address,
-                 owner_port, owner_key_id, owner):
+    def __init__(self, task_id, subtask_id, result, result_type, computing_time,
+                 last_sending_trial, delay_time, owner_address, owner_port,
+                 owner_key_id, owner, result_path=None, result_hash=None,
+                 result_secret=None, package_sha1=None):
+
         self.task_id = task_id
         self.subtask_id = subtask_id
         self.result = result
@@ -966,6 +981,11 @@ class WaitingTaskResult(object):
         self.owner_key_id = owner_key_id
         self.owner = owner
         self.already_sending = False
+
+        self.result_path = result_path
+        self.result_hash = result_hash
+        self.result_secret = result_secret
+        self.package_sha1 = package_sha1
 
 
 class WaitingTaskFailure(object):

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -971,8 +971,6 @@ class WaitingTaskResult(object):
 
         self.task_id = task_id
         self.subtask_id = subtask_id
-        self.result = result
-        self.result_type = result_type
         self.computing_time = computing_time
         self.last_sending_trial = last_sending_trial
         self.delay_time = delay_time
@@ -980,12 +978,15 @@ class WaitingTaskResult(object):
         self.owner_port = owner_port
         self.owner_key_id = owner_key_id
         self.owner = owner
-        self.already_sending = False
 
+        self.result = result
+        self.result_type = result_type
         self.result_path = result_path
         self.result_hash = result_hash
         self.result_secret = result_secret
         self.package_sha1 = package_sha1
+
+        self.already_sending = False
 
 
 class WaitingTaskFailure(object):

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -5,9 +5,7 @@ import pickle
 import time
 
 from golem_messages import message
-from twisted.internet import defer
 
-from golem.core.async import AsyncRequest, async_run
 from golem.core.common import HandleAttributeError
 from golem.core.simpleserializer import CBORSerializer
 from golem.core.variables import PROTOCOL_CONST
@@ -293,7 +291,6 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
 
     # TODO address, port and eth_account should be in node_info
     # (or shouldn't be here at all)
-    @defer.inlineCallbacks
     def send_report_computed_task(
             self,
             task_result,
@@ -329,7 +326,6 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
                 msg_cls='TaskToCompute',
             )
         except history.MessageNotFound:
-            task_to_compute = None
             logger.warning(
                 '[CONCENT] TaskToCompute not found for subtask: %r',
                 task_result.subtask_id,
@@ -350,12 +346,10 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
         report_computed_task.task_to_compute = task_to_compute
         self.send(report_computed_task)
 
-        msg = message.ForceReportComputedTask()
-        msg.task_to_compute = task_to_compute
-        result_hash = yield concent_helpers.deferred_compute_result_hash(
-            task_result,
+        msg = message.ForceReportComputedTask(
+            task_to_compute=task_to_compute,
+            result_hash='sha1:' + task_result.package_sha1
         )
-        msg.result_hash = 'sha1:' + result_hash.hexdigest()
         logger.debug('[CONCENT] ForceReport: %s', msg)
 
         self.concent_service.submit(
@@ -536,13 +530,24 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
         self.send(message.GetTaskResult(subtask_id=msg.subtask_id))
 
     @history.provider_history
-    def _react_to_get_task_result(self, msg):
-        res = self.task_server.get_waiting_task_result(msg.subtask_id)
-        if res is None:
-            return
+    def _react_to_get_task_result(self, msg) -> None:
+        wtr = self.task_server.get_waiting_task_result(msg.subtask_id)
+        if wtr is None:
+            logger.warning("Result was requested for an unknown subtask "
+                           "id: %r", msg.subtask_id)
+            return self.disconnect(message.Disconnect.REASON.NoMoreMessages)
 
-        res.already_sending = True
-        return self.__send_result_hash(res)
+        wtr.already_sending = True
+        client_options = self.task_server.get_share_options(wtr.task_id,
+                                                            self.key_id)
+
+        msg = message.TaskResultHash(
+            subtask_id=wtr.subtask_id,
+            multihash=wtr.result_hash,
+            secret=wtr.result_secret,
+            options=client_options
+        )
+        self.send(msg)
 
     def _react_to_task_result_hash(self, msg):
         secret = msg.secret
@@ -776,51 +781,6 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
         reasons = message.CannotComputeTask.REASON
         self.err_msg = reasons.WrongDockerImages
         return False
-
-    def __send_result_hash(self, res):
-        task_result_manager = self.task_manager.task_result_manager
-        client_options = self.task_server.get_share_options(res.task_id,
-                                                            self.key_id)
-
-        subtask_id = res.subtask_id
-        secret = task_result_manager.gen_secret()
-
-        def success(result):
-            result_hash, result_path = result
-            logger.debug(
-                "Task session: sending task result hash: %r (%r)",
-                result_hash, result_path
-            )
-
-            self.send(
-                message.TaskResultHash(
-                    subtask_id=subtask_id,
-                    multihash=result_hash,
-                    secret=secret,
-                    options=client_options
-                )
-            )
-
-        def error(exc):
-            logger.error(
-                "Couldn't create a task result package for subtask %r: %r",
-                res.subtask_id,
-                exc
-            )
-
-            if isinstance(exc, EnvironmentError):
-                self.task_server.retry_sending_task_result(subtask_id)
-            else:
-                self.send_task_failure(subtask_id, '{}'.format(exc))
-                self.task_server.task_result_sent(subtask_id)
-
-            self.dropped()
-
-        request = AsyncRequest(task_result_manager.create,
-                               self.task_server.node, res,
-                               key_or_secret=secret)
-
-        return async_run(request, success=success, error=error)
 
     def __receive_data_result(self, msg):
         extra_data = {

--- a/tests/golem/docker/test_docker_blender_task.py
+++ b/tests/golem/docker/test_docker_blender_task.py
@@ -92,6 +92,7 @@ class TestDockerBlenderTask(TempDirFixture, DockerTestCase):
 
         task_server = TaskServer(Mock(), ccd, Mock(), self.node.client,
                                  use_docker_machine_manager=False)
+        task_server.create_and_set_result_package = Mock()
         task_server.task_keeper.task_headers[task_id] = render_task.header
         task_computer = task_server.task_computer
 

--- a/tests/golem/docker/test_docker_luxrender_task.py
+++ b/tests/golem/docker/test_docker_luxrender_task.py
@@ -105,6 +105,7 @@ class TestDockerLuxrenderTask(TempDirFixture, DockerTestCase):
 
         task_server = TaskServer(Mock(), ccd, Mock(), self.node.client,
                                  use_docker_machine_manager=False)
+        task_server.create_and_set_result_package = Mock()
         task_server.task_keeper.task_headers[task_id] = render_task.header
         task_computer = task_server.task_computer
 

--- a/tests/golem/task/result/test_resultmanager.py
+++ b/tests/golem/task/result/test_resultmanager.py
@@ -1,7 +1,7 @@
-from unittest.mock import Mock
-
-import os
 import uuid
+import os
+
+from unittest.mock import Mock, patch
 
 from golem.resource.dirmanager import DirManager
 from golem.resource.hyperdrive.resourcesmanager import DummyResourceManager
@@ -96,6 +96,22 @@ class TestEncryptedResultPackageManager(TestDirFixture):
         self.assertIsInstance(sha1, str)
         self.assertIsInstance(path, str)
         self.assertTrue(os.path.isfile(path))
+
+    def testCreateEnvironmentError(self):
+        manager = EncryptedResultPackageManager(self.resource_manager)
+        manager.resource_manager.add_file = Mock()
+
+        with self.assertRaises(EnvironmentError):
+            create_package(manager, self.node_name, self.task_id)
+
+    def testCreateUnexpectedError(self):
+        manager = EncryptedResultPackageManager(self.resource_manager)
+        manager.resource_manager.add_file = Mock()
+
+        with patch('os.path.exists', return_value=False):
+            with self.assertRaises(Exception) as exc:
+                assert not isinstance(exc, EnvironmentError)
+                create_package(manager, self.node_name, self.task_id)
 
     def testExtract(self):
         manager = EncryptedResultPackageManager(self.resource_manager)

--- a/tests/golem/task/result/test_resultpackage.py
+++ b/tests/golem/task/result/test_resultpackage.py
@@ -1,217 +1,166 @@
-import os
-import shutil
 import uuid
+import os
+
+from unittest.mock import Mock
 
 from golem.core.fileencrypt import FileEncryptor
 from golem.resource.dirmanager import DirManager
-from golem.task.result.resultpackage import ZipPackager, EncryptingPackager, EncryptingTaskResultPackager, \
-    ExtractedPackage
+from golem.task.result.resultpackage import EncryptingPackager, \
+    EncryptingTaskResultPackager, ExtractedPackage, ZipPackager
 from golem.task.taskbase import ResultType
-from golem.tools.testdirfixture import TestDirFixture
-
-node_name = 'test_suite'
+from golem.testutils import TempDirFixture
 
 
-class MockNode:
-    def __init__(self, name, key=None):
-        if not key:
-            key = uuid.uuid4()
-
-        self.node_name = name
-        self.key = key
+def mock_node():
+    return Mock(name='test_node', key=uuid.uuid4())
 
 
-class MockTaskResult:
-    def __init__(self, task_id, result, result_type=None,
-                 owner_key_id=None, owner=None):
+def mock_task_result(task_id, result, result_type=None):
+    if result_type is None:
+        result_type = ResultType.FILES
 
-        if result_type is None:
-            result_type = ResultType.FILES
-        if owner_key_id is None:
-            owner_key_id = str(uuid.uuid4())
-        if owner is None:
-            owner = str(uuid.uuid4())
-
-        self.task_id = task_id
-        self.subtask_id = task_id
-        self.result = result
-        self.result_type = result_type
-        self.owner_key_id = owner_key_id
-        self.owner = owner
+    return Mock(
+        task_id=task_id,
+        subtask_id=task_id,
+        result=result,
+        result_type=result_type,
+        owner_key_id=str(uuid.uuid4()),
+        owner=str(uuid.uuid4())
+    )
 
 
-class MockDirContents(object):
+class PackageDirContentsFixture(TempDirFixture):
 
-    @staticmethod
-    def populate(dest_obj, dir_manager, task_id):
+    def setUp(self):
+        super().setUp()
+
+        task_id = str(uuid.uuid4())
+        dir_manager = DirManager(self.path)
+
         res_dir = dir_manager.get_task_temporary_dir(task_id)
-
-        out_file = os.path.join(res_dir, 'out_file')
         out_dir = os.path.join(res_dir, 'out_dir')
         out_dir_file = os.path.join(out_dir, 'dir_file')
+        out_file = os.path.join(res_dir, 'out_file')
 
-        files = [out_file, out_dir_file]
-        pickle_files = [('pickle1', 'pickle_data1'), ('pickle2', 'pickle_data2')]
+        memory_files = [('mem1', 'data1'), ('mem2', 'data2')]
+
+        os.makedirs(out_dir, exist_ok=True)
 
         with open(out_file, 'w') as f:
             f.write("File contents")
-
-        if not os.path.isdir(out_dir):
-            os.makedirs(out_dir)
-
         with open(out_dir_file, 'w') as f:
             f.write("Dir file contents")
 
-        dest_obj.file_list = MockDirContents.create_file_list(files, pickle_files)
-        dest_obj.res_dir = res_dir
-        dest_obj.files = files
-        dest_obj.pickle_files = pickle_files
-        dest_obj.out_dir = dest_obj.dir_manager.get_task_temporary_dir(task_id + '-extracted')
-        dest_obj.out_path = os.path.join(dest_obj.out_dir, str(uuid.uuid4()))
+        self.dir_manager = dir_manager
+        self.task_id = task_id
+        self.secret = FileEncryptor.gen_secret(10, 20)
 
-    @staticmethod
-    def create_file_list(files, pickle_files):
-        return [os.path.basename(f) for f in files] + [p[0] for p in pickle_files]
+        self.disk_files = [out_file, out_dir_file]
+        self.memory_files = memory_files
+
+        disk_file_names = [os.path.basename(f) for f in self.disk_files]
+        memory_file_names = [p[0] for p in self.memory_files]
+        self.all_files = disk_file_names + memory_file_names
+
+        self.res_dir = res_dir
+        self.out_dir = out_dir
+        self.out_path = os.path.join(self.out_dir, str(uuid.uuid4()))
 
 
-class TestZipPackager(TestDirFixture):
-
-    def setUp(self):
-        TestDirFixture.setUp(self)
-
-        self.task_id = str(uuid.uuid4())
-        self.dir_manager = DirManager(self.path)
-        MockDirContents.populate(self, self.dir_manager, self.task_id)
+class TestZipPackager(PackageDirContentsFixture):
 
     def testCreate(self):
         zp = ZipPackager()
-        path, _ = zp.create(self.out_path, self.files, self.pickle_files)
+        path, _ = zp.create(self.out_path, self.disk_files, self.memory_files)
 
         self.assertTrue(os.path.exists(path))
         os.remove(path)
 
     def testExtract(self):
         zp = ZipPackager()
-        zp.create(self.out_path, self.files, self.pickle_files)
+        zp.create(self.out_path, self.disk_files, self.memory_files)
         files, out_dir = zp.extract(self.out_path)
 
-        self.assertTrue(len(files) == len(self.file_list))
-        shutil.rmtree(out_dir)
+        self.assertTrue(len(files) == len(self.all_files))
 
 
-class TestEncryptingPackager(TestDirFixture):
-
-    def setUp(self):
-        TestDirFixture.setUp(self)
-
-        self.task_id = str(uuid.uuid4())
-        self.dir_manager = DirManager(self.path)
-        self.secret = FileEncryptor.gen_secret(10, 20)
-        MockDirContents.populate(self, self.dir_manager, self.task_id)
+class TestEncryptingPackager(PackageDirContentsFixture):
 
     def testCreate(self):
         ep = EncryptingPackager(self.secret)
-        path, _ = ep.create(self.out_path, self.files, self.pickle_files)
+        path, _ = ep.create(self.out_path, self.disk_files, self.memory_files)
 
         self.assertTrue(os.path.exists(path))
-        os.remove(path)
 
     def testExtract(self):
         ep = EncryptingPackager(self.secret)
-        ep.create(self.out_path, self.files, self.pickle_files)
-        files, outdir = ep.extract(self.out_path)
+        ep.create(self.out_path, self.disk_files, self.memory_files)
+        files, _ = ep.extract(self.out_path)
 
-        self.assertTrue(len(files) == len(self.file_list))
-        shutil.rmtree(self.out_dir)
+        self.assertTrue(len(files) == len(self.all_files))
 
 
-class TestEncryptingTaskResultPackager(TestDirFixture):
-
-    def setUp(self):
-        TestDirFixture.setUp(self)
-
-        self.task_id = str(uuid.uuid4())
-        self.dir_manager = DirManager(self.path)
-        self.secret = FileEncryptor.gen_secret(10, 20)
-        MockDirContents.populate(self, self.dir_manager, self.task_id)
+class TestEncryptingTaskResultPackager(PackageDirContentsFixture):
 
     def testCreate(self):
         etp = EncryptingTaskResultPackager(self.secret)
-        node = MockNode(node_name)
+        node = mock_node()
 
-        tr = MockTaskResult(self.task_id, self.files)
+        tr = mock_task_result(self.task_id, self.disk_files)
         path, _ = etp.create(self.out_path,
                              node=node,
                              task_result=tr,
-                             cbor_files=self.pickle_files)
+                             cbor_files=self.memory_files)
 
         self.assertTrue(os.path.exists(path))
-        os.remove(path)
 
-        tr = MockTaskResult(self.task_id, "Result string data",
-                            result_type=ResultType.DATA)
+    def testCreateData(self):
+        etp = EncryptingTaskResultPackager(self.secret)
+        node = mock_node()
+
+        tr = mock_task_result(self.task_id, "Result string data",
+                              result_type=ResultType.DATA)
 
         path, _ = etp.create(self.out_path,
                              node=node,
                              task_result=tr)
 
         self.assertTrue(os.path.exists(path))
-        os.remove(path)
 
     def testExtract(self):
         etp = EncryptingTaskResultPackager(self.secret)
-        node = MockNode(node_name)
-        tr = MockTaskResult(self.task_id, self.files)
+        node = mock_node()
+        tr = mock_task_result(self.task_id, self.disk_files)
 
         path, _ = etp.create(self.out_path,
                              node=node,
                              task_result=tr,
-                             cbor_files=self.pickle_files)
+                             cbor_files=self.memory_files)
 
         extracted = etp.extract(path)
 
         self.assertIsInstance(extracted, ExtractedPackage)
-        self.assertEqual(len(extracted.files), len(self.file_list))
-
-        shutil.rmtree(extracted.files_dir)
+        self.assertEqual(len(extracted.files), len(self.all_files))
 
 
-class TestExtractedPackage(TestDirFixture):
-
-    def setUp(self):
-        TestDirFixture.setUp(self)
-
-        self.task_id = str(uuid.uuid4())
-        self.dir_manager = DirManager(self.path)
-        self.secret = FileEncryptor.gen_secret(10, 20)
-        MockDirContents.populate(self, self.dir_manager, self.task_id)
+class TestExtractedPackage(PackageDirContentsFixture):
 
     def testToExtraData(self):
         etp = EncryptingTaskResultPackager(self.secret)
-        node = MockNode(node_name)
-        tr = MockTaskResult(self.task_id, self.files)
+        node = mock_node()
+        tr = mock_task_result(self.task_id, self.disk_files)
 
         path, _ = etp.create(self.out_path,
                              node=node,
                              task_result=tr,
-                             cbor_files=self.pickle_files)
+                             cbor_files=self.memory_files)
 
         extracted = etp.extract(path)
         extra_data = extracted.to_extra_data()
 
         self.assertEqual(extra_data.get('result_type', None), ResultType.FILES)
-        self.assertEqual(len(extra_data.get('result', [])), len(self.file_list))
+        self.assertEqual(len(extra_data.get('result', [])), len(self.all_files))
         self.assertIsNone(extra_data.get('data_type', None))
 
         for filename in extra_data.get('result', []):
             self.assertTrue(os.path.exists(filename))
-
-        os.remove(path)
-        shutil.rmtree(extracted.files_dir)
-
-
-
-
-
-
-

--- a/tests/golem/task/result/test_resultpackage.py
+++ b/tests/golem/task/result/test_resultpackage.py
@@ -85,7 +85,7 @@ class TestZipPackager(TestDirFixture):
 
     def testCreate(self):
         zp = ZipPackager()
-        path = zp.create(self.out_path, self.files, self.pickle_files)
+        path, _ = zp.create(self.out_path, self.files, self.pickle_files)
 
         self.assertTrue(os.path.exists(path))
         os.remove(path)
@@ -111,7 +111,7 @@ class TestEncryptingPackager(TestDirFixture):
 
     def testCreate(self):
         ep = EncryptingPackager(self.secret)
-        path = ep.create(self.out_path, self.files, self.pickle_files)
+        path, _ = ep.create(self.out_path, self.files, self.pickle_files)
 
         self.assertTrue(os.path.exists(path))
         os.remove(path)
@@ -140,10 +140,10 @@ class TestEncryptingTaskResultPackager(TestDirFixture):
         node = MockNode(node_name)
 
         tr = MockTaskResult(self.task_id, self.files)
-        path = etp.create(self.out_path,
-                          node=node,
-                          task_result=tr,
-                          cbor_files=self.pickle_files)
+        path, _ = etp.create(self.out_path,
+                             node=node,
+                             task_result=tr,
+                             cbor_files=self.pickle_files)
 
         self.assertTrue(os.path.exists(path))
         os.remove(path)
@@ -151,9 +151,9 @@ class TestEncryptingTaskResultPackager(TestDirFixture):
         tr = MockTaskResult(self.task_id, "Result string data",
                             result_type=ResultType.DATA)
 
-        path = etp.create(self.out_path,
-                          node=node,
-                          task_result=tr)
+        path, _ = etp.create(self.out_path,
+                             node=node,
+                             task_result=tr)
 
         self.assertTrue(os.path.exists(path))
         os.remove(path)
@@ -163,10 +163,10 @@ class TestEncryptingTaskResultPackager(TestDirFixture):
         node = MockNode(node_name)
         tr = MockTaskResult(self.task_id, self.files)
 
-        path = etp.create(self.out_path,
-                          node=node,
-                          task_result=tr,
-                          cbor_files=self.pickle_files)
+        path, _ = etp.create(self.out_path,
+                             node=node,
+                             task_result=tr,
+                             cbor_files=self.pickle_files)
 
         extracted = etp.extract(path)
 
@@ -191,10 +191,10 @@ class TestExtractedPackage(TestDirFixture):
         node = MockNode(node_name)
         tr = MockTaskResult(self.task_id, self.files)
 
-        path = etp.create(self.out_path,
-                          node=node,
-                          task_result=tr,
-                          cbor_files=self.pickle_files)
+        path, _ = etp.create(self.out_path,
+                             node=node,
+                             task_result=tr,
+                             cbor_files=self.pickle_files)
 
         extracted = etp.extract(path)
         extra_data = extracted.to_extra_data()

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -8,9 +8,11 @@ import unittest
 import unittest.mock as mock
 import uuid
 
-import golem_messages
 import os
 import random
+
+import golem_messages
+
 from golem_messages import message
 
 from golem import model, testutils

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -803,8 +803,7 @@ class TestCreatePackage(unittest.TestCase):
         self.ts.task_server.get_waiting_task_result.return_value = None
         self.ts._react_to_get_task_result(msg)
 
-        assert self.ts.send.called
-        assert self.ts.dropped.called
+        assert self.ts.disconnect.called
 
 
 class GetTaskMessageTest(unittest.TestCase):


### PR DESCRIPTION
- result packaging moved to `TaskComputer.task_computed` (executed in the computation thread)
- result package SHA1 sum calculation is a part of the packaging process
- SHA1 is a digest of the non-encrypted ZIP file
- `WaitingTaskResult` carries information on the generated package

Resolves #2021 