### PR TITLE
Fix: install reactor before raven does

### DIFF
--- a/golemapp.py
+++ b/golemapp.py
@@ -146,10 +146,12 @@ def start(monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
         start_crossbar_worker(m)
     # Golem headless
     else:
+        install_reactor()
+
         from golem.core.common import config_logging
         config_logging(datadir=datadir, loglevel=log_level,
                        enable_talkback=enable_talkback)
-        install_reactor()
+
         log_golem_version()
         log_platform_info()
         log_ethereum_chain(mainnet)

--- a/golemcli.py
+++ b/golemcli.py
@@ -57,6 +57,8 @@ def start():
     args = sys.argv[1:]
     parsed, forwarded = parser.parse_known_args(args)
 
+    install_reactor()
+
     # setup logging if in interactive mode
     interactive = parsed.interactive
 
@@ -69,7 +71,6 @@ def start():
         cli = CLI(main_parser=parser, main_parser_options=flag_options)
 
     # run the cli
-    install_reactor()
     ws_cli = WebSocketCLI(cli, host=parsed.address, port=parsed.port)
     ws_cli.execute(forwarded, interactive=interactive)
 


### PR DESCRIPTION
Currently it's not possible to start `golemapp` and `golemcli` on macOS and Windows.