### PR TITLE
Support multiple databases

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -34,7 +34,7 @@ from golem.diag.service import DiagnosticsService, DiagnosticsOutputFormat
 from golem.diag.vm import VMDiagnosticsProvider
 from golem.environments.environment import Environment as DefaultEnvironment
 from golem.environments.environmentsmanager import EnvironmentsManager
-from golem.model import DB_MODELS, db
+from golem.model import DB_MODELS, db, DB_FIELDS
 from golem.monitor.model.nodemetadatamodel import NodeMetadataModel
 from golem.monitor.monitor import SystemMonitor
 from golem.monitorconfig import MONITOR_CONFIG
@@ -113,7 +113,8 @@ class Client(HardwarePresetsMixin):
         )
 
         # Initialize database
-        self.db = Database(db, datadir, DB_MODELS)
+        self.db = Database(db, fields=DB_FIELDS, models=DB_MODELS,
+                           db_dir=datadir)
 
         # Hardware configuration
         HardwarePresets.initialize(self.datadir)

--- a/golem/database/database.py
+++ b/golem/database/database.py
@@ -7,7 +7,7 @@ from os import path
 from playhouse.shortcuts import RetryOperationalError
 
 from golem.database.migration import default_migrate_dir
-from golem.database.migration.migrate import migrate_schema, NoMigrationScripts
+from golem.database.migration.migrate import migrate_schema, MigrationError
 
 logger = logging.getLogger('golem.db')
 
@@ -71,9 +71,12 @@ class Database:
                     version, to_version)
 
         try:
+            if not self.schemas_dir:
+                raise MigrationError("Invalid schema directory")
+
             migrate_schema(self, version, to_version,
                            migrate_dir=self.schemas_dir)
-        except NoMigrationScripts as exc:
+        except MigrationError as exc:
             logger.warning("Cannot migrate database schema: %s", exc)
             self._drop_tables()
             self._create_tables()

--- a/golem/database/database.py
+++ b/golem/database/database.py
@@ -1,15 +1,18 @@
 import logging
+from typing import Optional, Type, Sequence
+
+import peewee
 from os import path
 
-from peewee import SqliteDatabase
 from playhouse.shortcuts import RetryOperationalError
 
+from golem.database.migration import default_migrate_dir
 from golem.database.migration.migrate import migrate_schema, NoMigrationScripts
 
 logger = logging.getLogger('golem.db')
 
 
-class GolemSqliteDatabase(RetryOperationalError, SqliteDatabase):
+class GolemSqliteDatabase(RetryOperationalError, peewee.SqliteDatabase):
 
     def sequence_exists(self, seq):
         raise NotImplementedError()
@@ -19,17 +22,27 @@ class Database:
 
     SCHEMA_VERSION = 13
 
-    def __init__(self, db, datadir, models, migrate=True):
-        self.db = db
+    def __init__(self,  # noqa pylint: disable=too-many-arguments
+                 db: peewee.Database,
+                 fields: Sequence[Type[peewee.Field]],
+                 models: Sequence[Type[peewee.Model]],
+                 db_dir: str,
+                 db_name: str = 'golem.db',
+                 schemas_dir: Optional[str] = default_migrate_dir()) -> None:
+
+        self.fields = fields
         self.models = models
-        self.db.init(path.join(datadir, 'golem.db'))
+        self.schemas_dir = schemas_dir
+
+        self.db = db
+        self.db.init(path.join(db_dir, db_name))
         self.db.connect()
 
         version = self.get_user_version()
 
         if not version:
             self._create_tables()
-        elif migrate and version < self.SCHEMA_VERSION:
+        elif schemas_dir and version < self.SCHEMA_VERSION:
             self._migrate_schema(version, to_version=self.SCHEMA_VERSION)
 
     def close(self):
@@ -58,7 +71,8 @@ class Database:
                     version, to_version)
 
         try:
-            migrate_schema(self, version, to_version)
+            migrate_schema(self, version, to_version,
+                           migrate_dir=self.schemas_dir)
         except NoMigrationScripts as exc:
             logger.warning("Cannot migrate database schema: %s", exc)
             self._drop_tables()

--- a/golem/database/migration/create.py
+++ b/golem/database/migration/create.py
@@ -1,5 +1,5 @@
 import sys
-from typing import Optional, Type
+from typing import Type
 
 import os
 
@@ -24,21 +24,14 @@ def latest_migration_exists(migrate_dir=default_migrate_dir()):
     return environment.last_version == Database.SCHEMA_VERSION
 
 
