### PR TITLE
Provide private key name explicitly

### DIFF
--- a/golem/core/keysauth.py
+++ b/golem/core/keysauth.py
@@ -9,7 +9,6 @@ from typing import Optional, Tuple, Union
 from golem_messages.cryptography import ECCx, mk_privkey, ecdsa_verify, \
     privtopub
 
-from golem.core.variables import PRIVATE_KEY
 from golem.utils import encode_hex, decode_hex
 from .simpleenv import get_local_datadir
 
@@ -69,7 +68,7 @@ class KeysAuth:
     key_id = ""  # type: str
     ecc = None  # type: ECCx
 
-    def __init__(self, datadir: str, private_key_name: str = PRIVATE_KEY,
+    def __init__(self, datadir: str, private_key_name: str,
                  difficulty: int = 0) -> None:
         """
         Create new ECC keys authorization manager, load or create keys.

--- a/golem/node.py
+++ b/golem/node.py
@@ -9,6 +9,7 @@ from golem.client import Client
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.core.async import async_callback
 from golem.core.keysauth import KeysAuth
+from golem.core.variables import PRIVATE_KEY
 from golem.docker.manager import DockerManager
 from golem.network.transport.tcpnetwork_helpers import SocketAddress
 from golem.rpc.mapping.rpcmethodnames import CORE_METHOD_MAP
@@ -86,6 +87,7 @@ class Node(object):
         return threads.deferToThread(
             KeysAuth,
             datadir=self._datadir,
+            private_key_name=PRIVATE_KEY,
             difficulty=self._config_desc.key_difficulty
         )
 

--- a/tests/golem/core/test_keysauth.py
+++ b/tests/golem/core/test_keysauth.py
@@ -17,6 +17,15 @@ from golem.utils import encode_hex
 class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
     PEP8_FILES = ['golem/core/keysauth.py']
 
+    def _create_keysauth(self, difficulty=0, key_name=None) -> KeysAuth:
+        if key_name is None:
+            key_name = str(random())
+        return KeysAuth(
+            datadir=self.path,
+            private_key_name=key_name,
+            difficulty=difficulty,
+        )
+
     def test_sha(self):
         """ Test sha2 function"""
         test_str = "qaz123WSX"
@@ -78,13 +87,13 @@ class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
 
     def test_difficulty(self):
         difficulty = 5
-        ek = KeysAuth(self.path, difficulty=difficulty)
+        ek = self._create_keysauth(difficulty)
         assert difficulty <= ek.difficulty
         assert ek.difficulty == KeysAuth.get_difficulty(ek.key_id)
 
     def test_get_difficulty(self):
         difficulty = 8
-        ek = KeysAuth(self.path, difficulty=difficulty)
+        ek = self._create_keysauth(difficulty)
         # first 8 bits of digest must be 0
         assert sha2(ek.public_key).to_bytes(256, 'big')[0] == 0
         assert KeysAuth.get_difficulty(ek.key_id) >= difficulty
@@ -96,13 +105,14 @@ class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
         # given
         old_difficulty = 0
         new_difficulty = 7
+        priv_key = str(random())
 
         assert old_difficulty < new_difficulty  # just in case
 
         keys_dir = KeysAuth._get_or_create_keys_dir(self.path)
         # create key that has difficulty lower than new_difficulty
         while True:
-            ek = KeysAuth(self.path, difficulty=old_difficulty)
+            ek = self._create_keysauth(old_difficulty, priv_key)
             if not ek.is_difficult(new_difficulty):
                 break
             os.rmdir(keys_dir)  # to enable keys regeneration
@@ -112,7 +122,7 @@ class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
         logger.reset_mock()  # just in case
 
         # when
-        ek = KeysAuth(self.path, difficulty=new_difficulty)
+        ek = self._create_keysauth(new_difficulty, priv_key)
 
         # then
         assert KeysAuth.get_difficulty(ek.key_id) >= new_difficulty
@@ -135,7 +145,8 @@ class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
     @patch('golem.core.keysauth.logger')
     def test_key_successful_load(self, logger):
         # given
-        ek = KeysAuth(self.path)
+        priv_key = str(random())
+        ek = self._create_keysauth(key_name=priv_key)
         private_key = ek._private_key
         public_key = ek.public_key
         del ek
@@ -145,7 +156,7 @@ class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
         logger.reset_mock()  # just in case
 
         # when
-        ek2 = KeysAuth(self.path)
+        ek2 = self._create_keysauth(key_name=priv_key)
 
         # then
         assert private_key == ek2._private_key
@@ -176,12 +187,12 @@ class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
         )
 
     def test_sign_verify(self):
-        ek = KeysAuth(self.path)
+        ek = self._create_keysauth()
         data = b"abcdefgh\nafjalfa\rtajlajfrlajl\t" * 100
         signature = ek.sign(data)
         self.assertTrue(ek.verify(signature, data))
         self.assertTrue(ek.verify(signature, data, ek.key_id))
-        ek2 = KeysAuth(os.path.join(self.path, str(random())))
+        ek2 = self._create_keysauth()
         self.assertTrue(ek2.verify(signature, data, ek.key_id))
         data2 = b"23103"
         sig = ek2.sign(data2)
@@ -195,7 +206,7 @@ class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
         data2 = b"qaz123WSY./;'[]"
 
         # when
-        ek = KeysAuth(self.path)
+        ek = self._create_keysauth()
         sig1 = ek.sign(data1)
         sig2 = ek.sign(data2)
 
@@ -218,7 +229,7 @@ class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
         private_key = b"1aab847dd0aa9c3993fea3c858775c183a588ac328e5deb9ceeee" \
                       b"3b4ac6ef078"
 
-        ek = KeysAuth(self.path)
+        ek = self._create_keysauth()
 
         ek.public_key = decode_hex(public_key)
         ek._private_key = decode_hex(private_key)
@@ -260,17 +271,16 @@ class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
 
     def test_encrypt_decrypt(self):
         """ Test encryption and decryption with KeysAuth """
-        path = os.path.join(self.path, str(random()))
-        ek = KeysAuth(path)
+        ek = self._create_keysauth()
         data = b"abcdefgh\nafjalfa\rtajlajfrlajl\t" * 1000
         enc = ek.encrypt(data)
         self.assertEqual(ek.decrypt(enc), data)
-        ek2 = KeysAuth(os.path.join(self.path, str(random())))
+        ek2 = self._create_keysauth()
         self.assertEqual(ek2.decrypt(ek.encrypt(data, ek2.key_id)), data)
         data2 = b"23103"
         self.assertEqual(ek.decrypt(ek2.encrypt(data2, ek.key_id)), data2)
         data3 = b"\x00" + os.urandom(1024)
-        ek2 = KeysAuth(path, difficulty=2)
+        ek2 = self._create_keysauth(difficulty=2)
         self.assertEqual(ek2.decrypt(ek2.encrypt(data3)), data3)
         with self.assertRaises(TypeError):
             ek2.encrypt(None)

--- a/tests/golem/network/concent/test_concent_client.py
+++ b/tests/golem/network/concent/test_concent_client.py
@@ -158,7 +158,10 @@ class TestReceiveFromConcent(TestCase):
 class TestConcentClientService(testutils.TempDirFixture):
     def setUp(self):
         super().setUp()
-        keys_auth = keysauth.KeysAuth(datadir=self.path)
+        keys_auth = keysauth.KeysAuth(
+            datadir=self.path,
+            private_key_name='priv_key',
+        )
         self.concent_service = client.ConcentClientService(
             keys_auth=keys_auth,
             enabled=True,
@@ -360,7 +363,10 @@ class ConcentCallLaterTestCase(testutils.TempDirFixture):
     def setUp(self):
         super().setUp()
         self.concent_service = client.ConcentClientService(
-            keys_auth=keysauth.KeysAuth(datadir=self.path),
+            keys_auth=keysauth.KeysAuth(
+                datadir=self.path,
+                private_key_name='priv_key',
+            ),
             enabled=True,
         )
         self.msg = message.ForceReportComputedTask()

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -22,7 +22,7 @@ class TestP2PService(testutils.DatabaseFixture):
     def setUp(self):
         super(TestP2PService, self).setUp()
         random.seed()
-        self.keys_auth = KeysAuth(self.path)
+        self.keys_auth = KeysAuth(self.path, 'priv_key')
         self.service = P2PService(
             None,
             ClientConfigDescriptor(),

--- a/tests/golem/network/p2p/test_peersession.py
+++ b/tests/golem/network/p2p/test_peersession.py
@@ -41,7 +41,7 @@ class TestPeerSession(testutils.TempDirFixture, LogTestCase,
         random.seed()
         self.peer_session = PeerSession(mock.MagicMock())
         node = p2p_factories.Node()
-        keys_auth = KeysAuth(self.path)
+        keys_auth = KeysAuth(self.path, 'priv_key')
         self.peer_session.conn.server = \
             self.peer_session.p2p_service = P2PService(
                 node=node,
@@ -356,7 +356,7 @@ class TestPeerSession(testutils.TempDirFixture, LogTestCase,
         conf.opt_peer_num = 10
 
         node = Node(node_name='node', key='ffffffff')
-        keys_auth = KeysAuth(self.path)
+        keys_auth = KeysAuth(self.path, 'priv_key')
 
         peer_session = PeerSession(conn)
         peer_session.p2p_service = P2PService(node, conf, keys_auth, False)

--- a/tests/golem/network/transport/test_tcpnetwork.py
+++ b/tests/golem/network/transport/test_tcpnetwork.py
@@ -57,7 +57,7 @@ class TestDataProducerAndConsumer(testutils.TempDirFixture):
         for args in datas:
             self.__producer_consumer_test(*args, session=MagicMock())
 
-        self.ek = KeysAuth(self.path)
+        self.ek = KeysAuth(self.path, 'priv_key')
         for args in datas:
             self.__producer_consumer_test(
                 *args,
@@ -141,7 +141,7 @@ class TestFileProducerAndConsumer(testutils.TempDirFixture):
             [self.tmp_file1, self.tmp_file2, self.tmp_file3],
             32,
             session=MagicMock())
-        self.ek = KeysAuth(self.path)
+        self.ek = KeysAuth(self.path, 'priv_key')
         self.__producer_consumer_test(
             [],
             file_producer_cls=EncryptFileProducer,

--- a/tests/golem/resource/base/test_base_resourceserver.py
+++ b/tests/golem/resource/base/test_base_resourceserver.py
@@ -66,7 +66,7 @@ class TestResourceServer(testwithreactor.TestDirFixtureWithReactor):
         shutil.copy(test_dir_file, test_dir_file_copy)
 
         self.resource_manager = DummyResourceManager(self.dir_manager)
-        self.keys_auth = KeysAuth(self.path)
+        self.keys_auth = KeysAuth(self.path, 'priv_key')
         self.client = MockClient()
         self.resource_server = BaseResourceServer(
             self.resource_manager,

--- a/tests/golem/task/dummy/runner.py
+++ b/tests/golem/task/dummy/runner.py
@@ -58,7 +58,11 @@ def create_client(datadir):
     config_desc.key_difficulty = 0
 
     from golem.core.keysauth import KeysAuth
-    keys_auth = KeysAuth(datadir=datadir, difficulty=config_desc.key_difficulty)
+    keys_auth = KeysAuth(
+        datadir=datadir,
+        private_key_name='priv_key',
+        difficulty=config_desc.key_difficulty,
+    )
 
     return Client(datadir=datadir,
                   config_desc=config_desc,

--- a/tests/golem/task/test_concent_logic.py
+++ b/tests/golem/task/test_concent_logic.py
@@ -30,6 +30,7 @@ class ReactToReportComputedTaskTestCase(testutils.TempDirFixture):
         self.task_session.task_server.keys_auth = keys_auth = \
             keysauth.KeysAuth(
                 datadir=self.tempdir,
+                private_key_name='priv_key',
             )
         self.task_session.key_id = "KEY_ID"
         self.msg = factories.messages.ReportComputedTask()

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -797,7 +797,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
                                "key_id", "environment", task_owner=node), '',
                     TaskDefinition())
 
-        self.tm.keys_auth = KeysAuth(self.path)
+        self.tm.keys_auth = KeysAuth(self.path, 'priv_key')
         self.tm.add_new_task(task)
         sig = task.header.signature
 

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -279,7 +279,7 @@ class TestTaskServer(LogTestCase, testutils.DatabaseFixture,  # noqa pylint: dis
         # self.assertEqual(ts.task_computer.use_waiting_ttl, False)
 
     def test_add_task_header(self, *_):
-        keys_auth_2 = KeysAuth(os.path.join(self.path, "2"))
+        keys_auth_2 = KeysAuth(os.path.join(self.path, "2"), 'priv_key')
 
         ts = self.ts
 

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -779,7 +779,7 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
 
     def test_node(self, *_):
         c = self.client
-        c.keys_auth = KeysAuth(self.path)
+        c.keys_auth = KeysAuth(self.path, 'priv_key')
 
         self.assertIsInstance(c.get_node(), dict)
 

--- a/tests/golem/transactions/ethereum/test_ethereumpaymentskeeper.py
+++ b/tests/golem/transactions/ethereum/test_ethereumpaymentskeeper.py
@@ -52,7 +52,7 @@ class TestEthereumPaymentsKeeper(TestWithDatabase, PEP8MixIn):
 class TestEthAccountInfo(TempDirFixture):
 
     def test_comparison(self):
-        k = KeysAuth(self.path)
+        k = KeysAuth(self.path, 'priv_key')
         addr1 = "0x09197b95a57ad20ee68b53e0843fb1d218db6a78"
         a = EthAccountInfo(k.key_id, 5111, "10.0.0.1", "test-test-test",
                            Node(), addr1)
@@ -64,7 +64,7 @@ class TestEthAccountInfo(TempDirFixture):
         c = EthAccountInfo(k.key_id, 5111, "10.0.0.1", "test-test-test",
                            n, addr1)
         self.assertEqual(a, c)
-        k = KeysAuth("%s_other" % self.path, difficulty=2)
+        k = KeysAuth("%s_other" % self.path, 'priv_key', difficulty=2)
         c.key_id = k.key_id
         self.assertNotEqual(a, c)
         addr2 = "0x7b82fd1672b8020415d269c53cd1a2230fde9386"

--- a/tests/golem/transactions/test_paymentskeeper.py
+++ b/tests/golem/transactions/test_paymentskeeper.py
@@ -157,7 +157,7 @@ class TestPaymentsKeeper(TestWithDatabase):
 
 class TestAccountInfo(TempDirFixture):
     def test_comparison(self):
-        k = KeysAuth(self.path)
+        k = KeysAuth(self.path, 'priv_key')
         e = urandom(20)
         a = EthAccountInfo(k.key_id, 5111, "10.0.0.1", "test-test-test", Node(),
                            e)
@@ -168,6 +168,6 @@ class TestAccountInfo(TempDirFixture):
                  pub_port=1032)
         c = EthAccountInfo(k.key_id, 5112, "10.0.0.2", "test-test2-test", n, e)
         self.assertEqual(a, c)
-        k = KeysAuth("%s_other" % self.path, difficulty=2)
+        k = KeysAuth("%s_other" % self.path, 'priv_key', difficulty=2)
         c.key_id = k.key_id
         self.assertNotEqual(a, c)


### PR DESCRIPTION
For password protection I will ask whether the key file exist before creating KeysAuth in `node.py`. We could keep the default in the constructor but I don't see the point.
Also tests were a bit flaky because they were reusing existing keys, changes to use random key name every time.