### PR TITLE
Catch EOFError 'Ran out of input'

### DIFF
--- a/golem/task/taskarchiver.py
+++ b/golem/task/taskarchiver.py
@@ -40,7 +40,7 @@ class TaskArchiver(object):
                 else:
                     log.info("Task archive not loaded: unsupported version: "
                              "%s", archive.class_version)
-            except (IOError, pickle.UnpicklingError) as e:
+            except (EOFError, IOError, pickle.UnpicklingError) as e:
                 log.info("Task archive not loaded: %s", str(e))
 
     def add_task(self, task_header):


### PR DESCRIPTION
This error can occur while unpickling erroneous task dumps. It does not present itself in the log files, execution abruptly ends on displaying version and protocol numbers.