### PR TITLE
Validate computation time

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -784,6 +784,20 @@ class TaskManager(TaskEventListener):
         :return:
         """
         task_id = self.subtask2task_mapping[subtask_id]
+
+        # Max computation time should be in range [0;timeout]
+        timeout = self.tasks[task_id].task_definition.subtask_timeout
+        if computation_time > timeout:
+            logger.warning(
+                'Received computation time (%r) for subtask %r exceeds subtask '
+                'timeout (%r)', computation_time, subtask_id, timeout)
+            computation_time = timeout
+        if computation_time < 0:
+            logger.warning(
+                'Received computation time (%r) for subtask %r is lower than 0',
+                computation_time, subtask_id)
+            computation_time = 0
+
         ss = self.tasks_states[task_id].subtask_states[subtask_id]
         ss.computation_time = computation_time
         ss.value = compute_subtask_value(ss.computer.price, computation_time)

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -744,6 +744,7 @@ class TestTaskServer2(TestDatabaseWithReactor, testutils.TestWithClient):
         task_mock = get_mock_task("xyz", "xxyyzz")
         task_mock.get_trust_mod.return_value = ts.max_trust
         task_mock.query_extra_data.return_value = extra_data
+        task_mock.task_definition.subtask_timeout = 3600
 
         ts.task_manager.add_new_task(task_mock)
         ts.task_manager.tasks_states["xyz"].status = \
@@ -791,6 +792,7 @@ class TestTaskServer2(TestDatabaseWithReactor, testutils.TestWithClient):
         task_mock = get_mock_task("xyz", "xxyyzz")
         task_mock.get_trust_mod.return_value = ts.max_trust
         task_mock.query_extra_data.return_value = extra_data
+        task_mock.task_definition.subtask_timeout = 3600
 
         ts.task_manager.add_new_task(task_mock)
         ts.task_manager.tasks_states["xyz"].status = \


### PR DESCRIPTION
This value is sent by provider so it needs to be validated. Otherwise provider could scam money by providing too high computation times.

Closes #2547