### PR TITLE
golem-monitor #21: add pinging every constant interval

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -488,7 +488,7 @@ class Client(HardwarePresetsMixin):
 
     def stop_monitor(self):
         logger.debug("Stopping monitor ...")
-        self.monitor.shut_down()
+        self.monitor.stop()
         self.diag_service.stop()
 
     def connect(self, socket_address):

--- a/golem/client.py
+++ b/golem/client.py
@@ -477,7 +477,10 @@ class Client(HardwarePresetsMixin):
     def init_monitor(self):
         logger.debug("Starting monitor ...")
         metadata = self.__get_nodemetadatamodel()
-        self.monitor = SystemMonitor(metadata, MONITOR_CONFIG)
+        self.monitor = SystemMonitor(
+            metadata,
+            MONITOR_CONFIG,
+            sign_key=self.keys_auth)
         self.monitor.start()
         self.diag_service = DiagnosticsService(DiagnosticsOutputFormat.data)
         self.diag_service.register(

--- a/golem/monitor/model/balancemodel.py
+++ b/golem/monitor/model/balancemodel.py
@@ -9,7 +9,6 @@ class BalanceModel(BasicModel):
                  gnt_balance: int, gntb_balance: int) -> None:
         super(BalanceModel, self).__init__(
             "Balance",
-            meta_data.cliid,
             meta_data.sessid
         )
         self.eth_balance = eth_balance

--- a/golem/monitor/model/loginlogoutmodel.py
+++ b/golem/monitor/model/loginlogoutmodel.py
@@ -3,15 +3,19 @@ from golem.monitorconfig import MONITOR_CONFIG
 
 from .modelbase import BasicModel
 
+
 class LoginLogoutBaseModel(BasicModel):
+    TYPE = "LoginLogoutBase"
+
     def __init__(self, metadata):
-        super(LoginLogoutBaseModel, self).__init__(self.TYPE, metadata.cliid, metadata.sessid)
+        super(LoginLogoutBaseModel, self).__init__(self.TYPE, metadata.sessid)
         self.metadata = metadata.dict_repr()
         self.protocol_versions = {
             'monitor': MONITOR_CONFIG['PROTO_VERSION'],
             'p2p': PROTOCOL_CONST.ID,
             'task': PROTOCOL_CONST.ID,
         }
+
 
 class LoginModel(LoginLogoutBaseModel):
     TYPE = "Login"

--- a/golem/monitor/model/modelbase.py
+++ b/golem/monitor/model/modelbase.py
@@ -11,11 +11,10 @@ class ModelBase(object, metaclass=abc.ABCMeta):
 
 class BasicModel(ModelBase):
 
-    def __init__(self, type_str_repr, cliid, sessid):
+    def __init__(self, type_str_repr, sessid):
         # TODO: use class.TYPE. issue #2413
         self.type = type_str_repr
         self.timestamp = time.time()
-        self.cliid = cliid
         self.sessid = sessid
 
     def dict_repr(self):

--- a/golem/monitor/model/nodemetadatamodel.py
+++ b/golem/monitor/model/nodemetadatamodel.py
@@ -8,7 +8,6 @@ class NodeMetadataModel(BasicModel):
     def __init__(self, client, os, ver):
         super(NodeMetadataModel, self).__init__(
             "NodeMetadata",
-            client.get_key_id(),
             client.session_id)
 
         self.os = os
@@ -19,5 +18,5 @@ class NodeMetadataModel(BasicModel):
 
 
 class NodeInfoModel(BasicModel):
-    def __init__(self, cliid, sessid):
-        super(NodeInfoModel, self).__init__("NodeInfo", cliid, sessid)
+    def __init__(self, sessid):
+        super(NodeInfoModel, self).__init__("NodeInfo", sessid)

--- a/golem/monitor/model/paymentmodel.py
+++ b/golem/monitor/model/paymentmodel.py
@@ -2,8 +2,10 @@ from .modelbase import BasicModel
 
 
 class BasePaymentModel(BasicModel):
-    def __init__(self, cliid, sessid, addr, value):
-        super(BasePaymentModel, self).__init__(self.TYPE, cliid, sessid)
+    TYPE = "Payment"
+
+    def __init__(self, sessid, addr, value):
+        super(BasePaymentModel, self).__init__(self.TYPE, sessid)
         self.addr = addr
         self.value = value
 

--- a/golem/monitor/model/pingmodel.py
+++ b/golem/monitor/model/pingmodel.py
@@ -7,8 +7,8 @@ from .modelbase import BasicModel
 class PingModel(BasicModel):  # pylint: disable=too-few-public-methods
     TYPE = "PingModel"
 