-def create_migration(data_dir: Optional[str] = None,
-                     migrate_dir: Optional[str] = None,
-                     migration_name: Optional[str] = None,
+def create_migration(data_dir: str = get_local_datadir('default'),
+                     migrate_dir: str = default_migrate_dir(),
+                     migration_name: str = 'schema',
                      db_class: Type[Database] = Database,
                      force: bool = False):
 
     """ Create a schema migration script """
     from peewee_migrate.router import MIGRATE_TEMPLATE
-
-    if not data_dir:
-        data_dir = get_local_datadir('default')
-    if not migrate_dir:
-        migrate_dir = default_migrate_dir()
-    if not migration_name:
-        migration_name = 'schema'
 
     environment = Router.Environment(migrate_dir)
     database = db_class(db, fields=DB_FIELDS, models=DB_MODELS,

--- a/golem/database/migration/migrate.py
+++ b/golem/database/migration/migrate.py
@@ -32,7 +32,7 @@ def migrate_schema(database: 'Database',
                                  "no suitable migration scripts found"
                                  .format(from_version, to_version))
 
-    with patch_peewee():
+    with patch_peewee(database.fields, database.models):
         migrator = Migrator(router.database)
 
         # Teach migrator previous changes

--- a/golem/model.py
+++ b/golem/model.py
@@ -2,6 +2,8 @@ import datetime
 import inspect
 import json
 import pickle
+
+import peewee
 from enum import Enum
 # Type is used for old-style (pre Python 3.6) type annotation
 from typing import Optional, Type  # pylint: disable=unused-import
@@ -423,9 +425,9 @@ class NetworkMessage(BaseModel):
         return msg
 
 
-def _collect_db_models():
+def collect_db_models(module: str = __name__):
     return inspect.getmembers(
-        sys.modules[__name__],
+        sys.modules[module],
         lambda cls: (
             inspect.isclass(cls) and
             issubclass(cls, BaseModel) and
@@ -434,4 +436,15 @@ def _collect_db_models():
     )
 
 
-DB_MODELS = [cls for _, cls in _collect_db_models()]
+def collect_db_fields(module: str = __name__):
+    return inspect.getmembers(
+        sys.modules[module],
+        lambda cls: (
+            inspect.isclass(cls) and
+            issubclass(cls, peewee.Field)
+        )
+    )
+
+
+DB_FIELDS = [cls for _, cls in collect_db_fields()]
+DB_MODELS = [cls for _, cls in collect_db_models()]

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -12,7 +12,7 @@ import pycodestyle
 from golem.core.common import get_golem_path, is_windows, is_osx
 from golem.core.simpleenv import get_local_datadir
 from golem.database import Database
-from golem.model import DB_MODELS, db
+from golem.model import DB_MODELS, db, DB_FIELDS
 
 
 class TempDirFixture(unittest.TestCase):
@@ -108,7 +108,8 @@ class DatabaseFixture(TempDirFixture):
 
     def setUp(self):
         super(DatabaseFixture, self).setUp()
-        self.database = Database(db, self.tempdir, DB_MODELS)
+        self.database = Database(db, fields=DB_FIELDS, models=DB_MODELS,
+                                 db_dir=self.tempdir)
 
     def tearDown(self):
         self.database.db.close()

--- a/tests/golem/database/test_database.py
+++ b/tests/golem/database/test_database.py
@@ -21,6 +21,7 @@ class TestDatabase(DatabaseFixture, PEP8MixIn):
         self.assertEqual(self.database.get_user_version(), 0)
 
         self.database.close()
-        database = Database(m.db, self.path, m.DB_MODELS)
+        database = Database(m.db, fields=m.DB_FIELDS, models=m.DB_MODELS,
+                            db_dir=self.path)
         self.assertEqual(database.get_user_version(), database.SCHEMA_VERSION)
         database.close()

--- a/tests/golem/database/test_migration.py
+++ b/tests/golem/database/test_migration.py
@@ -9,10 +9,11 @@ from peewee import CharField
 
 import golem
 from golem.database import Database
+from golem.database.migration import default_migrate_dir
 from golem.database.migration.create import create_from_commandline, \
     create_migration
 from golem.database.migration.migrate import migrate_schema, choose_scripts
-from golem.model import Account, BaseModel, DB_MODELS, Stats
+from golem.model import Account, BaseModel, DB_MODELS, Stats, DB_FIELDS
 from golem.testutils import DatabaseFixture, TempDirFixture
 
 
@@ -276,7 +277,9 @@ class TestSavedMigrations(TempDirFixture):
     def database_context(self):
         from golem.model import db
         version = Database.SCHEMA_VERSION
-        database = Database(db, self.tempdir, DB_MODELS, migrate=False)
+        database = Database(db, fields=DB_FIELDS, models=DB_MODELS,
+                            db_dir=self.tempdir, schemas_dir=None)
+        database.schemas_dir = default_migrate_dir()
         yield database
         Database.SCHEMA_VERSION = version
         database.close()

--- a/tests/golem/database/test_migration.py
+++ b/tests/golem/database/test_migration.py
@@ -56,16 +56,12 @@ class TestMigrationCommandLine(TestCase):
 
 class TestCreateMigration(TempDirFixture):
 
-    @patch('golem.database.migration.create.get_local_datadir')
-    @patch('golem.database.migration.create.default_migrate_dir')
-    def test_create_params(self, default_migrate_dir, get_local_datadir):
+    def test_create_params(self):
         out_dir = os.path.join(self.tempdir, 'schemas')
         os.makedirs(out_dir, exist_ok=True)
 
-        default_migrate_dir.return_value = out_dir
-        get_local_datadir.return_value = self.tempdir
-
-        output_file = create_migration()
+        output_file = create_migration(data_dir=self.tempdir,
+                                       migrate_dir=out_dir)
 
         assert len(os.listdir(out_dir)) == 1
         assert os.path.exists(output_file)


### PR DESCRIPTION
- introduces the ability to create multiple instances of `golem.database.Database`
- updates migration tools to support changes made in `golem.database.Database`

This is a prerequisite for https://github.com/golemfactory/golem/issues/2238 (point 2 and 3)