### PR TITLE
Merge Income and ExpectedIncome

### DIFF
--- a/golem/model.py
+++ b/golem/model.py
@@ -40,7 +40,7 @@ db = GolemSqliteDatabase(None, threadlocals=True,
 
 class Database:
     # Database user schema version, bump to recreate the database
-    SCHEMA_VERSION = 11
+    SCHEMA_VERSION = 12
 
     def __init__(self, datadir):
         # TODO: Global database is bad idea. Check peewee for other solutions.
@@ -62,7 +62,6 @@ class Database:
         tables = [
             GenericKeyValue,
             Account,
-            ExpectedIncome,
             GlobalRank,
             HardwarePreset,
             Income,
@@ -255,33 +254,23 @@ class Payment(BaseModel):
             )
 
 
-class ExpectedIncome(BaseModel):
+class Income(BaseModel):
     sender_node = CharField()
     subtask = CharField()
     value = BigIntegerField()
     accepted_ts = IntegerField(null=True)
-
-    def __repr__(self):
-        return "<ExpectedIncome: {!r} v:{:.3f}>"\
-            .format(self.subtask, self.value)
-
-
-class Income(BaseModel):
-    """Payments received from other nodes."""
-    sender_node = CharField()
-    subtask = CharField()
-    transaction = CharField()
-    value = BigIntegerField()
+    transaction = CharField(null=True)
 
     class Meta:
         database = db
         primary_key = CompositeKey('sender_node', 'subtask')
 
     def __repr__(self):
-        return "<Income: {!r} v:{:.3f} tid:{!r}>"\
+        return "<Income: {!r} v:{:.3f} accepted_ts:{!r} tid:{!r}>"\
             .format(
                 self.subtask,
                 self.value,
+                self.accepted_ts,
                 self.transaction,
             )
 

--- a/golem/transactions/ethereum/ethereumincomeskeeper.py
+++ b/golem/transactions/ethereum/ethereumincomeskeeper.py
@@ -2,11 +2,8 @@
 
 import logging
 
-from ethereum.utils import denoms, sha3
-
-from golem.model import Income, GenericKeyValue
+from golem.model import GenericKeyValue
 from golem.transactions.incomeskeeper import IncomesKeeper
-from golem.utils import decode_hex
 
 logger = logging.getLogger('golem.transactions.ethereum.ethereumincomeskeeper')
 
@@ -31,39 +28,12 @@ class EthereumIncomesKeeper(IncomesKeeper):
         )
 
     def _on_batch_event(self, event):
-        expected = Income.select().where(
-            Income.accepted_ts > 0,
-            Income.accepted_ts <= event.closure_time,
-            Income.transaction.is_null())
-
-        def is_sender(sender_node):
-            return sha3(decode_hex(sender_node))[12:] == \
-                decode_hex(event.sender)
-        expected = [e for e in expected if is_sender(e.sender_node)]
-        expected_value = sum([e.value for e in expected])
-        if expected_value == 0:
-            # Probably already handled event
-            return
-
-        if expected_value != event.amount:
-            # Need to report this to Concent if expected is greater
-            # and probably move all these expected incomes to a different table
-            logger.warning(
-                'Batch transfer amount does not match, expected %r, got %r',
-                expected_value / denoms.ether,
-                event.amount / denoms.ether)
-
-        amount_left = event.amount
-
-        for e in expected:
-            value = min(amount_left, e.value)
-            amount_left -= value
-            self.received(
-                sender_node_id=e.sender_node,
-                subtask_id=e.subtask,
-                transaction_id=event.tx_hash,
-                value=value,
-            )
+        self.received_batch_transfer(
+            event.tx_hash,
+            event.sender,
+            event.amount,
+            event.closure_time,
+        )
 
     def stop(self) -> None:
         block_number = self.__sci.get_block_number()

--- a/golem/transactions/ethereum/ethereumincomeskeeper.py
+++ b/golem/transactions/ethereum/ethereumincomeskeeper.py
@@ -4,7 +4,7 @@ import logging
 
 from ethereum.utils import denoms, sha3
 
