### PR TITLE
Return if the nonce was downloaded after a handshake timeout

### DIFF
--- a/golem/resource/resourcehandshake.py
+++ b/golem/resource/resourcehandshake.py
@@ -272,6 +272,10 @@ class ResourceHandshakeSessionMixin:
 
     def _nonce_downloaded(self, key_id, files):
         handshake = self._get_handshake(key_id)
+        if not handshake:
+            logger.debug('Resource handshake: nonce downloaded after '
+                         'handshake failure with peer %r', key_id)
+            return
 
         try:
             path = files[0]


### PR DESCRIPTION
Gets rid of a redundant error message appearing in logs.