### PR TITLE
Removed argument name collision with crossbar

### DIFF
--- a/golemapp.py
+++ b/golemapp.py
@@ -79,6 +79,15 @@ slogging.SManager.getLogger = monkey_patched_getLogger
               help="Connect with given geth node")
 @click.option('--version', '-v', is_flag=True, default=False,
               help="Show Golem version information")
+@click.option('--log-level', default=None,
+              type=click.Choice([
+                  'CRITICAL',
+                  'ERROR',
+                  'WARNING',
+                  'INFO',
+                  'DEBUG',
+              ]),
+              help="Change level for Golem loggers and handlers")
 # Python flags, needed by crossbar (package only)
 @click.option('-m', nargs=1, default=None)
 @click.option('--node', expose_value=False)
@@ -91,18 +100,10 @@ slogging.SManager.getLogger = monkey_patched_getLogger
 @click.option('--worker', expose_value=False)
 @click.option('--type', expose_value=False)
 @click.option('--realm', expose_value=False)
-@click.option('--loglevel', default=None,
-              type=click.Choice([
-                  'CRITICAL',
-                  'ERROR',
-                  'WARNING',
-                  'INFO',
-                  'DEBUG',
-              ]),
-              help="Change level for all loggers and handlers")
+@click.option('--loglevel', expose_value=False)  # Crossbar specific level
 @click.option('--title', expose_value=False)
 def start(payments, monitor, datadir, node_address, rpc_address, peer,
-          start_geth, start_geth_port, geth_address, version, m, loglevel):
+          start_geth, start_geth_port, geth_address, version, log_level, m):
     freeze_support()
     delete_reactor()
 
@@ -130,7 +131,7 @@ def start(payments, monitor, datadir, node_address, rpc_address, peer,
     # Golem headless
     else:
         from golem.core.common import config_logging
-        config_logging(datadir=datadir, loglevel=loglevel)
+        config_logging(datadir=datadir, loglevel=log_level)
         install_reactor()
         log_golem_version()
         log_platform_info()


### PR DESCRIPTION
 by renaming the golem argument to `--log-level`

When testing the latest develop build on linux i found:
```
INFO     [golemapp                           ] GOLEM Version: 0.12.0+dev124.g59f4a55
INFO     [golemapp                           ] Protocol Version: 23
INFO     [golemapp                           ] golem_messages Version: 1.16.0
INFO     [golemapp                           ] system: Linux, release: 4.4.0-1049-aws, version: #58-Ubuntu SMP Fri Jan 12 23:17:09 UTC 2018, machine: x86_64
INFO     [golemapp                           ] cpu: GenuineIntel Intel(R) Xeon(R) CPU E5-2676 v3 @ 2.40GHz, 2 cores
INFO     [golemapp                           ] memory: 3.9 GiB, swap: 0 Bytes
WARNING  [twisted                            ] Native worker connection closed uncleanly: A process has ended with a probable error condition: process ended with exit code 2.
ERROR    [twisted                            ] Failed to start native worker: A process has ended with a probable error condition: process ended with exit code 2.
ERROR    [twisted                            ] ApplicationError: ApplicationError(error=<crossbar.error.cannot_start>, args=['Failed to start native worker: A process has ended with a probable error condition: process ended with exit code 2.', ['Failed to import scrypt. This is not a fatal error but does', 'mean that you cannot create or decrypt privkey jsons that use', 'scrypt', 'Usage: golemapp [OPTIONS]', 'Error: Invalid value for "--loglevel": invalid choice: info. (choose from CRITICAL, ERROR, WARNING, INFO, DEBUG)']], kwargs={}, enc_algo=None): Traceback (most recent call last):
  File "/home/buildbot-worker/worker/buildpackage_linux/build/.venv/lib/python3.6/site-packages/twisted/internet/endpoints.py", line 384, in processEnded

  File "/home/buildbot-worker/worker/buildpackage_linux/build/.venv/lib/python3.6/site-packages/crossbar/controller/native.py", line 82, in connectionLost

  File "/home/buildbot-worker/worker/buildpackage_linux/build/.venv/lib/python3.6/site-packages/twisted/internet/defer.py", line 500, in errback

  File "/home/buildbot-worker/worker/buildpackage_linux/build/.venv/lib/python3.6/site-packages/twisted/internet/defer.py", line 567, in _startRunCallbacks

--- <exception caught here> ---
  File "/home/buildbot-worker/worker/buildpackage_linux/build/.venv/lib/python3.6/site-packages/twisted/internet/defer.py", line 653, in _runCallbacks

  File "/home/buildbot-worker/worker/buildpackage_linux/build/.venv/lib/python3.6/site-packages/crossbar/controller/process.py", line 506, in on_ready_error

autobahn.wamp.exception.ApplicationError: ApplicationError(error=<crossbar.error.cannot_start>, args=['Failed to start native worker: A process has ended with a probable error condition: process ended with exit code 2.', ['Failed to import scrypt. This is not a fatal error but does', 'mean that you cannot create or decrypt privkey jsons that use', 'scrypt', 'Usage: golemapp [OPTIONS]', 'Error: Invalid value for "--loglevel": invalid choice: info. (choose from CRITICAL, ERROR, WARNING, INFO, DEBUG)']], kwargs={}, enc_algo=None)

ERROR    [twisted                            ] crossbar.error.cannot_start: Failed to start native worker: A process has ended with a probable error condition: process ended with exit code 2. ['Failed to import scrypt. This is not a fatal error but does', 'mean that you cannot create or decrypt privkey jsons that use', 'scrypt', 'Usage: golemapp [OPTIONS]', 'Error: Invalid value for "--loglevel": invalid choice: info. (choose from CRITICAL, ERROR, WARNING, INFO, DEBUG)']
```

This PR resolves the issue, needs updates to the documentation afterwards.