-    def __init__(self, cliid, sessid,
+    def __init__(self, sessid,
                  ports: tuple, timestamp: Optional[float] = None) -> None:
-        super().__init__(self.TYPE, cliid, sessid)
+        super().__init__(self.TYPE, sessid)
         self.ports = ports
         self.timestamp = timestamp if timestamp else time.time()

--- a/golem/monitor/model/pingmodel.py
+++ b/golem/monitor/model/pingmodel.py
@@ -1,0 +1,14 @@
+import time
+from typing import Optional
+
+from .modelbase import BasicModel
+
+
+class PingModel(BasicModel):  # pylint: disable=too-few-public-methods
+    TYPE = "PingModel"
+
+    def __init__(self, cliid, sessid,
+                 ports: tuple, timestamp: Optional[float] = None) -> None:
+        super().__init__(self.TYPE, cliid, sessid)
+        self.ports = ports
+        self.timestamp = timestamp if timestamp else time.time()

--- a/golem/monitor/model/statssnapshotmodel.py
+++ b/golem/monitor/model/statssnapshotmodel.py
@@ -6,7 +6,6 @@ class StatsSnapshotModel(BasicModel):
     def __init__(self, meta_data, known_tasks, supported_tasks, stats):
         super(StatsSnapshotModel, self).__init__(
             "Stats",
-            meta_data.cliid,
             meta_data.sessid
         )
 
@@ -19,14 +18,14 @@ class StatsSnapshotModel(BasicModel):
 
 
 class VMSnapshotModel(BasicModel):
-    def __init__(self, cliid, sessid, vm_snapshot):
-        super(VMSnapshotModel, self).__init__("VMSnapshot", cliid, sessid)
+    def __init__(self, sessid, vm_snapshot):
+        super(VMSnapshotModel, self).__init__("VMSnapshot", sessid)
         self.vm_snapshot = vm_snapshot
 
 
 class P2PSnapshotModel(BasicModel):
-    def __init__(self, cliid, sessid, p2p_snapshot):
-        super(P2PSnapshotModel, self).__init__("P2PSnapshot", cliid, sessid)
+    def __init__(self, sessid, p2p_snapshot):
+        super(P2PSnapshotModel, self).__init__("P2PSnapshot", sessid)
         self.p2p_snapshot = p2p_snapshot
 
 
@@ -34,7 +33,6 @@ class ComputationTime(BasicModel):
     def __init__(self, meta_data, success, value):
         super(ComputationTime, self).__init__(
             "ComputationTime",
-            meta_data.cliid,
             meta_data.sessid
         )
         self.success = success
@@ -45,7 +43,7 @@ class RequestorStatsModel(BasicModel):
     # pylint: disable=too-many-instance-attributes,too-few-public-methods
     def __init__(self, meta_data: BasicModel, current_stats: CurrentStats,
                  finished_stats: FinishedTasksStats):
-        super().__init__("RequestorStats", meta_data.cliid, meta_data.sessid)
+        super().__init__("RequestorStats", meta_data.sessid)
 
         self.tasks_cnt = current_stats.tasks_cnt
         self.finished_task_cnt = current_stats.finished_task_cnt

--- a/golem/monitor/model/taskcomputersnapshotmodel.py
+++ b/golem/monitor/model/taskcomputersnapshotmodel.py
@@ -4,7 +4,9 @@ from .modelbase import BasicModel
 class TaskComputerSnapshotModel(BasicModel):
 
     def __init__(self, meta_data, task_computer):
-        super(TaskComputerSnapshotModel, self).__init__("TaskComputer", meta_data.cliid, meta_data.sessid)
+        super(TaskComputerSnapshotModel, self).__init__(
+            "TaskComputer",
+            meta_data.sessid)
 
         self.waiting_for_task = task_computer.waiting_for_task
         self.counting_task = task_computer.counting_task

--- a/golem/monitor/monitor.py
+++ b/golem/monitor/monitor.py
@@ -1,9 +1,6 @@
 import logging
 import queue
 import threading
-import time
-from typing import Optional, Dict
-from urllib.parse import urljoin
 
 import requests
 from pydispatch import dispatcher
@@ -12,78 +9,78 @@ from golem.config.active import SEND_PAYMENT_INFO_TO_MONITOR
 from golem.core import variables
 from golem.decorators import log_error
 from golem.task.taskrequestorstats import CurrentStats, FinishedTasksStats
+from golem.core.service import LoopingCallService
+from .model.modelbase import ModelBase
 from .model import statssnapshotmodel
 from .model.balancemodel import BalanceModel
 from .model.loginlogoutmodel import LoginModel, LogoutModel
 from .model.nodemetadatamodel import NodeInfoModel, NodeMetadataModel
 from .model.paymentmodel import ExpenditureModel, IncomeModel
+from .model.pingmodel import PingModel
 from .model.taskcomputersnapshotmodel import TaskComputerSnapshotModel
 from .transport.sender import DefaultJSONSender as Sender
 
 log = logging.getLogger('golem.monitor')
 
 
+class SenderAction:  # pylint: disable=too-few-public-methods
+    def __init__(self, action: str, args: dict) -> None:
+        self.action = action
+        self.args = args
+
+
 class SenderThread(threading.Thread):
-    def __init__(self, node_info, monitor_host, monitor_request_timeout,
-                 monitor_sender_thread_timeout, proto_ver):
-        super(SenderThread, self).__init__()
+    def __init__(self, node_info, config, sender):
+        super().__init__()
         self.queue = queue.Queue()
         self.stop_request = threading.Event()
         self.node_info = node_info
-        self.sender = Sender(monitor_host, monitor_request_timeout, proto_ver)
-        self.monitor_sender_thread_timeout = monitor_sender_thread_timeout
+        self.sender = sender
+        self.config = config
 
-    def send(self, o):
-        self.queue.put(o)
+    def process(self, action: str, **args):
+        self.queue.put(SenderAction(action, args))
 
     def run(self):
         while not self.stop_request.isSet():
             try:
-                msg = self.queue.get(True, self.monitor_sender_thread_timeout)
-                self.sender.send(msg)
+                action = self.queue.get(True,
+                                        self.config['SENDER_THREAD_TIMEOUT'])
+                action_handler = \
+                    getattr(self, 'do_'+action.action,
+                            lambda **_:  # default handler
+                            log.warning('Unsupported action %s arguments: %s',
+                                        action.action, action.args))
+                action_handler(**action.args)
             except queue.Empty:
                 # send ping message
-                self.sender.send(self.node_info)
+                self.do_send(self.node_info)
+            # TODO: handle more errors to prevent sender from stopping
 
-    def join(self, timeout=None):
+    def do_send(self, msg: ModelBase):
+        self.sender.send(msg)
+
+    def do_finish(self):
         self.stop_request.set()
-        super(SenderThread, self).join(timeout)
 
+    def do_ping_me(self, ports):
+        try:
+            for host in self.config['PING_ME_HOSTS']:
+                result = self.sender.send(
+                    PingModel(self.node_info.cliid,
+                              self.node_info.sessid, ports),
+                    host=host, url_path='ping-me')
+                if result:
+                    self.process_ping_result(result.json())
+                log.debug('Ping result: %r', result)
+        except requests.ConnectionError:
+            log.exception('Ping connection error')
 
-class SystemMonitor(object):
-    def __init__(self,
-                 meta_data: NodeMetadataModel,
-                 monitor_config: dict) -> None:
-        self.meta_data = meta_data
-        self.node_info = NodeInfoModel(meta_data.cliid, meta_data.sessid)
-        self.config = monitor_config
-        self.send_payment_info = SEND_PAYMENT_INFO_TO_MONITOR
-        dispatcher.connect(self.dispatch_listener, signal='golem.monitor')
-        dispatcher.connect(self.p2p_listener, signal='golem.p2p')
+    def do_update_node_info(self, node_info):
+        self.node_info = node_info
 
-    @property
-    def sender_thread(self):
-        if not hasattr(self, '_sender_thread'):
-            host = self.config['HOST']
-            request_timeout = self.config['REQUEST_TIMEOUT']
-            sender_thread_timeout = self.config['SENDER_THREAD_TIMEOUT']
-            proto_ver = self.config['PROTO_VERSION']
-            self._sender_thread = SenderThread(
-                self.node_info,
-                host,
-                request_timeout,
-                sender_thread_timeout,
-                proto_ver
-            )
-        return self._sender_thread
-
-    def p2p_listener(self, event='default', ports=None, *_, **__):
-        if event != 'listening':
-            return
-        result = self.ping_request(ports)
-        if not result:
-            return
-
+    @staticmethod
+    def process_ping_result(result):
         if not result['success']:
             for port_status in result['port_statuses']:
                 if not port_status['is_open']:
@@ -101,28 +98,79 @@ class SystemMonitor(object):
                 time_diff=result['time_diff']
             )
 
