### PR TITLE
Respect block gas limit

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ eth-tester==0.1.0b15
 eth-utils==0.7.4
 ethereum==1.6.1
 Golem-Messages==2.5.0
-Golem-Smart-Contracts-Interface==1.0.1
+Golem-Smart-Contracts-Interface==1.0.6
 h2==3.0.1
 hpack==3.0.0
 html2text==2018.1.9

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -54,5 +54,5 @@ py-cpuinfo==3.3.0
 humanize==0.5.1
 raven
 Golem-Messages==2.5.0
-Golem-Smart-Contracts-Interface==1.0.1
+Golem-Smart-Contracts-Interface==1.0.6
 html2text==2018.1.9

--- a/tests/golem/transactions/ethereum/test_paymentprocessor.py
+++ b/tests/golem/transactions/ethereum/test_paymentprocessor.py
@@ -63,6 +63,9 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         self.sci.get_eth_address.return_value = self.addr
         self.sci.get_gate_address.return_value = None
         self.sci.get_current_gas_price.return_value = self.sci.GAS_PRICE
+        latest_block = mock.Mock()
+        latest_block.gas_limit = 10 ** 10
+        self.sci.get_latest_block.return_value = latest_block
         # FIXME: PaymentProcessor should be started and stopped! #2455
         self.pp = PaymentProcessor(self.sci)
         self.pp._loopingCall.clock = Clock()  # Disable looping call.
@@ -359,6 +362,9 @@ class InteractionWithSmartContractInterfaceTest(DatabaseFixture):
         self.sci.GAS_PRICE = 20
         self.sci.get_gate_address.return_value = None
         self.sci.get_current_gas_price.return_value = self.sci.GAS_PRICE
+        latest_block = mock.Mock()
+        latest_block.gas_limit = 10 ** 10
+        self.sci.get_latest_block.return_value = latest_block
 
         self.tx_hash = '0xdead'
         self.sci.batch_transfer.return_value = self.tx_hash
@@ -587,6 +593,27 @@ class InteractionWithSmartContractInterfaceTest(DatabaseFixture):
         with freeze_time(timestamp_to_datetime(ts)):
             self.pp.sendout(0)
             self.sci.batch_transfer.assert_called_once_with([p], ts)
+
+    def test_block_gas_limit(self):
+        self.sci.get_eth_balance.return_value = denoms.ether
+        self.sci.get_gnt_balance.return_value = 0
+        self.sci.get_gntb_balance.return_value = 1000 * denoms.ether
+        self.sci.get_latest_block.return_value.gas_limit = \
+            (self.sci.GAS_BATCH_PAYMENT_BASE + self.sci.GAS_PER_PAYMENT) /\
+            self.pp.BLOCK_GAS_LIMIT_RATIO
+        self.pp.CLOSURE_TIME_DELAY = 0
+
+        p1 = make_awaiting_payment(value=1, ts=1)
+        p2 = make_awaiting_payment(value=2, ts=2)
+        self.pp.add(p1)
+        self.pp.add(p2)
+
+        with freeze_time(timestamp_to_datetime(10000)):
+            self.pp.sendout(0)
+            self.sci.batch_transfer.assert_called_with(
+                [p1],
+                1)
+            self.sci.batch_transfer.reset_mock()
 
 
 class FaucetTest(unittest.TestCase):


### PR DESCRIPTION
So we don't try to send a transaction with higher gas limit then the block gas limit - it wouldn't get accepted to the pool at all.

Fixes #2699