### PR TITLE
SCI upgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -52,4 +52,4 @@ miniupnpc<2.1,>=2.0
 py-cpuinfo==3.3.0
 humanize==0.5.1
 Golem-Messages==1.12.2
--e git://github.com/golemfactory/golem-smart-contracts-interface.git@384ba463c198efbe450b8432fb6a54bcb6558e3b#egg=golem_sci
+-e git://github.com/golemfactory/golem-smart-contracts-interface.git@ae86c86382620c88a43741efb67ddbdbcd040904#egg=golem_sci

--- a/tests/golem/transactions/ethereum/test_paymentprocessor.py
+++ b/tests/golem/transactions/ethereum/test_paymentprocessor.py
@@ -258,7 +258,7 @@ class PaymentProcessorInternalTest(DatabaseFixture):
             'blockNumber': tx_block_number,
             'blockHash': '0x' + 64 * 'f',
             'gasUsed': 55001,
-            'status': '0x1',
+            'status': 1,
         })
         self.sci.get_transaction_receipt.return_value = receipt
         self.pp.monitor_progress()
@@ -303,7 +303,7 @@ class PaymentProcessorInternalTest(DatabaseFixture):
             'blockNumber': tx_block_number,
             'blockHash': '0x' + 64 * 'f',
             'gasUsed': 55001,
-            'status': '0x0',
+            'status': 0,
         })
         self.sci.get_block_number.return_value = \
             tx_block_number + self.pp.REQUIRED_CONFIRMATIONS


### PR DESCRIPTION
To include https://github.com/golemfactory/golem-smart-contracts-interface/commit/ae86c86382620c88a43741efb67ddbdbcd040904
status in the receipt is now int after recent web3 upgrade