### PR TITLE
include `package_hash` in TaskToCompute (fulfill the `fixme` in the comments)

### DIFF
--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -483,15 +483,14 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin,
             )
             self.dropped()
         elif ctd:
-            # FIXME: uncomment after upgrading to Golem-Messages > 1.7.0
-            # task_state = self.task_manager.tasks_states[ctd['task_id']]
+            task_state = self.task_manager.tasks_states[ctd['task_id']]
             msg = message.tasks.TaskToCompute(
                 compute_task_def=ctd,
                 requestor_id=ctd['task_owner']['key'],
                 requestor_public_key=ctd['task_owner']['key'],
                 provider_id=self.key_id,
                 provider_public_key=self.key_id,
-                # package_hash='sha1:' + task_state.package_hash,
+                package_hash='sha1:' + task_state.package_hash,
             )
             self.send(msg)
         elif wait:

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,5 +47,6 @@ scipy==0.19.1
 pyssim
 enforce==0.3.4
 miniupnpc<2.1,>=2.0
-Golem-Messages==1.7.0
+#Golem-Messages==1.7.0
+-e git://github.com/golemfactory/golem-messages.git@v1.8.0#egg=golem_messages
 -e git://github.com/golemfactory/golem-smart-contracts-interface.git@96ac480fb8107c26d412b2691e264f233e3b9eda#egg=golem_sci

--- a/requirements.txt
+++ b/requirements.txt
@@ -47,6 +47,5 @@ scipy==0.19.1
 pyssim
 enforce==0.3.4
 miniupnpc<2.1,>=2.0
-#Golem-Messages==1.7.0
--e git://github.com/golemfactory/golem-messages.git@v1.8.0#egg=golem_messages
+Golem-Messages==1.8.1
 -e git://github.com/golemfactory/golem-smart-contracts-interface.git@96ac480fb8107c26d412b2691e264f233e3b9eda#egg=golem_sci

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -130,7 +130,7 @@ class TestTaskSession(LogTestCase, testutils.TempDirFixture,
             ['provider_public_key', provider_key],
             ['compute_task_def', ctd],
             ['package_hash', 'sha1:' + task_state.package_hash],
-            ['concent_enabled', None],
+            ['concent_enabled', True],
         ]
         self.assertCountEqual(ms.slots(), expected)
         ts2.task_manager.get_next_subtask.return_value = (ctd, True, False)

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -130,7 +130,7 @@ class TestTaskSession(LogTestCase, testutils.TempDirFixture,
             ['provider_public_key', provider_key],
             ['compute_task_def', ctd],
             ['package_hash', 'sha1:' + task_state.package_hash],
-            ['concent_enabled', True],
+            ['concent_enabled', None],
         ]
         self.assertCountEqual(ms.slots(), expected)
         ts2.task_manager.get_next_subtask.return_value = (ctd, True, False)


### PR DESCRIPTION
(since the `golem-messages` lib has been updated with that prerequisite)