### PR TITLE
* adds support for `golem-messages 2.6.0`

### DIFF
--- a/golem/network/concent/helpers.py
+++ b/golem/network/concent/helpers.py
@@ -58,7 +58,7 @@ def process_report_computed_task(
         )
         reject_msg = message.tasks.RejectReportComputedTask(
             reason=reason,
-            task_to_compute=msg.task_to_compute,
+            attached_task_to_compute=msg.task_to_compute,
             **kwargs,
         )
         return reject_msg

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ eth-keys==0.1.0b4
 eth-tester==0.1.0b15
 eth-utils==0.7.4
 ethereum==1.6.1
-Golem-Messages==2.5.0
+Golem-Messages==2.6.0
 Golem-Smart-Contracts-Interface==1.0.1
 h2==3.0.1
 hpack==3.0.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -53,6 +53,6 @@ token_bucket==0.2.0
 py-cpuinfo==3.3.0
 humanize==0.5.1
 raven
-Golem-Messages==2.5.0
+Golem-Messages==2.6.0
 Golem-Smart-Contracts-Interface==1.0.1
 html2text==2018.1.9

--- a/scripts/concent_integration_tests/force_report/test_messages.py
+++ b/scripts/concent_integration_tests/force_report/test_messages.py
@@ -93,7 +93,8 @@ class ForceReportComputedTaskTest(ConcentBaseTest, unittest.TestCase):
         frct_rcv = self.requestor_receive()
 
         rrct = message.tasks.RejectReportComputedTask(
-            task_to_compute=frct_rcv.report_computed_task.task_to_compute,
+            attached_task_to_compute=
+            frct_rcv.report_computed_task.task_to_compute,
             reason=message.tasks.RejectReportComputedTask.
             REASON.SubtaskTimeLimitExceeded
         )
@@ -140,7 +141,8 @@ class ForceReportComputedTaskTest(ConcentBaseTest, unittest.TestCase):
         )
 
         rrct = message.tasks.RejectReportComputedTask(
-            task_to_compute=frct_rcv.report_computed_task.task_to_compute,
+            attached_task_to_compute=
+            frct_rcv.report_computed_task.task_to_compute,
             cannot_compute_task=cct,
             reason=message.tasks.RejectReportComputedTask.
             REASON.GotMessageCannotComputeTask,
@@ -160,7 +162,8 @@ class ForceReportComputedTaskTest(ConcentBaseTest, unittest.TestCase):
         )
 
         rrct = message.tasks.RejectReportComputedTask(
-            task_to_compute=frct_rcv.report_computed_task.task_to_compute,
+            attached_task_to_compute=
+            frct_rcv.report_computed_task.task_to_compute,
             task_failure=tf,
             reason=message.tasks.RejectReportComputedTask.
             REASON.GotMessageTaskFailure,

--- a/scripts/concent_integration_tests/force_report/test_messages.py
+++ b/scripts/concent_integration_tests/force_report/test_messages.py
@@ -93,8 +93,8 @@ class ForceReportComputedTaskTest(ConcentBaseTest, unittest.TestCase):
         frct_rcv = self.requestor_receive()
 
         rrct = message.tasks.RejectReportComputedTask(
-            attached_task_to_compute=
-            frct_rcv.report_computed_task.task_to_compute,
+            attached_task_to_compute=frct_rcv.
+            report_computed_task.task_to_compute,
             reason=message.tasks.RejectReportComputedTask.
             REASON.SubtaskTimeLimitExceeded
         )
@@ -141,8 +141,8 @@ class ForceReportComputedTaskTest(ConcentBaseTest, unittest.TestCase):
         )
 
         rrct = message.tasks.RejectReportComputedTask(
-            attached_task_to_compute=
-            frct_rcv.report_computed_task.task_to_compute,
+            attached_task_to_compute=frct_rcv.
+            report_computed_task.task_to_compute,
             cannot_compute_task=cct,
             reason=message.tasks.RejectReportComputedTask.
             REASON.GotMessageCannotComputeTask,
@@ -162,8 +162,8 @@ class ForceReportComputedTaskTest(ConcentBaseTest, unittest.TestCase):
         )
 
         rrct = message.tasks.RejectReportComputedTask(
-            attached_task_to_compute=
-            frct_rcv.report_computed_task.task_to_compute,
+            attached_task_to_compute=frct_rcv.
+            report_computed_task.task_to_compute,
             task_failure=tf,
             reason=message.tasks.RejectReportComputedTask.
             REASON.GotMessageTaskFailure,

--- a/tests/golem/network/concent/test_received_handler.py
+++ b/tests/golem/network/concent/test_received_handler.py
@@ -1,4 +1,4 @@
-# pylint: disable=protected-access,no-self-use
+# pylint: disable=protected-access,no-self-use,no-member
 import datetime
 import gc
 import importlib
@@ -64,6 +64,7 @@ class FrctResponseTestBase(unittest.TestCase):
     def tearDown(self):
         library._handlers = {}
 
+
 @mock.patch("golem.network.history.add")
 class TestOnForceReportComputedTaskResponsePlain(FrctResponseTestBase):
     def _get_frctr(self):
@@ -81,6 +82,7 @@ class TestOnForceReportComputedTaskResponsePlain(FrctResponseTestBase):
             local_role=Actor.Provider,
             remote_role=Actor.Concent,
         )
+
 
 @mock.patch("golem.network.history.add")
 class TestOnForceReportComputedTaskResponseAck(FrctResponseTestBase):
@@ -121,8 +123,9 @@ class TestOnForceReportComputedTaskResponseAck(FrctResponseTestBase):
             call_inner,
         ])
 
+
 @mock.patch("golem.network.history.add")
-class TestOnForceReportComputedTaskResponseAck(FrctResponseTestBase):
+class TestOnForceReportComputedTaskResponseReject(FrctResponseTestBase):
     def _get_frctr(self):
         return msg_factories.concents. \
             ForceReportComputedTaskResponseFactory. \

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -168,14 +168,14 @@ class TestTaskSession(ConcentMessageMixin, LogTestCase,
         ts2.task_manager.get_node_id_for_subtask.return_value = "DEF"
         ts2._react_to_cannot_compute_task(message.CannotComputeTask(
             reason=message.CannotComputeTask.REASON.WrongCTD,
-            subtask_id=None,
+            task_to_compute=None,
         ))
         assert ts2.task_manager.task_computation_failure.called
         ts2.task_manager.task_computation_failure.called = False
         ts2.task_manager.get_node_id_for_subtask.return_value = "___"
         ts2._react_to_cannot_compute_task(message.CannotComputeTask(
             reason=message.CannotComputeTask.REASON.WrongCTD,
-            subtask_id=None,
+            task_to_compute=None,
         ))
         assert not ts2.task_manager.task_computation_failure.called
 
@@ -655,7 +655,7 @@ class TestTaskSession(ConcentMessageMixin, LogTestCase,
             report_computed_task=rct
         )
         msg_rej = message.tasks.RejectReportComputedTask(
-            task_to_compute=ttc
+            attached_task_to_compute=ttc
         )
 
         # Subtask is not known


### PR DESCRIPTION
* removes `ReportComputedTask.computation_time`
* adds support for nested `CannotComputeTask.task_to_compute`
* adds support for nested `TaskFailure.task_to_compute`
* adds support for changed signature of RejectReportComputedTask