### PR TITLE
shippable python version bump -> 3.6

### DIFF
--- a/shippable.yml
+++ b/shippable.yml
@@ -1,7 +1,7 @@
 language: python
 
 python:
-  - 3.5
+  - 3.6
 
 build:
   ci:


### PR DESCRIPTION
python version upgrade for shippable. I hope it is last place ;)