### PR TITLE
Fixed restore_resources error (#2343)

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -23,7 +23,7 @@ from golem.appconfig import (TASKARCHIVE_MAINTENANCE_INTERVAL,
 from golem.clientconfigdescriptor import ConfigApprover, ClientConfigDescriptor
 from golem.config.presets import HardwarePresetsMixin
 from golem.core.async import AsyncRequest, async_run
-from golem.core.common import to_unicode, string_to_timeout
+from golem.core.common import get_timestamp_utc, to_unicode, string_to_timeout
 from golem.core.fileshelper import du
 from golem.core.hardware import HardwarePresets
 from golem.core.keysauth import KeysAuth
@@ -293,48 +293,35 @@ class Client(HardwarePresetsMixin):
 
         logger.debug("Is super node? %s", self.node.is_super_node())
 
-        if not self.p2pservice:
-            self.p2pservice = P2PService(
-                self.node,
-                self.config_desc,
-                self.keys_auth,
-                connect_to_known_hosts=self.connect_to_known_hosts
-            )
+        self.p2pservice = P2PService(
+            self.node,
+            self.config_desc,
+            self.keys_auth,
+            connect_to_known_hosts=self.connect_to_known_hosts
+        )
 
-        if not self.task_server:
-            self.task_server = TaskServer(
-                self.node,
-                self.config_desc,
-                self,
-                use_ipv6=self.config_desc.use_ipv6,
-                use_docker_manager=self.use_docker_manager,
-                task_archiver=self.task_archiver)
+        self.task_server = TaskServer(
+            self.node,
+            self.config_desc,
+            self,
+            use_ipv6=self.config_desc.use_ipv6,
+            use_docker_manager=self.use_docker_manager,
+            task_archiver=self.task_archiver)
 
-            monitoring_publisher_service = MonitoringPublisherService(
-                self.task_server,
-                interval_seconds=max(
-                    int(self.config_desc.node_snapshot_interval),
-                    1))
-            monitoring_publisher_service.start()
-            self._services.append(monitoring_publisher_service)
-
-            clean_tasks_older_than = \
-                self.config_desc.clean_tasks_older_than_seconds
-            if clean_tasks_older_than > 0:
-                task_cleaner_service = TaskCleanerService(
-                    self,
-                    interval_seconds=max(1, int(clean_tasks_older_than / 10)),
-                    older_than_seconds=clean_tasks_older_than)
-                task_cleaner_service.start()
-                self._services.append(task_cleaner_service)
+        monitoring_publisher_service = MonitoringPublisherService(
+            self.task_server,
+            interval_seconds=max(
+                int(self.config_desc.node_snapshot_interval),
+                1))
+        monitoring_publisher_service.start()
+        self._services.append(monitoring_publisher_service)
 
         dir_manager = self.task_server.task_computer.dir_manager
 
         logger.info("Starting resource server ...")
 
-        if not self.daemon_manager:
-            self.daemon_manager = HyperdriveDaemonManager(self.datadir)
-            self.daemon_manager.start()
+        self.daemon_manager = HyperdriveDaemonManager(self.datadir)
+        self.daemon_manager.start()
 
         hyperdrive_addrs = self.daemon_manager.public_addresses(
             self.node.pub_addr)
@@ -342,13 +329,31 @@ class Client(HardwarePresetsMixin):
 
         self.node.hyperdrive_prv_port = next(iter(hyperdrive_ports))
 
-        if not self.resource_server:
-            resource_manager = HyperdriveResourceManager(dir_manager,
-                                                         hyperdrive_addrs)
-            self.resource_server = BaseResourceServer(resource_manager,
-                                                      dir_manager,
-                                                      self.keys_auth, self)
-            self.task_server.restore_resources()
+        clean_tasks_older_than = \
+            self.config_desc.clean_tasks_older_than_seconds
+        if clean_tasks_older_than > 0:
+            self.clean_old_tasks()
+
+        resource_manager = HyperdriveResourceManager(
+            dir_manager=dir_manager,
+            daemon_address=hyperdrive_addrs
+        )
+        self.resource_server = BaseResourceServer(
+            resource_manager=resource_manager,
+            dir_manager=dir_manager,
+            keys_auth=self.keys_auth,
+            client=self
+        )
+        self.task_server.restore_resources()
+
+        # Start service after restore_resources() to avoid race conditions
+        if clean_tasks_older_than:
+            task_cleaner_service = TaskCleanerService(
+                client=self,
+                interval_seconds=max(1, clean_tasks_older_than // 10)
+            )
+            task_cleaner_service.start()
+            self._services.append(task_cleaner_service)
 
         def connect(ports):
             logger.info(
@@ -985,6 +990,16 @@ class Client(HardwarePresetsMixin):
     def remove_task_header(self, task_id):
         self.task_server.remove_task_header(task_id)
 
+    def clean_old_tasks(self):
+        now = get_timestamp_utc()
+        for task in self.get_tasks():
+            deadline = task['time_started'] \
+                + string_to_timeout(task['timeout'])\
+                + self.config_desc.clean_tasks_older_than_seconds
+            if deadline <= now:
+                logger.info('Task %s got too old. Deleting.', task['id'])
+                self.delete_task(task['id'])
+
     def get_known_tasks(self):
         headers = {}
         for key, header in list(self.task_server.task_keeper.task_headers.items()):  # noqa
@@ -1316,22 +1331,12 @@ class ResourceCleanerService(LoopingCallService):
 
 class TaskCleanerService(LoopingCallService):
     _client = None  # type: Client
-    older_than_seconds = 0  # type: int
 
     def __init__(self,
                  client: Client,
-                 interval_seconds: int,
-                 older_than_seconds: int) -> None:
+                 interval_seconds: int) -> None:
         super().__init__(interval_seconds)
         self._client = client
-        self.older_than_seconds = older_than_seconds
 
     def _run(self):
-        now = time.time()
-        for task in self._client.get_tasks():
-            deadline = task['time_started'] \
-                + string_to_timeout(task['timeout'])\
-                + self.older_than_seconds
-            if deadline <= now:
-                logger.info('Task %s got too old. Deleting.', task['id'])
-                self._client.delete_task(task['id'])
+        self._client.clean_old_tasks()

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -548,6 +548,76 @@ class TestClient(TestWithDatabase, TestWithReactor):
         client.check_payments()
         trust.PAYMENT.decrease.assert_has_calls((call('a'), call('b')))
 
+    @patch('golem.client.EthereumTransactionSystem')
+    @patch('golem.client.get_timestamp_utc')
+    def test_clean_old_tasks_no_tasks(self, *_):
+        self.client = Client(
+            datadir=self.path,
+            app_config=Mock(),
+            config_desc=ClientConfigDescriptor(),
+            keys_auth=Mock(),
+            database=Mock(),
+            connect_to_known_hosts=False,
+            use_docker_manager=False,
+            use_monitor=False
+        )
+        self.client.get_tasks = Mock(return_value=[])
+        self.client.delete_task = Mock()
+        self.client.clean_old_tasks()
+        self.client.delete_task.assert_not_called()
+
+    @patch('golem.client.EthereumTransactionSystem')
+    @patch('golem.client.get_timestamp_utc')
+    def test_clean_old_tasks_only_new(self, get_timestamp, *_):
+        self.client = Client(
+            datadir=self.path,
+            app_config=Mock(),
+            config_desc=ClientConfigDescriptor(),
+            keys_auth=Mock(),
+            database=Mock(),
+            connect_to_known_hosts=False,
+            use_docker_manager=False,
+            use_monitor=False
+        )
+        self.client.config_desc.clean_tasks_older_than_seconds = 5
+        self.client.get_tasks = Mock(return_value=[{
+            'time_started': 0,
+            'timeout': timeout_to_string(5),
+            'id': 'new_task'
+        }])
+        get_timestamp.return_value = 7
+        self.client.delete_task = Mock()
+        self.client.clean_old_tasks()
+        self.client.delete_task.assert_not_called()
+
+    @patch('golem.client.EthereumTransactionSystem')
+    @patch('golem.client.get_timestamp_utc')
+    def test_clean_old_tasks_old_and_new(self, get_timestamp, *_):
+        self.client = Client(
+            datadir=self.path,
+            app_config=Mock(),
+            config_desc=ClientConfigDescriptor(),
+            keys_auth=Mock(),
+            database=Mock(),
+            connect_to_known_hosts=False,
+            use_docker_manager=False,
+            use_monitor=False
+        )
+        self.client.config_desc.clean_tasks_older_than_seconds = 5
+        self.client.get_tasks = Mock(return_value=[{
+            'time_started': 0,
+            'timeout': timeout_to_string(5),
+            'id': 'old_task'
+        }, {
+            'time_started': 5,
+            'timeout': timeout_to_string(5),
+            'id': 'new_task'
+        }])
+        get_timestamp.return_value = 10
+        self.client.delete_task = Mock()
+        self.client.clean_old_tasks()
+        self.client.delete_task.assert_called_once_with('old_task')
+
 
 class TestDoWorkService(TestWithReactor):
 
@@ -719,61 +789,14 @@ class TestResourceCleanerService(TestWithReactor):
 
 class TestTaskCleanerService(TestWithReactor):
 
-    @freeze_time('2017-11-27 10:00:00.1')
-    @patch('golem.client.logger')
-    def test_run_noop(self, logger):
-        older_than_seconds = 5
-        now = time.time()
-        timeout_seconds = 3
-
-        c = Mock()
-        c.get_tasks = lambda: [{
-            'id': 'some_task_id',
-            'time_started': int(now),
-            'timeout': timeout_to_string(timeout_seconds)
-        }]
-
+    def test_run(self):
+        client = Mock(spec=Client)
         service = TaskCleanerService(
-            c,
-            interval_seconds=1,
-            older_than_seconds=older_than_seconds)
+            client=client,
+            interval_seconds=1
+        )
         service._run()
-
-        c.delete_task.assert_not_called()
-        logger.info.assert_not_called()
-
-    @patch('golem.client.logger')
-    def test_run(self, logger):
-        with freeze_time('2017-11-27 10:00:00.1') as frozen_time:
-
-            older_than_seconds = 5
-            task_id = 'some_task_id'
-            now = time.time()
-            timeout_seconds = 3
-
-            c = Mock()
-            c.get_tasks = lambda: [{
-                'id': task_id,
-                'time_started': int(now),
-                'timeout': timeout_to_string(timeout_seconds)
-            }]
-
-            service = TaskCleanerService(
-                c,
-                interval_seconds=1,
-                older_than_seconds=older_than_seconds)
-
-            frozen_time.tick(delta=datetime.timedelta(
-                seconds=older_than_seconds + timeout_seconds - 1))
-            service._run()
-
-            c.delete_task.assert_not_called()
-
-            frozen_time.tick()
-            service._run()
-
-            c.delete_task.assert_called_with(task_id)
-            logger.info.assert_called()
+        client.clean_old_tasks.assert_called_once()
 
 
 def make_mock_payment_processor(sci, eth=100, gnt=100):


### PR DESCRIPTION
This error was caused by a race condition between `restore_resources` and `TaskCleanerService._run`. Service initialization was moved after calling `restore resources`. The cleaning logic was moved to a new
method `Client.clean_old_tasks` which is also called **before** `restore_resource` because it is pointless to restore resources for tasks which would be deleted anyway.

Some unnecessary if-s were removed from `Client.start_network`.

Closes #2343 