### PR TITLE
Make golem.network logs show up in debug

### DIFF
--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -185,8 +185,7 @@ def config_logging(suffix='', datadir=None, loglevel=None):
 
     if loglevel:
         for _logger in LOGGING.get('loggers', {}).values():
-            if 'level' in _logger:
-                _logger['level'] = loglevel
+            _logger['level'] = loglevel
         LOGGING['root']['level'] = loglevel
 
     try:


### PR DESCRIPTION
Today i found the logger `golem.network.*`  does not listen to the DEBUG flag so i have fixed it.