### PR TITLE
fixed subtask2task mapping creation when restoring tasks from pickle

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -234,7 +234,7 @@ class TaskManager(TaskEventListener):
                     self.tasks_states[task_id] = state
 
                     for sub in state.subtask_states.values():
-                        self.subtask2task_mapping[sub.subtask_id] = task
+                        self.subtask2task_mapping[sub.subtask_id] = task_id
 
                     logger.debug('TASK %s RESTORED from %r', task_id, path)
                 except (pickle.UnpicklingError, EOFError, ImportError,


### PR DESCRIPTION
Task restore procedure in current shape reads tasks from pickle file and puts task object into mapping where just `task_id`'s should be placed. 

This appears as error when using `golemcli`:

```
$ golemcli subtasks show ec9d09b6-3d89-11e8-8091-6e845eabffe0 
RPC: call error: [Failure instance: Traceback (failure with no frames): <class 'autobahn.wamp.exception.ApplicationError'>: ApplicationError(error=<wamp.error.runtime_error>, args=["local variable 'tid' referenced before assignment"], kwargs={}, enc_algo=None)
]
[17:26:22.175395] ERROR: Exception: ApplicationError(error=<wamp.error.runtime_error>, args=["local variable 'tid' referenced before assignment"], kwargs={}, enc_algo=None)
```

related golem log
```
  File "/Users/tworec/git/golem/golem/task/taskmanager.py", line 748, in get_subtask_dict
    task_state = self.tasks_states[task_id]
builtins.KeyError: <Task: <Header: '76e78670-3d88-11e8-8266-6e845eabffe0'>>
``` 

This PR fixes it.