### PR TITLE
client: publish Task.evt_subtask_status if subtask was changed

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -245,12 +245,17 @@ class Client(HardwarePresetsMixin):
             sender, signal, event, kwargs
         )
 
-        if 'op' in kwargs and kwargs['op'] is not None \
-                and kwargs['op'].subtask_related():
+        op = kwargs['op'] if 'op' in kwargs else None
+
+        if op is not None and op.subtask_related():
             self._publish(Task.evt_subtask_status, kwargs['task_id'],
-                          kwargs['subtask_id'])
+                          kwargs['subtask_id'], op.value)
         else:
-            self._publish(Task.evt_task_status, kwargs['task_id'])
+            op_class_name: str = op.__class__.__name__ \
+                                 if op is not None else None
+            op_value: int = op.value if op is not None else None
+            self._publish(Task.evt_task_status, kwargs['task_id'],
+                          op_class_name, op_value)
 
     # TODO: re-enable. issue #2398
     def sync(self):

--- a/golem/client.py
+++ b/golem/client.py
@@ -244,7 +244,13 @@ class Client(HardwarePresetsMixin):
             'taskmanager_listen (sender: %r, signal: %r, event: %r, args: %r)',
             sender, signal, event, kwargs
         )
-        self._publish(Task.evt_task_status, kwargs['task_id'])
+
+        if 'op' in kwargs and kwargs['op'] is not None \
+                and kwargs['op'].subtask_related():
+            self._publish(Task.evt_subtask_status, kwargs['task_id'],
+                          kwargs['subtask_id'])
+        else:
+            self._publish(Task.evt_task_status, kwargs['task_id'])
 
     # TODO: re-enable. issue #2398
     def sync(self):


### PR DESCRIPTION
Currently all changes in tasks and subtasks are reported as `Task.evt_task_status` annotated with a task_id.

We have in our RPC mapping defined a `Task.evt_subtask_status`, which is unused.

This change restores reporting subtasks changes using `Task.evt_subtask_status` annotated with a task_id and subtask_id.