-from golem.model import ExpectedIncome, GenericKeyValue
+from golem.model import Income, GenericKeyValue
 from golem.transactions.incomeskeeper import IncomesKeeper
 from golem.utils import decode_hex
 
@@ -31,9 +31,10 @@ class EthereumIncomesKeeper(IncomesKeeper):
         )
 
     def _on_batch_event(self, event):
-        expected = ExpectedIncome.select().where(
-            ExpectedIncome.accepted_ts > 0,
-            ExpectedIncome.accepted_ts <= event.closure_time)
+        expected = Income.select().where(
+            Income.accepted_ts > 0,
+            Income.accepted_ts <= event.closure_time,
+            Income.transaction.is_null())
 
         def is_sender(sender_node):
             return sha3(decode_hex(sender_node))[12:] == \

--- a/golem/transactions/incomeskeeper.py
+++ b/golem/transactions/incomeskeeper.py
@@ -1,11 +1,6 @@
 # -*- coding: utf-8 -*-
-import datetime
 import logging
-import peewee
-from pydispatch import dispatcher
 
-from golem.model import db
-from golem.model import ExpectedIncome
 from golem.model import Income
 
 logger = logging.getLogger("golem.transactions.incomeskeeper")
@@ -22,72 +17,30 @@ class IncomesKeeper(object):
         pass
 
     def run_once(self):
-        delta = datetime.datetime.now() - datetime.timedelta(minutes=10)
-        with db.atomic():
-            expected_incomes = ExpectedIncome\
-                    .select()\
-                    .where(ExpectedIncome.modified_date < delta)\
-                    .order_by(-ExpectedIncome.id)\
-                    .limit(50)\
-                    .execute()
-
-            for expected_income in expected_incomes:
-                is_subtask_paid = Income.select().where(
-                    Income.sender_node == expected_income.sender_node,
-                    Income.subtask == expected_income.subtask)\
-                    .exists()
-
-                if is_subtask_paid:
-                    expected_income.delete_instance()
-
-                else:  # ask for payment
-                    expected_income.modified_date = datetime.datetime.now()
-                    expected_income.save()
-                    dispatcher.send(
-                        signal="golem.transactions",
-                        event="expected_income",
-                        expected_income=expected_income)
+        # TODO Check for unpaid incomes and ask Concent for them
+        pass
 
     def received(self,
                  sender_node_id,
                  subtask_id,
                  transaction_id,
-                 value):
+                 value) -> None:
 
-        try:
-            with db.transaction():
-                expected_income = \
-                    ExpectedIncome.get(sender_node=sender_node_id,
-                                       subtask=subtask_id)
-                expected_income.delete_instance()
-
-        except ExpectedIncome.DoesNotExist:
-            logger.info("ExpectedIncome.DoesNotExist "
-                        "(sender_node_id %r, "
-                        "subtask_id %r, value %r) ",
-                        sender_node_id, subtask_id, value)
-
-        try:
-            with db.transaction():
-                income = Income.create(
+        with Income._meta.database.transaction():
+            try:
+                income = Income.get(
                     sender_node=sender_node_id,
                     subtask=subtask_id,
-                    transaction=transaction_id,
-                    value=value)
-                return income
-
-        except peewee.IntegrityError:
-            db_income = Income.get(
-                sender_node=sender_node_id,
-                subtask=subtask_id
-            )
-            logger.error(
-                'Duplicated entry for subtask: %r %dwGNT (tx: %r, dbtx: %r)',
-                subtask_id,
-                value,
-                transaction_id,
-                db_income.transaction
-            )
+                )
+            except Income.DoesNotExist:
+                logger.info("Income.DoesNotExist "
+                            "(sender_node_id %r, "
+                            "subtask_id %r, value %r) ",
+                            sender_node_id, subtask_id, value)
+                return
+            income.transaction = transaction_id[2:]
+            income.value = value
+            income.save()
 
     def expect(self, sender_node_id, subtask_id, value):
         logger.debug(
@@ -96,7 +49,7 @@ class IncomesKeeper(object):
             subtask_id,
             value
         )
