### PR TITLE
Subtask deadline workaround

### DIFF
--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -48,6 +48,9 @@ class CompTaskInfo:
         now_ = common.get_timestamp_utc()
         # FIXME: create a proper deadline check for 0.12.1
         if now_ > deadline:  # or deadline > now_ + self.header.subtask_timeout:
+            logger.debug('check_deadline failed: (now: %r, deadline: %r, '
+                         'timeout: %r)', now_, deadline,
+                         self.header.subtask_timeout)
             return False
         return True
 

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -46,7 +46,8 @@ class CompTaskInfo:
 
     def check_deadline(self, deadline):
         now_ = common.get_timestamp_utc()
-        if now_ > deadline or deadline > now_ + self.header.subtask_timeout:
+        # FIXME: create a proper deadline check for 0.12.1
+        if now_ > deadline:  # or deadline > now_ + self.header.subtask_timeout:
             return False
         return True
 

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -646,8 +646,9 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
 
         comp_task_def['deadline'] = get_timestamp_utc() + 240
 
-        with self.assertLogs(logger, level="INFO"):
-            assert not ctk.check_comp_task_def(comp_task_def)
+        # Fixme: see taskkeeper.CompTaskInfo.check_deadline
+        # with self.assertLogs(logger, level="INFO"):
+        #     assert not ctk.check_comp_task_def(comp_task_def)
 
         comp_task_def['deadline'] = get_timestamp_utc() + 100
         assert ctk.check_comp_task_def(comp_task_def)


### PR DESCRIPTION
Removes the forward-only clock tolerance check for deadlines. Should be fixed to support backward clock desync.