### PR TITLE
RPC method to add nodes to block list

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -151,7 +151,7 @@ class Client(HardwarePresetsMixin):
             keys_auth=self.keys_auth,
         )
 
-        self.task_server = None
+        self.task_server: Optional[TaskServer] = None
         self.port_mapper = None
 
         self.nodes_manager_client = None
@@ -1292,6 +1292,17 @@ class Client(HardwarePresetsMixin):
     @staticmethod
     def enable_talkback(value):
         enable_sentry_logger(value)
+
+    def block_node(self, node_id: str) -> Tuple[bool, Optional[str]]:
+        if self.task_server is not None:
+            try:
+                self.task_server.acl.disallow(node_id, persist=True)
+                return True, None
+
+            except Exception as e:  # pylint: disable=broad-except
+                return False, str(e)
+
+        return False, 'Client is not ready'
 
 
 class DoWorkService(LoopingCallService):

--- a/golem/interface/client/network.py
+++ b/golem/interface/client/network.py
@@ -12,6 +12,7 @@ class Network(object):
 
     ip_arg = Argument('ip', help='Remote IP address')
     port_arg = Argument('port_', help='Remote TCP port')
+    node_id = Argument('node_id', help='ID of a node')
 
     full_table = Argument(
         '--full',
@@ -51,6 +52,12 @@ class Network(object):
         deferred = Network.client.get_known_peers()
         peers = sync_wait(deferred) or []
         return self.__peers(peers, sort, full)
+
+    @command(argument=node_id, help="Block provider")
+    def block(self, node_id):
+        success, error = sync_wait(self.client.block_node(node_id))
+        if not success:
+            return error
 
     @staticmethod
     def __peers(peers, sort, full):

--- a/golem/rpc/mapping/rpcmethodnames.py
+++ b/golem/rpc/mapping/rpcmethodnames.py
@@ -31,6 +31,7 @@ CORE_METHOD_MAP = dict(
     get_known_peers=        'net.peers.known',
     get_connected_peers=    'net.peers.connected',
 
+    block_node=             'net.peer.block',
     connect=                'net.peer.connect',
     connection_status=      'net.status',
 

--- a/golem/task/acl.py
+++ b/golem/task/acl.py
@@ -15,14 +15,16 @@ class Acl(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def disallow(self, node_id: str, timeout_seconds: int) -> None:
+    def disallow(self, node_id: str, timeout_seconds: int, persist: bool) \
+            -> None:
         pass
 
 
 class _DenyAcl(Acl):
-    def __init__(self, deny_coll: Iterable[str]) -> None:
+    def __init__(self, deny_coll: Iterable[str], list_path: Path) -> None:
         key_sequence = list(deny_coll)
         self._deny_deadlines = dict.fromkeys(key_sequence, self._deadline())
+        self._list_path = list_path
 
     def is_allowed(self, node_id: str) -> bool:
         deadline = self._deny_deadlines.get(node_id)
@@ -37,8 +39,14 @@ class _DenyAcl(Acl):
         return False
 
     def disallow(self, node_id: str,
-                 timeout_seconds: int = DEFAULT_TIMEOUT) -> None:
+                 timeout_seconds: int = DEFAULT_TIMEOUT,
+                 persist: bool = False) -> None:
         self._deny_deadlines[node_id] = self._deadline(timeout_seconds)
+
+        if persist:
+            deny_set = _read_set_from_file(self._list_path)
+            if node_id not in deny_set:
+                _write_set_to_file(self._list_path, deny_set | {node_id})
 
     @staticmethod
     def _deadline(timeout: int = DEFAULT_TIMEOUT):
@@ -46,14 +54,22 @@ class _DenyAcl(Acl):
 
 
 class _AllowAcl(Acl):
-    def __init__(self, allow_set: Set[str]) -> None:
+    def __init__(self, allow_set: Set[str], list_path: Path) -> None:
         self._allow_set = allow_set
+        self._list_path = list_path
 
     def is_allowed(self, node_id: str) -> bool:
         return node_id in self._allow_set
 
-    def disallow(self, node_id: str, _timeout_seconds: int) -> None:
+    def disallow(self, node_id: str,
+                 _timeout_seconds: int = 0,
+                 persist: bool = False) -> None:
         self._allow_set.discard(node_id)
+
+        if persist:
+            allow_set = _read_set_from_file(self._list_path)
+            if node_id in allow_set:
+                _write_set_to_file(self._list_path, allow_set - {node_id})
 
 
 def _read_set_from_file(path: Path) -> Set[str]:
@@ -64,11 +80,18 @@ def _read_set_from_file(path: Path) -> Set[str]:
         return set()
 
 
+def _write_set_to_file(path: Path, node_set: Set[str]):
+    with path.open('w') as f:
+        for node_id in sorted(node_set):
+            f.write(node_id + '\n')
+
+
 def get_acl(datadir: Path) -> Union[_DenyAcl, _AllowAcl]:
-    nodes_ids = _read_set_from_file(datadir / DENY_LIST_NAME)
+    deny_list_path = datadir / DENY_LIST_NAME
+    nodes_ids = _read_set_from_file(deny_list_path)
 
     if ALL_EXCEPT_ALLOWED in nodes_ids:
         nodes_ids.remove(ALL_EXCEPT_ALLOWED)
-        return _AllowAcl(nodes_ids)
+        return _AllowAcl(nodes_ids, deny_list_path)
 
-    return _DenyAcl(nodes_ids)
+    return _DenyAcl(nodes_ids, deny_list_path)

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -162,6 +162,9 @@ class TestNetwork(unittest.TestCase):
         cls.n_clients = len(peer_info)
         cls.client = client
 
+    def tearDown(self):
+        self.client.reset_mock()
+
     def test_status(self):
 
         with client_ctx(Network, self.client):
@@ -206,6 +209,21 @@ class TestNetwork(unittest.TestCase):
             result_2 = net.dht(None, full=True)
 
             self.__assert_peer_result(result_1, result_2)
+
+    def test_block_success(self):
+        with client_ctx(Network, self.client):
+            self.client.block_node.return_value = True, None
+            network = Network()
+            network.block('node_id')
+            self.client.block_node.assert_called_once_with('node_id')
+
+    def test_block_error(self):
+        with client_ctx(Network, self.client):
+            self.client.block_node.return_value = False, 'error_msg'
+            network = Network()
+            result = network.block('node_id')
+            self.assertEqual(result, 'error_msg')
+            self.client.block_node.assert_called_once_with('node_id')
 
     def __assert_peer_result(self, result_1, result_2):
         self.assertEqual(result_1.data[1][0], [

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -34,6 +34,7 @@ from golem.network.p2p.peersession import PeerSessionInfo
 from golem.report import StatusPublisher
 from golem.resource.dirmanager import DirManager
 from golem.rpc.mapping.rpceventnames import UI, Environment
+from golem.task.acl import Acl
 from golem.task.taskbase import Task
 from golem.task.taskserver import TaskServer
 from golem.task.taskstate import TaskState, TaskStatus, SubtaskStatus, \
@@ -1433,6 +1434,12 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
     def test_get_performance_values(self, *_):
         expected_perf = {DefaultEnvironment.get_id(): 0.0}
         assert self.client.get_performance_values() == expected_perf
+
+    def test_block_node(self, *_):
+        self.client.task_server.acl = Mock(spec=Acl)
+        self.client.block_node('node_id')
+        self.client.task_server.acl.disallow.assert_called_once_with(
+            'node_id', persist=True)
 
     @classmethod
     def __new_incoming_peer(cls):


### PR DESCRIPTION
RPC method name: `net.peer.block`
Parameters: `node_id: str` - ID of the node to be blocked
Return value: `(success: bool, error: str)`
 * `success` - was the operation successful
 * `error` - error message (`None` if there was no error)