### PR TITLE
Fixed golemcli incomes error (#2234)

### DIFF
--- a/golem/interface/client/payments.py
+++ b/golem/interface/client/payments.py
@@ -4,7 +4,7 @@ from golem.core.common import to_unicode
 from golem.core.deferred import sync_wait
 from golem.interface.command import command, Argument, CommandResult
 
-incomes_table_headers = ['payer', 'status', 'value', 'block']
+incomes_table_headers = ['payer', 'status', 'value']
 payments_table_headers = ['subtask', 'payee', 'status', 'value', 'fee']
 
 sort_incomes = Argument(
@@ -40,11 +40,10 @@ def incomes(sort):
             to_unicode(income["payer"]),
             to_unicode(income["status"]),
             __value(float(income["value"])),
-            str(income["block_number"])
         ]
         values.append(entry)
 
-    return CommandResult.to_tabular(payments_table_headers, values, sort=sort)
+    return CommandResult.to_tabular(incomes_table_headers, values, sort=sort)
 
 
 @command(argument=sort_payments, help="Display payments", root=True)

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -242,10 +242,9 @@ class TestPayments(unittest.TestCase):
     def setUpClass(cls):
 
         incomes_list = [{
-            'value': '{}'.format(i),
             'payer': 'node_{}'.format(i),
             'status': 'waiting',
-            'block_number': 'deadbeef0{}'.format(i)
+            'value': '{}'.format(i),
         } for i in range(1, 6)]
 
         payments_list = [{
@@ -273,7 +272,7 @@ class TestPayments(unittest.TestCase):
             assert result.type == CommandResult.TABULAR
             assert len(result.data[1]) == self.n_incomes
             assert result.data[1][0] == [
-                'node_1', 'waiting', '0.000000 GNT', 'deadbeef01'
+                'node_1', 'waiting', '0.000000 GNT'
             ]
 
     def test_payments(self):


### PR DESCRIPTION
Field `block_number` was no longer returned by `TransactionSystem.get_incoming_payments()`.
Also fixed table headers.

Closes #2234 