### PR TITLE
 Don't duplicate in ComputeTaskDef parameters from TaskHeader

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -136,11 +136,12 @@ class CoreTask(Task):
             src_code = ""
 
         # docker_images stuff
-        docker_images = None
         if task_definition.docker_images:
-            docker_images = task_definition.docker_images
+            self.docker_images = task_definition.docker_images
         elif isinstance(self.environment, DockerEnvironment):
-            docker_images = self.environment.docker_images
+            self.docker_images = self.environment.docker_images
+        else:
+            self.docker_images = None
 
         th = TaskHeader(
             node_name=node_name,
@@ -155,7 +156,6 @@ class CoreTask(Task):
             resource_size=self.resource_size,
             estimated_memory=task_definition.estimated_memory,
             max_price=task_definition.max_price,
-            docker_images=docker_images,
         )
 
         Task.__init__(self, th, src_code, task_definition)
@@ -181,9 +181,7 @@ class CoreTask(Task):
         self.max_pending_client_results = max_pending_client_results
 
     def is_docker_task(self):
-        return hasattr(self.header, 'docker_images') \
-            and self.header.docker_images \
-            and len(self.header.docker_images) > 0
+        return len(self.docker_images or ()) > 0
 
     def initialize(self, dir_manager: DirManager) -> None:
         dir_manager.clear_temporary(self.header.task_id)
@@ -336,14 +334,10 @@ class CoreTask(Task):
         ctd['src_code'] = self.src_code
         ctd['performance'] = perf_index
         ctd['working_directory'] = working_directory
-        if self.header.docker_images:
-            ctd['docker_images'] = [
-                di.to_dict() for di in self.header.docker_images
-            ]
+        if self.docker_images:
+            ctd['docker_images'] = [di.to_dict() for di in self.docker_images]
         ctd['deadline'] = min(timeout_to_deadline(self.header.subtask_timeout),
                               self.header.deadline)
-        ctd['task_owner'] = self.header.task_owner.to_dict()
-        ctd['environment'] = self.header.environment
 
         return ctd
 

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -55,7 +55,6 @@ class TaskHeader(object):
                  estimated_memory=0,
                  min_version=golem.__version__,
                  max_price: int=0,
-                 docker_images=None,
                  signature=None):
         """
         :param max_price: maximum price that this (requestor) node may
@@ -64,7 +63,6 @@ class TaskHeader(object):
         """
 
         self.task_id = task_id
-        # TODO Remove task_owner_key_id, task_onwer_address and task_owner_port
         self.task_owner_key_id = task_owner_key_id
         self.task_owner_address = task_owner_address
         self.task_owner_port = task_owner_port
@@ -78,7 +76,6 @@ class TaskHeader(object):
         self.environment = environment
         self.estimated_memory = estimated_memory
         self.min_version = min_version
-        self.docker_images = docker_images
         self.max_price = max_price
         self.signature = signature
 
@@ -97,11 +94,7 @@ class TaskHeader(object):
         th.last_checking = time.time()
 
         if isinstance(th.task_owner, dict):
-            th.task_owner = DictSerializer.load(th.task_owner, as_class=Node)
-        if hasattr(th, 'docker_images') and th.docker_images is not None:
-            for i, di in enumerate(th.docker_images):
-                if isinstance(di, dict):
-                    th.docker_images[i] = DictSerializer.load(di, as_class=DockerImage)
+            th.task_owner = Node.from_dict(th.task_owner)
         return th
 
     @classmethod

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -144,15 +144,10 @@ class TaskComputer(object):
         subtask_id = self.task_to_subtask_mapping.pop(task_id)
         if subtask_id in self.assigned_subtasks:
             subtask = self.assigned_subtasks.pop(subtask_id)
-            p2p_node = P2PNode.from_dict(subtask['task_owner'])
             self.task_server.send_task_failed(
-                subtask_id, subtask['task_id'],
+                subtask_id,
+                subtask['task_id'],
                 'Error downloading resources: {}'.format(reason),
-                subtask['return_address'],
-                subtask['return_port'],
-                subtask['key_id'],
-                p2p_node,
-                self.node_name,
             )
         self.session_closed()
 
