### PR TITLE
Allow HTTPS scheme for --geth-address

### DIFF
--- a/golem/argsparser.py
+++ b/golem/argsparser.py
@@ -1,4 +1,5 @@
 import ipaddress
+from urllib.parse import urlparse
 
 import click
 
@@ -18,14 +19,16 @@ def parse_http_addr(ctx, param, value):
     del ctx, param
     if value:
         try:
-            http_prefix = 'http://'
-            if not value.startswith(http_prefix):
+            parsed_url = urlparse(value)
+            if parsed_url.scheme not in ['http', 'https']:
                 raise click.BadParameter(
-                    "Address without http:// prefix"
+                    "Address without http(s):// prefix "
                     "specified: {}".format(value))
-            SocketAddress.parse(value[len(http_prefix):])
+            SocketAddress.parse(
+                value.replace(parsed_url.scheme + '://', '')
+            )
             return value
-        except ipaddress.AddressValueError as e:
+        except (ValueError, ipaddress.AddressValueError) as e:
             raise click.BadParameter(
                 "Invalid network address specified: {}".format(e))
     return None

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -167,7 +167,8 @@ class TestNode(TestWithDatabase):
                                      password=None)
 
     @patch('golem.node.Client')
-    def test_geth_http_address_should_be_passed_to_client(self, mock_client, *_):
+    def test_geth_http_address_should_be_passed_to_client(
+            self, mock_client, *_):
         # given
         geth_address = 'http://3.14.15.92:6535'
 
@@ -191,7 +192,8 @@ class TestNode(TestWithDatabase):
                                        apps_manager=ANY)
 
     @patch('golem.node.Client')
-    def test_geth_https_address_should_be_passed_to_client(self, mock_client, *_):
+    def test_geth_https_address_should_be_passed_to_client(
+            self, mock_client, *_):
         # given
         geth_address = 'https://3.14.15.92:6535'
 


### PR DESCRIPTION
This PR modifies `argparser.parse_http_addr` to accept https urls, that allows users to pass a custom geth node which is behind a https reverse proxy.