### PR TITLE
Don't request GNT from faucet unnecessarily

### DIFF
--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -338,6 +338,10 @@ class PaymentProcessor(LoopingCallService):
             return False
 
         if self.__faucet and gnt_balance < 100 * denoms.ether:
+            # During GNT-GNTW convertion gnt_balance will be zero, but we don't
+            # want to request GNT from faucet again
+            if self._gnt_converter.is_converting():
+                return False
             log.info("Requesting GNT from faucet")
             self._sci.request_gnt_from_faucet()
             return False


### PR DESCRIPTION
Otherwise user ends up with 1k GNT and 1k GNTW which introduces unnecessary confusion.