### PR TITLE
Add gate balance to the GNT balance

### DIFF
--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -97,7 +97,8 @@ class PaymentProcessor(LoopingCallService):
             gnt_balance = self._sci.get_gnt_balance(
                 self._sci.get_eth_address())
             if gnt_balance is not None:
-                self.__gnt_balance = gnt_balance
+                self.__gnt_balance = \
+                    gnt_balance + self._gnt_converter.get_gate_balance()
             else:
                 log.warning("Failed to retrieve GNT balance")
 

--- a/tests/golem/transactions/ethereum/test_paymentprocessor.py
+++ b/tests/golem/transactions/ethereum/test_paymentprocessor.py
@@ -67,6 +67,7 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         self.pp._loopingCall.clock = Clock()  # Disable looping call.
         self.pp._gnt_converter = mock.Mock()
         self.pp._gnt_converter.is_converting.return_value = False
+        self.pp._gnt_converter.get_gate_balance.return_value = 0
 
     def test_eth_balance(self):
         expected_balance = random.randint(0, 2**128 - 1)
@@ -362,6 +363,7 @@ class InteractionWithSmartContractInterfaceTest(DatabaseFixture):
         self.pp = PaymentProcessor(self.sci)
         self.pp._gnt_converter = mock.Mock()
         self.pp._gnt_converter.is_converting.return_value = False
+        self.pp._gnt_converter.get_gate_balance.return_value = 0
 
     def test_faucet(self):
         self.pp._PaymentProcessor__faucet = True


### PR DESCRIPTION
This way GNT balance better reflect the amount of GNT tokens user actually owns. Which means that during conversion to GNTB the balance will not be zero for a period of time.