### PR TITLE
Handle key errors in CLI calls

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -673,15 +673,18 @@ class Client(HardwarePresetsMixin):
         try:
             task_manager.put_task_in_restarted_state(task_id)
         except task_manager.AlreadyRestartedError:
-            return None
+            return "Task already restarted: '{}'".format(task_id)
 
         # Create new task that is a copy of the definition of the old one.
         # It has a new deadline and a new task id.
-        task_dict = deepcopy(
-            task_manager.get_task_definition_dict(
-                task_manager.tasks[task_id]))
-        del task_dict['id']
+        try:
+            task_dict = deepcopy(
+                task_manager.get_task_definition_dict(
+                    task_manager.tasks[task_id]))
+        except KeyError:
+            return "Task not found: '{}'".format(task_id)
 
+        del task_dict['id']
         return self.create_task(task_dict)
 
     def restart_frame_subtasks(self, task_id, frame):
@@ -798,7 +801,10 @@ class Client(HardwarePresetsMixin):
         return []
 
     def get_subtasks(self, task_id):
-        return self.task_server.task_manager.get_subtasks_dict(task_id)
+        try:
+            return self.task_server.task_manager.get_subtasks_dict(task_id)
+        except KeyError:
+            return "Task not found: '{}'".format(task_id)
 
     def get_subtasks_borders(self, task_id, part=1):
         return self.task_server.task_manager.get_subtasks_borders(task_id,
@@ -808,7 +814,10 @@ class Client(HardwarePresetsMixin):
         return self.task_server.task_manager.get_output_states(task_id)
 
     def get_subtask(self, subtask_id):
-        return self.task_server.task_manager.get_subtask_dict(subtask_id)
+        try:
+            return self.task_server.task_manager.get_subtask_dict(subtask_id)
+        except KeyError:
+            return "Subtask not found: '{}'".format(subtask_id)
 
     def get_task_preview(self, task_id, single=False):
         return self.task_server.task_manager.get_task_preview(task_id,

--- a/golem/client.py
+++ b/golem/client.py
@@ -803,6 +803,7 @@ class Client(HardwarePresetsMixin):
     def get_subtasks(self, task_id: str) \
             -> Tuple[Optional[List[Dict]], Optional[str]]:
         try:
+            assert isinstance(self.task_server, TaskServer)
             subtasks = self.task_server.task_manager.get_subtasks_dict(task_id)
             return subtasks, None
         except KeyError:
@@ -818,6 +819,7 @@ class Client(HardwarePresetsMixin):
     def get_subtask(self, subtask_id: str) \
             -> Tuple[Optional[Dict], Optional[str]]:
         try:
+            assert isinstance(self.task_server, TaskServer)
             subtask = self.task_server.task_manager.get_subtask_dict(subtask_id)
             return subtask, None
         except KeyError:

--- a/golem/client.py
+++ b/golem/client.py
@@ -8,7 +8,7 @@ from copy import copy, deepcopy
 from os import path, makedirs
 from pathlib import Path
 from threading import Lock, Thread
-from typing import Dict, Hashable, Optional, Union, List
+from typing import Dict, Hashable, Optional, Union, List, Tuple
 
 from pydispatch import dispatcher
 from twisted.internet.defer import (
@@ -664,7 +664,7 @@ class Client(HardwarePresetsMixin):
         logger.debug('Aborting task "%r" ...', task_id)
         self.task_server.task_manager.abort_task(task_id)
 
-    def restart_task(self, task_id):
+    def restart_task(self, task_id: str) -> Tuple[bool, Optional[str]]:
         logger.debug('Restarting task "%r" ...', task_id)
         task_manager = self.task_server.task_manager
 
@@ -673,7 +673,7 @@ class Client(HardwarePresetsMixin):
         try:
             task_manager.put_task_in_restarted_state(task_id)
         except task_manager.AlreadyRestartedError:
-            return "Task already restarted: '{}'".format(task_id)
+            return False, "Task already restarted: '{}'".format(task_id)
 
         # Create new task that is a copy of the definition of the old one.
         # It has a new deadline and a new task id.
@@ -682,7 +682,7 @@ class Client(HardwarePresetsMixin):
                 task_manager.get_task_definition_dict(
                     task_manager.tasks[task_id]))
         except KeyError:
-            return "Task not found: '{}'".format(task_id)
+            return False, "Task not found: '{}'".format(task_id)
 
         del task_dict['id']
         return self.create_task(task_dict)
@@ -800,11 +800,13 @@ class Client(HardwarePresetsMixin):
             return self.task_server.task_manager.get_tasks_dict()
         return []
 
-    def get_subtasks(self, task_id):
+    def get_subtasks(self, task_id: str) \
+            -> Tuple[Optional[List[Dict]], Optional[str]]:
         try:
-            return self.task_server.task_manager.get_subtasks_dict(task_id)
+            subtasks = self.task_server.task_manager.get_subtasks_dict(task_id)
+            return subtasks, None
         except KeyError:
-            return "Task not found: '{}'".format(task_id)
+            return None, "Task not found: '{}'".format(task_id)
 
     def get_subtasks_borders(self, task_id, part=1):
         return self.task_server.task_manager.get_subtasks_borders(task_id,
@@ -813,11 +815,13 @@ class Client(HardwarePresetsMixin):
     def get_subtasks_frames(self, task_id):
         return self.task_server.task_manager.get_output_states(task_id)
 
-    def get_subtask(self, subtask_id):
+    def get_subtask(self, subtask_id: str) \
+            -> Tuple[Optional[Dict], Optional[str]]:
         try:
-            return self.task_server.task_manager.get_subtask_dict(subtask_id)
+            subtask = self.task_server.task_manager.get_subtask_dict(subtask_id)
+            return subtask, None
         except KeyError:
-            return "Subtask not found: '{}'".format(subtask_id)
+            return None, "Subtask not found: '{}'".format(subtask_id)
 
     def get_task_preview(self, task_id, single=False):
         return self.task_server.task_manager.get_task_preview(task_id,

--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -88,10 +88,10 @@ class Tasks:
         values = []
 
         deferred = Tasks.client.get_subtasks(id)
-        result = sync_wait(deferred)
+        result, error = sync_wait(deferred)
 
-        if isinstance(result, str):
-            return result
+        if error:
+            return error
 
         if isinstance(result, list):
             for subtask in result:
@@ -109,7 +109,10 @@ class Tasks:
     @command(argument=id_req, help="Restart a task")
     def restart(self, id):
         deferred = Tasks.client.restart_task(id)
-        return sync_wait(deferred)
+        ok, error = sync_wait(deferred)
+        if not ok:
+            return error
+        return None
 
     @command(argument=id_req, help="Abort a task")
     def abort(self, id):
@@ -230,7 +233,10 @@ class Subtasks:
     @command(argument=subtask_id, help="Show subtask details")
     def show(self, subtask_id):
         deferred = Subtasks.client.get_subtask(subtask_id)
-        return sync_wait(deferred)
+        result, error = sync_wait(deferred)
+        if error:
+            return error
+        return result
 
     @command(argument=subtask_id, help="Restart a subtask")
     def restart(self, subtask_id):

--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -90,6 +90,9 @@ class Tasks:
         deferred = Tasks.client.get_subtasks(id)
         result = sync_wait(deferred)
 
+        if isinstance(result, str):
+            return result
+
         if isinstance(result, list):
             for subtask in result:
                 values.append([

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -390,7 +390,7 @@ class TestTasks(TempDirFixture):
         cls.n_subtasks = len(cls.subtasks)
         cls.get_tasks = lambda s, _id: dict(cls.tasks[0]) if _id \
             else [dict(t) for t in cls.tasks]
-        cls.get_subtasks = lambda s, x: [dict(s) for s in cls.subtasks]
+        cls.get_subtasks = lambda s, x: ([dict(s) for s in cls.subtasks], None)
         cls.get_unsupport_reasons = lambda s, x: cls.reasons
 
     def setUp(self):
@@ -416,14 +416,28 @@ class TestTasks(TempDirFixture):
         with client_ctx(Tasks, client):
             tasks = Tasks()
 
-            assert tasks.restart('valid')
-            client.restart_task.assert_called_with('valid')
             assert tasks.abort('valid')
             client.abort_task.assert_called_with('valid')
             assert tasks.delete('valid')
             client.delete_task.assert_called_with('valid')
             assert tasks.stats()
             client.get_task_stats.assert_called_with()
+
+    def test_restart_success(self):
+        with client_ctx(Tasks, self.client):
+            self.client.restart_task.return_value = True, 'whatever'
+            tasks = Tasks()
+            result = tasks.restart('task_id')
+            self.assertIsNone(result)
+            self.client.restart_task.assert_called_once_with('task_id')
+
+    def test_restart_error(self):
+        with client_ctx(Tasks, self.client):
+            self.client.restart_task.return_value = False, 'error'
+            tasks = Tasks()
+            result = tasks.restart('task_id')
+            self.assertEqual(result, 'error')
+            self.client.restart_task.assert_called_once_with('task_id')
 
     def test_create(self) -> None:
         client = self.client
@@ -527,7 +541,7 @@ class TestTasks(TempDirFixture):
                 'progress': '0.00 %'
             })
 
-    def test_subtasks(self):
+    def test_subtasks_ok(self):
         client = self.client
 
         with client_ctx(Tasks, client):
@@ -538,6 +552,14 @@ class TestTasks(TempDirFixture):
             assert subtasks.data[1][0] == [
                 'node_1', 'subtask_1', '0:00:09', 'waiting', '1.00 %'
             ]
+
+    def test_subtasks_error(self):
+        with client_ctx(Tasks, self.client):
+            self.client.get_subtasks = Mock(return_value=(None, 'error'))
+            tasks = Tasks()
+            result = tasks.subtasks('task_id', None)
+            self.assertEqual(result, 'error')
+            self.client.get_subtasks.assert_called_once_with('task_id')
 
     def test_unsupport(self):
         client = self.client
@@ -567,17 +589,22 @@ class TestSubtasks(unittest.TestCase):
         self.client = Mock()
         self.client.__getattribute__ = assert_client_method
 
-    def test_show(self):
-        client = self.client
-
-        with client_ctx(Subtasks, client):
+    def test_show_ok(self):
+        with client_ctx(Subtasks, self.client):
+            subtask_dict = {'subtask_id': 'subtask_id'}
+            self.client.get_subtask.return_value = subtask_dict, None
             subtasks = Subtasks()
+            result = subtasks.show('subtask_id')
+            self.assertEqual(result, subtask_dict)
+            self.client.get_subtask.assert_called_with('subtask_id')
 
-            subtasks.show('valid')
-            client.get_subtask.assert_called_with('valid')
-
-            subtasks.show('invalid')
-            client.get_subtask.assert_called_with('invalid')
+    def test_show_error(self):
+        with client_ctx(Subtasks, self.client):
+            self.client.get_subtask.return_value = None, 'error'
+            subtasks = Subtasks()
+            result = subtasks.show('subtask_id')
+            self.assertEqual(result, 'error')
+            self.client.get_subtask.assert_called_with('subtask_id')
 
     def test_restart(self):
         client = self.client


### PR DESCRIPTION
These method now return a nice error message instead of raising unhandled key errors:
- `golemcli subtasks show`
- `golemcli tasks subtasks`
- `golemcli tasks restart`

Closes #2583 