### PR TITLE
test_client: properly mock PaymentProcessor

### DIFF
--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -13,8 +13,6 @@ from freezegun import freeze_time
 from pydispatch import dispatcher
 from twisted.internet.defer import Deferred
 
-from golem_sci.implementation import SCIImplementation as sci
-
 import golem
 from apps.appsmanager import AppsManager
 from apps.dummy.task.dummytask import DummyTask
@@ -77,11 +75,10 @@ def done_deferred(return_value=None):
 
 def make_mock_payment_processor(eth=100, gnt=100):
     pp = MagicMock(name="MockPaymentProcessor")
-    pp.ETH_PER_PAYMENT = sci.GAS_PRICE * sci.GAS_PER_PAYMENT
-    pp.ETH_BATCH_PAYMENT_BASE = sci.GAS_PRICE * sci.GAS_BATCH_PAYMENT_BASE
 
-    val = pp.ETH_BATCH_PAYMENT_BASE + pp.ETH_PER_PAYMENT * 10
-    pp.get_gas_cost_per_payment.return_value = val
+    pp.ETH_BATCH_PAYMENT_BASE = 0
+
+    pp.get_gas_cost_per_payment.return_value = 0
 
     pp.gnt_balance.return_value = gnt * denoms.ether, time.time()
     pp.eth_balance.return_value = eth * denoms.ether, time.time()

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -13,6 +13,8 @@ from freezegun import freeze_time
 from pydispatch import dispatcher
 from twisted.internet.defer import Deferred
 
+from golem_sci.implementation import SCIImplementation as sci
+
 import golem
 from apps.appsmanager import AppsManager
 from apps.dummy.task.dummytask import DummyTask
@@ -71,6 +73,21 @@ def done_deferred(return_value=None):
     deferred = Deferred()
     deferred.callback(return_value)
     return deferred
+
+
+def make_mock_payment_processor(eth=100, gnt=100):
+    pp = MagicMock(name="MockPaymentProcessor")
+    pp.ETH_PER_PAYMENT = sci.GAS_PRICE * sci.GAS_PER_PAYMENT
+    pp.ETH_BATCH_PAYMENT_BASE = sci.GAS_PRICE * sci.GAS_BATCH_PAYMENT_BASE
+
+    val = pp.ETH_BATCH_PAYMENT_BASE + pp.ETH_PER_PAYMENT * 10
+    pp.get_gas_cost_per_payment.return_value = val
+
+    pp.gnt_balance.return_value = gnt * denoms.ether, time.time()
+    pp.eth_balance.return_value = eth * denoms.ether, time.time()
+    pp._gnt_available.return_value = gnt * denoms.ether
+    pp._eth_available.return_value = eth * denoms.ether
+    return pp
 
 
 @patch(
@@ -537,6 +554,9 @@ class TestClient(TestWithDatabase, TestWithReactor):
     @patch('golem.client.async_run', mock_async_run)
     @patch('golem.network.concent.client.ConcentClientService.start')
     @patch('golem.client.SystemMonitor')
+    @patch('golem.transactions.ethereum.ethereumtransactionsystem.'
+           'PaymentProcessor',
+           return_value=make_mock_payment_processor())
     @patch('golem.client.P2PService.connect_to_network')
     def test_restart_task(self, connect_to_network, *_):
         apps_manager = AppsManager(False)
@@ -553,10 +573,6 @@ class TestClient(TestWithDatabase, TestWithReactor):
             use_docker_manager=False,
             apps_manager=apps_manager
         )
-
-        sci = self.client.transaction_system._sci
-        pp = make_mock_payment_processor(sci)
-        self.client.transaction_system.payment_processor = pp
 
         deferred = Deferred()
         connect_to_network.side_effect = lambda *_: deferred.callback(True)
@@ -899,21 +915,6 @@ class TestTaskCleanerService(TestWithReactor):
         client.clean_old_tasks.assert_called_once()
 
 
-def make_mock_payment_processor(sci, eth=100, gnt=100):
-    pp = MagicMock()
-    pp.ETH_PER_PAYMENT = sci.GAS_PRICE * sci.GAS_PER_PAYMENT
-    pp.ETH_BATCH_PAYMENT_BASE = sci.GAS_PRICE * sci.GAS_BATCH_PAYMENT_BASE
-
-    val = pp.ETH_BATCH_PAYMENT_BASE + pp.ETH_PER_PAYMENT * 10
-    pp.get_gas_cost_per_payment.return_value = val
-
-    pp.gnt_balance.return_value = gnt * denoms.ether, time.time()
-    pp.eth_balance.return_value = eth * denoms.ether, time.time()
-    pp._gnt_available.return_value = gnt * denoms.ether
-    pp._eth_available.return_value = eth * denoms.ether
-    return pp
-
-
 @patch('signal.signal')
 @patch('golem.network.p2p.node.Node.collect_network_info')
 class TestClientRPCMethods(TestWithDatabase, LogTestCase):
@@ -1019,7 +1020,7 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         c.resource_server = Mock()
         c.task_server = Mock()
         c.transaction_system.payment_processor = \
-            make_mock_payment_processor(c.transaction_system._sci)
+            make_mock_payment_processor()
 
         task_header = Mock(
             max_price=1 * 10**18,
@@ -1103,7 +1104,7 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
             side_effect=add_task)
 
         c.transaction_system.payment_processor = \
-            make_mock_payment_processor(c.transaction_system._sci)
+            make_mock_payment_processor()
         deferred = c.enqueue_new_task(t_dict)
         task = sync_wait(deferred)
         assert isinstance(task, Task)


### PR DESCRIPTION
In test_restart_task PaymentProcessor was replaced by a mock after
creating Client object.

The problem is that EthereumTransactionSystem starts the
PaymentProcessor in constructor. So after replacing the real object by
a mock, the real object is still running in the background.

Fixes #2729 
