### PR TITLE
Correction to Linux Mint docker sources

### DIFF
--- a/Installer/Installer_Linux/install.sh
+++ b/Installer/Installer_Linux/install.sh
@@ -129,7 +129,7 @@ function install_dependencies()
         source /etc/os-release
         sudo add-apt-repository \
             "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-            echo $UBUNTU_CODENAME \
+            $(echo $UBUNTU_CODENAME) \
             stable"
     fi
 

--- a/Installer/Installer_Linux/install.sh
+++ b/Installer/Installer_Linux/install.sh
@@ -126,9 +126,10 @@ function install_dependencies()
                     ca-certificates \
                     software-properties-common)
         wget -qO- https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+        source /etc/os-release
         sudo add-apt-repository \
             "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
-            $(lsb_release -cs) \
+            echo $UBUNTU_CODENAME \
             stable"
     fi
 


### PR DESCRIPTION
Mint requires Ubuntu repositories for Docker, Mint repositories do not exist. 
Lsb_release therefore changed in favor of echoing ubuntu-codename.
Reference: https://github.com/golemfactory/golem/issues/2611