### PR TITLE
network/transport: Make it harder to use incorrectly

### DIFF
--- a/golem/core/types.py
+++ b/golem/core/types.py
@@ -1,0 +1,4 @@
+from typing import Any, Dict
+
+
+Kwargs = Dict[str, Any]

--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -837,7 +837,7 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):
         for p in list(self.peers.values()):
             p.send_get_tasks()
 
-    def __connection_established(self, session, conn_id=None):
+    def __connection_established(self, session, conn_id: str):
         peer_conn = session.conn.transport.getPeer()
         ip_address = peer_conn.host
         port = peer_conn.port
@@ -845,16 +845,16 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):
         session.conn_id = conn_id
         self._mark_connected(conn_id, session.address, session.port)
 
-        logger.debug("Connection to peer established. {}: {}, conn_id {}"
-                     .format(ip_address, port, conn_id))
+        logger.debug("Connection to peer established. %s: %s, conn_id %s",
+                     ip_address, port, conn_id)
 
     @staticmethod
-    def __connection_failure(conn_id=None):
-        logger.info("Connection to peer failure {}.".format(conn_id))
+    def __connection_failure(conn_id: str):
+        logger.debug("Connection to peer failure %s.", conn_id)
 
     @staticmethod
-    def __connection_final_failure(conn_id=None):
-        logger.info("Can't connect to peer {}.".format(conn_id))
+    def __connection_final_failure(conn_id: str):
+        logger.debug("Can't connect to peer %s.", conn_id)
 
     def __is_new_peer(self, id_):
         return id_ not in self.incoming_peers\

--- a/golem/network/transport/network.py
+++ b/golem/network/transport/network.py
@@ -1,19 +1,20 @@
 import abc
-from twisted.internet.tcp import Client, Server
 from twisted.internet.protocol import Factory, Protocol, connectionDone
 
+from .tcpnetwork_helpers import TCPConnectInfo, TCPListenInfo, TCPListeningInfo
 
-class Network(object, metaclass=abc.ABCMeta):
+
+class Network(abc.ABC):
     @abc.abstractmethod
-    def connect(self, connect_info, **kwargs):
+    def connect(self, connect_info: TCPConnectInfo) -> None:
         return
 
     @abc.abstractmethod
-    def listen(self, listen_info, **kwargs):
+    def listen(self, listen_info: TCPListenInfo) -> None:
         return
 
     @abc.abstractmethod
-    def stop_listening(self, listening_info, **kwargs):
+    def stop_listening(self, listening_info: TCPListeningInfo):
         return
 
 

--- a/golem/network/transport/tcpnetwork.py
+++ b/golem/network/transport/tcpnetwork.py
@@ -111,6 +111,7 @@ class TCPNetwork(Network):
                 None,
                 listening_info.stopped_errback,
             )
+            return None
 
     def __filter_host_addresses(self, addresses):
         result = []
@@ -170,7 +171,8 @@ class TCPNetwork(Network):
                          self.__connection_to_address_failure,
                          connect_info)
 
-    def __connection_established(self, conn, established_callback,
+    @staticmethod
+    def __connection_established(conn, established_callback,
                                  connect_info: TCPConnectInfo):
         pp = conn.transport.getPeer()
         logger.debug("Connection established %r %r", pp.host, pp.port)
@@ -180,12 +182,14 @@ class TCPNetwork(Network):
             connect_info,
         )
 
