### PR TITLE
fix rlp version to 0.6.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -57,3 +57,4 @@ raven
 Golem-Messages==1.17.2
 Golem-Smart-Contracts-Interface==1.0.3
 html2text==2018.1.9
+rlp==0.6.0


### PR DESCRIPTION
Without this the `pip install -r requirements.txt` fails with
```
rlp 1.0.1 has requirement eth-utils<2,>=1.0.2, but you'll have eth-utils 0.7.4 which is incompatible.
eth-tester 0.1.0b15 has requirement rlp<1.0.0,>=0.6.0, but you'll have rlp 1.0.1 which is incompatible.
```
and then golemapp fails with
```
Traceback (most recent call last):
  File "/home/golem/golem_git/golemapp.py", line 12, in <module>
    from ethereum import slogging
  File "/home/golem/golem_git/venv/lib/python3.6/site-packages/ethereum/__init
    from . import slogging  # noqa
  File "/home/golem/golem_git/venv/lib/python3.6/site-packages/ethereum/sloggi
    from ethereum.utils import bcolors, isnumeric
  File "/home/golem/golem_git/venv/lib/python3.6/site-packages/ethereum/utils.
    from rlp.utils import decode_hex, encode_hex as _encode_hex, ascii_chr, st
ImportError: cannot import name 'decode_hex'
```

This is already fixed in `develop` branch.