### PR TITLE
Rename BigIntegerField to HexIntegerField

### DIFF
--- a/golem/database/schemas/007_schema.py
+++ b/golem/database/schemas/007_schema.py
@@ -56,7 +56,7 @@ def migrate(migrator, _database, **_kwargs):
         sender_node_details = pw.NodeField()
         task = pw.CharField(max_length=255)
         subtask = pw.CharField(max_length=255)
-        value = pw.BigIntegerField()
+        value = pw.HexIntegerField()
 
         class Meta:
             db_table = "expectedincome"
@@ -94,8 +94,8 @@ def migrate(migrator, _database, **_kwargs):
         task = pw.CharField(max_length=255)
         subtask = pw.CharField(max_length=255)
         transaction = pw.CharField(max_length=255)
-        block_number = pw.BigIntegerField()
-        value = pw.BigIntegerField()
+        block_number = pw.HexIntegerField()
+        value = pw.HexIntegerField()
 
         class Meta:
             db_table = "income"
@@ -170,7 +170,7 @@ def migrate(migrator, _database, **_kwargs):
         status = pw.EnumField(PaymentStatus, default=PaymentStatus.awaiting,
                               index=True)
         payee = pw.RawCharField()
-        value = pw.BigIntegerField()
+        value = pw.HexIntegerField()
         details = pw.PaymentDetailsField()
         processed_ts = pw.IntegerField(null=True)
 

--- a/golem/database/schemas/010_schema.py
+++ b/golem/database/schemas/010_schema.py
@@ -18,4 +18,4 @@ def rollback(migrator, _database, **_kwargs):
 
     migrator.add_fields('expectedincome', task=pw.CharField(max_length=255))
     migrator.add_fields('income', task=pw.CharField(max_length=255))
-    migrator.add_fields('income', block_number=pw.BigIntegerField())
+    migrator.add_fields('income', block_number=pw.HexIntegerField())

--- a/golem/database/schemas/012_schema.py
+++ b/golem/database/schemas/012_schema.py
@@ -17,11 +17,11 @@ def migrate(migrator, _database, **_kwargs):
 
     migrator.add_fields('income', accepted_ts=pw.IntegerField(null=True))
 
-    migrator.change_fields('income', value=pw.BigIntegerField())
+    migrator.change_fields('income', value=pw.HexIntegerField())
 
     migrator.drop_not_null('income', 'transaction')
 
-    migrator.change_fields('payment', value=pw.BigIntegerField())
+    migrator.change_fields('payment', value=pw.HexIntegerField())
 
     migrator.drop_index('performance', 'environment_id')
 
@@ -37,11 +37,11 @@ def rollback(migrator, _database, **_kwargs):
 
     migrator.add_index('performance', 'environment_id', unique=True)
 
-    migrator.change_fields('payment', value=pw.BigIntegerField())
+    migrator.change_fields('payment', value=pw.HexIntegerField())
 
     migrator.remove_fields('income', 'accepted_ts')
 
-    migrator.change_fields('income', value=pw.BigIntegerField())
+    migrator.change_fields('income', value=pw.HexIntegerField())
 
     migrator.add_not_null('income', 'transaction')
 
@@ -55,7 +55,7 @@ def rollback(migrator, _database, **_kwargs):
         modified_date = pw.DateTimeField(default=dt.datetime.now)
         sender_node = pw.CharField(max_length=255)
         subtask = pw.CharField(max_length=255)
-        value = pw.BigIntegerField()
+        value = pw.HexIntegerField()
         accepted_ts = pw.IntegerField(null=True)
 
         class Meta:

--- a/golem/model.py
+++ b/golem/model.py
@@ -58,7 +58,7 @@ class RawCharField(CharField):
         return decode_hex(value)
 
 
-class BigIntegerField(CharField):
+class HexIntegerField(CharField):
     """ Standard Integer field is limited to 2^63-1. This field extends the
         range by storing the numbers as hex-encoded char strings.
     """
@@ -202,7 +202,7 @@ class Payment(BaseModel):
     subtask = CharField(primary_key=True)
     status = PaymentStatusField(index=True, default=PaymentStatus.awaiting)
     payee = RawCharField()
-    value = BigIntegerField()
+    value = HexIntegerField()
     details = PaymentDetailsField()
     processed_ts = IntegerField(null=True)
 
@@ -229,7 +229,7 @@ class Payment(BaseModel):
 class Income(BaseModel):
     sender_node = CharField()
     subtask = CharField()
-    value = BigIntegerField()
+    value = HexIntegerField()
     accepted_ts = IntegerField(null=True)
     transaction = CharField(null=True)
 

--- a/tests/golem/transactions/test_incomeskeeper.py
+++ b/tests/golem/transactions/test_incomeskeeper.py
@@ -14,7 +14,7 @@ from golem.utils import pubkeytoaddr
 #  2^63-1 (9,223,372,036,854,775,807)
 
 MAX_INT = 2 ** 63
-# this proves that Golem's BigIntegerField wrapper does not
+# this proves that Golem's HexIntegerField wrapper does not
 # overflows in contrast to standard SQL implementation
 
 


### PR DESCRIPTION
During migration, `golem.model.BigIntegerField` conflicts with `peewee.BigIntegerField`