### PR TITLE
Drop waiting_for_task_timeout

### DIFF
--- a/golem/appconfig.py
+++ b/golem/appconfig.py
@@ -57,7 +57,6 @@ TASKARCHIVE_MAX_TASKS = 10000000
 P2P_SESSION_TIMEOUT = 240
 TASK_SESSION_TIMEOUT = 900
 RESOURCE_SESSION_TIMEOUT = 600
-WAITING_FOR_TASK_TIMEOUT = 720  # 36000
 WAITING_FOR_TASK_SESSION_TIMEOUT = 20
 FORWARDED_SESSION_REQUEST_TIMEOUT = 30
 CLEAN_RESOURES_OLDER_THAN_SECS = 3*24*60*60  # 3 days
@@ -140,7 +139,6 @@ class AppConfig:
             p2p_session_timeout=P2P_SESSION_TIMEOUT,
             task_session_timeout=TASK_SESSION_TIMEOUT,
             resource_session_timeout=RESOURCE_SESSION_TIMEOUT,
-            waiting_for_task_timeout=WAITING_FOR_TASK_TIMEOUT,
             waiting_for_task_session_timeout=WAITING_FOR_TASK_SESSION_TIMEOUT,
             forwarded_session_request_timeout=FORWARDED_SESSION_REQUEST_TIMEOUT,
             clean_resources_older_than_seconds=CLEAN_RESOURES_OLDER_THAN_SECS,

--- a/golem/clientconfigdescriptor.py
+++ b/golem/clientconfigdescriptor.py
@@ -28,7 +28,6 @@ class ClientConfigDescriptor(object):
         self.getting_peers_interval = 0.0
         self.getting_tasks_interval = 0.0
         self.task_request_interval = 0.0
-        self.waiting_for_task_timeout = 0.0
         self.waiting_for_task_session_timeout = 0.0
         self.forwarded_session_request_timeout = 0.0
         self.p2p_session_timeout = 0
@@ -83,9 +82,9 @@ class ConfigApprover(object):
                        'use_ipv6', 'use_upnp', 'eth_account', 'accept_tasks',
                        'node_name']
     to_int_opt = ['seed_port', 'num_cores', 'opt_peer_num',
-                  'waiting_for_task_timeout', 'p2p_session_timeout',
-                  'task_session_timeout', 'pings_interval',
-                  'max_results_sending_delay', 'min_price', 'max_price']
+                  'p2p_session_timeout', 'task_session_timeout',
+                  'pings_interval', 'max_results_sending_delay', 'min_price',
+                  'max_price']
     to_float_opt = ['getting_peers_interval', 'getting_tasks_interval',
                     'computing_trust', 'requesting_trust']
 

--- a/golem/interface/client/settings.py
+++ b/golem/interface/client/settings.py
@@ -64,12 +64,6 @@ class Settings(object):
             _int,
             lambda x: x > 0
         ),
-        'waiting_for_task_timeout': Setting(
-            'Timeout value to use when waiting for task',
-            'int > 0 [s]',
-            _int,
-            lambda x: x > 0
-        ),
         'getting_tasks_interval': Setting(
             'Interval between task requests',
             'int > 0 [s]',

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -633,7 +633,6 @@ class TestSettings(TempDirFixture):
             'node_name': Values(['node'], ['', None, 12, lambda x: x]),
             'accept_tasks': _bool,
             'max_resource_size': _int_gt0,
-            'waiting_for_task_timeout': _int_gt0,
             'getting_tasks_interval': _int_gt0,
             'getting_peers_interval': _int_gt0,
             'task_session_timeout': _int_gt0,

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -37,7 +37,6 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
     def test_run(self):
         task_server = self.task_server
         task_server.config_desc.task_request_interval = 0.5
-        task_server.config_desc.waiting_for_task_timeout = 1
         task_server.config_desc.accept_tasks = True
         task_server.get_task_computer_root.return_value = self.path
         tc = TaskComputer("ABC", task_server, use_docker_machine_manager=False)

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -270,14 +270,12 @@ class TestTaskServer(LogTestCase, testutils.DatabaseFixture,  # noqa pylint: dis
         ccd2.use_distributed_resource_management = 0
         ccd2.task_request_interval = 31
         # ccd2.use_waiting_ttl = False
-        ccd2.waiting_for_task_timeout = 90
         ts.change_config(ccd2)
         self.assertEqual(ts.config_desc, ccd2)
         self.assertEqual(ts.last_message_time_threshold, 124)
         self.assertEqual(ts.task_keeper.min_price, 0.0057)
         self.assertEqual(ts.task_manager.use_distributed_resources, False)
         self.assertEqual(ts.task_computer.task_request_frequency, 31)
-        self.assertEqual(ts.task_computer.waiting_for_task_timeout, 90)
         # self.assertEqual(ts.task_computer.use_waiting_ttl, False)
 
     def test_add_task_header(self, *_):


### PR DESCRIPTION
A follow up on https://github.com/golemfactory/golem/pull/2117

Relies on hyperg download timeouts.