@@ -194,7 +189,6 @@ class TaskComputer(object):
             logger.error("No subtask with id %r", subtask_id)
             return
 
-        p2p_node = P2PNode.from_dict(subtask['task_owner'])
         if task_thread.error or task_thread.error_msg:
             if "Task timed out" in task_thread.error_msg:
                 self.stats.increase_stat('tasks_with_timeout')
@@ -204,11 +198,6 @@ class TaskComputer(object):
                     subtask_id,
                     subtask['task_id'],
                     task_thread.error_msg,
-                    subtask['return_address'],
-                    subtask['return_port'],
-                    subtask['key_id'],
-                    p2p_node,
-                    self.node_name,
                 )
             dispatcher.send(signal='golem.monitor', event='computation_time_spent', success=False, value=work_time_to_be_paid)
 
@@ -222,11 +211,6 @@ class TaskComputer(object):
                 subtask['task_id'],
                 task_thread.result,
                 work_time_to_be_paid,
-                subtask['return_address'],
-                subtask['return_port'],
-                subtask['key_id'],
-                p2p_node,
-                self.node_name,
             )
             dispatcher.send(signal='golem.monitor', event='computation_time_spent', success=True, value=work_time_to_be_paid)
 
@@ -236,11 +220,6 @@ class TaskComputer(object):
                 subtask_id,
                 subtask['task_id'],
                 "Wrong result format",
-                subtask['return_address'],
-                subtask['return_port'],
-                subtask['key_id'],
-                p2p_node,
-                self.node_name,
             )
             dispatcher.send(signal='golem.monitor', event='computation_time_spent', success=False, value=work_time_to_be_paid)
         self.counting_task = None
@@ -404,16 +383,10 @@ class TaskComputer(object):
         else:
             logger.error("Cannot run PyTaskThread in this version")
             subtask = self.assigned_subtasks.pop(subtask_id)
-            p2p_node = P2PNode.from_dict(subtask['task_owner'])
             self.task_server.send_task_failed(
                 subtask_id,
                 subtask['task_id'],
                 "Host direct task not supported",
-                subtask['return_address'],
-                subtask['return_port'],
-                subtask['key_id'],
-                p2p_node,
-                self.node_name,
             )
             self.counting_task = None
             return

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -139,6 +139,10 @@ class CompTaskKeeper:
         return self.active_tasks[task_id].header.environment
 
     @handle_key_error
+    def get_task_header(self, task_id):
+        return self.active_tasks[task_id].header
+
+    @handle_key_error
     def receive_subtask(self, comp_task_def):
         logger.debug('CT.receive_subtask()')
         if not self.check_comp_task_def(comp_task_def):
@@ -170,11 +174,6 @@ class CompTaskKeeper:
         if comp_task_def['subtask_id'] in task.subtasks:
             logger.info(not_accepted_message, *log_args,
                         "Definition of this subtask was already received.")
-            return False
-        if comp_task_def['environment'] != task.header.environment:
-            msg = "Expected environment: %s, received: %s." % (
-                task.header.environment, comp_task_def['environment'])
-            logger.info(not_accepted_message, *log_args, msg)
             return False
         return True
 

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -366,11 +366,6 @@ class TaskManager(TaskEventListener):
         if not check_compute_task_def():
             return None, False, False
 
