### PR TITLE
Remove PendingConnectionsServer._is_address_valid quickfix

### DIFF
--- a/golem/core/hostaddress.py
+++ b/golem/core/hostaddress.py
@@ -1,10 +1,10 @@
 import ipaddress
 import logging
+import os
 import socket
 from collections import Iterable
 from typing import Union, List
 
-import os
 import netifaces
 
 from golem.network.stun import pystun as stun

--- a/golem/core/hostaddress.py
+++ b/golem/core/hostaddress.py
@@ -1,12 +1,14 @@
+import ipaddress
 import logging
-import netifaces
+import socket
+from typing import Union, List
 
 import os
-import socket
+import netifaces
 
-import ipaddress
+from collections import Iterable
+
 from golem.network.stun import pystun as stun
-
 from .variables import DEFAULT_CONNECT_TO, DEFAULT_CONNECT_TO_PORT
 
 logger = logging.getLogger(__name__)
@@ -16,11 +18,11 @@ logger = logging.getLogger(__name__)
 #   return [i[4][0] for i in socket.getaddrinfo(socket.gethostname(), 0, socket.AF_INET)]
 
 
-def ip_addresses(use_ipv6=False):
+def ip_addresses(use_ipv6: bool = False) -> List[str]:
     """ Return list of internet addresses that this host have
-    :param bool use_ipv6: *Default: False* if True it returns this host IPv6 addresses, otherwise IPv4 addresses are
-     returned
-     :return list: list of host addresses
+    :param bool use_ipv6: *Default: False* if True it returns this host IPv6
+    addresses, otherwise IPv4 addresses are returned
+    :return list: list of host addresses
     """
     if use_ipv6:
         addr_family = netifaces.AF_INET6
@@ -29,14 +31,21 @@ def ip_addresses(use_ipv6=False):
     addresses = []
     for inter in netifaces.interfaces():
         ip = netifaces.ifaddresses(inter).get(addr_family)
-        if ip is None:
+        if not isinstance(ip, Iterable):
             continue
         for addrInfo in ip:
             addr = addrInfo.get('addr')
-            if addr is not None:
-                addresses.append(addr.split("%")[0])
-            if '127.0.0.1' in addresses:
-                addresses.remove('127.0.0.1')
+
+            try:
+                ip_addr = ipaddress.ip_address(addr)
+            except Exception as exc:  # pylint: disable=broad-except
+                logger.error("Error parsing ip address %r: %r", addr, exc)
+                continue
+
+            if not is_ip_address_allowed(ip_addr):
+                continue
+            addresses.append(str(ip_addr))
+
     return addresses
 
 
@@ -46,25 +55,45 @@ def ipv4_networks():
 
     for inter in netifaces.interfaces():
         ip = netifaces.ifaddresses(inter).get(addr_family)
-        if not ip:
+        if not isinstance(ip, Iterable):
             continue
         for addrInfo in ip:
-            addr = str(addrInfo.get('addr'))
-            mask = str(addrInfo.get('netmask', '255.255.255.0'))
+            addr = addrInfo.get('addr')
+            mask = addrInfo.get('netmask', '255.255.255.0')
 
             try:
-                ip_addr = ipaddress.ip_network((addr, mask), strict=False)
+                ip_net = ipaddress.ip_network((addr, mask), strict=False)
             except Exception as exc:
-                logger.error("Error parsing ip address {}: {}".format(addr, exc))
+                logger.error("Error parsing ip address %r: %r", addr, exc)
                 continue
 
-            if addr != '127.0.0.1':
-                split = str(ip_addr).split('/')
-                addresses.append((split[0], split[1]))
+            if not is_ip_network_allowed(ip_net):
+                continue
+            split = str(ip_net).split('/')
+            addresses.append((split[0], split[1]))
+
     return addresses
 
 
 get_host_addresses = ip_addresses
+
+
+def is_ip_address_allowed(ip_addr: Union[ipaddress.IPv4Address,
+                                         ipaddress.IPv6Address]) -> bool:
+    return not (ip_addr.is_loopback or
+                ip_addr.is_link_local or
+                ip_addr.is_multicast or
+                ip_addr.is_unspecified or
+                ip_addr.is_reserved)
+
+
+def is_ip_network_allowed(ip_net: Union[ipaddress.IPv4Network,
+                                        ipaddress.IPv6Network]) -> bool:
+    return not (ip_net.is_loopback or
+                ip_net.is_link_local or
+                ip_net.is_multicast or
+                ip_net.is_unspecified or
+                ip_net.is_reserved)
 
 
 def ip_address_private(address):

--- a/golem/core/hostaddress.py
+++ b/golem/core/hostaddress.py
@@ -1,12 +1,11 @@
 import ipaddress
 import logging
 import socket
+from collections import Iterable
 from typing import Union, List
 
 import os
 import netifaces
-
-from collections import Iterable
 
 from golem.network.stun import pystun as stun
 from .variables import DEFAULT_CONNECT_TO, DEFAULT_CONNECT_TO_PORT

--- a/golem/network/transport/tcpnetwork_helpers.py
+++ b/golem/network/transport/tcpnetwork_helpers.py
@@ -28,8 +28,8 @@ class SocketAddress():
     def is_proper_address(cls, address, port):
         try:
             SocketAddress(address, port)
-        except (ipaddress.AddressValueError, TypeError) as err:
-            logger.info("Wrong address %r", err)
+        except Exception as exc:  # pylint: disable=broad-except
+            logger.info("Wrong address %r", exc)
             return False
         return True
 

--- a/golem/network/transport/tcpserver.py
+++ b/golem/network/transport/tcpserver.py
@@ -245,10 +245,6 @@ class PendingConnectionsServer(TCPServer):
     @classmethod
     def _is_address_valid(cls, address: str, port: int) -> bool:
         try:
-            # FIXME: Where did None become 'None'? #2461
-            if address == 'None':
-                logger.debug('Got "None" as socket address. Skipping...')
-                return False
             return port > 0 and SocketAddress.is_proper_address(address, port)
         except TypeError:
             return False

--- a/tests/golem/core/test_hostaddress.py
+++ b/tests/golem/core/test_hostaddress.py
@@ -142,11 +142,17 @@ class TestHostAddress(unittest.TestCase):
         address, port, nat = get_external_address()
         assert stun.called_once_with(0)
 
-    def testGetHostAddress(self):
-        self.assertGreater(len(get_host_address('127.0.0.1')), 0)
-        self.assertTrue(is_ip_address(get_host_address(None, False)))
-        self.assertTrue(is_ip_address(get_host_address(None, True)))
-        self.assertTrue(is_ip_address(get_host_address("::1", True)))
+    @patch('golem.core.hostaddress.socket.gethostname')
+    def testGetHostAddress(self, *_):
+        with patch('golem.core.hostaddress.socket.gethostbyname',
+                   return_value='127.0.0.1'):
+            self.assertGreater(len(get_host_address('127.0.0.1')), 0)
+            self.assertTrue(is_ip_address(get_host_address(None, False)))
+
+        with patch('golem.core.hostaddress.socket.gethostbyname',
+                   return_value='::1'):
+            self.assertTrue(is_ip_address(get_host_address(None, True)))
+            self.assertTrue(is_ip_address(get_host_address("::1", True)))
 
     @unittest.skip("Find network testing framework")
     def testGetHostAddress2(self):


### PR DESCRIPTION
- removes the quickfix introduced in #2352
- improves address filtering in `ip_addresses` and `ipv4_networks` (`hostaddress.py`)
- catches all exceptions in `SocketAddress.is_proper_address`

Moved from #2385