-    def ping_request(self, ports) -> Optional[Dict]:
-        timeout = 2.5  # seconds
+    def join(self, timeout=None):
+        self.process('finish')
+        super().join(timeout)
 
-        for host in self.config['PING_ME_HOSTS']:
-            try:
-                response = requests.post(
-                    urljoin(host, 'ping-me'),
-                    data={
-                        'ports': ports,
-                        'timestamp': time.time()
-                    },
-                    timeout=timeout,
-                )
-                result = response.json()
-                log.debug('Ping result: %r', result)
-                return result
-            except (requests.RequestException, ValueError):
-                log.exception('Ping error (%r)', host)
-        return None
+
+class PingService(LoopingCallService):
+    ports: tuple = ()
+
+    def __init__(self,
+                 interval_seconds: int,
+                 ports: tuple = ()) -> None:
+        super().__init__(interval_seconds)
+        self.ports = ports
+
+    def _run(self):
+        dispatcher.send(
+            signal='golem.monitor',
+            event='ping_me',
+            ports=self.ports)
+
+    def start(self, now: bool = True):
+        if self.ports:
+            super().start(now)
+
+    def stop(self):
+        if self.running:
+            super().stop()
+
+    def reconfigure(self,
+                    interval_seconds=None,
+                    ports=None):
+        self.stop()
+
+        if interval_seconds is not None:
+            self.__interval_seconds = interval_seconds
+        if ports is not None:
+            self.ports = ports
+
+        self.start()
+
+
+class SystemMonitor:
+    def __init__(self,
+                 meta_data: NodeMetadataModel,
+                 monitor_config: dict) -> None:
+        self.meta_data = meta_data
+        self.node_info = NodeInfoModel(meta_data.cliid, meta_data.sessid)
+        self.config = monitor_config
+        self.send_payment_info = SEND_PAYMENT_INFO_TO_MONITOR
+        dispatcher.connect(self.dispatch_listener, signal='golem.monitor')
+        dispatcher.connect(self.p2p_listener, signal='golem.p2p')
+        self.sender_thread = self._create_sender_thread()
+        self.ping_service = PingService(
+            interval_seconds=self.config['PING_INTERVAL'])
+
+    def _create_sender_thread(self) -> SenderThread:
+        host = self.config['HOST']
+        request_timeout = self.config['REQUEST_TIMEOUT']
+        proto_ver = self.config['PROTO_VERSION']
+        return SenderThread(
+            node_info=self.node_info,
+            config=self.config,
+            sender=Sender(host, request_timeout, proto_ver)
+        )
+
+    def p2p_listener(self, event='default', ports=None, *_, **__):
+        if event != 'listening':
+            return
+        self.ping_service.reconfigure(ports=ports)
 
     @log_error()