-        ctd['key_id'] = task.header.task_owner_key_id
-        ctd['return_address'] = task.header.task_owner_address
-        ctd['return_port'] = task.header.task_owner_port
-        ctd['task_owner'] = task.header.task_owner.to_dict()
-
         self.subtask2task_mapping[ctd['subtask_id']] = task_id
         self.__add_subtask_to_tasks_states(
             node_name, node_id, price, ctd, address,

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,5 +52,5 @@ miniupnpc<2.1,>=2.0
 token_bucket==0.2.0
 py-cpuinfo==3.3.0
 humanize==0.5.1
-Golem-Messages==1.14.0
+Golem-Messages==1.15.0
 -e git://github.com/golemfactory/golem-smart-contracts-interface.git@ae86c86382620c88a43741efb67ddbdbcd040904#egg=golem_sci

--- a/tests/apps/blender/task/test_blender_verification.py
+++ b/tests/apps/blender/task/test_blender_verification.py
@@ -48,7 +48,6 @@ class TestGenerateCrops(TempDirFixture):
         self.subtask_info['ctd']['deadline'] = time.time() + 3600
         self.subtask_info['ctd']['docker_images'] = [DockerImage(
             'golemfactory/blender', tag='1.4').to_dict()]
-        self.subtask_info['ctd']['environment'] = 'BLENDER'
         self.subtask_info['ctd']['extra_data'] = dict()
         self.subtask_info['ctd']['extra_data']['end_task'] =\
             self.subtask_info['end_task']
@@ -68,10 +67,7 @@ class TestGenerateCrops(TempDirFixture):
             self.subtask_info['start_task']
         self.subtask_info['ctd']['extra_data']['total_tasks'] =\
             self.subtask_info['total_tasks']
-        self.subtask_info['ctd']['key_id'] = 'deadbeef'
         self.subtask_info['ctd']['performance'] = self.subtask_info['perf']
-        self.subtask_info['ctd']['return_address'] = '127.0.0.1'
-        self.subtask_info['ctd']['return_port'] = 40103
         self.subtask_info['ctd']['short_description'] = ''
         self.subtask_info['ctd']['src_code'] = open(
             os.path.join(
@@ -81,7 +77,6 @@ class TestGenerateCrops(TempDirFixture):
         self.subtask_info['ctd']['subtask_id'] = self.subtask_info['subtask_id']
         self.subtask_info['ctd']['task_id'] =\
             '7d8cb5f8-2a8c-43a1-9189-44a5f422fbe1'
-        self.subtask_info['ctd']['task_owner'] = dict()
         self.subtask_info['ctd']['working_directory'] = self.tempdir
 
     @ci_skip

--- a/tests/apps/core/task/test_coretask.py
+++ b/tests/apps/core/task/test_coretask.py
@@ -541,9 +541,7 @@ class TestCoreTask(LogTestCase, TestDirFixture):
         assert ctd['src_code'] == c.src_code
         assert ctd['performance'] == perf_index
         assert ctd['working_directory'] == working_directory
-        assert ctd['docker_images'] == c.header.docker_images
-        assert ctd['task_owner'] == c.header.task_owner.to_dict()
-        assert ctd['environment'] == c.header.environment
+        assert ctd['docker_images'] == c.docker_images
 
 
 class TestLogKeyError(LogTestCase):

--- a/tests/factories/messages.py
+++ b/tests/factories/messages.py
@@ -2,8 +2,6 @@
 import calendar
 import time
 
-import factory
-
 import factory.fuzzy
 
 from golem_messages.message import base
@@ -20,18 +18,12 @@ class Hello(factory.Factory):
     node_name = factory.Faker("name")
 
 
-class TaskOwner(factory.DictFactory):
-    node_name = factory.Faker('name')
-    key = factory.Faker('binary', length=64)
-
-
 class ComputeTaskDef(factory.DictFactory):
     class Meta:
         model = tasks.ComputeTaskDef
 
     task_id = factory.Faker('uuid4')
     subtask_id = factory.Faker('uuid4')
-    task_owner = factory.SubFactory(TaskOwner)
     deadline = factory.LazyFunction(lambda: calendar.timegm(time.gmtime()))
     src_code = factory.Faker('text')
 
@@ -47,7 +39,6 @@ class TaskToCompute(factory.Factory):
     @classmethod
     def _create(cls, *args, **kwargs):
         instance = super()._create(*args, **kwargs)
-        instance.compute_task_def['task_owner']['key'] = instance.requestor_id
         return instance
 
 

--- a/tests/golem/docker/test_docker_blender_task.py
+++ b/tests/golem/docker/test_docker_blender_task.py
@@ -230,8 +230,8 @@ class TestDockerBlenderTask(TempDirFixture, DockerTestCase):
         assert task.header.resource_size > 0
         assert task.header.environment == 'BLENDER'
         assert task.header.estimated_memory == 0
-        assert task.header.docker_images[0].repository == 'golemfactory/blender'
-        assert task.header.docker_images[0].tag == '1.4'
+        assert task.docker_images[0].repository == 'golemfactory/blender'
+        assert task.docker_images[0].tag == '1.4'
         assert task.header.max_price == 10.2
         assert not task.header.signature
         assert task.listeners == []
@@ -269,7 +269,7 @@ class TestDockerBlenderTask(TempDirFixture, DockerTestCase):
 
     def test_wrong_image_repository_specified(self):
         task = self._create_test_task()
-        task.header.docker_images = [DockerImage("%$#@!!!")]
+        task.docker_images = [DockerImage("%$#@!!!")]
         task_thread, error_msg, out_dir = self._run_docker_task(task)
         if task_thread:
             assert not task_thread.result
@@ -277,8 +277,8 @@ class TestDockerBlenderTask(TempDirFixture, DockerTestCase):
 
     def test_wrong_image_id_specified(self):
         task = self._create_test_task()
-        image = task.header.docker_images[0]
-        task.header.docker_images = [
+        image = task.docker_images[0]
+        task.docker_images = [
             DockerImage(image.repository, image_id="%$#@!!!")]
         task_thread, error_msg, out_dir = self._run_docker_task(task)
         if task_thread:

--- a/tests/golem/docker/test_docker_dummy_task.py
+++ b/tests/golem/docker/test_docker_dummy_task.py
@@ -181,7 +181,7 @@ class TestDockerDummyTask(TempDirFixture, DockerTestCase):
                 makedirs(dest_dirname)
             shutil.copyfile(os.path.join(td.code_dir, res_file), dest_file)
 
-        def send_task_failed(self_, subtask_id, task_id, error_msg, *args):
+        def send_task_failed(_, __, ___, error_msg):
             self.error_msg = error_msg
 
         TaskServer.send_task_failed = send_task_failed

--- a/tests/golem/docker/test_docker_luxrender_task.py
+++ b/tests/golem/docker/test_docker_luxrender_task.py
@@ -141,7 +141,7 @@ class TestDockerLuxrenderTask(TempDirFixture, DockerTestCase):
                 makedirs(dest_dirname)
             shutil.copyfile(res_file, dest_file)
 
-        def send_task_failed(self_, subtask_id, task_id, error_msg, *args):
+        def send_task_failed(_, __, ___, error_msg):
             self.error_msg = error_msg
 
         TaskServer.send_task_failed = send_task_failed

--- a/tests/golem/task/dummy/task.py
+++ b/tests/golem/task/dummy/task.py
@@ -67,7 +67,7 @@ class DummyTask(Task):
             subtask_timeout=1200,
             resource_size=params.shared_data_size + params.subtask_data_size,
             estimated_memory=0,
-            max_price=MIN_PRICE, docker_images=None)
+            max_price=MIN_PRICE)
 
         # load the script to be run remotely from the file in the current dir
         script_path = path.join(path.dirname(__file__), 'computation.py')
@@ -169,10 +169,6 @@ class DummyTask(Task):
         subtask_def['task_id'] = self.task_id
         subtask_def['subtask_id'] = subtask_id
         subtask_def['src_code'] = self.src_code
-        subtask_def['task_owner'] = self.header.task_owner.to_dict()
-        subtask_def['environment'] = self.header.environment
-        subtask_def['return_address'] = self.header.task_owner_address
-        subtask_def['return_port'] = self.header.task_owner_port
         subtask_def['deadline'] = timeout_to_deadline(5 * 60)
         subtask_def['extra_data'] = {
             'data_file': self.shared_data_file,

--- a/tests/golem/task/test_taskbase.py
+++ b/tests/golem/task/test_taskbase.py
@@ -24,8 +24,7 @@ class TestTaskBase(LogTestCase):
 
         task_header = TaskHeader(
             "ABC", "xyz", "10.10.10.10", 1023, "key", "DEFAULT",
-            task_owner=node, docker_images=docker_images
-        )
+            task_owner=node)
         # ignore dynamic properties
         task_header.last_checking = 0
 
@@ -39,10 +38,6 @@ class TestTaskBase(LogTestCase):
 
         assert task_header_from_dict.to_dict() == task_header_dict
         assert isinstance(task_header_from_dict.task_owner, Node)
-        assert all([
-            isinstance(di, DockerImage)
-            for di in task_header_from_dict.docker_images
-        ])
 
         task_header_bin = task_header.to_binary()
         bin_serialized = CBORSerializer.dumps(task_header_bin)

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -102,10 +102,6 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         ctd = ComputeTaskDef()
         ctd['task_id'] = "xyz"
         ctd['subtask_id'] = "xxyyzz"
-        ctd['return_address'] = "10.10.10.10"
-        ctd['return_port'] = 10203
-        ctd['key_id'] = "key"
-        ctd['task_owner'] = p2p_node.to_dict()
         ctd['src_code'] = \
             "cnt=0\n" \
             "for i in range(10000):\n" \
@@ -144,8 +140,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         assert tc.counting_thread is None
         assert tc.assigned_subtasks.get("xxyyzz") is None
         task_server.send_task_failed.assert_called_with(
-            "xxyyzz", "xyz", "Host direct task not supported",
-            "10.10.10.10", 10203, "key", p2p_node, "ABC")
+            "xxyyzz", "xyz", "Host direct task not supported")
 
         tc.support_direct_computation = True
         tc.task_given(ctd)
@@ -168,11 +163,6 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         self.assertEqual(args[2]["data"], 10000)
         self.assertGreater(args[3], 0)
         self.assertLess(args[3], 10)
-        self.assertEqual(args[4], "10.10.10.10")
-        self.assertEqual(args[5], 10203)
-        self.assertEqual(args[6], "key")
-        self.assertEqual(args[7], p2p_node)
-        self.assertEqual(args[8], "ABC")
 
         ctd['subtask_id'] = "aabbcc"
         ctd['src_code'] = "raise Exception('some exception')"
@@ -191,8 +181,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         self.assertIsNone(tc.counting_thread)
         self.assertIsNone(tc.assigned_subtasks.get("aabbcc"))
         task_server.send_task_failed.assert_called_with(
-            "aabbcc", "xyz", 'some exception', "10.10.10.10",
-            10203, "key", p2p_node, "ABC")
+            "aabbcc", "xyz", 'some exception')
 
         ctd['subtask_id'] = "aabbcc2"
         ctd['src_code'] = "print('Hello world')"
