### PR TITLE
Display proper task duration

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -807,10 +807,9 @@ class TaskManager(TaskEventListener):
         task_type_name = task.task_definition.task_type.lower()
         task_type = self.task_types[task_type_name]
         state = self.query_task_state(task.header.task_id)
-        timeout = task.task_definition.full_task_timeout
 
         dictionary = {
-            'duration': max(timeout - (state.remaining_time or 0), 0),
+            'duration': state.elapsed_time,
             # single=True retrieves one preview file. If rendering frames,
             # it's the preview of the most recently computed frame.
             'preview': task_type.get_preview(task, single=True)


### PR DESCRIPTION
The value displayed as 'duration' has been being computed as timeout - estimated time to compute. Which makes absolutely no sense and has been changed to current time - start time.