-        return ExpectedIncome.create(
+        return Income.create(
             sender_node=sender_node_id,
             subtask=subtask_id,
             value=value
@@ -105,10 +58,10 @@ class IncomesKeeper(object):
     def update_awaiting(self, subtask_id, accepted_ts):
         try:
             # FIXME: query by (sender_id, subtask_id)
-            income = ExpectedIncome.get(subtask=subtask_id)
-        except ExpectedIncome.DoesNotExist:
+            income = Income.get(subtask=subtask_id)
+        except Income.DoesNotExist:
             logger.error(
-                "ExpectedIncome.DoesNotExist subtask_id: %r",
+                "Income.DoesNotExist subtask_id: %r",
                 subtask_id)
             return
         income.accepted_ts = accepted_ts
@@ -116,20 +69,10 @@ class IncomesKeeper(object):
 
     def get_list_of_all_incomes(self):
         # TODO: pagination
-        union = ExpectedIncome.select(
-            ExpectedIncome.created_date,
-            ExpectedIncome.sender_node,
-            ExpectedIncome.subtask,
-            peewee.SQL("NULL as 'transaction'"),
-            ExpectedIncome.value
-        ) | Income.select(
+        return Income.select(
             Income.created_date,
             Income.sender_node,
             Income.subtask,
             Income.transaction,
             Income.value
-        )
-
-        # Usage of .c : http://docs.peewee-orm.com/en/latest/peewee
-        # /querying.html#using-subqueries
-        return union.order_by(union.c.created_date.desc()).execute()
+        ).order_by(Income.created_date.desc())

--- a/golem/utils.py
+++ b/golem/utils.py
@@ -2,6 +2,8 @@ import logging
 import socket
 import sys
 
+from ethereum.utils import sha3
+
 import binascii
 
 
@@ -61,6 +63,10 @@ def encode_hex(b):
             b = b[2:]
         return str(binascii.hexlify(b), 'utf-8')
     raise TypeError('Value must be an instance of str or bytes')
+
+
+def pubkeytoaddr(pubkey: str) -> str:
+    return '0x' + encode_hex(sha3(decode_hex(pubkey))[12:])
 
 
 def tee_target(prefix, proc, input_stream, path, stream):

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1,4 +1,3 @@
-import datetime
 import os
 import random
 import uuid
@@ -214,7 +213,7 @@ class TestTaskServer(TestWithKeysAuth, LogTestCase, testutils.DatabaseFixture):
         ctd['task_id'] = "xyz"
         ctd['subtask_id'] = "xxyyzz"
         ts.task_manager.comp_task_keeper.receive_subtask(ctd)
-        model.ExpectedIncome.create(
+        model.Income.create(
             sender_node="key",
             task=ctd['task_id'],
             subtask=ctd['subtask_id'],

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -157,9 +157,8 @@ class TestClient(TestWithDatabase, TestWithReactor):
 
         n = 9
         incomes = [
-            Income(
+            Income.create(
                 sender_node=random_hex_str(),
-                sender_node_details=Node(),
                 subtask=random_hex_str(),
                 value=i * 10**18,
                 created_date=timestamp_to_datetime(i).replace(tzinfo=None),

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -26,7 +26,7 @@ from golem.core.deferred import sync_wait
 from golem.core.keysauth import EllipticalKeysAuth
 from golem.core.simpleserializer import DictSerializer
 from golem.environments.environment import Environment as DefaultEnvironment
-from golem.model import Payment, PaymentStatus, ExpectedIncome
+from golem.model import Payment, PaymentStatus, Income
 from golem.network.p2p.node import Node
 from golem.network.p2p.peersession import PeerSessionInfo
 from golem.report import StatusPublisher
@@ -157,7 +157,7 @@ class TestClient(TestWithDatabase, TestWithReactor):
 
         n = 9
         incomes = [
-            ExpectedIncome(
+            Income(
                 sender_node=random_hex_str(),
                 sender_node_details=Node(),
                 subtask=random_hex_str(),

--- a/tests/golem/transactions/test_incomeskeeper.py
+++ b/tests/golem/transactions/test_incomeskeeper.py
@@ -1,11 +1,11 @@
 import random
 import time
 
-from golem.model import db
-from golem.model import Income
+from golem.model import db, Income
 from golem.testutils import PEP8MixIn
 from golem.tools.testwithdatabase import TestWithDatabase
 from golem.transactions.incomeskeeper import IncomesKeeper
+from golem.utils import pubkeytoaddr
 
 # SQLITE3_MAX_INT = 2 ** 31 - 1 # old one
 
@@ -43,43 +43,118 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
                 sender_node=sender_node_id,
                 subtask=subtask_id,
             )
-        self.assertEqual(expected_income.value, value)
+        assert expected_income.value == value
+        assert expected_income.accepted_ts is None
+        assert expected_income.transaction is None
 
-    def test_received(self):
-        sender_node_id = generate_some_id('sender_node_id')
-        subtask_id = generate_some_id('subtask_id')
-        value = random.randint(MAX_INT, MAX_INT + 10)
+    def test_received_batch_transfer_closure_time(self):
+        sender_node_id = '0x' + 64 * 'a'
+        subtask_id1 = 'sample_subtask_id1'
+        value1 = MAX_INT + 10
+        accepted_ts1 = 1337
+        subtask_id2 = 'sample_subtask_id2'
+        value2 = MAX_INT + 100
+        accepted_ts2 = 2137
 
-        self.assertEqual(Income.select().count(), 0)
-        self._test_expect_income(sender_node_id=sender_node_id,
-                                 subtask_id=subtask_id,
-                                 value=value
-                                 )
-        self.assertEqual(Income.select().count(), 1)
-
-        transaction_id = '0x' + generate_some_id('transaction_id')
-        self.incomes_keeper.received(
+        assert 0 == Income.select().count()
+        self._test_expect_income(
             sender_node_id=sender_node_id,
-            subtask_id=subtask_id,
-            transaction_id=transaction_id,
-            value=value
+            subtask_id=subtask_id1,
+            value=value1,
         )
-
-        self.assertEqual(Income.select().count(), 1)
-
-        with db.atomic():
-            income = Income.get(sender_node=sender_node_id, subtask=subtask_id)
-        self.assertEqual(income.value, value)
-        self.assertEqual(income.transaction, transaction_id[2:])
-
-        # try to duplicate key
-        # same sender cannot pay for the same subtask twice
-        new_transaction = generate_some_id('transaction_id2')
-        new_value = random.randint(MAX_INT, MAX_INT + 10)
-        income = self.incomes_keeper.received(
+        self._test_expect_income(
             sender_node_id=sender_node_id,
-            subtask_id=subtask_id,
-            transaction_id=new_transaction,
-            value=new_value
+            subtask_id=subtask_id2,
+            value=value2,
         )
-        self.assertIsNone(income)
+        assert 2 == Income.select().count()
+
+        transaction_id = '0x' + 64 * '1'
+        transaction_id1 = '0x' + 64 * 'b'
+        transaction_id2 = '0x' + 64 * 'c'
+
+        # incomes not accepted, so this in no op
+        self.incomes_keeper.received_batch_transfer(
+            transaction_id,
+            pubkeytoaddr(sender_node_id),
+            value1,
+            accepted_ts2,
+        )
+        income1 = Income.get(sender_node=sender_node_id, subtask=subtask_id1)
+        assert income1.transaction is None
+        income2 = Income.get(sender_node=sender_node_id, subtask=subtask_id2)
+        assert income2.transaction is None
+
+        # now we accept both
+        self.incomes_keeper.update_awaiting(subtask_id1, accepted_ts1)
+        self.incomes_keeper.update_awaiting(subtask_id2, accepted_ts2)
+        self.incomes_keeper.received_batch_transfer(
+            transaction_id1,
+            pubkeytoaddr(sender_node_id),
+            value1,
+            accepted_ts1,
+        )
+        income1 = Income.get(sender_node=sender_node_id, subtask=subtask_id1)
+        assert transaction_id1[2:] == income1.transaction
+        income2 = Income.get(sender_node=sender_node_id, subtask=subtask_id2)
+        assert income2.transaction is None
+        self.incomes_keeper.received_batch_transfer(
+            transaction_id2,
+            pubkeytoaddr(sender_node_id),
+            value2,
+            accepted_ts2,
+        )
+        income1 = Income.get(sender_node=sender_node_id, subtask=subtask_id1)
+        assert transaction_id1[2:] == income1.transaction
+        income2 = Income.get(sender_node=sender_node_id, subtask=subtask_id2)
+        assert transaction_id2[2:] == income2.transaction
+
+    def test_received_batch_transfer_two_senders(self):
+        sender_node_id1 = '0x' + 64 * 'a'
+        sender_node_id2 = '0x' + 64 * 'b'
+        subtask_id1 = 'sample_subtask_id1'
+        subtask_id2 = 'sample_subtask_id2'
+        value1 = MAX_INT + 10
+        value2 = MAX_INT + 100
+
+        assert 0 == Income.select().count()
+        self._test_expect_income(
+            sender_node_id=sender_node_id1,
+            subtask_id=subtask_id1,
+            value=value1,
+        )
+        self._test_expect_income(
+            sender_node_id=sender_node_id2,
+            subtask_id=subtask_id2,
+            value=value2,
+        )
+        assert 2 == Income.select().count()
+
+        transaction_id1 = '0x' + 64 * 'b'
+        transaction_id2 = '0x' + 64 * 'd'
+        closure_time1 = 1337
+        closure_time2 = 2137
+
+        self.incomes_keeper.update_awaiting(subtask_id1, closure_time1)
+        self.incomes_keeper.received_batch_transfer(
+            transaction_id1,
+            pubkeytoaddr(sender_node_id1),
+            value1,
+            closure_time1,
+        )
+        income1 = Income.get(sender_node=sender_node_id1, subtask=subtask_id1)
+        assert transaction_id1[2:] == income1.transaction
+        income2 = Income.get(sender_node=sender_node_id2, subtask=subtask_id2)
+        assert income2.transaction is None
+
+        self.incomes_keeper.update_awaiting(subtask_id2, closure_time2)
+        self.incomes_keeper.received_batch_transfer(
+            transaction_id2,
+            pubkeytoaddr(sender_node_id2),
+            value2,
+            closure_time2,
+        )
+        income1 = Income.get(sender_node=sender_node_id1, subtask=subtask_id1)
+        assert transaction_id1[2:] == income1.transaction
+        income2 = Income.get(sender_node=sender_node_id2, subtask=subtask_id2)
+        assert transaction_id2[2:] == income2.transaction

--- a/tests/golem/transactions/test_incomeskeeper.py
+++ b/tests/golem/transactions/test_incomeskeeper.py
@@ -1,11 +1,8 @@
-import datetime
 import random
 import time
 
 from golem.model import db
-from golem.model import ExpectedIncome
 from golem.model import Income
-from golem.network.p2p.node import Node
 from golem.testutils import PEP8MixIn
 from golem.tools.testwithdatabase import TestWithDatabase
 from golem.transactions.incomeskeeper import IncomesKeeper
@@ -42,8 +39,10 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
             value=value
         )
         with db.atomic():
-            expected_income = ExpectedIncome.get(sender_node=sender_node_id,
-                                                 subtask=subtask_id)
+            expected_income = Income.get(
+                sender_node=sender_node_id,
+                subtask=subtask_id,
+            )
         self.assertEqual(expected_income.value, value)
 
     def test_received(self):
@@ -51,29 +50,27 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
         subtask_id = generate_some_id('subtask_id')
         value = random.randint(MAX_INT, MAX_INT + 10)
 
-        self.assertEqual(ExpectedIncome.select().count(), 0)
+        self.assertEqual(Income.select().count(), 0)
         self._test_expect_income(sender_node_id=sender_node_id,
                                  subtask_id=subtask_id,
                                  value=value
                                  )
-        self.assertEqual(ExpectedIncome.select().count(), 1)
+        self.assertEqual(Income.select().count(), 1)
 
-        transaction_id = generate_some_id('transaction_id')
-        income = self.incomes_keeper.received(
+        transaction_id = '0x' + generate_some_id('transaction_id')
+        self.incomes_keeper.received(
             sender_node_id=sender_node_id,
             subtask_id=subtask_id,
             transaction_id=transaction_id,
             value=value
         )
 
-        self.assertEqual(ExpectedIncome.select().count(), 0)
-        assert type(income) is Income
-        self.assertIsNotNone(income)
+        self.assertEqual(Income.select().count(), 1)
 
         with db.atomic():
             income = Income.get(sender_node=sender_node_id, subtask=subtask_id)
         self.assertEqual(income.value, value)
-        self.assertEqual(income.transaction, transaction_id)
+        self.assertEqual(income.transaction, transaction_id[2:])
 
         # try to duplicate key
         # same sender cannot pay for the same subtask twice
@@ -86,56 +83,3 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
             value=new_value
         )
         self.assertIsNone(income)
-
-    def test_run_once(self):
-        sender_node_id = generate_some_id('sender_node_id')
-        subtask_id = generate_some_id('subtask_id')
-        value = random.randint(MAX_INT, MAX_INT + 10)
-        transaction_id = generate_some_id('transaction_id')
-
-        expected_income = self.incomes_keeper.expect(
-            sender_node_id=sender_node_id,
-            subtask_id=subtask_id,
-            value=value
-        )
-
-        # expected payment written to DB
-        self.assertEqual(ExpectedIncome.select().count(), 1)
-
-        # Time is right but no matching payment received
-        with db.atomic():
-            expected_income.modified_date \
-                = datetime.datetime.now() \
-                - datetime.timedelta(hours=1)
-            expected_income.save()
-
-        self.incomes_keeper.run_once()
-        self.assertEqual(ExpectedIncome.select().count(), 1)
-
-        # Matching received but too early to check
-        Income.create(
-            sender_node=sender_node_id,
-            subtask=subtask_id,
-            transaction=transaction_id,
-            value=value)
-
-        with db.atomic():
-            self.assertEqual(ExpectedIncome.select().count(), 1)
-            expected_income.modified_date \
-                = datetime.datetime.now() \
-                + datetime.timedelta(hours=1)
-            expected_income.save()
-
-        self.incomes_keeper.run_once()
-        self.assertEqual(ExpectedIncome.select().count(), 1)
-
-        # Match
-        with db.atomic():
-            expected_income.modified_date = \
-                datetime.datetime.now() \
-                - datetime.timedelta(hours=1)
-            expected_income.save()
-
-        self.incomes_keeper.run_once()
-        with db.atomic():
-            self.assertEqual(ExpectedIncome.select().count(), 0)

--- a/tests/golem/transactions/test_incomeskeeper.py
+++ b/tests/golem/transactions/test_incomeskeeper.py
@@ -56,7 +56,7 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
         value2 = MAX_INT + 100
         accepted_ts2 = 2137
 
-        assert 0 == Income.select().count()
+        assert Income.select().count() == 0
         self._test_expect_income(
             sender_node_id=sender_node_id,
             subtask_id=subtask_id1,
@@ -67,7 +67,7 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
             subtask_id=subtask_id2,
             value=value2,
         )
-        assert 2 == Income.select().count()
+        assert Income.select().count() == 2
 
         transaction_id = '0x' + 64 * '1'
         transaction_id1 = '0x' + 64 * 'b'
@@ -117,7 +117,7 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
         value1 = MAX_INT + 10
         value2 = MAX_INT + 100
 
-        assert 0 == Income.select().count()
+        assert Income.select().count() == 0
         self._test_expect_income(
             sender_node_id=sender_node_id1,
             subtask_id=subtask_id1,
@@ -128,7 +128,7 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
             subtask_id=subtask_id2,
             value=value2,
         )
-        assert 2 == Income.select().count()
+        assert Income.select().count() == 2
 
         transaction_id1 = '0x' + 64 * 'b'
         transaction_id2 = '0x' + 64 * 'd'


### PR DESCRIPTION
These tables are almost identical. And currently we lose `accepted_ts` when moving from `ExpectedIncome` to `Income`.
Income's lifecycle:
- created expected income
- approved by requestor - `accepted_ts` not null
- paid by requestor  - transaction not null