-    def dispatch_listener(self, sender, signal, event='default', **kwargs):
+    def dispatch_listener(self, sender, signal, event='default',
+                          **kwargs):  # pylint: disable=unused-argument
         """ Main PubSub listener for golem_monitor channel """
         method_name = "on_%s" % (event,)
         if not hasattr(self, method_name):
@@ -134,25 +182,41 @@ class SystemMonitor(object):
 
     def start(self):
         self.sender_thread.start()
+        self.ping_service.start()
 
     def shut_down(self):
         dispatcher.disconnect(self.dispatch_listener, signal='golem.monitor')
         dispatcher.disconnect(self.p2p_listener, signal='golem.p2p')
+        self.ping_service.stop()
         self.sender_thread.join()
 
     # Public interface
 
-    def on_shutdown(self):
+    def stop(self):
         self.on_logout()
         self.shut_down()
 
+    def send_model(self, model: ModelBase):
+        self.sender_thread.process('send', msg=model)
+
+    def on_ping_me(self, ports):
+        self.sender_thread.process(
+            'ping_me',
+            ports=ports)
+
+    def on_shutdown(self):
+        self.stop()
+
     def on_login(self):
-        self.sender_thread.send(LoginModel(self.meta_data))
+        self.send_model(LoginModel(self.meta_data))
 
     def on_config_update(self, meta_data):
         self.meta_data = meta_data
         self.node_info = NodeInfoModel(meta_data.cliid, meta_data.sessid)
-        self.sender_thread.send(LoginModel(self.meta_data))
+        self.sender_thread.process('update_node_info', node_info=self.node_info)
+        self.send_model(LoginModel(self.meta_data))
+        self.ping_service.reconfigure(
+            interval_seconds=self.config['PING_INTERVAL'])
 
     def on_computation_time_spent(self, success, value):
         msg = statssnapshotmodel.ComputationTime(
@@ -160,10 +224,10 @@ class SystemMonitor(object):
             success,
             value
         )
-        self.sender_thread.send(msg)
+        self.send_model(msg)
 
     def on_logout(self):
-        self.sender_thread.send(LogoutModel(self.meta_data))
+        self.send_model(LogoutModel(self.meta_data))
 
     def on_stats_snapshot(self, known_tasks, supported_tasks, stats):
         msg = statssnapshotmodel.StatsSnapshotModel(
@@ -172,7 +236,7 @@ class SystemMonitor(object):
             supported_tasks,
             stats
         )
-        self.sender_thread.send(msg)
+        self.send_model(msg)
 
     def on_vm_snapshot(self, vm_data):
         msg = statssnapshotmodel.VMSnapshotModel(
@@ -180,7 +244,7 @@ class SystemMonitor(object):
             self.meta_data.sessid,
             vm_data
         )
