### PR TITLE
Don't store public keys on disk

### DIFF
--- a/golem/core/variables.py
+++ b/golem/core/variables.py
@@ -9,7 +9,6 @@ LONG_STANDARD_SIZE = 4
 ############################
 APP_NAME = "Brass Golem"
 PRIVATE_KEY = "golem_private_key.peb"
-PUBLIC_KEY = "golem_public_key.pubkey"
 DEFAULT_PROC_FILE = "node_processes.ctl"
 MAX_PROC_FILE_SIZE = 1024 * 1024
 

--- a/tests/golem/core/test_keysauth.py
+++ b/tests/golem/core/test_keysauth.py
@@ -80,7 +80,7 @@ class TestRSAKeysAuth(TestWithKeysAuth):
         signature = km.sign(data)
         self.assertTrue(km.verify(signature, data))
         self.assertTrue(km.verify(signature, data, km.public_key))
-        km2 = RSAKeysAuth(self.path, "PRIVATE2", "PUBLIC2")
+        km2 = RSAKeysAuth(self.path, "PRIVATE2")
         self.assertTrue(km2.verify(signature, data, km.public_key))
         data2 = b"ABBALJL\nafaoawuoauofa\ru0180141mfa\t" * 100
         signature2 = km2.sign(data2)
@@ -109,18 +109,15 @@ class TestRSAKeysAuth(TestWithKeysAuth):
         if not path.isdir(self.path):
             mkdir(self.path)
         ek = RSAKeysAuth(self.path)
-        pub_key_file = join(self.path, "pub_rsa.key")
         priv_key_file = join(self.path, "priv_rsa.key")
         pub_key = ek.get_public_key().exportKey()
         priv_key = ek._private_key.exportKey()
-        self.assertTrue(ek.save_to_files(priv_key_file, pub_key_file))
+        self.assertTrue(ek.save_to_files(priv_key_file))
         with self.assertRaises(TypeError):
             ek.generate_new(None)
         ek.generate_new(5)
         self.assertNotEqual(ek.get_public_key(), pub_key)
         self.assertNotEqual(ek._private_key, priv_key)
-        with open(pub_key_file, 'rb') as f:
-            self.assertEqual(f.read(), pub_key)
         with open(priv_key_file, 'rb') as f:
             self.assertEqual(f.read(), priv_key)
         self.assertTrue(ek.load_from_file(priv_key_file))
@@ -133,10 +130,7 @@ class TestRSAKeysAuth(TestWithKeysAuth):
                 priv_key_file = join(self.path, "priv_rsa_incorrect.key")
                 open(priv_key_file, 'w').close()
                 chmod(priv_key_file, 0x700)
-                pub_key_file = join(self.path, "pub_rsa_incorrect.key")
-                open(pub_key_file, 'w').close()
-                chmod(pub_key_file, 0x700)
-                self.assertFalse(ek.save_to_files(priv_key_file, pub_key_file))
+                self.assertFalse(ek.save_to_files(priv_key_file))
 
 
 class TestEllipticalKeysAuth(TestWithKeysAuth):
@@ -181,18 +175,15 @@ class TestEllipticalKeysAuth(TestWithKeysAuth):
         from os import chmod
         from golem.core.common import is_windows
         ek = EllipticalKeysAuth(self.path)
-        pub_key_file = join(self.path, "pub.key")
         priv_key_file = join(self.path, "priv.key")
         pub_key = ek.get_public_key()
         priv_key = ek._private_key
-        ek.save_to_files(priv_key_file, pub_key_file)
+        ek.save_to_files(priv_key_file)
         with self.assertRaises(TypeError):
             ek.generate_new(None)
         ek.generate_new(5)
         self.assertNotEqual(ek.get_public_key(), pub_key)
         self.assertNotEqual(ek._private_key, priv_key)
-        with open(pub_key_file, 'rb') as f:
-            self.assertEqual(f.read(), pub_key)
         with open(priv_key_file, 'rb') as f:
             self.assertEqual(f.read(), priv_key)
         self.assertTrue(ek.load_from_file(priv_key_file))
