### PR TITLE
Use requests sessions

### DIFF
--- a/golem/network/hyperdrive/client.py
+++ b/golem/network/hyperdrive/client.py
@@ -37,6 +37,7 @@ class HyperdriveClient(IClient):
         # default POST request headers
         self._url = 'http://{}:{}/api'.format(self.host, self.port)
         self._headers = {'content-type': 'application/json'}
+        self._session = requests.Session()
 
     @classmethod
     def build_options(cls, peers=None, **kwargs):
@@ -103,10 +104,10 @@ class HyperdriveClient(IClient):
         return response['hash']
 
     def _request(self, **data):
-        response = requests.post(url=self._url,
-                                 headers=self._headers,
-                                 data=json.dumps(data),
-                                 timeout=self.timeout)
+        response = self._session.post(url=self._url,
+                                      headers=self._headers,
+                                      data=json.dumps(data),
+                                      timeout=self.timeout)
 
         try:
             response.raise_for_status()

--- a/tests/golem/network/hyperdrive/test_hyperdrive_client.py
+++ b/tests/golem/network/hyperdrive/test_hyperdrive_client.py
@@ -84,21 +84,20 @@ class TestHyperdriveClient(unittest.TestCase):
             assert client.cancel(content_hash) == response_hash
 
     @mock.patch('json.loads')
-    @mock.patch('requests.post')
-    def test_request(self, post, json_loads):
+    def test_request(self, json_loads):
         client = HyperdriveClient()
-        response = mock.Mock()
-        post.return_value = response
+        client._session = mock.Mock()
 
         client._request(key="value")
         assert json_loads.called
 
     @mock.patch('json.loads')
-    @mock.patch('requests.post')
-    def test_request_exception(self, post, json_loads):
+    def test_request_exception(self, json_loads):
         client = HyperdriveClient()
+        client._session = mock.Mock()
+
         response = mock.Mock()
-        post.return_value = response
+        client._session.post.return_value = response
 
         exception = Exception()
         response.raise_for_status.side_effect = exception
@@ -109,11 +108,12 @@ class TestHyperdriveClient(unittest.TestCase):
             assert not json_loads.called
 
     @mock.patch('json.loads')
-    @mock.patch('requests.post')
-    def test_request_http_error(self, post, json_loads):
+    def test_request_http_error(self, json_loads):
         client = HyperdriveClient()
+        client._session = mock.Mock()
+
         response = mock.Mock()
-        post.return_value = response
+        client._session.post.return_value = response
 
         exception = HTTPError()
         response.raise_for_status.side_effect = exception


### PR DESCRIPTION
This allows to reuse one connection for many requests.