@@ -202,8 +191,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         self.__wait_for_tasks(tc)
 
         task_server.send_task_failed.assert_called_with(
-            "aabbcc2", "xyz", "Wrong result format", "10.10.10.10", 10203,
-            "key", p2p_node, "ABC")
+            "aabbcc2", "xyz", "Wrong result format")
 
         task_server.task_keeper.task_headers["xyz"].deadline = \
             timeout_to_deadline(20)
@@ -225,8 +213,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         tc.task_computed(tc.counting_thread)
         self.assertIsNone(tc.counting_thread)
         task_server.send_task_failed.assert_called_with(
-            "xxyyzz2", "xyz", "Wrong result format", "10.10.10.10", 10203,
-            "key", p2p_node, "ABC")
+            "xxyyzz2", "xyz", "Wrong result format")
         tt.end_comp()
         time.sleep(0.5)
         if tt.is_alive():

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -504,9 +504,8 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
             ctd = ComputeTaskDef()
             ctd['task_id'] = header.task_id
             ctd['subtask_id'] = "test_subtask%d-%d" % (x, random.random() * 1000)
-            ctd['environment'] = header.environment
             ctd['deadline'] = timeout_to_deadline(header.subtask_timeout - 10)
-            ctk.receive_subtask(ctd)
+            self.assertTrue(ctk.receive_subtask(ctd))
             test_subtasks_ids.append(ctd['subtask_id'])
         del ctk
 
