### PR TITLE
Handle gracefully errors in add_task

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -557,7 +557,6 @@ class Client(HardwarePresetsMixin):
 
         def error(exception):
             logger.error("Task '%s' creation failed: %r", task_id, exception)
-            _result.errback(exception)
 
         _package = self.resource_server.create_resource_package(files, task_id)
         _package.addCallbacks(package_created, error)

--- a/golem/client.py
+++ b/golem/client.py
@@ -557,6 +557,7 @@ class Client(HardwarePresetsMixin):
 
         def error(exception):
             logger.error("Task '%s' creation failed: %r", task_id, exception)
+            _result.errback(exception)
 
         _package = self.resource_server.create_resource_package(files, task_id)
         _package.addCallbacks(package_created, error)
@@ -643,7 +644,9 @@ class Client(HardwarePresetsMixin):
 
     def create_task(self, t_dict):
         try:
-            self.enqueue_new_task(t_dict)
+            deferred = self.enqueue_new_task(t_dict)
+            deferred.addErrback(
+                lambda err: logger.error("Cannot create task: %r", err))
             return True, ''
         except Exception as ex:
             logger.exception("Cannot create task %r", t_dict)


### PR DESCRIPTION
Errors were propagated to a non-existent errback which resulted in displaying critical errors and tracebacks in logs.

Closes #2153