### PR TITLE
is_mainnet RPC call v2

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -1124,9 +1124,6 @@ class Client(HardwarePresetsMixin):
     def get_golem_status():
         return StatusPublisher.last_status()
 
-    def is_mainnet(self) -> bool:
-        return self.mainnet
-
     def activate_hw_preset(self, name, run_benchmarks=False):
         HardwarePresets.update_config(name, self.config_desc)
         if hasattr(self, 'task_server') and self.task_server:

--- a/golem/rpc/mapping/rpcmethodnames.py
+++ b/golem/rpc/mapping/rpcmethodnames.py
@@ -4,7 +4,6 @@
 CORE_METHOD_MAP = dict(
     get_golem_version=      'golem.version',
     get_golem_status=       'golem.status',
-    is_mainnet=             'golem.mainnet',
 
     get_settings=           'env.opts',
     update_settings=        'env.opts.update',

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -542,19 +542,6 @@ class TestClient(TestWithDatabase, TestWithReactor):
         client.check_payments()
         trust.PAYMENT.decrease.assert_has_calls((call('a'), call('b')))
 
-    @patch('golem.client.EthereumTransactionSystem', autospec=True)
-    def test_is_mainnet(self, *_):
-        client = Client(
-            datadir=self.path,
-            config_desc=ClientConfigDescriptor(),
-            app_config=Mock(),
-            keys_auth=Mock(),
-            connect_to_known_hosts=False,
-            use_docker_manager=False,
-            use_monitor=False
-        )
-        assert not client.is_mainnet()
-
 
 class TestDoWorkService(TestWithReactor):
 

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -599,3 +599,10 @@ class TestOptNode(TempDirFixture):
         assert self.node.client.start.call_count == 1
         self.node.client.connect.assert_called_with(parsed_peer[0])
         assert reactor.addSystemEventTrigger.call_count == 2
+
+    def test_is_mainnet(self, *_):
+        self.node = Node(datadir=self.path,
+                         app_config=Mock(),
+                         config_desc=ClientConfigDescriptor(),
+                         use_docker_manager=False)
+        assert not self.node.is_mainnet()


### PR DESCRIPTION
Moves `is_mainnet` call from `Client` to `Node`; `Client` instance is not yet created when the call is needed.