@@ -595,7 +594,6 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         ctd['task_id'] = "xyz"
         ctd['subtask_id'] = "abc"
         ctd['deadline'] = timeout_to_deadline(th.subtask_timeout - 1)
-        ctd['environment'] = th.environment
         ctk.receive_subtask(ctd)
         assert ctk.active_tasks["xyz"].requests == 0
         assert ctk.subtask_to_task["abc"] == "xyz"
@@ -635,9 +633,11 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         header = get_task_header()
         ctk.add_request(header, 40003)
         ctk.active_tasks['xyz'].requests = 0
-        comp_task_def = {'task_id': "xyz", 'subtask_id': 'xxyyzz',
-                         'deadline': get_timestamp_utc() + 100,
-                         'environment': 'DEFAULT'}
+        comp_task_def = {
+            'task_id': "xyz",
+            'subtask_id': 'xxyyzz',
+            'deadline': get_timestamp_utc() + 100,
+        }
         with self.assertLogs(logger, level="INFO") as l:
             assert not ctk.check_comp_task_def(comp_task_def)
         assert 'Cannot accept subtask xxyyzz for task xyz. ' \
@@ -667,13 +667,3 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
 
         del ctk.active_tasks['xyz'].subtasks['xxyyzz']
         assert ctk.check_comp_task_def(comp_task_def)
