### PR TITLE
Fixed `remaining` in `golemcli tasks show`

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -687,7 +687,7 @@ class TaskManager(TaskEventListener):
             proportion = (ts.elapsed_time / ts.progress)
             ts.remaining_time = proportion - ts.elapsed_time
         else:
-            ts.remaining_time = -0.0
+            ts.remaining_time = None
 
         t.update_task_state(ts)
 
@@ -721,11 +721,11 @@ class TaskManager(TaskEventListener):
 
         task_type_name = task.task_definition.task_type.lower()
         task_type = self.task_types[task_type_name]
-        state = self.tasks_states.get(task.header.task_id)
+        state = self.query_task_state(task.header.task_id)
         timeout = task.task_definition.full_task_timeout
 
         dictionary = {
-            'duration': max(timeout - state.remaining_time, 0),
+            'duration': max(timeout - (state.remaining_time or 0), 0),
             # single=True retrieves one preview file. If rendering frames,
             # it's the preview of the most recently computed frame.
             'preview': task_type.get_preview(task, single=True)

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -49,6 +49,7 @@ class SubtaskState(object):
         self.time_started = 0
         self.deadline = 0
         self.extra_data = {}
+        # FIXME: subtask_rem_time is always equal 0 (#2562)
         self.subtask_rem_time = 0
         self.subtask_status = ""
         self.value = 0


### PR DESCRIPTION
Renamed the column to 'ETA' and added time formatting. Also got rid of -0.0 which seemed like a very hacky way to mark missing value.

Looks like this:
```
id                                    ETA        subtasks  status     completion
------------------------------------  -------  ----------  ---------  ------------
60ce8f9c-37ef-11e8-bce7-6478de4573b1  0:00:00          10  Finished   100.00 %
dabd4382-380f-11e8-83b6-6478de4573b1  0:02:45          10  Computing  80.00 %
```

Close #2272