### PR TITLE
Encrypt wallet

### DIFF
--- a/golem/core/keysauth.py
+++ b/golem/core/keysauth.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import math
 import os
@@ -6,11 +7,11 @@ from datetime import datetime
 from hashlib import sha256
 from typing import Optional, Tuple, Union
 
+from ethereum.keys import decode_keystore_json, make_keystore_json
+
 from golem_messages.cryptography import ECCx, mk_privkey, ecdsa_verify, \
     privtopub
-
 from golem.utils import encode_hex, decode_hex
-from .simpleenv import get_local_datadir
 
 logger = logging.getLogger(__name__)
 
@@ -50,6 +51,32 @@ def get_random_float() -> float:
     return float(result - 1) / float(10 ** len(str(result)))
 
 
+def _serialize_keystore(keystore):
+    def encode_bytes(obj):
+        if isinstance(obj, bytes):
+            return '0x' + encode_hex(obj)
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                obj[k] = encode_bytes(v)
+        return obj
+    return json.dumps(encode_bytes(keystore))
+
+
+def _deserialize_keystore(keystore):
+    def decode_bytes(obj):
+        if isinstance(obj, str) and obj[:2] == '0x':
+            return decode_hex(obj)
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                obj[k] = decode_bytes(v)
+        return obj
+    return decode_bytes(json.loads(keystore))
+
+
+class WrongPasswordException(Exception):
+    pass
+
+
 class KeysAuth:
     """
     Elliptical curves cryptographic authorization manager. Generates
@@ -68,7 +95,7 @@ class KeysAuth:
     key_id = ""  # type: str
     ecc = None  # type: ECCx
 
-    def __init__(self, datadir: str, private_key_name: str,
+    def __init__(self, datadir: str, private_key_name: str, password: str,
                  difficulty: int = 0) -> None:
         """
         Create new ECC keys authorization manager, load or create keys.
