### PR TITLE
Synchronization of node time with monitor (#2038)

### DIFF
--- a/golem/core/variables.py
+++ b/golem/core/variables.py
@@ -31,6 +31,9 @@ CONCENT_PUBKEY = b'b\x9b>\xf3\xb3\xefW\x92\x93\xfeIW\xd1\n\xf0j\x91\t\xdf\x95\x8
 # Number of task headers transmitted per message
 TASK_HEADERS_LIMIT = 20
 
+# Maximum acceptable difference between node time and monitor time (seconds)
+MAX_TIME_DIFF = 10
+
 
 ###############
 # PROTOCOL ID #

--- a/golem/monitor/monitor.py
+++ b/golem/monitor/monitor.py
@@ -1,16 +1,21 @@
 import logging
-from pydispatch import dispatcher
-import threading
 import queue
+import threading
+import time
+from urllib.parse import urljoin
 
+import requests
+from pydispatch import dispatcher
+
+from golem.core import variables
 from golem.decorators import log_error
 from golem.task.taskrequestorstats import CurrentStats, FinishedTasksStats
 from .model import statssnapshotmodel
 from .model.balancemodel import BalanceModel
 from .model.loginlogoutmodel import LoginModel, LogoutModel
 from .model.nodemetadatamodel import NodeInfoModel
-from .model.taskcomputersnapshotmodel import TaskComputerSnapshotModel
 from .model.paymentmodel import ExpenditureModel, IncomeModel
+from .model.taskcomputersnapshotmodel import TaskComputerSnapshotModel
 from .transport.sender import DefaultJSONSender as Sender
 
 log = logging.getLogger('golem.monitor')
@@ -67,37 +72,44 @@ class SystemMonitor(object):
             )
         return self._sender_thread
 
-    def p2p_listener(self, sender, signal, event='default', **kwargs):
+    def p2p_listener(self, event='default', ports=None, *_, **__):
         if event != 'listening':
             return
-        try:
-            result = self.ping_request(kwargs['port'])
-            if not result['success']:
-                status = result['description'].replace('\n', ', ')
-                log.warning('Port status: {}'.format(status))
-                dispatcher.send(
-                    'golem.p2p',
-                    event='unreachable',
-                    port=kwargs['port'],
-                    description=result['description']
-                )
-        except Exception:
-            log.exception('Port reachability check error')
+        result = self.ping_request(ports)
 
-    def ping_request(self, port):
-        import requests
+        if not result['success']:
+            for port_status in result['port_statuses']:
+                if not port_status['is_open']:
+                    dispatcher.send(
+                        signal='golem.p2p',
+                        event='unreachable',
+                        port=port_status['port'],
+                        description=port_status['description']
+                    )
+
+        if result['time_diff'] > variables.MAX_TIME_DIFF:
+            dispatcher.send(
+                signal='golem.p2p',
+                event='unsynchronized',
+                time_diff=result['time_diff']
+            )
+
+    def ping_request(self, ports):
         timeout = 2.5  # seconds
         try:
             response = requests.post(
-                '%sping-me' % (self.config['HOST'],),
-                data={'port': port, },
+                urljoin(self.config['HOST'], 'ping-me'),
+                data={
+                    'ports': ports,
+                    'timestamp': time.time()
+                },
                 timeout=timeout,
             )
             result = response.json()
-        except requests.ConnectionError as e:
-            result = {'success': False, 'description': 'Local error: %s' % e}
-        log.debug('ping result %r', result)
-        return result
+            log.debug('Ping result: %r', result)
+            return result
+        except requests.ConnectionError:
+            log.exception('Ping connection error')
 
     @log_error()
     def dispatch_listener(self, sender, signal, event='default', **kwargs):

--- a/golem/monitorconfig.py
+++ b/golem/monitorconfig.py
@@ -6,7 +6,7 @@ MONITOR_CONFIG = {
 
     # Increase this number every time any change is made to the protocol
     # (e.g. message object representation changes)
-    'PROTO_VERSION': 0,
+    'PROTO_VERSION': 1,
 }
 
 # so that the queue will not get filled up

--- a/golem/network/p2p/node.py
+++ b/golem/network/p2p/node.py
@@ -38,7 +38,7 @@ class Node(DictSerializable):
         self.hyperdrive_prv_port = hyperdrive_prv_port
         self.hyperdrive_pub_port = hyperdrive_pub_port
 
-        self.port_status = None
+        self.port_statuses = {}  # type: dict
 
         self.nat_type = nat_type  # Please do not remove the nat_type property,
         # it's still useful for stats / debugging connectivity.


### PR DESCRIPTION
Local time of node is included in ping-me request. Monitor sends back difference between received timestamp and its own time. Of course this is **not** the exact difference between node's time and monitor's time because it includes network latency. If the received value exceeds defined maximum (10 seconds for now) a warning is displayed and an `unsynchronized` event is published to `golem.p2p` channel.

The whole ping-me feature was significantly refactored:
  * `listening` event has now `ports` argument instead of `port` (it was already representing multiple ports so the name was misleading)
  * requests sent to `/ping-me` endpoint have `ports` field instead of `port` as well
  * response from `/ping-me` is expected to contain `port_statuses`: an array of objects of the following format:
    ```
    {
      "port": 12345,            // port number
      "is_open": false,         // is the port ping-able
      "description": "timeout"  // description (e.g. "open", "timeout")
    }
    ```
  * `Node` contains a nice `port_statuses` dict instead of messy `port_status` all-containing string

Tests for ping-me were improved.

Because of API changes `PROTO_VERSION` was bumped to 1.

Closes #2038 
Closes #2100 