### PR TITLE
ZIP task resources

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -515,8 +515,11 @@ class Client(HardwarePresetsMixin):
                                        tmp_dir=tmp_dir,
                                        resources=task.get_resources())
 
-        def add_task(result):
-            task_state.resource_hash = result[0]
+        def add_task(resource_server_result):
+            resource_manager_result, package_hash = resource_server_result
+            task_state.package_hash = package_hash
+            task_state.resource_hash = resource_manager_result[0]
+
             request = AsyncRequest(task_manager.start_task, task_id)
             async_run(request, None, error)
 

--- a/golem/core/fileshelper.py
+++ b/golem/core/fileshelper.py
@@ -210,3 +210,16 @@ def format_cmd_line_path(path):
         return "{}".format(path)
     else:
         return '"{}"'.format(path)
+
+
+def relative_path(path, prefix):
+    if path.startswith(prefix):
+        return_path = path.replace(prefix, '', 1)
+    else:
+        return_path = path
+
+    if prefix:
+        while return_path and return_path.startswith(os.path.sep):
+            return_path = return_path[len(os.path.sep):]
+
+    return return_path

--- a/golem/core/variables.py
+++ b/golem/core/variables.py
@@ -43,7 +43,7 @@ class PROTOCOL_CONST(object):
     https://docs.python.org/3/faq/programming.html#how-do-i-share-global-variables-across-modules # noqa
     https://bytes.com/topic/python/answers/19859-accessing-updating-global-variables-among-several-modules # noqa
     """
-    ID = 22
+    ID = 23
 
     @staticmethod
     def patch_protocol_id(ctx, param, value):

--- a/golem/resource/base/resourceserver.py
+++ b/golem/resource/base/resourceserver.py
@@ -2,6 +2,12 @@ import logging
 from enum import Enum
 from threading import Lock
 
+import os
+from twisted.internet.defer import Deferred
+
+from golem.core.async import AsyncRequest, async_run
+from golem.task.result.resultpackage import ZipPackager
+
 logger = logging.getLogger(__name__)
 
 
@@ -33,6 +39,7 @@ class BaseResourceServer(object):
         self.dir_manager = dir_manager
         self.resource_manager = resource_manager
 
+        self.packager = ZipPackager()
         self.resource_dir = self.dir_manager.res
         self.pending_resources = {}
 
@@ -54,9 +61,22 @@ class BaseResourceServer(object):
         self._download_resources()
 
     def add_task(self, files, task_id):
-        result = self.resource_manager.add_task(files, task_id)
-        result.addErrback(self._add_task_error)
-        return result
+        _result = Deferred()
+        _result.addErrback(self._add_task_error)
+
+        resource_dir = self.resource_manager.storage.get_dir(task_id)
+        package_path = os.path.join(resource_dir,
+                                    self.packager.package_name(task_id))
+
+        def _add_task_resources(*_):
+            _deferred = self.resource_manager.add_task([package_path], task_id)
+            _deferred.chainDeferred(_result)
+
+        async_req = AsyncRequest(self.packager.create, package_path, files)
+        _create = async_run(async_req)
+        _create.addCallbacks(_add_task_resources, _result.errback)
+
+        return _result
 
     @staticmethod
     def _add_task_error(error):
@@ -97,32 +117,55 @@ class BaseResourceServer(object):
             return task_id
 
     def _download_resources(self, async_=True):
+        download_statuses = [TransferStatus.idle, TransferStatus.failed]
         pending = dict(self.pending_resources)
 
-        for task_id, entries in list(pending.items()):
-            for entry in list(entries):
-                if entry.status in [TransferStatus.idle, TransferStatus.failed]:
-                    entry.status = TransferStatus.transferring
-                    self.resource_manager.pull_resource(entry.resource, entry.task_id,
-                                                        client_options=entry.client_options,
-                                                        success=self._download_success,
-                                                        error=self._download_error,
-                                                        async_=async_)
+        for task_id, entries in pending.items():
+            for entry in entries:
+
+                if entry.status not in download_statuses:
+                    continue
+                entry.status = TransferStatus.transferring
+
+                self.resource_manager.pull_resource(
+                    entry.resource, entry.task_id,
+                    client_options=entry.client_options,
+                    success=self._download_success,
+                    error=self._download_error,
+                    async_=async_
+                )
 
     def _download_success(self, resource, _, task_id):
-        if resource:
+        if not resource:
+            self._download_error("Downloaded an empty resource package",
+                                 resource, task_id)
+            return
 
-            collected = self._remove_pending_resource(resource, task_id)
-            if collected:
-                self.client.task_resource_collected(collected,
-                                                    unpack_delta=False)
-        else:
-            logger.error("Empty resource downloaded for task {}"
-                         .format(task_id))
+        if not self._remove_pending_resource(resource, task_id):
+            logger.warning("Resources for task %r were re-downloaded", task_id)
+            return
+
+        self._extract_task_resources(resource, task_id)
 
     def _download_error(self, error, resource, task_id):
         self._remove_pending_resource(resource, task_id)
         self.client.task_resource_failure(task_id, error)
+
+    def _extract_task_resources(self, resource, task_id):
+        resource_dir = self.resource_manager.storage.get_dir(task_id)
+
+        def extract_packages(package_files):
+            for package_file in package_files:
+                package_path = os.path.join(resource_dir, package_file)
+                logger.debug('Extracting task resource: %r', package_path)
+                self.packager.extract(package_path, resource_dir)
+
+        async_req = AsyncRequest(extract_packages, resource[1])
+        async_run(async_req).addCallbacks(
+            lambda _:  self.client.task_resource_collected(task_id,
+                                                           unpack_delta=False),
+            lambda e: self._download_error(e, resource, task_id)
+        )
 
     def get_key_id(self):
         return self.keys_auth.get_key_id()

--- a/golem/resource/hyperdrive/resource.py
+++ b/golem/resource/hyperdrive/resource.py
@@ -19,6 +19,19 @@ def norm_path(path):
     return os.path.join(*split) if split else ''
 
 
+def relative_path(path, prefix):
+    if path.startswith(prefix):
+        return_path = path.replace(prefix, '', 1)
+    else:
+        return_path = path
+
+    if prefix:
+        while return_path and return_path.startswith(os.path.sep):
+            return_path = return_path[len(os.path.sep):]
+
+    return return_path
+
+
 class ResourceError(RuntimeError):
     pass
 
@@ -151,20 +164,9 @@ class ResourceStorage(object):
         return self.cache.has_resource(resource) and resource.exists
 
     def relative_path(self, path, task_id):
-
         path = norm_path(path)
         common_prefix = self.cache.get_prefix(task_id)
-
-        if path.startswith(common_prefix):
-            return_path = path.replace(common_prefix, '', 1)
-        else:
-            return_path = path
-
-        if common_prefix:
-            while return_path and return_path.startswith(os.path.sep):
-                return_path = return_path[len(os.path.sep):]
-
-        return return_path
+        return relative_path(path, common_prefix)
 
     def copy_dir(self, src_dir):
 

--- a/golem/resource/hyperdrive/resource.py
+++ b/golem/resource/hyperdrive/resource.py
@@ -4,7 +4,7 @@ import shutil
 from threading import Lock
 from typing import List
 
-from golem.core.fileshelper import copy_file_tree
+from golem.core.fileshelper import copy_file_tree, relative_path
 
 
 def split_path(path):
@@ -17,19 +17,6 @@ def norm_path(path):
     while split and split[0] in ['.', '..']:
         split = split[1:]
     return os.path.join(*split) if split else ''
-
-
-def relative_path(path, prefix):
-    if path.startswith(prefix):
-        return_path = path.replace(prefix, '', 1)
-    else:
-        return_path = path
-
-    if prefix:
-        while return_path and return_path.startswith(os.path.sep):
-            return_path = return_path[len(os.path.sep):]
-
-    return return_path
 
 
 class ResourceError(RuntimeError):

--- a/golem/task/result/resultpackage.py
+++ b/golem/task/result/resultpackage.py
@@ -7,10 +7,9 @@ import abc
 import os
 
 from golem.core.fileencrypt import AESFileEncryptor
-from golem.core.fileshelper import common_dir
+from golem.core.fileshelper import common_dir, relative_path
 from golem.core.simplehash import SimpleHash
 from golem.core.simpleserializer import CBORSerializer
-from golem.resource.hyperdrive.resource import relative_path
 from golem.task.taskbase import ResultType
 
 

--- a/golem/task/result/resultpackage.py
+++ b/golem/task/result/resultpackage.py
@@ -1,13 +1,16 @@
 import binascii
 import uuid
 import zipfile
+from typing import Iterable, Tuple, Optional
 
 import abc
 import os
 
 from golem.core.fileencrypt import AESFileEncryptor
+from golem.core.fileshelper import common_dir
 from golem.core.simplehash import SimpleHash
 from golem.core.simpleserializer import CBORSerializer
+from golem.resource.hyperdrive.resource import relative_path
 from golem.task.taskbase import ResultType
 
 
@@ -32,17 +35,21 @@ def backup_rename(file_path, max_iterations=100):
 
 class Packager(object):
 
-    def create(self, output_path, disk_files=None, cbor_files=None,
-               sha1_path=None, **kwargs):
+    def create(self,
+               output_path: str,
+               disk_files: Iterable[str] = None,
+               cbor_files: Iterable[Tuple[str, str]] = None,
+               sha1_path: Optional[str] = None,
+               **kwargs):
 
         if not disk_files and not cbor_files:
             raise ValueError('No files to pack')
 
+        disk_files = self._prepare_file_dict(disk_files)
         with self.generator(output_path) as of:
 
             if disk_files:
-                for file_path in disk_files:
-                    file_name = os.path.basename(file_path)
+                for file_path, file_name in disk_files.items():
                     self.write_disk_file(of, file_path, file_name)
 
             if cbor_files:
@@ -69,6 +76,19 @@ class Packager(object):
         with open(sha1_path, 'w') as sf:
             sf.write(pkg_sha1)
         return pkg_sha1
+
+    @classmethod
+    def _prepare_file_dict(cls, disk_files):
+        if len(disk_files) == 1:
+            disk_file = next(iter(disk_files))
+            prefix = os.path.dirname(disk_file)
+        else:
+            prefix = common_dir(disk_files)
+
+        return {
+            absolute_path: relative_path(absolute_path, prefix)
+            for absolute_path in disk_files
+        }
 
     @abc.abstractmethod
     def extract(self, input_path, output_dir=None, **kwargs):
@@ -130,7 +150,12 @@ class EncryptingPackager(Packager):
         self._packager = self.creator_class()
         self._secret = secret
 
-    def create(self, output_path, disk_files=None, cbor_files=None, **kwargs):
+    def create(self,
+               output_path: str,
+               disk_files: Iterable[str] = None,
+               cbor_files: Iterable[Tuple[str, str]] = None,
+               **kwargs):
+
         tmp_file_path = self.package_name(output_path)
         backup_rename(tmp_file_path)
 
@@ -162,8 +187,8 @@ class EncryptingPackager(Packager):
     def write_disk_file(self, obj, file_path, file_name):
         self._packager.write_disk_file(obj, file_path, file_name)
 
-    def write_cbor_file(self, obj, file_name, cbord_data):
-        self._packager.write_cbor_file(obj, file_name, cbord_data)
+    def write_cbor_file(self, obj, file_name, cbor_data):
+        self._packager.write_cbor_file(obj, file_name, cbor_data)
 
 
 class TaskResultDescriptor(object):
@@ -184,8 +209,10 @@ class EncryptingTaskResultPackager(EncryptingPackager):
     descriptor_file_name = '.package_desc'
     result_file_name = '.result_cbor'
 
-    def create(self, output_path,
-               disk_files=None, cbor_files=None,
+    def create(self,
+               output_path: str,
+               disk_files: Iterable[str] = None,
+               cbor_files: Iterable[Tuple[str, str]] = None,
                node=None, task_result=None, **kwargs):
 
         disk_files, cbor_files = self.__collect_files(task_result,

--- a/golem/task/result/resultpackage.py
+++ b/golem/task/result/resultpackage.py
@@ -138,6 +138,8 @@ class ZipPackager(Packager):
 
     @classmethod
     def package_name(cls, file_path):
+        if file_path.lower().endswith('.zip'):
+            return file_path
         return file_path + '.zip'
 
 

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -481,12 +481,14 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
             )
             self.dropped()
         elif ctd:
+            # task_state = self.task_manager.tasks_states[ctd['task_id']]
             msg = message.tasks.TaskToCompute(
                 compute_task_def=ctd,
                 requestor_id=ctd['task_owner']['key'],
                 requestor_public_key=ctd['task_owner']['key'],
                 provider_id=self.key_id,
                 provider_public_key=self.key_id,
+                # package_hash='sha1:' + task_state.package_hash,
             )
             self.send(msg)
         elif wait:

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -481,6 +481,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
             )
             self.dropped()
         elif ctd:
+            # FIXME: uncomment after upgrading to Golem-Messages > 1.7.0
             # task_state = self.task_manager.tasks_states[ctd['task_id']]
             msg = message.tasks.TaskToCompute(
                 compute_task_def=ctd,

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -14,7 +14,7 @@ class TaskState(object):
         self.total_subtasks = 0
         self.subtask_states = {}
         self.resource_hash = None
-
+        self.package_hash = None
         self.extra_data = {}
 
     def __repr__(self):

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -44,14 +44,20 @@ from golem.task.taskstate import TaskTestStatus
 
 
 def mock_async_run(req, success, error):
+    deferred = Deferred()
+    if success:
+        deferred.addCallback(success)
+    if error:
+        deferred.addErrback(error)
+
     try:
         result = req.method(*req.args, **req.kwargs)
-    # pylint: disable=broad-except
-    except Exception as e:
-        error(e)
+    except Exception as e:  # pylint: disable=broad-except
+        deferred.errback(e)
     else:
-        if success:
-            success(result)
+        deferred.callback(result)
+
+    return deferred
 
 
 def random_hex_str() -> str:


### PR DESCRIPTION
- task resources are zipped into a single package
- resource package is not encrypted
- `TaskComputer.package_hash` slot filling is commented out; requires `Golem-Messages>1.7.0`

Resolves #2022 