@@ -205,10 +196,7 @@ class TestEllipticalKeysAuth(TestWithKeysAuth):
                 priv_key_file = join(self.path, "priv_incorrect.hey")
                 open(priv_key_file, 'w').close()
                 chmod(priv_key_file, 0x700)
-                pub_key_file = join(self.path, "pub_incorrect.hey")
-                open(pub_key_file, 'w').close()
-                chmod(pub_key_file, 0x700)
-                self.assertFalse(ek.save_to_files(priv_key_file, pub_key_file))
+                self.assertFalse(ek.save_to_files(priv_key_file))
 
     def test_fixed_sign_verify_elliptical(self):
         public_key = b"cdf2fa12bef915b85d94a9f210f2e432542f249b8225736d923fb0" \

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -109,8 +109,7 @@ class TestP2PService(testutils.DatabaseFixture):
 
     def test_remove_old_peers(self):
         node = mock.MagicMock()
-        node.key = EllipticalKeysAuth(self.path, "TESTPRIV",
-                                      "TESTPUB").get_key_id()
+        node.key = EllipticalKeysAuth(self.path, "TESTPRIV").get_key_id()
         node.key_id = node.key
 
         self.service.last_peers_request = time.time() + 10
@@ -131,14 +130,12 @@ class TestP2PService(testutils.DatabaseFixture):
         sa = SocketAddress('127.0.0.1', 11111)
 
         node = mock.MagicMock()
-        node.key = EllipticalKeysAuth(self.path, "TESTPRIV",
-                                      "TESTPUB").get_key_id()
+        node.key = EllipticalKeysAuth(self.path, "TESTPRIV").get_key_id()
         node.key_id = node.key
         node.address = sa
 
         node2 = mock.MagicMock()
-        node2.key = EllipticalKeysAuth(self.path, "TESTPRIV2",
-                                       "TESTPUB2").get_key_id()
+        node2.key = EllipticalKeysAuth(self.path, "TESTPRIV2").get_key_id()
         node2.key_id = node2.key
         node2.address = sa
 
@@ -162,8 +159,7 @@ class TestP2PService(testutils.DatabaseFixture):
         assert len(self.service.peers) == 2
 
     def test_add_known_peer(self):
-        key_id = EllipticalKeysAuth(self.path, "TESTPRIV",
-                                    "TESTPUB").get_key_id()
+        key_id = EllipticalKeysAuth(self.path, "TESTPRIV").get_key_id()
         nominal_seeds = len(self.service.seeds)
 
         node = Node(
@@ -221,8 +217,7 @@ class TestP2PService(testutils.DatabaseFixture):
 
     def test_sync_free_peers(self):
         node = mock.MagicMock()
-        node.key = EllipticalKeysAuth(self.path, "PRIVTEST",
-                                      "PUBTEST").get_key_id()
+        node.key = EllipticalKeysAuth(self.path, "PRIVTEST").get_key_id()
         node.key_id = node.key
         node.pub_addr = '127.0.0.1'
         node.pub_port = 10000
@@ -325,8 +320,7 @@ class TestP2PService(testutils.DatabaseFixture):
         m2.transport.getPeer.return_value.port = "11432"
         m2.transport.getPeer.return_value.host = "127.0.0.1"
         ps2 = PeerSession(m2)
-        keys_auth2 = EllipticalKeysAuth(self.path, "PUBTESTPATH1",
-                                        "PUBTESTPATH2")
+        keys_auth2 = EllipticalKeysAuth(self.path, "PUBTESTPATH1")
         ps2.key_id = keys_auth2.key_id
         self.service.add_peer(keys_auth2.key_id, ps2)
         self.service.get_diagnostics(DiagnosticsOutputFormat.json)


### PR DESCRIPTION
Public keys are easily computable from private keys, storing them on the disk is redundant.
Two freshly generated golem clients were able to talk to each other with this change, so I assume I didn't miss anything.