### PR TITLE
Keep information in CompTaskKeeper longer

### DIFF
--- a/golem/core/variables.py
+++ b/golem/core/variables.py
@@ -76,3 +76,8 @@ REACTOR_THREAD_POOL_SIZE = 20
 # INCOMES CONST #
 #################
 PAYMENT_DEADLINE = 24 * 60 * 60
+
+#################
+# CONCENT CONST #
+#################
+NUM_OF_RES_TRANSFERS_NEEDED_FOR_VER = 3

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -6,13 +6,15 @@ import typing
 
 import random
 from collections import Counter
-from golem_messages import message
+
+from golem_messages import message, helpers
 from golem_messages.constants import MTD
 from semantic_version import Version
 
 import golem
 from golem.core import common
 from golem.core.async import AsyncRequest, async_run
+from golem.core.variables import NUM_OF_RES_TRANSFERS_NEEDED_FOR_VER
 from golem.environments.environment import SupportStatus, UnsupportReason
 from .taskbase import TaskHeader
 
@@ -30,12 +32,26 @@ def compute_subtask_value(price: int, computation_time: int):
     return (price * computation_time + 3599) // 3600
 
 
+def comp_task_info_keeping_timeout(subtask_timeout: int, resource_size: int,
+                                   num_of_res_transfers_needed: int =
+                                   NUM_OF_RES_TRANSFERS_NEEDED_FOR_VER):
+    # FIXME get num of res transfers needed
+    verification_timeout = subtask_timeout
+    resource_timeout = helpers.maximum_download_time(resource_size).seconds
+    resource_timeout *= num_of_res_transfers_needed
+    return common.timeout_to_deadline(subtask_timeout + verification_timeout
+                                      + resource_timeout)
+
+
 class CompTaskInfo:
     def __init__(self, header: TaskHeader, price: int):
         self.header = header
         self.price = price
         self.requests = 1
         self.subtasks = {}
+        # TODO Add concent communication timeout
+        self.keeping_deadline = comp_task_info_keeping_timeout(
+            self.header.subtask_timeout, self.header.resource_size)
 
     def __repr__(self):
         return "<CompTaskInfo(%r, %r) reqs: %r>" % (
@@ -216,7 +232,7 @@ class CompTaskKeeper:
 
     def remove_old_tasks(self):
         for task_id in frozenset(self.active_tasks):
-            deadline = self.active_tasks[task_id].header.deadline
+            deadline = self.active_tasks[task_id].keeping_deadline
             delta = deadline - common.get_timestamp_utc()
             if delta > 0:
                 continue

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -497,6 +497,8 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         for x in range(10):
             header = get_task_header()
             header.deadline = timeout_to_deadline(1)
+            header.subtask_timeout = 1.5
+            header.resource_size = 1
             header.task_id = "test%d-%d" % (x, random.random() * 1000)
             test_headers.append(header)
             ctk.add_request(header, int(random.random() * 100))
@@ -504,7 +506,7 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
             ctd = ComputeTaskDef()
             ctd['task_id'] = header.task_id
             ctd['subtask_id'] = "test_subtask%d-%d" % (x, random.random() * 1000)
-            ctd['deadline'] = timeout_to_deadline(header.subtask_timeout - 10)
+            ctd['deadline'] = timeout_to_deadline(header.subtask_timeout - 0.5)
             self.assertTrue(ctk.receive_subtask(ctd))
             test_subtasks_ids.append(ctd['subtask_id'])
         del ctk
@@ -521,7 +523,9 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         self._dump_some_tasks(tasks_dir)
 
     @mock.patch('golem.task.taskkeeper.async_run', async_run)
-    def test_remove_old_tasks(self):
+    @mock.patch('golem.task.taskkeeper.common.get_timestamp_utc')
+    def test_remove_old_tasks(self, timestamp):
+        timestamp.return_value = time.time()
         tasks_dir = Path(self.path)
         self._dump_some_tasks(tasks_dir)
 
@@ -530,7 +534,11 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
 
         self.assertTrue(any(ctk.active_tasks))
         self.assertTrue(any(ctk.subtask_to_task))
-        time.sleep(1)
+        timestamp.return_value = time.time() + 1
+        ctk.remove_old_tasks()
+        self.assertTrue(any(ctk.active_tasks))
+        self.assertTrue(any(ctk.subtask_to_task))
+        timestamp.return_value = time.time() + 300
         ctk.remove_old_tasks()
         self.assertTrue(not any(ctk.active_tasks))
         self.assertTrue(not any(ctk.subtask_to_task))


### PR DESCRIPTION
In current branch provider removes information about tasks after deadline is hit. We want to keep this information much longer, including verification time,  time for communication with concent and sending resources to concent. 