### PR TITLE
Do not count 'None' as valid ip address

### DIFF
--- a/golem/network/transport/tcpserver.py
+++ b/golem/network/transport/tcpserver.py
@@ -232,7 +232,8 @@ class PendingConnectionsServer(TCPServer):
     @classmethod
     def _is_address_valid(cls, address: str, port: int) -> bool:
         try:
-            if address is None:
+            # FIXME: Where did None become 'None'?
+            if address == 'None':
                 logger.debug('Got "None" as socket address. Skipping...')
                 return False
             return port > 0 and SocketAddress.is_proper_address(address, port)

--- a/golem/network/transport/tcpserver.py
+++ b/golem/network/transport/tcpserver.py
@@ -232,6 +232,9 @@ class PendingConnectionsServer(TCPServer):
     @classmethod
     def _is_address_valid(cls, address: str, port: int) -> bool:
         try:
+            if address is None:
+                logger.debug('Got "None" as socket address. Skipping...')
+                return False
             return port > 0 and SocketAddress.is_proper_address(address, port)
         except TypeError:
             return False


### PR DESCRIPTION
Resolves: 
```
2018-03-13 13:29:38 ERROR    golem.core.hostaddress              Cannot parse IPv4 address None: Expected 4 octets in 'None'
```