-        self.sender_thread.send(msg)
+        self.send_model(msg)
 
     def on_peer_snapshot(self, p2p_data):
         msg = statssnapshotmodel.P2PSnapshotModel(
@@ -188,23 +252,23 @@ class SystemMonitor(object):
             self.meta_data.sessid,
             p2p_data
         )
-        self.sender_thread.send(msg)
+        self.send_model(msg)
 
     def on_task_computer_snapshot(self, task_computer):
         msg = TaskComputerSnapshotModel(self.meta_data, task_computer)
-        self.sender_thread.send(msg)
+        self.send_model(msg)
 
     def on_requestor_stats_snapshot(self,
                                     current_stats: CurrentStats,
                                     finished_stats: FinishedTasksStats):
         msg = statssnapshotmodel.RequestorStatsModel(
             self.meta_data, current_stats, finished_stats)
-        self.sender_thread.send(msg)
+        self.send_model(msg)
 
     def on_payment(self, addr, value):
         if not self.send_payment_info:
             return
-        self.sender_thread.send(
+        self.send_model(
             ExpenditureModel(
                 self.meta_data.cliid,
                 self.meta_data.sessid,
@@ -216,7 +280,7 @@ class SystemMonitor(object):
     def on_income(self, addr, value):
         if not self.send_payment_info:
             return
-        self.sender_thread.send(
+        self.send_model(
             IncomeModel(
                 self.meta_data.cliid,
                 self.meta_data.sessid,
@@ -229,7 +293,7 @@ class SystemMonitor(object):
                             gntb_balance: int):
         if not self.send_payment_info:
             return
-        self.sender_thread.send(
+        self.send_model(
             BalanceModel(
                 self.meta_data,
                 eth_balance,

--- a/golem/monitor/test_helper.py
+++ b/golem/monitor/test_helper.py
@@ -10,8 +10,8 @@ from golem.monitorconfig import MONITOR_CONFIG
 
 def meta_data():
     client_mock = mock.MagicMock()
-    client_mock.cliid = str(uuid4())
-    client_mock.sessid = str(uuid4())
+    client_mock.get_key_id.return_value = str(uuid4())
+    client_mock.session_id = str(uuid4())
     client_mock.config_desc = ClientConfigDescriptor()
     client_mock.mainnet = False
     return NodeMetadataModel(client_mock, sys.platform, 'app_version')

--- a/golem/monitor/test_helper.py
+++ b/golem/monitor/test_helper.py
@@ -10,8 +10,7 @@ from golem.monitorconfig import MONITOR_CONFIG
 
 def meta_data():
     client_mock = mock.MagicMock()
-    client_mock.get_key_id.return_value = str(uuid4())
-    client_mock.session_id = str(uuid4())
+    client_mock.session_id = 'sessid'
     client_mock.config_desc = ClientConfigDescriptor()
     client_mock.mainnet = False
     return NodeMetadataModel(client_mock, sys.platform, 'app_version')
@@ -19,4 +18,7 @@ def meta_data():
 
 class MonitorTestBaseClass(TestCase):
     def setUp(self):
-        self.monitor = SystemMonitor(meta_data(), MONITOR_CONFIG)
+        sign_mock = mock.MagicMock()
+        sign_mock.public_key = b''
+        sign_mock.sign.return_value = b''
+        self.monitor = SystemMonitor(meta_data(), MONITOR_CONFIG, sign_mock)

--- a/golem/monitor/transport/httptransport.py
+++ b/golem/monitor/transport/httptransport.py
@@ -1,29 +1,38 @@
 import logging
-import requests
 import time
+from typing import Optional
+from urllib.parse import urljoin
+
+import requests
+
 
 log = logging.getLogger('golem.monitor.transport')
 
 
 class DefaultHttpSender(object):
-    def __init__(self, url, request_timeout):
-        self.url = url
+    def __init__(self, base_url, request_timeout):
+        self.base_url = base_url
         self.timeout = request_timeout
         self.json_headers = {'content-type': 'application/json'}
         self.last_exception_time = 0
 
-    def _post(self, headers, payload):
+    def post(self, headers, payload,
+             base_url: str, url_path: str) -> Optional[requests.Response]:
         try:
-            r = requests.post(self.url, data=payload, headers=headers,
+            if not base_url:
+                base_url = self.base_url
+            r = requests.post(urljoin(base_url, url_path),
+                              data=payload,
+                              headers=headers,
                               timeout=self.timeout)
-            return r.status_code == 200
+            return r if r.status_code == 200 else None
         except requests.exceptions.RequestException as e:
             delta = time.time() - self.last_exception_time
             if delta > 60*10:  # seconds
                 log.warning('Problem sending payload to: %r, because %s',
-                            self.url, e)
+                            urljoin(base_url, url_path), e)
                 self.last_exception_time = time.time()
-            return False
+            return None
 
-    def post_json(self, json_payload):
-        return self._post(self.json_headers, json_payload)
+    def post_json(self, json_payload, base_url, url_path):
+        return self.post(self.json_headers, json_payload, base_url, url_path)

--- a/golem/monitor/transport/sender.py
+++ b/golem/monitor/transport/sender.py
@@ -7,6 +7,6 @@ class DefaultJSONSender(object):
         self.transport = DefaultHttpSender(host, timeout)
         self.proto = DefaultProto(proto_ver)
 
-    def send(self, o):
+    def send(self, o, host: str = '', url_path: str = ''):
         msg = self.proto.prepare_json_message(o.dict_repr())
-        return self.transport.post_json(msg)
+        return self.transport.post_json(msg, host, url_path)

--- a/golem/monitor/transport/sender.py
+++ b/golem/monitor/transport/sender.py
@@ -1,10 +1,12 @@
+from golem.core.keysauth import KeysAuth
 from .httptransport import DefaultHttpSender
 from .proto import DefaultProto
 
 
 class DefaultJSONSender(object):
-    def __init__(self, host, timeout, proto_ver):
-        self.transport = DefaultHttpSender(host, timeout)
+    def __init__(self, host, timeout, proto_ver,
+                 sign_key: KeysAuth) -> None:
+        self.transport = DefaultHttpSender(host, timeout, sign_key)
         self.proto = DefaultProto(proto_ver)
 
     def send(self, o, host: str = '', url_path: str = ''):

--- a/golem/monitorconfig.py
+++ b/golem/monitorconfig.py
@@ -7,10 +7,11 @@ MONITOR_CONFIG = {
         "https://stats.golem.network/",
     ],
     'REQUEST_TIMEOUT': 10,
+    'PING_INTERVAL': 1000,
 
     # Increase this number every time any change is made to the protocol
     # (e.g. message object representation changes)
-    'PROTO_VERSION': 1,
+    'PROTO_VERSION': 2,
 }
 
 # so that the queue will not get filled up
@@ -19,7 +20,9 @@ MONITOR_CONFIG['SENDER_THREAD_TIMEOUT'] = max(
     MONITOR_CONFIG['REQUEST_TIMEOUT']
 )
 
+# load local configuration if present
 try:
-    from golem.monitorconfig_local import *  # noqa
+    from golem.monitorconfig_local import MONITOR_CONFIG as MONITOR_CONFIG_LOCAL
+    MONITOR_CONFIG.update(MONITOR_CONFIG_LOCAL)
 except ImportError:
     pass

--- a/tests/golem/monitor/model/test_balancemodel.py
+++ b/tests/golem/monitor/model/test_balancemodel.py
@@ -16,7 +16,8 @@ class TestBalanceModel(MonitorTestBaseClass):
         gnt_balance = random.randint(1, 10 ** 20)
         gntb_balance = random.randint(1, 10 ** 20)
 
-        with mock.patch('golem.monitor.monitor.SenderThread.send') as send:
+        with mock.patch('golem.monitor.monitor.SenderThread.process') \
+                as process:
             dispatcher.send(
                 signal='golem.monitor',
                 event='balance_snapshot',
@@ -25,8 +26,8 @@ class TestBalanceModel(MonitorTestBaseClass):
                 gntb_balance=gntb_balance
             )
 
-            send.assert_called_once()
-            result = send.call_args[0][0]
+            process.assert_called_once()
+            result = process.call_args[1]['msg']
             self.assertIsInstance(result, BalanceModel)
             self.assertEqual(result.type, 'Balance')
             self.assertEqual(result.eth_balance, eth_balance)
@@ -36,7 +37,8 @@ class TestBalanceModel(MonitorTestBaseClass):
     def test_channel_disabled(self):
         self.monitor.send_payment_info = False
 
-        with mock.patch('golem.monitor.monitor.SenderThread.send') as send:
+        with mock.patch('golem.monitor.monitor.SenderThread.process') \
+                as process:
             dispatcher.send(
                 signal='golem.monitor',
                 event='balance_snapshot',
@@ -44,4 +46,4 @@ class TestBalanceModel(MonitorTestBaseClass):
                 gnt_balance=0,
                 gntb_balance=0
             )
-            send.assert_not_called()
+            process.assert_not_called()

--- a/tests/golem/monitor/model/test_paymentmodel.py
+++ b/tests/golem/monitor/model/test_paymentmodel.py
@@ -16,7 +16,8 @@ class TestExpenditureModel(MonitorTestBaseClass):
         addr = str(uuid.UUID(int=random.getrandbits(128)))
         value = random.randint(1, 10 ** 20)
 
-        with mock.patch('golem.monitor.monitor.SenderThread.send') as send:
+        with mock.patch('golem.monitor.monitor.SenderThread.process') \
+                as process:
             dispatcher.send(
                 signal='golem.monitor',
                 event='payment',
@@ -24,8 +25,8 @@ class TestExpenditureModel(MonitorTestBaseClass):
                 value=value
             )
 
-            send.assert_called_once()
-            result = send.call_args[0][0]
+            process.assert_called_once()
+            result = process.call_args[1]['msg']
             self.assertIsInstance(result, ExpenditureModel)
             self.assertEqual(result.type, 'Expense')
             self.assertEqual(result.addr, addr)
@@ -34,14 +35,15 @@ class TestExpenditureModel(MonitorTestBaseClass):
     def test_channel_disabled(self):
         self.monitor.send_payment_info = False
 
-        with mock.patch('golem.monitor.monitor.SenderThread.send') as send:
+        with mock.patch('golem.monitor.monitor.SenderThread.process') \
+                as process:
             dispatcher.send(
                 signal='golem.monitor',
                 event='payment',
                 addr='',
                 value=0
             )
-            send.assert_not_called()
+            process.assert_not_called()
 
 
 class TestIncomeModel(MonitorTestBaseClass):
@@ -50,7 +52,8 @@ class TestIncomeModel(MonitorTestBaseClass):
         addr = str(uuid.UUID(int=random.getrandbits(128)))
         value = random.randint(1, 10 ** 20)
 
-        with mock.patch('golem.monitor.monitor.SenderThread.send') as send:
+        with mock.patch('golem.monitor.monitor.SenderThread.process') \
+                as process:
             dispatcher.send(
                 signal='golem.monitor',
                 event='income',
@@ -58,8 +61,8 @@ class TestIncomeModel(MonitorTestBaseClass):
                 value=value
             )
 
-            send.assert_called_once()
-            result = send.call_args[0][0]
+            process.assert_called_once()
+            result = process.call_args[1]['msg']
             self.assertIsInstance(result, IncomeModel)
             self.assertEqual(result.type, 'Income')
             self.assertEqual(result.addr, addr)
@@ -68,11 +71,12 @@ class TestIncomeModel(MonitorTestBaseClass):
     def test_channel_disabled(self):
         self.monitor.send_payment_info = False
 
-        with mock.patch('golem.monitor.monitor.SenderThread.send') as send:
+        with mock.patch('golem.monitor.monitor.SenderThread.process') \
+                as process:
             dispatcher.send(
                 signal='golem.monitor',
                 event='income',
                 addr='',
                 value=0
             )
-            send.assert_not_called()
+            process.assert_not_called()

--- a/tests/golem/monitor/model/test_statssnapshotmodel.py
+++ b/tests/golem/monitor/model/test_statssnapshotmodel.py
@@ -39,7 +39,7 @@ class TestStatsSnapshotModel(MonitorTestBaseClass):
             )
             self.assertEqual(mock_send.call_count, 1)
             result = mock_send.call_args[1]['msg'].dict_repr()
-            for key in ('cliid', 'sessid', 'timestamp'):
+            for key in ('sessid', 'timestamp'):
                 del result[key]
             expected = {
                 'type': 'Stats',
@@ -52,7 +52,6 @@ class TestStatsSnapshotModel(MonitorTestBaseClass):
 
 class TestP2PSnapshotModel(TestCase):
     def test_init(self):
-        cliid = str(uuid4())
         sessid = str(uuid4())
         p2psnapshot = [{"key_id": "peer1",
                         "port": 1030,
@@ -60,9 +59,8 @@ class TestP2PSnapshotModel(TestCase):
                        {"key_id": "peer1",
                         "port": 1111,
                         "host": "192.19.19.19"}]
-        model = P2PSnapshotModel(cliid, sessid, p2psnapshot)
+        model = P2PSnapshotModel(sessid, p2psnapshot)
         assert isinstance(model, P2PSnapshotModel)
-        assert model.cliid == cliid
         assert model.sessid == sessid
         assert model.p2p_snapshot == p2psnapshot
         assert model.type == "P2PSnapshot"
@@ -72,13 +70,11 @@ class TestP2PSnapshotModel(TestCase):
 
 class TestVMnapshotModel(TestCase):
     def test_init(self):
-        cliid = str(uuid4())
         sessid = str(uuid4())
         vmsnapshot = VMDiagnosticsProvider() \
             .get_diagnostics(DiagnosticsOutputFormat.data)
-        model = VMSnapshotModel(cliid, sessid, vmsnapshot)
+        model = VMSnapshotModel(sessid, vmsnapshot)
         assert isinstance(model, VMSnapshotModel)
-        assert model.cliid == cliid
         assert model.sessid == sessid
         assert model.vm_snapshot == vmsnapshot
         assert model.type == "VMSnapshot"

--- a/tests/golem/monitor/model/test_taskcomputersnapshotmodel.py
+++ b/tests/golem/monitor/model/test_taskcomputersnapshotmodel.py
@@ -15,14 +15,15 @@ class TestTaskComputerSnapshotModel(MonitorTestBaseClass):
         computer_mock.compute_tasks = compute_tasks = random.random() > 0.5
         computer_mock.assigned_subtasks = assigned_subtasks = dict((x, None) for x in range(100))
 
-        with mock.patch('golem.monitor.monitor.SenderThread.send') as mock_send:
+        with mock.patch('golem.monitor.monitor.SenderThread.process') \
+                as mock_send:
             dispatcher.send(
                 signal='golem.monitor',
                 event='task_computer_snapshot',
                 task_computer=computer_mock,
             )
             self.assertEqual(mock_send.call_count, 1)
-            result = mock_send.call_args[0][0].dict_repr()
+            result = mock_send.call_args[1]['msg'].dict_repr()
             for key in ('cliid', 'sessid', 'timestamp'):
                 del result[key]
             self.maxDiff = None

--- a/tests/golem/monitor/model/test_taskcomputersnapshotmodel.py
+++ b/tests/golem/monitor/model/test_taskcomputersnapshotmodel.py
@@ -24,7 +24,7 @@ class TestTaskComputerSnapshotModel(MonitorTestBaseClass):
             )
             self.assertEqual(mock_send.call_count, 1)
             result = mock_send.call_args[1]['msg'].dict_repr()
-            for key in ('cliid', 'sessid', 'timestamp'):
+            for key in ('sessid', 'timestamp'):
                 del result[key]
             self.maxDiff = None
             expected = {

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -378,8 +378,8 @@ class TestTaskMonitor(DatabaseFixture):
         from golem.monitorconfig import MONITOR_CONFIG
         #  hold reference to avoid GC of monitor
         client_mock = mock.MagicMock()
-        client_mock.cliid = 'CLIID'
-        client_mock.sessid = 'SESSID'
+        client_mock.get_key_id.return_value = 'CLIID'
+        client_mock.session_id = 'SESSID'
         client_mock.config_desc = ClientConfigDescriptor()
         monitor = SystemMonitor(  # noqa pylint: disable=unused-variable
             NodeMetadataModel(client_mock, "hackix", "3.1337"),
@@ -404,11 +404,11 @@ class TestTaskMonitor(DatabaseFixture):
             task_thread.subtask_id = subtask_id
 
         def check(expected):
-            with mock.patch('golem.monitor.monitor.SenderThread.send') \
+            with mock.patch('golem.monitor.monitor.SenderThread.process') \
                     as mock_send:
                 task.task_computed(task_thread)
                 self.assertEqual(mock_send.call_count, 1)
-                result = mock_send.call_args[0][0].dict_repr()
+                result = mock_send.call_args[1]['msg'].dict_repr()
                 for key in ('cliid', 'sessid', 'timestamp'):
                     del result[key]
                 expected_d = {

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -378,12 +378,14 @@ class TestTaskMonitor(DatabaseFixture):
         from golem.monitorconfig import MONITOR_CONFIG
         #  hold reference to avoid GC of monitor
         client_mock = mock.MagicMock()
-        client_mock.get_key_id.return_value = 'CLIID'
         client_mock.session_id = 'SESSID'
         client_mock.config_desc = ClientConfigDescriptor()
+        sign_mock = mock.MagicMock()
+        sign_mock.public_key = b''
+        sign_mock.sign.return_value = b''
         monitor = SystemMonitor(  # noqa pylint: disable=unused-variable
             NodeMetadataModel(client_mock, "hackix", "3.1337"),
-            MONITOR_CONFIG)
+            MONITOR_CONFIG, sign_mock)
         task_server = mock.MagicMock()
         task_server.config_desc = ClientConfigDescriptor()
         task = TaskComputer("ABC", task_server,
@@ -409,7 +411,7 @@ class TestTaskMonitor(DatabaseFixture):
                 task.task_computed(task_thread)
                 self.assertEqual(mock_send.call_count, 1)
                 result = mock_send.call_args[1]['msg'].dict_repr()
-                for key in ('cliid', 'sessid', 'timestamp'):
+                for key in ('sessid', 'timestamp'):
                     del result[key]
                 expected_d = {
                     'type': 'ComputationTime',


### PR DESCRIPTION
Changes related to periodically requesting port status check from the monitor:
- Add option PING_INTERVAL, which specifies ping interval in seconds
- Move waiting for ping response to SenderThread in monitor.py
- Add finish action to SenderThread
- Send logout on Golem shutdown

Note that for the ping requests to work, monitor needs to be updated as well.

This now includes #2439 as well. The commits are not related, but we need to push this code and it depends on golem-monitor #21.
