### PR TITLE
Increase port ping request's timeout

### DIFF
--- a/golem/monitor/monitor.py
+++ b/golem/monitor/monitor.py
@@ -85,7 +85,7 @@ class SystemMonitor(object):
 
     def ping_request(self, port):
         import requests
-        timeout = 1  # seconds
+        timeout = 2.5  # seconds
         try:
             response = requests.post(
                 '%sping-me' % (self.config['HOST'],),


### PR DESCRIPTION
In monitor, port ping timeout has recently been increased to 2s. Users without forwarded ports see an error (with traceback) each time starting Golem.