### PR TITLE
Create rpc router before creating client

### DIFF
--- a/golemapp.py
+++ b/golemapp.py
@@ -125,7 +125,7 @@ def start(payments, monitor, datadir, node_address, rpc_address, peer,
             start_geth_port=start_geth_port,
             geth_address=geth_address,
         )
-        node.run(use_rpc=True)
+        node.run()
 
 
 def delete_reactor():

--- a/tests/golem/docker/test_docker_blender_task.py
+++ b/tests/golem/docker/test_docker_blender_task.py
@@ -87,10 +87,8 @@ class TestDockerBlenderTask(TempDirFixture, DockerTestCase):
             config_desc=ClientConfigDescriptor(),
             use_docker_machine_manager=False,
         )
-        self.node.client.ranking = Mock()
+        self.node.client = self.node._client_factory()
         self.node.client.start = Mock()
-        self.node.client.p2pservice = Mock()
-        self.node.client.datadir = self.path
         self.node._run()
 
         ccd = ClientConfigDescriptor()

--- a/tests/golem/docker/test_docker_dummy_task.py
+++ b/tests/golem/docker/test_docker_dummy_task.py
@@ -128,8 +128,8 @@ class TestDockerDummyTask(TempDirFixture, DockerTestCase):
             config_desc=ClientConfigDescriptor(),
             use_docker_machine_manager=False,
         )
+        self.node.client = self.node._client_factory()
         self.node.client.start = Mock()
-        self.node.client.datadir = self.path
         self.node._run()
 
         ccd = ClientConfigDescriptor()

--- a/tests/golem/docker/test_docker_luxrender_task.py
+++ b/tests/golem/docker/test_docker_luxrender_task.py
@@ -102,8 +102,8 @@ class TestDockerLuxrenderTask(TempDirFixture, DockerTestCase):
             config_desc=ClientConfigDescriptor(),
             use_docker_machine_manager=False,
         )
+        self.node.client = self.node._client_factory()
         self.node.client.start = Mock()
-        self.node.client.datadir = self.path
         self.node._run()
 
         ccd = ClientConfigDescriptor()

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -61,15 +61,23 @@ class TestNode(TestWithDatabase):
             node_address,
         )
 
-    @patch('golem.node.Node.run')
     @patch('golem.docker.manager.DockerManager')
     @patch('twisted.internet.reactor', create=True)
     @patch('golemapp.delete_reactor')
+    @patch('golem.node.CrossbarRouter')
     @patch('golem.node.Client')
-    def test_node_address_should_be_passed_to_client(self, mock_client, *_):
+    def test_node_address_should_be_passed_to_client(
+            self,
+            mock_client,
+            mock_rpc_router,
+            *_):
         """Test that with '--node-address <addr>' arg the client is started with
         a 'config_desc' arg such that 'config_desc.node_address' is <addr>.
         """
+        mock_rpc_router.start.side_effect = \
+            lambda _, on_ready, on_err: on_ready()
+        mock_rpc_router.return_value = mock_rpc_router
+
         node_address = '1.2.3.4'
         runner = CliRunner()
         args = self.args + ['--node-address', node_address]
@@ -121,12 +129,20 @@ class TestNode(TestWithDatabase):
                                      transaction_system=True,
                                      use_monitor=True)
 
-    @patch('golem.node.Node.run')
     @patch('golem.docker.manager.DockerManager')
     @patch('twisted.internet.reactor', create=True)
     @patch('golemapp.delete_reactor')
+    @patch('golem.node.CrossbarRouter')
     @patch('golem.node.Client')
-    def test_geth_address_should_be_passed_to_client(self, mock_client, *_):
+    def test_geth_address_should_be_passed_to_client(
+            self,
+            mock_client,
+            mock_rpc_router,
+            *_):
+        mock_rpc_router.start.side_effect = \
+            lambda _, on_ready, on_err: on_ready()
+        mock_rpc_router.return_value = mock_rpc_router
+
         geth_address = 'http://3.14.15.92:6535'
         runner = CliRunner()
         args = self.args + ['--geth-address', geth_address]
@@ -195,12 +211,19 @@ class TestNode(TestWithDatabase):
                                      transaction_system=True,
                                      use_monitor=True)
 
-    @patch('golem.node.Node.run')
     @patch('golem.docker.manager.DockerManager')
     @patch('twisted.internet.reactor', create=True)
     @patch('golemapp.delete_reactor')
+    @patch('golem.node.CrossbarRouter')
     @patch('golem.node.Client')
-    def test_start_geth_should_be_passed_to_client(self, mock_client, *_):
+    def test_start_geth_should_be_passed_to_client(
+            self,
+            mock_client,
+            mock_rpc_router,
+            *_):
+        mock_rpc_router.start.side_effect = \
+            lambda _, on_ready, on_err: on_ready()
+        mock_rpc_router.return_value = mock_rpc_router
         runner = CliRunner()
         args = self.args + ['--start-geth']
         return_value = runner.invoke(start, args, catch_exceptions=False)
