### PR TITLE
Resolved double docker env init

### DIFF
--- a/golem/docker/manager.py
+++ b/golem/docker/manager.py
@@ -87,7 +87,7 @@ class DockerManager(DockerConfigManager):
     @report_calls(Component.docker, 'instance.check')
     def check_environment(self):
         if self._env_checked:
-            return True
+            return bool(self.docker_machine)
 
         if is_windows():
             import pythoncom

--- a/golem/docker/manager.py
+++ b/golem/docker/manager.py
@@ -86,6 +86,8 @@ class DockerManager(DockerConfigManager):
 
     @report_calls(Component.docker, 'instance.check')
     def check_environment(self):
+        if self._env_checked:
+            return True
 
         if is_windows():
             import pythoncom
@@ -150,8 +152,7 @@ class DockerManager(DockerConfigManager):
         return bool(self.docker_machine)
 
     def update_config(self, status_callback, done_callback, in_background=True):
-        if not self._env_checked:
-            self.check_environment()
+        self.check_environment()
 
         if in_background:
             thread = Thread(target=self._wait_for_tasks,
@@ -225,8 +226,7 @@ class DockerManager(DockerConfigManager):
         :param in_background: Run the recovery process in a separate thread.
         :return:
         """
-        if not self._env_checked:
-            self.check_environment()
+        self.check_environment()
 
         if self.docker_machine:
             if in_background:


### PR DESCRIPTION
Resolves #2367 

Moved check for `_env_checked` to inside the `check_environment()` to let external calls also adhere to it.