-    def __connection_failure(self, err_desc, failure_callback,
+    @staticmethod
+    def __connection_failure(err_desc, failure_callback,
                              connect_info: TCPConnectInfo):
         logger.debug("Connection failure. %r", err_desc)
         TCPNetwork.__call_failure_callback(failure_callback, connect_info)
 
-    def __connection_to_address_established(self, conn,
+    @staticmethod
+    def __connection_to_address_established(conn,
                                             connect_info: TCPConnectInfo):
         TCPNetwork.__call_established_callback(
             connect_info.established_callback,

--- a/golem/network/transport/tcpnetwork.py
+++ b/golem/network/transport/tcpnetwork.py
@@ -66,38 +66,20 @@ class TCPNetwork(Network):
         else:
             self.rate_limiter = None
 
-    def connect(self, connect_info, **kwargs):
+    def connect(self, connect_info: TCPConnectInfo) -> None:
         """
         Connect network protocol factory to address from connect_info via TCP.
-        :param TCPConnectInfo connect_info:
-        :param kwargs: any additional parameters
-        :return None:
         """
-        self.__try_to_connect_to_addresses(
-            connect_info.socket_addresses,
-            connect_info.established_callback,
-            connect_info.failure_callback,
-            **kwargs
-        )
+        self.__try_to_connect_to_addresses(connect_info)
 
-    def listen(self, listen_info, **kwargs):
+    def listen(self, listen_info: TCPListenInfo) -> None:
         """
         Listen with network protocol factory on a TCP socket
         specified by listen_info
-
-        :param TCPListenInfo listen_info:
-        :param kwargs: any additional parameters
-        :return None:
         """
-        self.__try_to_listen_on_port(
-            listen_info.port_start,
-            listen_info.port_end,
-            listen_info.established_callback,
-            listen_info.failure_callback,
-            **kwargs
-        )
+        self.__try_to_listen_on_port(listen_info)
 
-    def stop_listening(self, listening_info, **kwargs):
+    def stop_listening(self, listening_info):
         """
         Stop listening on a TCP socket specified by listening_info
         :param TCPListeningInfo listening_info:
@@ -113,12 +95,10 @@ class TCPNetwork(Network):
                 defer.addCallback(
                     TCPNetwork.__stop_listening_success,
                     listening_info.stopped_callback,
-                    **kwargs
                 )
                 defer.addErrback(
                     TCPNetwork.__stop_listening_failure,
                     listening_info.stopped_errback,
-                    **kwargs
                 )
             del self.active_listeners[port]
             return defer
@@ -130,7 +110,6 @@ class TCPNetwork(Network):
             TCPNetwork.__stop_listening_failure(
                 None,
                 listening_info.stopped_errback,
-                **kwargs,
             )
 
     def __filter_host_addresses(self, addresses):
@@ -148,39 +127,25 @@ class TCPNetwork(Network):
             result.append(sa)
         return result
 
-    def __try_to_connect_to_addresses(self, addresses, established_callback,
-                                      failure_callback, **kwargs):
-        addresses = self.__filter_host_addresses(addresses)
+    def __try_to_connect_to_addresses(self, connect_info: TCPConnectInfo):
+        addresses = self.__filter_host_addresses(connect_info.socket_addresses)
         logger.debug('__try_to_connect_to_addresses(%r) filtered', addresses)
 
         if not addresses:
             logger.warning("No addresses for connection given")
-            TCPNetwork.__call_failure_callback(failure_callback, **kwargs)
+            TCPNetwork.__call_failure_callback(connect_info.failure_callback)
             return
 
-        address = addresses[0].address
-        port = addresses[0].port
-
-        _args = (
-            address, port,
-            self.__connection_to_address_established,
-            self.__connection_to_address_failure,
-        )
-        _kwargs = dict(
-            addresses_to_arg=addresses,
-            established_callback_to_arg=established_callback,
-            failure_callback_to_arg=failure_callback,
-            **kwargs
-        )
-
         if self.rate_limiter:
-            self.rate_limiter.call(self.__try_to_connect_to_address, *_args,
-                                   **_kwargs)
+            self.rate_limiter.call(self.__try_to_connect_to_address,
+                                   connect_info)
         else:
-            self.__try_to_connect_to_address(*_args, **_kwargs)
+            self.__try_to_connect_to_address(connect_info)
 
-    def __try_to_connect_to_address(self, address, port, established_callback,
-                                    failure_callback, **kwargs):
+    def __try_to_connect_to_address(self, connect_info: TCPConnectInfo):
+        address = connect_info.socket_addresses[0].address
+        port = connect_info.socket_addresses[0].port
+
         logger.debug("Connection to host %r: %r", address, port)
 
         use_ipv6 = False
@@ -198,120 +163,101 @@ class TCPNetwork(Network):
 
         defer = endpoint.connect(self.outgoing_protocol_factory)
 
-        defer.addCallback(self.__connection_established, established_callback,
-                          **kwargs)
-        defer.addErrback(self.__connection_failure, failure_callback, **kwargs)
+        defer.addCallback(self.__connection_established,
+                          self.__connection_to_address_established,
+                          connect_info)
+        defer.addErrback(self.__connection_failure,
+                         self.__connection_to_address_failure,
+                         connect_info)
 
-    def __connection_established(self, conn, established_callback, **kwargs):
+    def __connection_established(self, conn, established_callback,
+                                 connect_info: TCPConnectInfo):
         pp = conn.transport.getPeer()
         logger.debug("Connection established %r %r", pp.host, pp.port)
         TCPNetwork.__call_established_callback(
             established_callback,
             conn.session,
-            **kwargs,
+            connect_info,
         )
 
-    def __connection_failure(self, err_desc, failure_callback, **kwargs):
+    def __connection_failure(self, err_desc, failure_callback,
+                             connect_info: TCPConnectInfo):
         logger.debug("Connection failure. %r", err_desc)
-        TCPNetwork.__call_failure_callback(failure_callback, **kwargs)
+        TCPNetwork.__call_failure_callback(failure_callback, connect_info)
 
-    def __connection_to_address_established(self, conn, **kwargs):
-        established_callback = kwargs.pop("established_callback_to_arg", None)
-        kwargs.pop("failure_callback_to_arg", None)
-        kwargs.pop("addresses_to_arg", None)
+    def __connection_to_address_established(self, conn,
+                                            connect_info: TCPConnectInfo):
         TCPNetwork.__call_established_callback(
-            established_callback,
+            connect_info.established_callback,
             conn,
-            **kwargs,
         )
 
-    def __connection_to_address_failure(self, **kwargs):
-        established_callback = kwargs.pop("established_callback_to_arg", None)
-        failure_callback = kwargs.pop("failure_callback_to_arg", None)
-        addresses = kwargs.pop("addresses_to_arg", [])
-        if len(addresses) > 1:
-            self.__try_to_connect_to_addresses(
-                addresses[1:],
-                established_callback,
-                failure_callback,
-                **kwargs,
-            )
+    def __connection_to_address_failure(self, connect_info: TCPConnectInfo):
+        if len(connect_info.socket_addresses) > 1:
+            connect_info.socket_addresses.pop(0)
+            self.__try_to_connect_to_addresses(connect_info)
         else:
-            TCPNetwork.__call_failure_callback(failure_callback, **kwargs)
+            TCPNetwork.__call_failure_callback(connect_info.failure_callback)
 
-    def __try_to_listen_on_port(self, port, max_port, established_callback,
-                                failure_callback, **kwargs):
+    def __try_to_listen_on_port(self, listen_info: TCPListenInfo):
         if self.use_ipv6:
-            ep = TCP6ServerEndpoint(self.reactor, port)
+            ep = TCP6ServerEndpoint(self.reactor, listen_info.port_start)
         else:
-            ep = TCP4ServerEndpoint(self.reactor, port)
+            ep = TCP4ServerEndpoint(self.reactor, listen_info.port_start)
 
         defer = ep.listen(self.incoming_protocol_factory)
 
         defer.addCallback(
             self.__listening_established,
-            established_callback,
-            **kwargs,
+            listen_info.established_callback,
         )
         defer.addErrback(
             self.__listening_failure,
-            port,
-            max_port,
-            established_callback,
-            failure_callback,
-            **kwargs,
+            listen_info
         )
 
-    def __listening_established(self, listening_port, established_callback,
-                                **kwargs):
+    def __listening_established(self, listening_port, established_callback):
         port = listening_port.getHost().port
         self.active_listeners[port] = listening_port
         TCPNetwork.__call_established_callback(
             established_callback,
             port,
-            **kwargs,
         )
 
-    def __listening_failure(self, err_desc, port, max_port,
-                            established_callback, failure_callback, **kwargs):
+    def __listening_failure(self, err_desc, listen_info: TCPListenInfo):
         err = str(err_desc.value)
-        if port < max_port:
-            port += 1
-            self.__try_to_listen_on_port(
-                port,
-                max_port,
-                established_callback,
-                failure_callback,
-                **kwargs,
-            )
+        logger.debug("Can't listen on port %r: %r", listen_info.port_start, err)
+        if listen_info.port_start < listen_info.port_end:
+            listen_info.port_start += 1
+            self.__try_to_listen_on_port(listen_info)
         else:
-            logger.debug("Can't listen on port %r: %r", port, err)
-            TCPNetwork.__call_failure_callback(failure_callback, **kwargs)
+            TCPNetwork.__call_failure_callback(listen_info.failure_callback)
 
     @staticmethod
-    def __call_failure_callback(failure_callback, **kwargs):
+    def __call_failure_callback(failure_callback, *args, **kwargs):
         if failure_callback is None:
             return
-        failure_callback(**kwargs)
+        failure_callback(*args, **kwargs)
 
     @staticmethod
-    def __call_established_callback(established_callback, result, **kwargs):
+    def __call_established_callback(established_callback, result, *args,
+                                    **kwargs):
         if established_callback is None:
             return
-        established_callback(result, **kwargs)
+        established_callback(result, *args, **kwargs)
 
     @staticmethod
-    def __stop_listening_success(result, callback, **kwargs):
+    def __stop_listening_success(result, callback):
         if result:
             logger.info("Stop listening result %r", result)
         if callback is None:
             return
-        callback(**kwargs)
+        callback()
 
     @staticmethod
-    def __stop_listening_failure(fail, errback, **kwargs):
+    def __stop_listening_failure(fail, errback):
         logger.error("Can't stop listening %r", fail)
-        TCPNetwork.__call_failure_callback(errback, **kwargs)
+        TCPNetwork.__call_failure_callback(errback)
 
 #############
 # Protocols #

--- a/golem/network/transport/tcpnetwork_helpers.py
+++ b/golem/network/transport/tcpnetwork_helpers.py
@@ -1,7 +1,11 @@
 import ipaddress
 import logging
 import re
+import uuid
+from functools import partial
+from typing import Callable, List, Optional
 
+from golem.core.types import Kwargs
 from golem.core import variables
 
 logger = logging.getLogger(__name__)
@@ -139,28 +143,28 @@ class SocketAddress():
 
 
 class TCPListenInfo(object):
-    def __init__(self, port_start, port_end=None, established_callback=None,
-                 failure_callback=None):
+    def __init__(self,
+                 port_start: int,
+                 port_end: Optional[int] = None,
+                 established_callback: Optional[Callable] = None,
+                 failure_callback: Optional[Callable] = None) \
+                 -> None:
         """
         Information needed for listen function. Network will try to start
         listening on port_start, then iterate by 1 to port_end.
         If port_end is None, than network will only try to listen on
         port_start.
-        :param int port_start: try to start listening from that port
-        :param int port_end: *Default: None* highest port that network
-                             will try to listen on
-        :param fun|None established_callback: *Default: None* deferred
-                                              callback after listening
-                                              established
-        :param fun|None failure_callback: *Default: None* deferred callback
-                                          after listening failure
+        :param port_start: try to start listening from that port
+        :param port_end: *Default: None* highest port that network will try to
+                         listen on
+        :param established_callback: *Default: None* deferred callback after
+                                     listening established
+        :param failure_callback: *Default: None* deferred callback after
+                                 listening failure
         :return:
         """
         self.port_start = port_start
-        if port_end:
-            self.port_end = port_end
-        else:
-            self.port_end = port_start
+        self.port_end = port_end if port_end else port_start
         self.established_callback = established_callback
         self.failure_callback = failure_callback
 
@@ -174,16 +178,18 @@ class TCPListenInfo(object):
 
 
 class TCPListeningInfo(object):
-    def __init__(self, port, stopped_callback=None, stopped_errback=None):
+    def __init__(self,
+                 port: int,
+                 stopped_callback: Optional[Callable] = None,
+                 stopped_errback: Optional[Callable] = None) \
+                 -> None:
         """
         TCP listening port information
-        :param int port: port opened for listening
-        :param fun|None stopped_callback: *Default: None* deferred callback
-                                          after listening on this port
-                                          is stopped
-        :param fun|None stopped_errback: *Default: None* deferred callback
-                                         after stop listening failed
-        :return:
+        :param port: port opened for listening
+        :param stopped_callback: *Default: None* deferred callback after
+                                 listening on this port is stopped
+        :param stopped_errback: *Default: None* deferred callback after stop
+                                listening failed
         """
         self.port = port
         self.stopped_callback = stopped_callback
@@ -194,22 +200,32 @@ class TCPListeningInfo(object):
 
 
 class TCPConnectInfo(object):
-    def __init__(self, socket_addresses, established_callback=None,
-                 failure_callback=None):
+    def __init__(self,
+                 socket_addresses: List[SocketAddress],
+                 established_callback: Optional[Callable] = None,
+                 failure_callback: Optional[Callable] = None,
+                 final_failure_callback: Optional[Callable] = None,
+                 kwargs: Kwargs = {}) \
+                 -> None:
         """
         Information for TCP connect function
-        :param list socket_addresses: list of SocketAddresses
-        :param fun|None established_callback:
-        :param fun|None failure_callback:
-        :return None:
         """
+        self.id = str(uuid.uuid4())
         self.socket_addresses = socket_addresses
-        self.established_callback = established_callback
-        self.failure_callback = failure_callback
+        self.established_callback = (
+            partial(established_callback, conn_id=self.id, **kwargs)
+            if established_callback else None)
+        self.failure_callback = (
+            partial(failure_callback, conn_id=self.id, **kwargs)
+            if failure_callback else None)
+        self.final_failure_callback = (
+            partial(final_failure_callback, conn_id=self.id, **kwargs)
+            if final_failure_callback else None)
 
     def __str__(self):
         return ("TCP connection information: addresses {}, "
-                "callback {}, errback {}").format(
+                "callback {}, errback {}, final_errback {}").format(
                     self.socket_addresses,
-                    self.established_callback,
-                    self.failure_callback, )
+                    self.established_callback.func,
+                    self.failure_callback.func,
+                    self.final_failure_callback.func)

--- a/golem/network/transport/tcpnetwork_helpers.py
+++ b/golem/network/transport/tcpnetwork_helpers.py
@@ -200,12 +200,13 @@ class TCPListeningInfo(object):
 
 
 class TCPConnectInfo(object):
+    # pylint: disable-msg=too-many-arguments
     def __init__(self,
                  socket_addresses: List[SocketAddress],
                  established_callback: Optional[Callable] = None,
                  failure_callback: Optional[Callable] = None,
                  final_failure_callback: Optional[Callable] = None,
-                 kwargs: Kwargs = {}) \
+                 kwargs: Kwargs = dict()) \
                  -> None:
         """
         Information for TCP connect function

--- a/golem/network/transport/tcpserver.py
+++ b/golem/network/transport/tcpserver.py
@@ -1,11 +1,14 @@
 import logging
-import uuid
 import time
+from functools import partial
+from typing import Callable, Dict, List, Optional, Set
 
 from golem.clientconfigdescriptor import ClientConfigDescriptor
+from golem.core.types import Kwargs
 from golem.core.hostaddress import ip_address_private, ip_network_contains, \
     ipv4_networks
 
+from .session import BasicSession
 from .tcpnetwork import TCPNetwork, TCPListeningInfo, TCPListenInfo, \
     SocketAddress, TCPConnectInfo
 
@@ -100,11 +103,16 @@ class PendingConnectionsServer(TCPServer):
         :param network: network that server will use
         """
         # Pending connections
-        self.pending_connections = {}  # Connections that should be accomplished
-        self.pending_sessions = set()  # Sessions a.k.a Peers before handshake
-        self.conn_established_for_type = {}  # Reactions for established connections of certain types
-        self.conn_failure_for_type = {}  # Reactions for failed connection attempts of certain types
-        self.conn_final_failure_for_type = {}  # Reactions for final connection attempts failure
+        #  Connections that should be accomplished
+        self.pending_connections: Dict[str, PendingConnection] = {}
+        #  Sessions a.k.a Peers before handshake
+        self.pending_sessions: Set[BasicSession] = set()
+        #  Reactions for established connections of certain types
+        self.conn_established_for_type: Dict[int, Callable] = {}
+        #  Reactions for failed connection attempts of certain types
+        self.conn_failure_for_type: Dict[int, Callable] = {}
+        #  Reactions for final connection attempts failure
+        self.conn_final_failure_for_type: Dict[int, Callable] = {}
 
         # Set reactions
         self._set_conn_established()
@@ -128,12 +136,12 @@ class PendingConnectionsServer(TCPServer):
         method and then remove it from pending connections list.
         :param uuid|None conn_id: id of verified connection
         """
-        conn = self.pending_connections.get(conn_id)
+        conn: PendingConnection = self.pending_connections.get(conn_id)
         if conn:
-            self.conn_final_failure_for_type[conn.type](conn_id, **conn.args)
+            conn.final_failure()
             self.remove_pending_conn(conn_id)
         else:
-            logger.debug("Connection {} is unknown".format(conn_id))
+            logger.debug("Connection %s is unknown", conn_id)
 
     def _add_pending_request(self, req_type, task_owner, port, key_id, args):
         if not self.active:
@@ -147,7 +155,9 @@ class PendingConnectionsServer(TCPServer):
 
         pc = PendingConnection(req_type, sockets,
                                self.conn_established_for_type[req_type],
-                               self.conn_failure_for_type[req_type], args)
+                               self.conn_failure_for_type[req_type],
+                               self.conn_final_failure_for_type[req_type],
+                               args)
 
         self.pending_connections[pc.id] = pc
 
@@ -181,13 +191,12 @@ class PendingConnectionsServer(TCPServer):
         for conn in conns:
             if len(conn.socket_addresses) == 0:
                 conn.status = PenConnStatus.WaitingAlt
-                conn.failure(conn.id, **conn.args)
+                conn.failure()
                 # TODO Implement proper way to deal with failures
             else:
                 conn.status = PenConnStatus.Waiting
                 conn.last_try_time = time.time()
-                connect_info = TCPConnectInfo(conn.socket_addresses, conn.established, conn.failure)
-                self.network.connect(connect_info, conn_id=conn.id, **conn.args)
+                self.network.connect(conn.connect_info)
 
     def get_socket_addresses(self, node_info, port, key_id):
         socket_addresses = [SocketAddress(i, port) for i in node_info.prv_addresses]
@@ -233,23 +242,52 @@ class PenConnStatus(object):
     WaitingAlt = 5
 
 
-class PendingConnection(object):
-    """ Describe pending connections parameters for PendingConnectionsServer  """
+class PendingConnection:
+    """ Describe pending connections parameters for PendingConnectionsServer """
     connect_statuses = [PenConnStatus.Inactive, PenConnStatus.Failure]
 
-    def __init__(self, type_, socket_addresses, established=None, failure=None, args=None):
+    def __init__(self,
+                 type_: int,
+                 socket_addresses: List[SocketAddress],
+                 established: Optional[Callable] = None,
+                 failure: Optional[Callable] = None,
+                 final_failure: Optional[Callable] = None,
+                 kwargs: Kwargs = {}) -> None:
         """ Create new pending connection
-        :param int type_: connection type that allows to select proper reactions
-        :param list socket_addresses: list of socket_addresses that the node should try to connect to
-        :param func|None established: established connection callback
-        :param func|None failure: connection errback
-        :param dict args: arguments that should be passed to established or failure function
+        :param type_: connection type that allows to select proper reactions
+        :param socket_addresses: list of socket_addresses that the node should
+                                 try to connect to
+        :param established: established connection callback
+        :param failure: connection errback
+        :param kwargs: arguments that should be passed to established or
+                       failure function
         """
-        self.id = str(uuid.uuid4())
-        self.socket_addresses = socket_addresses
+        self.connect_info = TCPConnectInfo(socket_addresses, established,
+                                           failure, final_failure, kwargs)
         self.last_try_time = time.time()
-        self.established = established
-        self.failure = failure
-        self.args = args
         self.type = type_
         self.status = PenConnStatus.Inactive
+
+    @property
+    def id(self):
+        return self.connect_info.id
+
+    @property
+    def socket_addresses(self):
+        return self.connect_info.socket_addresses
+
+    @socket_addresses.setter
+    def socket_addresses(self, new_addresses):
+        self.connect_info.socket_addresses = new_addresses
+
+    @property
+    def established(self):
+        return self.connect_info.established_callback
+
+    @property
+    def failure(self):
+        return self.connect_info.failure_callback
+
+    @property
+    def final_failure(self):
+        return self.connect_info.final_failure_callback

--- a/golem/network/transport/tcpserver.py
+++ b/golem/network/transport/tcpserver.py
@@ -1,6 +1,5 @@
 import logging
 import time
-from functools import partial
 from typing import Callable, Dict, List, Optional, Set
 
 from golem.clientconfigdescriptor import ClientConfigDescriptor
@@ -246,6 +245,7 @@ class PendingConnection:
     """ Describe pending connections parameters for PendingConnectionsServer """
     connect_statuses = [PenConnStatus.Inactive, PenConnStatus.Failure]
 
+    # pylint: disable-msg=too-many-arguments
     def __init__(self,
                  type_: int,
                  socket_addresses: List[SocketAddress],

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -5,7 +5,8 @@ import time
 import unittest.mock as mock
 import uuid
 
-from golem import testutils
+from twisted.internet.tcp import EISCONN
+
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.core.keysauth import KeysAuth
 from golem.diag.service import DiagnosticsOutputFormat
@@ -16,10 +17,11 @@ from golem.network.p2p.p2pservice import HISTORY_LEN, P2PService
 from golem.network.p2p.peersession import PeerSession
 from golem.network.transport.tcpnetwork import SocketAddress
 from golem.task.taskconnectionshelper import TaskConnectionsHelper
+from golem.tools.testwithreactor import TestDatabaseWithReactor
 from golem.utils import encode_hex
 
 
-class TestP2PService(testutils.DatabaseFixture):
+class TestP2PService(TestDatabaseWithReactor):
 
     def setUp(self):
         super(TestP2PService, self).setUp()
@@ -409,3 +411,29 @@ class TestP2PService(testutils.DatabaseFixture):
             seed = self.service._get_next_random_seed()
             seeds.remove(seed)
         assert not seeds
+
+    @mock.patch('twisted.internet.tcp.BaseClient.createInternetSocket')
+    @mock.patch('golem.network.p2p.p2pservice.'
+                'P2PService._P2PService__connection_established')
+    def test_connect_success(self, connection_established, createSocket):
+        createSocket.return_value = socket = mock.Mock()
+        socket.fileno = mock.Mock(return_value=0)
+        socket.getsockopt = mock.Mock(return_value=None)
+        socket.connect_ex = mock.Mock(return_value=EISCONN)
+
+        addr = SocketAddress('127.0.0.1', 40102)
+        self.service.connect(addr)
+        time.sleep(0.1)
+        assert connection_established.called
+        assert connection_established.call_args[0][0] is not None
+        assert connection_established.call_args[1]['conn_id'] is not None
+
+    @mock.patch('twisted.internet.tcp.BaseClient.createInternetSocket',
+                side_effect=Exception('something has failed'))
+    @mock.patch('golem.network.p2p.p2pservice.'
+                'P2PService._P2PService__connection_failure')
+    def test_connect_failure(self, connection_failure, createSocket):
+        addr = SocketAddress('127.0.0.1', 40102)
+        self.service.connect(addr)
+        assert connection_failure.called
+        assert connection_failure.call_args[1]['conn_id'] is not None

--- a/tests/golem/network/transport/test_network.py
+++ b/tests/golem/network/transport/test_network.py
@@ -75,7 +75,6 @@ class TestNetwork(TestWithReactor):
         self.connect_success = None
         self.stop_listening_success = None
         self.port = None
-        self.kwargs_len = 0
         session_factory = SessionFactory(ASession)
         protocol_factory = ProtocolFactory(SafeProtocol, Server(), session_factory)
         self.network = TCPNetwork(protocol_factory)
@@ -142,9 +141,8 @@ class TestNetwork(TestWithReactor):
         self.assertEqual(len(self.network.active_listeners), 2)
 
         with async_scope(listen_status):
-            self.network.listen(listen_info, a=1, b=2, c=3, d=4, e=5)
+            self.network.listen(listen_info)
         self.assertEqual(self.port, port + 2)
-        self.assertEqual(self.kwargs_len, 5)
         self.assertEqual(len(self.network.active_listeners), 3)
 
         # connect
@@ -229,12 +227,11 @@ class TestNetwork(TestWithReactor):
             self.network.stop_listening(listening_info)
         self.assertEqual(len(self.network.active_listeners), 0)
 
-    def __listen_success(self, port, **kwargs):
+    def __listen_success(self, port):
         self.listen_success = True
         self.port = port
-        self.kwargs_len = len(kwargs)
 
-    def __listen_failure(self, **kwargs):
+    def __listen_failure(self):
         self.port = None
         self.listen_success = False
 

--- a/tests/golem/network/transport/test_tcpnetwork.py
+++ b/tests/golem/network/transport/test_tcpnetwork.py
@@ -13,6 +13,7 @@ from golem import testutils
 from golem.network.transport import tcpnetwork
 from golem.network.transport.tcpnetwork import (SafeProtocol, SocketAddress,
                                                 MAX_MESSAGE_SIZE, TCPNetwork)
+from golem.network.transport.tcpnetwork_helpers import TCPConnectInfo
 from golem.tools.assertlogs import LogTestCase
 from tests.factories import messages as msg_factories
 from tests.factories import p2p as p2p_factories
@@ -174,7 +175,7 @@ class TestTCPNetworkConnections(unittest.TestCase):
         connect_all = network._TCPNetwork__try_to_connect_to_addresses
         network._TCPNetwork__try_to_connect_to_address = connect
 
-        connect_all(self.addresses, mock.Mock(), mock.Mock())
+        connect_all(TCPConnectInfo(self.addresses, mock.Mock(), mock.Mock()))
         assert connect.called
 
     def test_with_rate_limiter(self):
@@ -190,6 +191,6 @@ class TestTCPNetworkConnections(unittest.TestCase):
         network._TCPNetwork__try_to_connect_to_address = connect
         network.rate_limiter.call = call
 
-        connect_all(self.addresses, mock.Mock(), mock.Mock())
+        connect_all(TCPConnectInfo(self.addresses, mock.Mock(), mock.Mock()))
         assert not connect.called
         assert call.called

--- a/tests/golem/network/transport/test_tcpserver.py
+++ b/tests/golem/network/transport/test_tcpserver.py
@@ -26,7 +26,7 @@ class Network(object):
     def stop_listening(self, _):
         self.stop_listening_called = True
 
-    def connect(self, connect_info, conn_id, *args):
+    def connect(self, connect_info):
         self.connected = True
 
 
@@ -127,7 +127,7 @@ class TestPendingConnectionServer(unittest.TestCase):
         req_type = 0
         final_failure_called = [False]
 
-        def final_failure(_):
+        def final_failure(*args, **kwargs):
             final_failure_called[0] = True
 
         server.conn_established_for_type[req_type] = lambda x: x
@@ -166,7 +166,7 @@ class TestPendingConnectionServer(unittest.TestCase):
         node_info.pub_addr = "1.2.3.4"
         node_info.pub_port = self.port
 
-        def final_failure(_):
+        def final_failure(*args, **kwargs):
             final_failure_called[0] = True
 
         server.conn_established_for_type[req_type] = lambda x: x


### PR DESCRIPTION
- Create `conn_id` in `TCPConnectInfo.__init__`.
- Bind `conn_id` and `kwargs` to handlers in `TCPConnectInfo`.
- Keep using `TCP*Info` objects internally. Don't decompose them on entry.
- More type annotations.

Fixes #2226 