@@ -249,12 +272,19 @@ class TestNode(TestWithDatabase):
                                      transaction_system=True,
                                      use_monitor=True)
 
-    @patch('golem.node.Node.run')
     @patch('golem.docker.manager.DockerManager')
     @patch('twisted.internet.reactor', create=True)
     @patch('golemapp.delete_reactor')
+    @patch('golem.node.CrossbarRouter')
     @patch('golem.node.Client')
-    def test_start_geth_port_should_be_passed_to_client(self, mock_client, *_):
+    def test_start_geth_port_should_be_passed_to_client(
+            self,
+            mock_client,
+            mock_rpc_router,
+            *_):
+        mock_rpc_router.start.side_effect = \
+            lambda _, on_ready, on_err: on_ready()
+        mock_rpc_router.return_value = mock_rpc_router
         port = 27182
 
         runner = CliRunner()
@@ -281,7 +311,7 @@ class TestNode(TestWithDatabase):
                                      catch_exceptions=False)
         self.assertEqual(return_value.exit_code, 0)
         # TODO: check peer == [addr1]
-        mock_node.run.assert_called_once_with(use_rpc=True)
+        mock_node.run.assert_called_once_with()
 
     @patch('golemapp.Node')
     def test_many_peers(self, mock_node, *_):
@@ -295,7 +325,7 @@ class TestNode(TestWithDatabase):
 
         self.assertEqual(return_value.exit_code, 0)
         # TODO: check peer == [addr1, addr2]
-        mock_node.run.assert_called_once_with(use_rpc=True)
+        mock_node.run.assert_called_once_with()
 
     @patch('golemapp.Node')
     def test_bad_peer(self, *_):
@@ -319,7 +349,7 @@ class TestNode(TestWithDatabase):
         )
         self.assertEqual(return_value.exit_code, 0)
         # TODO: check peer == [addrs...]
-        mock_node.run.assert_called_with(use_rpc=True)
+        mock_node.run.assert_called_with()
 
     @patch('golemapp.Node')
     def test_rpc_address(self, *_):
@@ -363,12 +393,12 @@ def mock_async_callback(call):
 
 
 @patch('golem.node.async_callback', mock_async_callback)
-@patch('golem.rpc.router.CrossbarRouter', create=True)
-@patch('twisted.internet.reactor', create=True)
+@patch('golem.node.CrossbarRouter', create=True)
+@patch('golem.node.reactor', create=True)
 class TestOptNode(TempDirFixture):
 
     def tearDown(self):
-        if hasattr(self, 'node'):
+        if self.node.client:
             self.node.client.quit()
         super().tearDown()
 
@@ -384,21 +414,18 @@ class TestOptNode(TempDirFixture):
             use_docker_machine_manager=False,
         )
 
-        config = self.node.client.config_desc
-
         router.return_value = router
-        router.address = WebSocketAddress(config.rpc_address,
-                                          config.rpc_port,
+        router.address = WebSocketAddress(config_desc.rpc_address,
+                                          config_desc.rpc_port,
                                           realm='test_realm')
         self.node._setup_rpc()
-        self.node._start_rpc_router()
 
         assert self.node.rpc_router
         assert self.node.rpc_router.start.called
         assert reactor.addSystemEventTrigger.called
 
     @patch('golem.docker.image.DockerImage')
-    def test_setup_without_docker(self, *_):
+    def test_setup_without_docker(self, docker_image, *_):
         self.parsed_peer = argsparser.parse_peer(
             None,
             None,
@@ -412,10 +439,11 @@ class TestOptNode(TempDirFixture):
         )
 
         self.node._setup_docker = Mock()
+        self.node.client = self.node._client_factory()
         self.node.client.connect = Mock()
         self.node.client.start = Mock()
         self.node.client.environments_manager = Mock()
-        self.node.run()
+        self.node._run()
 
         assert self.node.client.start.called
         assert self.node._apps_manager is not None
@@ -433,10 +461,11 @@ class TestOptNode(TempDirFixture):
         )
 
         self.node._setup_docker = Mock()
+        self.node.client = self.node._client_factory()
         self.node.client.connect = Mock()
         self.node.client.start = Mock()
         self.node.client.environments_manager = Mock()
-        self.node.run()
+        self.node._run()
 
         assert self.node.client.start.called
         assert self.node._apps_manager is not None


### PR DESCRIPTION
Lazy `Client` class creation only after RPC has been initialized.
This is needed for implementing the password feature. The idea is to get the password from RPC and only then try to create the `Client` object which may fail if the password is incorrect. In which case we can try again.