-
-        comp_task_def['environment'] = "DIFFERENT_ENV"
-        with self.assertLogs(logger, level="INFO") as l:
-            assert not ctk.check_comp_task_def(comp_task_def)
-        assert 'Cannot accept subtask xxyyzz for task xyz. ' \
-               'Expected environment: DEFAULT, received: DIFFERENT_ENV.' in \
-               l.output[0]
-
-
-

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -112,7 +112,6 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
         ctd = ComputeTaskDef()
         ctd['task_id'] = task_id
         ctd['subtask_id'] = subtask_id
-        ctd['environment'] = "DEFAULT"
         ctd['deadline'] = timeout_to_deadline(subtask_timeout)
 
         task_mock.query_extra_data_return_value = Task.ExtraData(
@@ -396,7 +395,6 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
                 ctd = ComputeTaskDef()
                 ctd['task_id'] = self.header.task_id
                 ctd['subtask_id'] = self.subtasks_id[0]
-                ctd['environment'] = "DEFAULT"
                 self.subtasks_id = self.subtasks_id[1:]
                 e = self.ExtraData(False, ctd)
                 return e

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -187,13 +187,9 @@ class TestTaskServer(LogTestCase, testutils.DatabaseFixture,  # noqa pylint: dis
         task_header["task_id"] = "xyz"
         ts.add_task_header(task_header)
         ts.request_task()
-        self.assertTrue(
-            ts.send_results("xxyyzz", "xyz", results, 40, "10.10.10.10", 10101,
-                            "key", n, "node_name"))
+        self.assertTrue(ts.send_results("xxyyzz", "xyz", results, 40))
         ts.client.transaction_system.incomes_keeper.expect.reset_mock()
-        self.assertTrue(
-            ts.send_results("xyzxyz", "xyz", results, 40, "10.10.10.10", 10101,
-                            "key", n, "node_name"))
+        self.assertTrue(ts.send_results("xyzxyz", "xyz", results, 40))
         wtr = ts.results_to_send["xxyyzz"]
         self.assertIsInstance(wtr, WaitingTaskResult)
         self.assertEqual(wtr.subtask_id, "xxyyzz")
@@ -702,7 +698,6 @@ class TestTaskServer2(TestDatabaseWithReactor, testutils.TestWithClient):
         extra_data.ctd = ComputeTaskDef()
         extra_data.ctd['task_id'] = "xyz"
         extra_data.ctd['subtask_id'] = "xxyyzz"
-        extra_data.ctd['environment'] = "DEFAULT"
         extra_data.should_wait = False
 
         task_mock = get_mock_task("xyz", "xxyyzz")
@@ -750,7 +745,6 @@ class TestTaskServer2(TestDatabaseWithReactor, testutils.TestWithClient):
         extra_data.ctd = ComputeTaskDef()
         extra_data.ctd['task_id'] = "xyz"
         extra_data.ctd['subtask_id'] = "xxyyzz"
-        extra_data.ctd['environment'] = "DEFAULT"
         extra_data.should_wait = False
 
         task_mock = get_mock_task("xyz", "xxyyzz")


### PR DESCRIPTION
Fields removed from `ComputeTaskDef`:
  * `return_address`
  * `return_port`
  * `task_owner`
  * `key_id`
  * `environment`

Fields removed from `TaskHeader`:
  * `docker_images`

Closes #2073 