### PR TITLE
Client.quit called many times

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -1,4 +1,3 @@
-import atexit
 import logging
 import sys
 import time
@@ -216,8 +215,6 @@ class Client(HardwarePresetsMixin):
             self.taskmanager_listener,
             signal='golem.taskmanager'
         )
-
-        atexit.register(self.quit)
 
     def configure_rpc(self, rpc_session):
         self.rpc_publisher = Publisher(rpc_session)
@@ -482,6 +479,7 @@ class Client(HardwarePresetsMixin):
 
     @report_calls(Component.client, 'quit', once=True)
     def quit(self):
+        log.info('Shutting down ...')
         self.stop()
 
         if self.transaction_system:

--- a/golem/core/processmonitor.py
+++ b/golem/core/processmonitor.py
@@ -1,4 +1,3 @@
-import atexit
 import subprocess
 import time
 from multiprocessing import Process
@@ -19,7 +18,6 @@ class ProcessMonitor(Thread):
         self.daemon = True
         self.working = False
 
-        atexit.register(self.exit)
         self.add_child_processes(*child_processes)
 
     def _start(self):

--- a/golem/docker/job.py
+++ b/golem/docker/job.py
@@ -1,4 +1,3 @@
-import atexit
 import logging
 import os
 import posixpath
@@ -308,10 +307,3 @@ class DockerJob(object):
             inspect = client.inspect_container(self.container_id)
             return inspect["State"]["Status"]
         return self.state
-
-    @staticmethod
-    @atexit.register
-    def kill_jobs():
-        for job in DockerJob.running_jobs:
-            logger.info("Killing job {}".format(job.container_id))
-            job.kill()

--- a/golem/docker/job.py
+++ b/golem/docker/job.py
@@ -47,8 +47,6 @@ class DockerJob(object):
     # Name of the parameters file, relative to WORK_DIR
     PARAMS_FILE = "params.py"
 
-    running_jobs = []
-
     def __init__(self, image, script_src, parameters,
                  resources_dir, work_dir, output_dir,
                  host_config=None, container_log_level=None):
@@ -156,7 +154,6 @@ class DockerJob(object):
         if self.container_id is None:
             raise KeyError("container does not have key: Id")
 
-        self.running_jobs.append(self)
         logger.debug("Container {} prepared, image: {}, dirs: {}; {}; {}"
                      .format(self.container_id, self.image.name,
                              self.work_dir, self.resources_dir, self.output_dir)
@@ -164,7 +161,6 @@ class DockerJob(object):
 
     def _cleanup(self):
         if self.container:
-            self.running_jobs.remove(self)
             client = local_client()
             self._host_dir_chmod(self.work_dir, self.work_dir_mod)
             self._host_dir_chmod(self.resources_dir, self.resources_dir_mod)

--- a/golem/ethereum/node.py
+++ b/golem/ethereum/node.py
@@ -1,4 +1,3 @@
-import atexit
 import logging
 import os
 import random
@@ -71,7 +70,6 @@ class NodeProcess(object):
             provider = self._create_remote_rpc_provider()
 
         self.web3 = Web3(provider)
-        atexit.register(lambda: self.stop())
 
         started = time.time()
         deadline = started + self.CONNECTION_TIMEOUT

--- a/golem/network/hyperdrive/daemon_manager.py
+++ b/golem/network/hyperdrive/daemon_manager.py
@@ -1,4 +1,3 @@
-import atexit
 import copy
 import logging
 import os
@@ -31,8 +30,6 @@ class HyperdriveDaemonManager(object):
         self._monitor.add_callbacks(self._start)
 
         self._dir = os.path.join(datadir, self._executable)
-
-        atexit.register(self.stop)
 
         logsdir = os.path.join(datadir, "logs")
         if not os.path.exists(logsdir):

--- a/golem/node.py
+++ b/golem/node.py
@@ -52,7 +52,8 @@ class Node(object):
 
     def run(self, use_rpc=False):
         from twisted.internet import reactor
-
+        reactor.addSystemEventTrigger("before", "shutdown",
+                                      self.client.quit)
         try:
             if use_rpc:
                 self._setup_rpc()
@@ -62,9 +63,7 @@ class Node(object):
 
             reactor.run()
         except Exception as exc:
-            self.logger.error("Application error: {}".format(exc))
-        finally:
-            self.client.quit()
+            self.logger.exception("Application error: %r", exc)
 
     def _run(self, *_):
         if self.client.use_docker_machine_manager:
@@ -111,12 +110,8 @@ class Node(object):
 
     def _start_rpc_router(self):
         from twisted.internet import reactor
-
-        reactor.addSystemEventTrigger("before", "shutdown",
-                                      self.client.quit)
         reactor.addSystemEventTrigger("before", "shutdown",
                                       self.rpc_router.stop)
-
         self.rpc_router.start(reactor, self._rpc_router_ready, self._rpc_error)
 
     def _rpc_router_ready(self, *_):

--- a/tests/golem/docker/test_docker_job.py
+++ b/tests/golem/docker/test_docker_job.py
@@ -378,22 +378,3 @@ with open("../output/out.txt", "w") as f:
             job.kill()
             assert local_client.called
             assert client.kill.called
-
-    @patch('golem.docker.job.DockerJob.kill')
-    def test_kill_jobs(self, kill):
-
-        def create_job():
-            job = DockerJob.__new__(DockerJob)
-            job.container = mock.Mock()
-            job.container_id = str(uuid.uuid4())
-            return job
-
-        DockerJob.kill_jobs()
-        assert not kill.called
-
-        DockerJob.running_jobs = [
-            create_job(), create_job(),
-        ]
-
-        DockerJob.kill_jobs()
-        assert kill.call_count == 2


### PR DESCRIPTION
- remove `atexit` wherever possible
- shutdown ops are performed only in `Client.quit`, triggered by the reactor before shutdown
- fixes #2069