### PR TITLE
WebSocket certificate generation with "golemapp --generate-rpc-cert"

### DIFF
--- a/golemapp.py
+++ b/golemapp.py
@@ -240,6 +240,8 @@ def generate_rpc_certificate(datadir: str):
     from golem.rpc.common import CROSSBAR_DIR
 
     cert_dir = os.path.join(datadir, CROSSBAR_DIR)
+    os.makedirs(cert_dir, exist_ok=True)
+
     cert_manager = CertificateManager(cert_dir)
     cert_manager.generate_if_needed()
 

--- a/tests/test_golemapp.py
+++ b/tests/test_golemapp.py
@@ -66,3 +66,15 @@ class TestGolemApp(TempDirFixture, PEP8MixIn):
         )
         assert node_class.called
         assert PROTOCOL_CONST.ID == custom_id
+
+    @mock.patch('golem.rpc.cert.CertificateManager')
+    def test_generate_rpc_cert(self, cert_manager, *_):
+        cert_manager.return_value = cert_manager
+
+        runner = CliRunner()
+        runner.invoke(
+            start,
+            ['--datadir', self.path, '--generate-rpc-cert'],
+            catch_exceptions=False,
+        )
+        assert cert_manager.generate_if_needed.called


### PR DESCRIPTION
GUI needs to load and trust the certificate in order to communicate via secure websockets. In order to have a better control of the starting process, the UI may now trigger certificate generation using `golemapp --generate-rpc-cert [--mainnet]`.