### PR TITLE
Fix startup issues

### DIFF
--- a/golem/node.py
+++ b/golem/node.py
@@ -140,7 +140,6 @@ class Node(object):  # pylint: disable=too-few-public-methods
         )
         self._reactor.addSystemEventTrigger("before", "shutdown", rpc.stop)
 
-        # pylint: disable=protected-access
         deferred = rpc.start(self._reactor)
         return chain_function(deferred, self._start_session)
 
@@ -156,7 +155,7 @@ class Node(object):  # pylint: disable=too-few-public-methods
 
         def on_connect(*_):
             methods = object_method_map(self, NODE_METHOD_MAP)
-            self.rpc_session.register_methods(methods)
+            self.rpc_session.add_methods(methods)
 
             self._rpc_publisher = Publisher(self.rpc_session)
             StatusPublisher.set_publisher(self._rpc_publisher)
@@ -245,7 +244,8 @@ class Node(object):  # pylint: disable=too-few-public-methods
                                             self.client.quit)
 
         methods = object_method_map(self.client, CORE_METHOD_MAP)
-        self.rpc_session.register_methods(methods)
+        self.rpc_session.add_methods(methods)
+
         self.client.set_rpc_publisher(self._rpc_publisher)
 
         async_run(AsyncRequest(self._run),

--- a/golem/report.py
+++ b/golem/report.py
@@ -46,13 +46,16 @@ class StatusPublisher(object):
         :return: None
         """
         if cls._rpc_publisher:
+            from twisted.internet import reactor
+
             cls._last_status = (to_unicode(component),
                                 to_unicode(method),
                                 to_unicode(stage),
                                 data)
 
-            cls._rpc_publisher.publish(Golem.evt_golem_status,
-                                       *cls._last_status)
+            reactor.callFromThread(cls._rpc_publisher.publish,
+                                   Golem.evt_golem_status,
+                                   *cls._last_status)
 
     @classmethod
     def last_status(cls):

--- a/golem/rpc/session.py
+++ b/golem/rpc/session.py
@@ -161,6 +161,11 @@ class Session(ApplicationSession):
         super(Session, self).onDisconnect()
 
     @inlineCallbacks
+    def add_methods(self, methods):
+        self.methods += methods
+        yield self.register_methods(methods)
+
+    @inlineCallbacks
     def register_methods(self, methods):
         for method, rpc_name in methods:
             deferred = self.register(method, str(rpc_name))


### PR DESCRIPTION
- registered methods in Node were not re-registered after re-establishing the session
- event publishing from another thread terminated the RPC session