@@ -82,7 +109,7 @@ class KeysAuth:
         """
 
         prv, pub = KeysAuth._load_or_generate_keys(
-            datadir, private_key_name, difficulty)
+            datadir, private_key_name, password, difficulty)
 
         self._private_key = prv
         self.ecc = ECCx(prv)
@@ -91,37 +118,47 @@ class KeysAuth:
         self.difficulty = KeysAuth.get_difficulty(self.key_id)
 
     @staticmethod
-    def _load_or_generate_keys(datadir: str, filename: str,
+    def _load_or_generate_keys(datadir: str, filename: str, password: str,
                                difficulty: int) -> Tuple[bytes, bytes]:
         keys_dir = KeysAuth._get_or_create_keys_dir(datadir)
         priv_key_path = os.path.join(keys_dir, filename)
 
-        loaded_keys = KeysAuth._load_and_check_keys(priv_key_path, difficulty)
+        loaded_keys = KeysAuth._load_and_check_keys(
+            priv_key_path,
+            password,
+            difficulty,
+        )
 
         if loaded_keys:
             priv_key, pub_key = loaded_keys
         else:
             priv_key, pub_key = KeysAuth._generate_keys(difficulty)
-            KeysAuth._save_private_key(priv_key, priv_key_path)
+            KeysAuth._save_private_key(priv_key, priv_key_path, password)
 
         return priv_key, pub_key
 
     @staticmethod
     def _get_or_create_keys_dir(datadir: str) -> str:
-        path = datadir or get_local_datadir('default')
-        keys_dir = os.path.join(path, KeysAuth.KEYS_SUBDIR)
+        keys_dir = os.path.join(datadir, KeysAuth.KEYS_SUBDIR)
         if not os.path.isdir(keys_dir):
             os.makedirs(keys_dir)
         return keys_dir
 
     @staticmethod
     def _load_and_check_keys(priv_key_path: str,
+                             password: str,
                              difficulty: int) -> Optional[Tuple[bytes, bytes]]:
         try:
-            with open(priv_key_path, 'rb') as f:
-                priv_key = f.read()
+            with open(priv_key_path, 'r') as f:
+                keystore = f.read()
         except FileNotFoundError:
             return None
+        keystore = _deserialize_keystore(keystore)
+
+        try:
+            priv_key = decode_keystore_json(keystore, password)
+        except ValueError:
+            raise WrongPasswordException()
 
         if not len(priv_key) == KeysAuth.PRIV_KEY_LEN:
             logger.error("Wrong loaded private key size: %d.", len(priv_key))
@@ -149,18 +186,19 @@ class KeysAuth:
         return priv_key, pub_key
 
     @staticmethod
-    def _save_private_key(key, key_path):
+    def _save_private_key(key, key_path, password: str):
         def backup_file(path):
-            if os.path.exists(path):
-                logger.info("Backing up existing private key.")
-                dirname, filename = os.path.split(path)
-                date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S_%f")
-                filename_bak = filename.replace('.', '_') + '_' + date + '.bak'
-                os.rename(path, os.path.join(dirname, filename_bak))
+            logger.info("Backing up existing private key.")
+            dirname, filename = os.path.split(path)
+            date = datetime.now().strftime("%Y-%m-%d_%H-%M-%S_%f")
+            filename_bak = filename.replace('.', '_') + '_' + date + '.bak'
+            os.rename(path, os.path.join(dirname, filename_bak))
 
-        backup_file(key_path)
-        with open(key_path, 'wb') as f:
-            f.write(key)
+        if os.path.exists(key_path):
+            backup_file(key_path)
+        keystore = make_keystore_json(key, password)
+        with open(key_path, 'w') as f:
+            f.write(_serialize_keystore(keystore))
 
     @staticmethod
     def _count_max_hash(difficulty: int) -> int:

--- a/golem/core/variables.py
+++ b/golem/core/variables.py
@@ -8,7 +8,7 @@ LONG_STANDARD_SIZE = 4
 #       VARIABLES          #
 ############################
 APP_NAME = "Brass Golem"
-PRIVATE_KEY = "golem_private_key.peb"
+PRIVATE_KEY = "golem_wallet_const_password.json"
 DEFAULT_PROC_FILE = "node_processes.ctl"
 MAX_PROC_FILE_SIZE = 1024 * 1024
 

--- a/golem/node.py
+++ b/golem/node.py
@@ -88,6 +88,8 @@ class Node(object):
             KeysAuth,
             datadir=self._datadir,
             private_key_name=PRIVATE_KEY,
+            # TODO: user provided password
+            password='verystrongpasswodmuchsecurity',
             difficulty=self._config_desc.key_difficulty
         )
 

--- a/tests/golem/network/concent/test_concent_client.py
+++ b/tests/golem/network/concent/test_concent_client.py
@@ -161,6 +161,7 @@ class TestConcentClientService(testutils.TempDirFixture):
         keys_auth = keysauth.KeysAuth(
             datadir=self.path,
             private_key_name='priv_key',
+            password='password',
         )
         self.concent_service = client.ConcentClientService(
             keys_auth=keys_auth,
@@ -366,6 +367,7 @@ class ConcentCallLaterTestCase(testutils.TempDirFixture):
             keys_auth=keysauth.KeysAuth(
                 datadir=self.path,
                 private_key_name='priv_key',
+                password='password',
             ),
             enabled=True,
         )

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from os import urandom
 import random
 import time
 import unittest.mock as mock
@@ -15,6 +16,7 @@ from golem.network.p2p.p2pservice import HISTORY_LEN, P2PService
 from golem.network.p2p.peersession import PeerSession
 from golem.network.transport.tcpnetwork import SocketAddress
 from golem.task.taskconnectionshelper import TaskConnectionsHelper
+from golem.utils import encode_hex
 
 
 class TestP2PService(testutils.DatabaseFixture):
@@ -22,7 +24,9 @@ class TestP2PService(testutils.DatabaseFixture):
     def setUp(self):
         super(TestP2PService, self).setUp()
         random.seed()
-        self.keys_auth = KeysAuth(self.path, 'priv_key')
+        # Mock saving keys as it takes long to compute and isn't needed here
+        KeysAuth._save_private_key = mock.Mock()
+        self.keys_auth = KeysAuth(self.path, 'priv_key', 'password')
         self.service = P2PService(
             None,
             ClientConfigDescriptor(),
@@ -79,7 +83,7 @@ class TestP2PService(testutils.DatabaseFixture):
 
     def test_add_to_peer_keeper(self):
         node = Node()
-        node.key = KeysAuth(self.path, "TESTPRIV").key_id
+        node.key = encode_hex(urandom(64))
         m_test2 = mock.MagicMock()
         m_test3 = mock.MagicMock()
         self.service.peers["TEST3"] = m_test3
@@ -109,7 +113,7 @@ class TestP2PService(testutils.DatabaseFixture):
 
     def test_remove_old_peers(self):
         node = mock.MagicMock()
-        node.key = KeysAuth(self.path, "TESTPRIV").key_id
+        node.key = encode_hex(urandom(64))
         node.key_id = node.key
 
         self.service.last_peers_request = time.time() + 10
@@ -130,12 +134,12 @@ class TestP2PService(testutils.DatabaseFixture):
         sa = SocketAddress('127.0.0.1', 11111)
 
         node = mock.MagicMock()
-        node.key = KeysAuth(self.path, "TESTPRIV").key_id
+        node.key = encode_hex(urandom(64))
         node.key_id = node.key
         node.address = sa
 
         node2 = mock.MagicMock()
-        node2.key = KeysAuth(self.path, "TESTPRIV2").key_id
+        node2.key = encode_hex(urandom(64))
         node2.key_id = node2.key
         node2.address = sa
 
@@ -159,7 +163,7 @@ class TestP2PService(testutils.DatabaseFixture):
         assert len(self.service.peers) == 2
 
     def test_add_known_peer(self):
-        key_id = KeysAuth(self.path, "TESTPRIV").key_id
+        key_id = encode_hex(urandom(64))
         nominal_seeds = len(self.service.seeds)
 
         node = Node(
@@ -217,7 +221,7 @@ class TestP2PService(testutils.DatabaseFixture):
 
     def test_sync_free_peers(self):
         node = mock.MagicMock()
-        node.key = KeysAuth(self.path, "PRIVTEST").key_id
+        node.key = encode_hex(urandom(64))
         node.key_id = node.key
         node.pub_addr = '127.0.0.1'
         node.pub_port = 10000
@@ -320,8 +324,8 @@ class TestP2PService(testutils.DatabaseFixture):
         m2.transport.getPeer.return_value.port = "11432"
         m2.transport.getPeer.return_value.host = "127.0.0.1"
         ps2 = PeerSession(m2)
-        keys_auth2 = KeysAuth(self.path, "PUBTESTPATH1")
-        ps2.key_id = keys_auth2.key_id
+        key_id2 = encode_hex(urandom(64))
+        ps2.key_id = key_id2
         self.service.add_peer(ps2)
         self.service.get_diagnostics(DiagnosticsOutputFormat.json)
 

--- a/tests/golem/network/p2p/test_peersession.py
+++ b/tests/golem/network/p2p/test_peersession.py
@@ -41,7 +41,7 @@ class TestPeerSession(testutils.TempDirFixture, LogTestCase,
         random.seed()
         self.peer_session = PeerSession(mock.MagicMock())
         node = p2p_factories.Node()
-        keys_auth = KeysAuth(self.path, 'priv_key')
+        keys_auth = KeysAuth(self.path, 'priv_key', 'password')
         self.peer_session.conn.server = \
             self.peer_session.p2p_service = P2PService(
                 node=node,
@@ -356,7 +356,7 @@ class TestPeerSession(testutils.TempDirFixture, LogTestCase,
         conf.opt_peer_num = 10
 
         node = Node(node_name='node', key='ffffffff')
-        keys_auth = KeysAuth(self.path, 'priv_key')
+        keys_auth = KeysAuth(self.path, 'priv_key', 'password')
 
         peer_session = PeerSession(conn)
         peer_session.p2p_service = P2PService(node, conf, keys_auth, False)

--- a/tests/golem/network/transport/test_tcpnetwork.py
+++ b/tests/golem/network/transport/test_tcpnetwork.py
@@ -57,7 +57,7 @@ class TestDataProducerAndConsumer(testutils.TempDirFixture):
         for args in datas:
             self.__producer_consumer_test(*args, session=MagicMock())
 
-        self.ek = KeysAuth(self.path, 'priv_key')
+        self.ek = KeysAuth(self.path, 'priv_key', 'password')
         for args in datas:
             self.__producer_consumer_test(
                 *args,
@@ -141,7 +141,7 @@ class TestFileProducerAndConsumer(testutils.TempDirFixture):
             [self.tmp_file1, self.tmp_file2, self.tmp_file3],
             32,
             session=MagicMock())
-        self.ek = KeysAuth(self.path, 'priv_key')
+        self.ek = KeysAuth(self.path, 'priv_key', 'password')
         self.__producer_consumer_test(
             [],
             file_producer_cls=EncryptFileProducer,

--- a/tests/golem/resource/base/test_base_resourceserver.py
+++ b/tests/golem/resource/base/test_base_resourceserver.py
@@ -66,7 +66,7 @@ class TestResourceServer(testwithreactor.TestDirFixtureWithReactor):
         shutil.copy(test_dir_file, test_dir_file_copy)
 
         self.resource_manager = DummyResourceManager(self.dir_manager)
-        self.keys_auth = KeysAuth(self.path, 'priv_key')
+        self.keys_auth = KeysAuth(self.path, 'priv_key', 'password')
         self.client = MockClient()
         self.resource_server = BaseResourceServer(
             self.resource_manager,

--- a/tests/golem/task/dummy/runner.py
+++ b/tests/golem/task/dummy/runner.py
@@ -61,6 +61,7 @@ def create_client(datadir):
     keys_auth = KeysAuth(
         datadir=datadir,
         private_key_name='priv_key',
+        password='password',
         difficulty=config_desc.key_difficulty,
     )
 

--- a/tests/golem/task/test_concent_logic.py
+++ b/tests/golem/task/test_concent_logic.py
@@ -31,6 +31,7 @@ class ReactToReportComputedTaskTestCase(testutils.TempDirFixture):
             keysauth.KeysAuth(
                 datadir=self.tempdir,
                 private_key_name='priv_key',
+                password='password',
             )
         self.task_session.key_id = "KEY_ID"
         self.msg = factories.messages.ReportComputedTask()

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -797,7 +797,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
                                "key_id", "environment", task_owner=node), '',
                     TaskDefinition())
 
-        self.tm.keys_auth = KeysAuth(self.path, 'priv_key')
+        self.tm.keys_auth = KeysAuth(self.path, 'priv_key', 'password')
         self.tm.add_new_task(task)
         sig = task.header.signature
 

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -279,7 +279,11 @@ class TestTaskServer(LogTestCase, testutils.DatabaseFixture,  # noqa pylint: dis
         # self.assertEqual(ts.task_computer.use_waiting_ttl, False)
 
     def test_add_task_header(self, *_):
-        keys_auth_2 = KeysAuth(os.path.join(self.path, "2"), 'priv_key')
+        keys_auth_2 = KeysAuth(
+            os.path.join(self.path, "2"),
+            'priv_key',
+            'password',
+        )
 
         ts = self.ts
 

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -780,7 +780,7 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
 
     def test_node(self, *_):
         c = self.client
-        c.keys_auth = KeysAuth(self.path, 'priv_key')
+        c.keys_auth = KeysAuth(self.path, 'priv_key', 'password')
 
         self.assertIsInstance(c.get_node(), dict)
 

--- a/tests/golem/transactions/ethereum/test_ethereumpaymentskeeper.py
+++ b/tests/golem/transactions/ethereum/test_ethereumpaymentskeeper.py
@@ -52,7 +52,7 @@ class TestEthereumPaymentsKeeper(TestWithDatabase, PEP8MixIn):
 class TestEthAccountInfo(TempDirFixture):
 
     def test_comparison(self):
-        k = KeysAuth(self.path, 'priv_key')
+        k = KeysAuth(self.path, 'priv_key', 'password')
         addr1 = "0x09197b95a57ad20ee68b53e0843fb1d218db6a78"
         a = EthAccountInfo(k.key_id, 5111, "10.0.0.1", "test-test-test",
                            Node(), addr1)
@@ -64,7 +64,12 @@ class TestEthAccountInfo(TempDirFixture):
         c = EthAccountInfo(k.key_id, 5111, "10.0.0.1", "test-test-test",
                            n, addr1)
         self.assertEqual(a, c)
-        k = KeysAuth("%s_other" % self.path, 'priv_key', difficulty=2)
+        k = KeysAuth(
+            "%s_other" % self.path,
+            'priv_key',
+            'password',
+            difficulty=2,
+        )
         c.key_id = k.key_id
         self.assertNotEqual(a, c)
         addr2 = "0x7b82fd1672b8020415d269c53cd1a2230fde9386"

--- a/tests/golem/transactions/test_paymentskeeper.py
+++ b/tests/golem/transactions/test_paymentskeeper.py
@@ -157,7 +157,7 @@ class TestPaymentsKeeper(TestWithDatabase):
 
 class TestAccountInfo(TempDirFixture):
     def test_comparison(self):
-        k = KeysAuth(self.path, 'priv_key')
+        k = KeysAuth(self.path, 'priv_key', 'password')
         e = urandom(20)
         a = EthAccountInfo(k.key_id, 5111, "10.0.0.1", "test-test-test", Node(),
                            e)
@@ -168,6 +168,11 @@ class TestAccountInfo(TempDirFixture):
                  pub_port=1032)
         c = EthAccountInfo(k.key_id, 5112, "10.0.0.2", "test-test2-test", n, e)
         self.assertEqual(a, c)
-        k = KeysAuth("%s_other" % self.path, 'priv_key', difficulty=2)
+        k = KeysAuth(
+            "%s_other" % self.path,
+            'priv_key',
+            'password',
+            difficulty=2,
+        )
         c.key_id = k.key_id
         self.assertNotEqual(a, c)


### PR DESCRIPTION
Use password encrypted storage for ethereum wallet.
Using constant password right now just to split the changes into smaller PRs. Next PR will grab the password from RPC.