### PR TITLE
Don't send information about task failure after timeout

### DIFF
--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -198,16 +198,16 @@ class TaskComputer(object):
                 self.stats.increase_stat('tasks_with_timeout')
             else:
                 self.stats.increase_stat('tasks_with_errors')
-            self.task_server.send_task_failed(
-                subtask_id,
-                subtask['task_id'],
-                task_thread.error_msg,
-                subtask['return_address'],
-                subtask['return_port'],
-                subtask['key_id'],
-                p2p_node,
-                self.node_name,
-            )
+                self.task_server.send_task_failed(
+                    subtask_id,
+                    subtask['task_id'],
+                    task_thread.error_msg,
+                    subtask['return_address'],
+                    subtask['return_port'],
+                    subtask['key_id'],
+                    p2p_node,
+                    self.node_name,
+                )
             dispatcher.send(signal='golem.monitor', event='computation_time_spent', success=False, value=work_time_to_be_paid)
 
         elif task_thread.result and 'data' in task_thread.result and 'result_type' in task_thread.result:


### PR DESCRIPTION
Requestor has to detect on her own that subtasks got timeout. Sending this information as additional message only increase amount of information sent in network, but doesn't give any additional value.  What's more after receiving failure message we decrease providers trust. Same happens when we detect timeout. So if we detect timeout first and then got this information from provider we'll decrease providers reputation twice. 