### PR TITLE
Graceful shutdown

### DIFF
--- a/golem/appconfig.py
+++ b/golem/appconfig.py
@@ -35,6 +35,7 @@ SEND_PEERS_NUM = 10
 USE_IP6 = 0
 USE_UPNP = 1
 ACCEPT_TASKS = 1
+IN_SHUTDOWN = 0
 SEND_PINGS = 1
 ENABLE_MONITOR = 1
 DEBUG_THIRD_PARTY = 0
@@ -125,6 +126,7 @@ class AppConfig:
             key_difficulty=KEY_DIFFICULTY,
             # flags
             accept_tasks=ACCEPT_TASKS,
+            in_shutdown=IN_SHUTDOWN,
             send_pings=SEND_PINGS,
             enable_talkback=ENABLE_TALKBACK,
             enable_monitor=ENABLE_MONITOR,

--- a/golem/appconfig.py
+++ b/golem/appconfig.py
@@ -35,7 +35,6 @@ SEND_PEERS_NUM = 10
 USE_IP6 = 0
 USE_UPNP = 1
 ACCEPT_TASKS = 1
-IN_SHUTDOWN = 0
 SEND_PINGS = 1
 ENABLE_MONITOR = 1
 DEBUG_THIRD_PARTY = 0
@@ -125,8 +124,8 @@ class AppConfig:
             opt_peer_num=OPTIMAL_PEER_NUM,
             key_difficulty=KEY_DIFFICULTY,
             # flags
+            in_shutdown=0,
             accept_tasks=ACCEPT_TASKS,
-            in_shutdown=IN_SHUTDOWN,
             send_pings=SEND_PINGS,
             enable_talkback=ENABLE_TALKBACK,
             enable_monitor=ENABLE_MONITOR,

--- a/golem/client.py
+++ b/golem/client.py
@@ -110,7 +110,8 @@ class Client(HardwarePresetsMixin):
             start_geth: bool = False,
             start_geth_port: Optional[int] = None,
             geth_address: Optional[str] = None,
-            apps_manager: AppsManager = AppsManager()) -> None:
+            apps_manager: AppsManager = AppsManager(),
+            task_finished_cb=None) -> None:
 
         self.apps_manager = apps_manager
         self.datadir = datadir
@@ -124,6 +125,9 @@ class Client(HardwarePresetsMixin):
         self.app_config = app_config
         self.config_desc = config_desc
         self.config_approver = ConfigApprover(self.config_desc)
+
+        if self.config_desc.in_shutdown:
+            self.update_setting('in_shutdown', False)
 
         logger.info(
             'Client "%s", datadir: %s',
@@ -207,6 +211,7 @@ class Client(HardwarePresetsMixin):
         self.use_monitor = use_monitor
         self.monitor = None
         self.session_id = str(uuid.uuid4())
+        self._task_finished_cb = task_finished_cb
 
         dispatcher.connect(
             self.p2p_listener,
@@ -317,7 +322,8 @@ class Client(HardwarePresetsMixin):
             use_ipv6=self.config_desc.use_ipv6,
             use_docker_manager=self.use_docker_manager,
             task_archiver=self.task_archiver,
-            apps_manager=self.apps_manager
+            apps_manager=self.apps_manager,
+            task_finished_cb=self._task_finished_cb,
         )
 
         monitoring_publisher_service = MonitoringPublisherService(

--- a/golem/client.py
+++ b/golem/client.py
@@ -529,6 +529,9 @@ class Client(HardwarePresetsMixin):
         self._unlock_datadir()
 
     def enqueue_new_task(self, task_dict):
+        if self.config_desc.in_shutdown:
+            raise Exception('Can not enqueue tasks when shutdown is in progress, '
+                            'toggle shutdown mode off to create a new tasks.')
         task_manager = self.task_server.task_manager
         _result = Deferred()
 

--- a/golem/client.py
+++ b/golem/client.py
@@ -530,7 +530,7 @@ class Client(HardwarePresetsMixin):
 
     def enqueue_new_task(self, task_dict):
         if self.config_desc.in_shutdown:
-            raise Exception('Can not enqueue tasks when shutdown is in progress, '
+            raise Exception('Can not enqueue task: shutdown is in progress,'
                             'toggle shutdown mode off to create a new tasks.')
         task_manager = self.task_server.task_manager
         _result = Deferred()

--- a/golem/client.py
+++ b/golem/client.py
@@ -530,7 +530,7 @@ class Client(HardwarePresetsMixin):
 
     def enqueue_new_task(self, task_dict):
         if self.config_desc.in_shutdown:
-            raise Exception('Can not enqueue task: shutdown is in progress,'
+            raise Exception('Can not enqueue task: shutdown is in progress, '
                             'toggle shutdown mode off to create a new tasks.')
         task_manager = self.task_server.task_manager
         _result = Deferred()

--- a/golem/clientconfigdescriptor.py
+++ b/golem/clientconfigdescriptor.py
@@ -60,6 +60,7 @@ class ClientConfigDescriptor(object):
 
         self.accept_tasks = 1
         self.debug_third_party = 0
+        self.in_shutdown = 0
 
     def init_from_app_config(self, app_config):
         """Initializes config parameters based on the specified AppConfig

--- a/golem/interface/client/account.py
+++ b/golem/interface/client/account.py
@@ -115,12 +115,12 @@ class Account:
         amount = str(int(Decimal(amount) * denoms.ether))
         return sync_wait(Account.client.withdraw(amount, destination, currency))
 
-    @command(help="Trigger gracefull shutdown of your golem")
+    @command(help="Trigger graceful shutdown of your golem")
     def shutdown(self) -> str:  # pylint: disable=no-self-use
 
-        sync_wait(Account.client.gracefull_shutdown())
+        result = sync_wait(Account.client.graceful_shutdown())
 
-        return "Gracefull shutdown triggered with success"
+        return "Graceful shutdown triggered result: {}".format(result)
 
 
 def _fmt(value: float, unit: str = "GNT") -> str:

--- a/golem/interface/client/account.py
+++ b/golem/interface/client/account.py
@@ -115,6 +115,13 @@ class Account:
         amount = str(int(Decimal(amount) * denoms.ether))
         return sync_wait(Account.client.withdraw(amount, destination, currency))
 
+    @command(help="Trigger gracefull shutdown of your golem")
+    def shutdown(self) -> str:  # pylint: disable=no-self-use
+
+        sync_wait(Account.client.gracefull_shutdown())
+
+        return "Gracefull shutdown triggered with success"
+
 
 def _fmt(value: float, unit: str = "GNT") -> str:
     return "{:.6f} {}".format(value / denoms.ether, unit)

--- a/golem/node.py
+++ b/golem/node.py
@@ -206,24 +206,26 @@ class Node(object):  # pylint: disable=too-few-public-methods
     def show_terms():
         return TermsOfUse.show_terms()
 
-    def gracefull_shutdown(self):
-        # is in shutdown? turn off as toggle?
+    def graceful_shutdown(self):
+        # is in shutdown? turn off as toggle
         if self._config_desc.in_shutdown:
             self.client.update_setting('in_shutdown', False)
             logger.info('Turning off shutdown mode')
-            return
+            return 'off'
 
         # is not providing nor requesting, normal shutdown
         if not self._is_task_in_progress():
             logger.info('Node not working, executing normal shutdown')
             self.quit()
-            return
+            return 'quit'
 
         # configure in_shutdown
         logger.info('Enabling shutdown mode, no more tasks can be started')
         self.client.update_setting('in_shutdown', True)
 
-        # subscrive to events
+        # subscribe to events
+
+        return 'on'
 
     def check_shutdown(self):
         # is not in shutdown?
@@ -245,7 +247,8 @@ class Node(object):  # pylint: disable=too-few-public-methods
             logger.debug('_is_task_in_progress? requestor=%r', True)
             return True
         task_provider_progress = task_server.task_computer.assigned_subtasks
-        logger.debug('_is_task_in_progress? provider=%r, requestor=False', task_provider_progress)
+        logger.debug('_is_task_in_progress? provider=%r, requestor=False',
+                     task_provider_progress)
         return task_provider_progress
 
     def _check_terms(self) -> Optional[Deferred]:

--- a/golem/node.py
+++ b/golem/node.py
@@ -261,8 +261,8 @@ class Node(object):  # pylint: disable=too-few-public-methods
             logger.debug('_is_task_in_progress? False: task_manager=None')
             return False
 
-        task_requester_progress = task_server.task_manager.get_progresses()
-        if task_requester_progress:
+        task_requestor_progress = task_server.task_manager.get_progresses()
+        if task_requestor_progress:
             logger.debug('_is_task_in_progress? requestor=%r', True)
             return True
 

--- a/golem/node.py
+++ b/golem/node.py
@@ -249,7 +249,7 @@ class Node(object):  # pylint: disable=too-few-public-methods
         task_provider_progress = task_server.task_computer.assigned_subtasks
         logger.debug('_is_task_in_progress? provider=%r, requestor=False',
                      task_provider_progress)
-        return task_provider_progress
+        return task_provider_progress != {}
 
     def _check_terms(self) -> Optional[Deferred]:
         if not self.rpc_session:

--- a/golem/rpc/mapping/rpcmethodnames.py
+++ b/golem/rpc/mapping/rpcmethodnames.py
@@ -105,6 +105,6 @@ NODE_METHOD_MAP = dict(
     accept_terms=           'golem.terms.accept',
     show_terms=             'golem.terms.show',
 
-    gracefull_shutdown=     'golem.gracefull_shutdown',
+    graceful_shutdown=      'golem.graceful_shutdown',
     quit=                   'ui.quit',
 )

--- a/golem/rpc/mapping/rpcmethodnames.py
+++ b/golem/rpc/mapping/rpcmethodnames.py
@@ -105,5 +105,6 @@ NODE_METHOD_MAP = dict(
     accept_terms=           'golem.terms.accept',
     show_terms=             'golem.terms.show',
 
+    gracefull_shutdown=     'golem.gracefull_shutdown',
     quit=                   'ui.quit',
 )

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -95,7 +95,6 @@ class TaskComputer(object):
             and not task_server.config_desc.in_shutdown
         self.finished_cb = finished_cb
 
-
     def task_given(self, ctd):
         if ctd['subtask_id'] in self.assigned_subtasks:
             return False
@@ -121,9 +120,13 @@ class TaskComputer(object):
                             "But I'm busy with another one. Ignoring.",
                             task_id)
                         return  # busy
-                    self.__compute_task(subtask_id, subtask['docker_images'],
-                                        subtask['src_code'], subtask['extra_data'],
-                                        subtask['short_description'], subtask['deadline'])
+                    self.__compute_task(
+                        subtask_id,
+                        subtask['docker_images'],
+                        subtask['src_code'],
+                        subtask['extra_data'],
+                        subtask['short_description'],
+                        subtask['deadline'])
                     self.waiting_for_task = None
                 return True
             else:
@@ -135,11 +138,17 @@ class TaskComputer(object):
             if subtask_id in self.assigned_subtasks:
                 subtask = self.assigned_subtasks[subtask_id]
                 if unpack_delta:
-                    self.task_server.unpack_delta(self.dir_manager.get_task_resource_dir(task_id), self.delta, task_id)
+                    rs_dir = self.dir_manager.get_task_resource_dir(task_id)
+                    self.task_server.unpack_delta(rs_dir, self.delta, task_id)
                 self.delta = None
                 self.last_task_timeout_checking = time.time()
-                self.__compute_task(subtask_id, subtask['docker_images'], subtask['src_code'], subtask['extra_data'],
-                                    subtask['short_description'], subtask['deadline'])
+                self.__compute_task(
+                    subtask_id,
+                    subtask['docker_images'],
+                    subtask['src_code'],
+                    subtask['extra_data'],
+                    subtask['short_description'],
+                    subtask['deadline'])
                 return True
             return False
 
@@ -163,11 +172,11 @@ class TaskComputer(object):
                 self.delta = delta
 
     def task_request_rejected(self, task_id, reason):
-        logger.info("Task {} request rejected: {}".format(task_id, reason))
+        logger.info("Task %r request rejected: %r", task_id, reason)
 
     def resource_request_rejected(self, subtask_id, reason):
-        logger.info("Task {} resource request rejected: {}".format(subtask_id,
-                                                                   reason))
+        logger.info("Task %r resource request rejected: %r",
+                    subtask_id, reason)
         self.assigned_subtasks.pop(subtask_id, None)
         self.reset()
 

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -41,7 +41,8 @@ class TaskComputer(object):
     lock = Lock()
     dir_lock = Lock()
 
-    def __init__(self, node_name, task_server, use_docker_manager=True) -> None:
+    def __init__(self, node_name, task_server, use_docker_manager=True,
+                 finished_cb=None) -> None:
         """ Create new task computer instance
         :param node_name:
         :param task_server:
@@ -92,6 +93,8 @@ class TaskComputer(object):
         # Should this node behave as provider and compute tasks?
         self.compute_tasks = task_server.config_desc.accept_tasks \
             and not task_server.config_desc.in_shutdown
+        self.finished_cb = finished_cb
+
 
     def task_given(self, ctd):
         if ctd['subtask_id'] in self.assigned_subtasks:
@@ -231,6 +234,8 @@ class TaskComputer(object):
                         success=was_success, value=work_time_to_be_paid)
 
         self.counting_task = None
+        if self.finished_cb:
+            self.finished_cb()
 
     def run(self):
         """ Main loop of task computer """
@@ -419,6 +424,9 @@ class TaskComputer(object):
                 "Host direct task not supported",
             )
             self.counting_task = None
+            if self.finished_cb:
+                self.finished_cb()
+
             return
 
         self.counting_thread = tt

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -90,7 +90,8 @@ class TaskComputer(object):
         self.last_task_timeout_checking = None
         self.support_direct_computation = False
         # Should this node behave as provider and compute tasks?
-        self.compute_tasks = task_server.config_desc.accept_tasks
+        self.compute_tasks = task_server.config_desc.accept_tasks \
+            and not task_server.config_desc.in_shutdown
 
     def task_given(self, ctd):
         if ctd['subtask_id'] in self.assigned_subtasks:
@@ -274,7 +275,8 @@ class TaskComputer(object):
         self.task_request_frequency = config_desc.task_request_interval
         self.waiting_for_task_session_timeout = \
             config_desc.waiting_for_task_session_timeout
-        self.compute_tasks = config_desc.accept_tasks
+        self.compute_tasks = config_desc.accept_tasks \
+            and not config_desc.in_shutdown
         return self.change_docker_config(config_desc, run_benchmarks,
                                          in_background)
 

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -253,9 +253,10 @@ class TaskComputer(object):
                 self.counting_thread.check_timeout()
         elif self.compute_tasks and self.runnable:
             if not self.waiting_for_task:
-                if time.time() - self.last_task_request > self.task_request_frequency:
-                    if self.counting_thread is None:
-                        self.__request_task()
+                last_request = time.time() - self.last_task_request
+                if last_request > self.task_request_frequency \
+                        and self.counting_thread is None:
+                    self.__request_task()
             elif self.use_waiting_deadline:
                 if self.waiting_deadline < time.time():
                     self.reset()

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -1004,5 +1004,6 @@ class TaskManager(TaskEventListener):
 
         logger.info('taskOp %r', op)
 
-        if op and TaskOp.is_completed(op):
+        if persist and op and op.task_related() and op.is_completed():
+            logger.info('Finished_cb')
             self.finished_cb()

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -687,7 +687,7 @@ class TaskManager(TaskEventListener):
             for s in list(ts.subtask_states.values()):
                 if s.subtask_status.is_computed():
                     if cur_time > s.deadline:
-                        logger.info("Subtask {} dies".format(s.subtask_id))
+                        logger.info("Subtask %r dies", s.subtask_id)
                         s.subtask_status = SubtaskStatus.failure
                         nodes_with_timeouts.append(s.computer.node_id)
                         t.computation_failed(s.subtask_id)
@@ -697,7 +697,7 @@ class TaskManager(TaskEventListener):
                                                  op=SubtaskOp.TIMEOUT)
             # Check task timeout
             if cur_time > th.deadline:
-                logger.info("Task {} dies".format(th.task_id))
+                logger.info("Task %r dies", th.task_id)
                 self.tasks_states[th.task_id].status = TaskStatus.timeout
                 # TODO: t.tell_it_has_timeout()?
                 self.notice_task_updated(th.task_id, op=TaskOp.TIMEOUT)

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -718,12 +718,10 @@ class TaskManager(TaskEventListener):
                     t.get_total_tasks(),
                     t.get_active_tasks(),
                     t.get_progress(),
-                    None,  # t.short_extra_data_repr(extra_data={})
+                    t.short_extra_data_repr(2200.0)
                 )  # FIXME in short_extra_data_repr should there be extra data
                 # Issue #2460
                 tasks_progresses[task_id] = ltss
-
-        logger.info('all progress %r', tasks_progresses)
 
         return tasks_progresses
 
@@ -1002,9 +1000,6 @@ class TaskManager(TaskEventListener):
             op=op,
         )
 
-        logger.info('taskOp %r', op)
-
         if self.finished_cb and persist and op \
                 and op.task_related() and op.is_completed():
-            logger.info('Finished_cb')
             self.finished_cb()

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -718,7 +718,7 @@ class TaskManager(TaskEventListener):
                     t.get_total_tasks(),
                     t.get_active_tasks(),
                     t.get_progress(),
-                    None, # t.short_extra_data_repr(extra_data={})
+                    None,  # t.short_extra_data_repr(extra_data={})
                 )  # FIXME in short_extra_data_repr should there be extra data
                 # Issue #2460
                 tasks_progresses[task_id] = ltss
@@ -815,8 +815,8 @@ class TaskManager(TaskEventListener):
 
         self.dir_manager.clear_temporary(task_id)
         self.remove_dump(task_id)
-        self.finished_cb()
-
+        if self.finished_cb:
+            self.finished_cb()
 
     @handle_task_key_error
     def query_task_state(self, task_id):
@@ -1004,6 +1004,7 @@ class TaskManager(TaskEventListener):
 
         logger.info('taskOp %r', op)
 
-        if persist and op and op.task_related() and op.is_completed():
+        if self.finished_cb and persist and op \
+                and op.task_related() and op.is_completed():
             logger.info('Finished_cb')
             self.finished_cb()

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -72,7 +72,7 @@ class TaskManager(TaskEventListener):
             self, node_name, node, keys_auth, listen_address="",
             listen_port=0, root_path="res", use_distributed_resources=True,
             tasks_dir="tasks", task_persistence=True,
-            apps_manager=AppsManager()):
+            apps_manager=AppsManager(), finished_cb=None):
         super().__init__()
 
         self.apps_manager = apps_manager
@@ -119,6 +119,8 @@ class TaskManager(TaskEventListener):
         )
 
         self.requestor_stats_manager = RequestorTaskStatsManager()
+
+        self.finished_cb = finished_cb
 
         if self.task_persistence:
             self.restore_tasks()
@@ -680,10 +682,7 @@ class TaskManager(TaskEventListener):
             if self.tasks_states[th.task_id].status not in self.activeStatus:
                 continue
             cur_time = get_timestamp_utc()
-            if cur_time > th.deadline:
-                logger.info("Task {} dies".format(th.task_id))
-                self.tasks_states[th.task_id].status = TaskStatus.timeout
-                self.notice_task_updated(th.task_id, op=TaskOp.TIMEOUT)
+            # Check subtask timeout
             ts = self.tasks_states[th.task_id]
             for s in list(ts.subtask_states.values()):
                 if s.subtask_status.is_computed():
@@ -696,22 +695,35 @@ class TaskManager(TaskEventListener):
                         self.notice_task_updated(th.task_id,
                                                  subtask_id=s.subtask_id,
                                                  op=SubtaskOp.TIMEOUT)
+            # Check task timeout
+            if cur_time > th.deadline:
+                logger.info("Task {} dies".format(th.task_id))
+                self.tasks_states[th.task_id].status = TaskStatus.timeout
+                # TODO: t.tell_it_has_timeout()?
+                self.notice_task_updated(th.task_id, op=TaskOp.TIMEOUT)
         return nodes_with_timeouts
 
     def get_progresses(self):
         tasks_progresses = {}
 
         for t in list(self.tasks.values()):
-            if t.get_progress() < 1.0:
+            task_id = t.header.task_id
+            task_status = self.tasks_states[task_id].status
+            in_progress = not TaskStatus.is_completed(task_status)
+            logger.info('Collecting progress %r %r %r',
+                        task_id, task_status, in_progress)
+            if in_progress:
                 ltss = LocalTaskStateSnapshot(
-                    t.header.task_id,
+                    task_id,
                     t.get_total_tasks(),
                     t.get_active_tasks(),
                     t.get_progress(),
-                    t.short_extra_data_repr(2200.0)
+                    None, # t.short_extra_data_repr(extra_data={})
                 )  # FIXME in short_extra_data_repr should there be extra data
                 # Issue #2460
-                tasks_progresses[t.header.task_id] = ltss
+                tasks_progresses[task_id] = ltss
+
+        logger.info('all progress %r', tasks_progresses)
 
         return tasks_progresses
 
@@ -803,6 +815,8 @@ class TaskManager(TaskEventListener):
 
         self.dir_manager.clear_temporary(task_id)
         self.remove_dump(task_id)
+        self.finished_cb()
+
 
     @handle_task_key_error
     def query_task_state(self, task_id):
@@ -977,11 +991,18 @@ class TaskManager(TaskEventListener):
         # self.save_state()
         if persist and self.task_persistence:
             self.dump_task(task_id)
+
+        task_state = self.tasks_states.get(task_id)
         dispatcher.send(
             signal='golem.taskmanager',
             event='task_status_updated',
             task_id=task_id,
-            task_state=self.tasks_states.get(task_id),
+            task_state=task_state,
             subtask_id=subtask_id,
             op=op,
         )
+
+        logger.info('taskOp %r', op)
+
+        if op and TaskOp.is_completed(op):
+            self.finished_cb()

--- a/golem/task/taskrequestorstats.py
+++ b/golem/task/taskrequestorstats.py
@@ -146,9 +146,7 @@ class TaskInfo:
             if (msg.op in [TaskOp.CREATED, TaskOp.RESTORED]
                     and not start_time):
                 start_time = msg.ts
-            elif (msg.op in [TaskOp.FINISHED, TaskOp.NOT_ACCEPTED,
-                             TaskOp.ABORTED, TaskOp.TIMEOUT]
-                  and not finish_time):
+            elif msg.op.is_completed() and not finish_time:
                 finish_time = msg.ts
 
         assert finish_time >= start_time

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -54,7 +54,8 @@ class TaskServer(
                  use_ipv6=False,
                  use_docker_manager=True,
                  task_archiver=None,
-                 apps_manager=AppsManager()) -> None:
+                 apps_manager=AppsManager(),
+                 task_finished_cb=None) -> None:
         self.client = client
         self.keys_auth = client.keys_auth
         self.config_desc = config_desc
@@ -73,7 +74,8 @@ class TaskServer(
             use_distributed_resources=config_desc.
             use_distributed_resource_management,
             tasks_dir=os.path.join(client.datadir, 'tasks'),
-            apps_manager=apps_manager
+            apps_manager=apps_manager,
+            finished_cb=task_finished_cb,
         )
         benchmarks = self.task_manager.apps_manager.get_benchmarks()
         self.benchmark_manager = BenchmarkManager(config_desc.node_name, self,

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -84,7 +84,8 @@ class TaskServer(
         self.task_computer = TaskComputer(
             config_desc.node_name,
             task_server=self,
-            use_docker_manager=udmm)
+            use_docker_manager=udmm,
+            finished_cb=task_finished_cb)
         self.task_connections_helper = TaskConnectionsHelper()
         self.task_connections_helper.task_server = self
         self.task_sessions = {}
@@ -427,8 +428,7 @@ class TaskServer(
             sender_node_id, subtask_id, settled_ts)
 
     def subtask_failure(self, subtask_id, err):
-        logger.info("Computation for task {} failed: {}.".format(
-            subtask_id, err))
+        logger.info("Computation for task %r failed: %r.", subtask_id, err)
         node_id = self.task_manager.get_node_id_for_subtask(subtask_id)
         Trust.COMPUTED.decrease(node_id)
         self.task_manager.task_computation_failure(subtask_id, err)

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -92,7 +92,7 @@ class TaskStatus(Enum):
     restarted = "Restart"
 
     def is_completed(self) -> bool:
-        return self in [self.finished, self.aborted, self.timeout]
+        return self in [self.finished, self.aborted, self.timeout, self.restarted]
 
 
 class SubtaskStatus(Enum):
@@ -130,6 +130,8 @@ class Operation(Enum):
     def unnoteworthy() -> bool:
         return False
 
+    def is_completed(self) -> bool:
+        pass
 
 class TaskOp(Operation):
     """Ops that result in storing of task level information"""
@@ -137,6 +139,14 @@ class TaskOp(Operation):
     @staticmethod
     def task_related() -> bool:
         return True
+
+    def is_completed(self) -> bool:
+        return self in [
+            TaskOp.FINISHED,
+            TaskOp.NOT_ACCEPTED,
+            TaskOp.TIMEOUT,
+            TaskOp.RESTARTED,
+            TaskOp.ABORTED]
 
     WORK_OFFER_RECEIVED = auto()
     CREATED = auto()

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -92,7 +92,8 @@ class TaskStatus(Enum):
     restarted = "Restart"
 
     def is_completed(self) -> bool:
-        return self in [self.finished, self.aborted, self.timeout, self.restarted]
+        return self in [self.finished, self.aborted,
+                        self.timeout, self.restarted]
 
 
 class SubtaskStatus(Enum):
@@ -132,6 +133,7 @@ class Operation(Enum):
 
     def is_completed(self) -> bool:
         pass
+
 
 class TaskOp(Operation):
     """Ops that result in storing of task level information"""

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -123,7 +123,9 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
             )
         }
 
-        tc = TaskComputer("ABC", task_server, use_docker_manager=False)
+        mock_finished = mock.Mock()
+        tc = TaskComputer("ABC", task_server, use_docker_manager=False,
+                          finished_cb=mock_finished)
 
         self.assertEqual(len(tc.assigned_subtasks), 0)
         tc.task_given(ctd)
@@ -149,6 +151,8 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         assert tc.counting_thread is not None
         self.assertGreater(tc.counting_thread.time_to_compute, 9)
         self.assertLessEqual(tc.counting_thread.time_to_compute, 10)
+        mock_finished.assert_called_once()
+        mock_finished.reset_mock()
         self.__wait_for_tasks(tc)
 
         prev_task_failed_count = task_server.send_task_failed.call_count
@@ -161,6 +165,8 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         self.assertEqual(args[0], "xxyyzz")
         self.assertEqual(args[1], "xyz")
         self.assertEqual(args[2]["data"], 10000)
+        mock_finished.assert_called_once()
+        mock_finished.reset_mock()
 
         ctd['subtask_id'] = "aabbcc"
         ctd['src_code'] = "raise Exception('some exception')"
@@ -180,6 +186,8 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         self.assertIsNone(tc.assigned_subtasks.get("aabbcc"))
         task_server.send_task_failed.assert_called_with(
             "aabbcc", "xyz", 'some exception')
+        mock_finished.assert_called_once()
+        mock_finished.reset_mock()
 
         ctd['subtask_id'] = "aabbcc2"
         ctd['src_code'] = "print('Hello world')"
@@ -190,6 +198,8 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
 
         task_server.send_task_failed.assert_called_with(
             "aabbcc2", "xyz", "Wrong result format")
+        mock_finished.assert_called_once()
+        mock_finished.reset_mock()
 
         task_server.task_keeper.task_headers["xyz"].deadline = \
             timeout_to_deadline(20)
@@ -207,9 +217,13 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         ctd['deadline'] = timeout_to_deadline(1)
         tc.task_given(ctd)
         self.assertTrue(tc.task_resource_collected("xyz"))
+        mock_finished.assert_called_once()
+        mock_finished.reset_mock()
         tt = tc.counting_thread
         tc.task_computed(tc.counting_thread)
         self.assertIsNone(tc.counting_thread)
+        mock_finished.assert_called_once()
+        mock_finished.reset_mock()
         task_server.send_task_failed.assert_called_with(
             "xxyyzz2", "xyz", "Wrong result format")
         tt.end_comp()

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -151,7 +151,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         assert tc.counting_thread is not None
         self.assertGreater(tc.counting_thread.time_to_compute, 9)
         self.assertLessEqual(tc.counting_thread.time_to_compute, 10)
-        mock_finished.assert_called_once()
+        mock_finished.assert_called_once_with()
         mock_finished.reset_mock()
         self.__wait_for_tasks(tc)
 
@@ -165,7 +165,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         self.assertEqual(args[0], "xxyyzz")
         self.assertEqual(args[1], "xyz")
         self.assertEqual(args[2]["data"], 10000)
-        mock_finished.assert_called_once()
+        mock_finished.assert_called_once_with()
         mock_finished.reset_mock()
 
         ctd['subtask_id'] = "aabbcc"
@@ -186,7 +186,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         self.assertIsNone(tc.assigned_subtasks.get("aabbcc"))
         task_server.send_task_failed.assert_called_with(
             "aabbcc", "xyz", 'some exception')
-        mock_finished.assert_called_once()
+        mock_finished.assert_called_once_with()
         mock_finished.reset_mock()
 
         ctd['subtask_id'] = "aabbcc2"
@@ -198,7 +198,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
 
         task_server.send_task_failed.assert_called_with(
             "aabbcc2", "xyz", "Wrong result format")
-        mock_finished.assert_called_once()
+        mock_finished.assert_called_once_with()
         mock_finished.reset_mock()
 
         task_server.task_keeper.task_headers["xyz"].deadline = \
@@ -217,12 +217,12 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         ctd['deadline'] = timeout_to_deadline(1)
         tc.task_given(ctd)
         self.assertTrue(tc.task_resource_collected("xyz"))
-        mock_finished.assert_called_once()
+        mock_finished.assert_called_once_with()
         mock_finished.reset_mock()
         tt = tc.counting_thread
         tc.task_computed(tc.counting_thread)
         self.assertIsNone(tc.counting_thread)
-        mock_finished.assert_called_once()
+        mock_finished.assert_called_once_with()
         mock_finished.reset_mock()
         task_server.send_task_failed.assert_called_with(
             "xxyyzz2", "xyz", "Wrong result format")

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -704,9 +704,9 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             self.tm.check_timeouts()
             assert self.tm.tasks_states["qwe"].status == TaskStatus.timeout
             assert self.tm.tasks_states["qwe"].subtask_states[
-                       "qwerty"].subtask_status == SubtaskStatus.failure
-            checker([("qwe", None, TaskOp.TIMEOUT),
-                     ("qwe", "qwerty", SubtaskOp.TIMEOUT)])
+                "qwerty"].subtask_status == SubtaskStatus.failure
+            checker([("qwe", "qwerty", SubtaskOp.TIMEOUT),
+                     ("qwe", None, TaskOp.TIMEOUT)])
             del handler
 
     def test_task_event_listener(self):

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -84,7 +84,8 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             Node(),
             keys_auth,
             root_path=self.path,
-            task_persistence=True
+            task_persistence=True,
+            finished_cb=Mock()
         )
         self.tm.key_id = "KEYID"
         self.tm.listen_address = "10.10.10.10"
@@ -460,6 +461,8 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
                       verify_subtasks={"aabbcc": True})
         self.tm.add_new_task(t2)
         self.tm.start_task(t2.header.task_id)
+        progress = self.tm.get_progresses()
+        assert progress != {}
         ctd, wrong_task, should_wait = self.tm.get_next_subtask("DEF", "DEF",
                                                                 "abc", 1030, 10,
                                                                 10000, 10000,

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -925,7 +925,7 @@ class TestOptNode(TempDirFixture):
 
         result = self.node._is_task_in_progress()
 
-        assert result == False
+        assert result is False
         assert mock_tm.get_progresses.called
 
     def test__is_task_in_progress_in_progress(self, *_):
@@ -938,11 +938,11 @@ class TestOptNode(TempDirFixture):
         self.node.client.task_server.task_manager = mock_tm
         self.node.client.task_server.task_computer = mock_tc
 
-        mock_tm.get_progresses = Mock(return_value={'a':'a'})
+        mock_tm.get_progresses = Mock(return_value={'a': 'a'})
 
         result = self.node._is_task_in_progress()
 
-        assert result == True
+        assert result is True
         assert mock_tm.get_progresses.called
 
     def test__is_task_in_progress_quit(self, *_):
@@ -955,10 +955,10 @@ class TestOptNode(TempDirFixture):
         self.node.client.task_server.task_manager = mock_tm
         self.node.client.task_server.task_computer = mock_tc
 
-        mock_tm.get_progresses = Mock(return_value={'a':'a'})
-        mock_tc.assigned_subtasks = {'a':'a'}
+        mock_tm.get_progresses = Mock(return_value={'a': 'a'})
+        mock_tc.assigned_subtasks = {'a': 'a'}
 
         result = self.node._is_task_in_progress()
 
-        assert result == True
+        assert result is True
         assert mock_tm.get_progresses.called

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -880,7 +880,8 @@ class TestOptNode(TempDirFixture):
 
         result = self.node.graceful_shutdown()
         assert result == 'off'
-        assert self.node.client.update_settings.called_with('in_shutdown', False)
+        assert self.node.client.update_settings.called_with('in_shutdown',
+                                                            False)
         assert self.node._is_task_in_progress.not_called
         assert self.node.client.quit.not_called
         assert self.node._reactor.stop.not_called
@@ -903,7 +904,8 @@ class TestOptNode(TempDirFixture):
         assert self.node.client.quit.not_called
         assert self.node._is_task_in_progress.called
         assert result == 'on'
-        assert self.node.client.update_settings.called_with('in_shutdown', True)
+        assert self.node.client.update_settings.called_with('in_shutdown'
+                                                            True)
 
         self.node._config_desc.in_shutdown = True
         self.node._is_task_in_progress = Mock(return_value=False)

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -865,17 +865,12 @@ class TestOptNode(TempDirFixture):
         assert self.node.client.quit.called
         assert self.node._reactor.stop.called
 
-    @patch('golem.node.Database')
-    @patch('threading.Thread', MockThread)
-    @patch('twisted.internet.reactor', create=True)
-    def test_graceful_shutdown_off(self, reactor, *_):
-        reactor.running = True
-
+    def test_graceful_shutdown_off(self, *_):
         self.node_kwargs['config_desc'].in_shutdown = True
 
         self.node = Node(**self.node_kwargs)
+        self.node.quit = Mock()
         self.node.client = Mock()
-        self.node._reactor.callFromThread = call_now
         self.node._is_task_in_progress = Mock(return_value=False)
 
         result = self.node.graceful_shutdown()
@@ -883,33 +878,57 @@ class TestOptNode(TempDirFixture):
         assert self.node.client.update_settings.called_with('in_shutdown',
                                                             False)
         assert self.node._is_task_in_progress.not_called
-        assert self.node.client.quit.not_called
-        assert self.node._reactor.stop.not_called
+        assert self.node.quit.not_called
 
-    @patch('golem.node.Database')
-    @patch('threading.Thread', MockThread)
-    @patch('twisted.internet.reactor', create=True)
-    def test_graceful_shutdown_on(self, reactor, *_):
-        reactor.running = True
-
+    def test_graceful_shutdown_on(self, *_):
         self.node = Node(**self.node_kwargs)
+        self.node.quit = Mock()
         self.node.client = Mock()
         self.node._reactor.callFromThread = call_now
         self.node._is_task_in_progress = Mock(return_value=True)
 
         self.node.check_shutdown()
-        assert self.node.client.quit.not_called
+        assert self.node.quit.not_called
 
         result = self.node.graceful_shutdown()
-        assert self.node.client.quit.not_called
-        assert self.node._is_task_in_progress.called
         assert result == 'on'
-        assert self.node.client.update_settings.called_with('in_shutdown'
+        assert self.node.client.update_settings.called_with('in_shutdown',
                                                             True)
+        assert self.node.quit.not_called
+        assert self.node._is_task_in_progress.called
 
         self.node._config_desc.in_shutdown = True
         self.node._is_task_in_progress = Mock(return_value=False)
         self.node.check_shutdown()
         assert self.node._is_task_in_progress.called
-        assert self.node.client.quit.called
-        assert self.node._reactor.stop.called
+        assert self.node.quit.called
+
+    def test__is_task_in_progress_no_shutdown(self, *_):
+        self.node = Node(**self.node_kwargs)
+        self.node.quit = Mock()
+
+        self.node.check_shutdown()
+
+        assert self.node.quit.not_called
+
+    def test__is_task_in_progress_in_progress(self, *_):
+        self.node_kwargs['config_desc'].in_shutdown = True
+
+        self.node = Node(**self.node_kwargs)
+        self.node.quit = Mock()
+        self.node._is_task_in_progress = Mock(return_value=True)
+
+        self.node.check_shutdown()
+
+        assert self.node.quit.not_called
+
+    def test__is_task_in_progress_quit(self, *_):
+        self.node_kwargs['config_desc'].in_shutdown = True
+
+        self.node = Node(**self.node_kwargs)
+        self.node.quit = Mock()
+        self.node._is_task_in_progress = Mock(return_value=False)
+
+        self.node.check_shutdown()
+
+        assert self.node.quit.called

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -100,7 +100,8 @@ class TestNode(TestWithDatabase):
                                        use_docker_manager=True,
                                        concent_variant=concent_disabled,
                                        use_monitor=False,
-                                       apps_manager=ANY)
+                                       apps_manager=ANY,
+                                       task_finished_cb=node.check_shutdown)
         self.assertEqual(
             self.node_kwargs['config_desc'].node_address,
             mock_client.mock_calls[0][2]['config_desc'].node_address,
@@ -164,7 +165,8 @@ class TestNode(TestWithDatabase):
                                        use_docker_manager=True,
                                        concent_variant=concent_disabled,
                                        use_monitor=False,
-                                       apps_manager=ANY)
+                                       apps_manager=ANY,
+                                       task_finished_cb=node.check_shutdown)
 
     def test_geth_address_wo_http_should_fail(self, *_):
         runner = CliRunner()
@@ -241,7 +243,8 @@ class TestNode(TestWithDatabase):
                                        use_docker_manager=True,
                                        concent_variant=concent_disabled,
                                        use_monitor=False,
-                                       apps_manager=ANY)
+                                       apps_manager=ANY,
+                                       task_finished_cb=node.check_shutdown)
 
     @patch('golem.node.Node')
     def test_mainnet_should_be_passed_to_node(self, mock_node, *_):
@@ -288,7 +291,8 @@ class TestNode(TestWithDatabase):
                                        use_docker_manager=True,
                                        concent_variant=concent_disabled,
                                        use_monitor=False,
-                                       apps_manager=ANY)
+                                       apps_manager=ANY,
+                                       task_finished_cb=node.check_shutdown)
 
     @patch('golem.node.Node')
     def test_net_testnet_should_be_passed_to_node(self, mock_node, *_):
@@ -448,7 +452,8 @@ class TestNode(TestWithDatabase):
                                        use_docker_manager=True,
                                        concent_variant=concent_disabled,
                                        use_monitor=False,
-                                       apps_manager=ANY)
+                                       apps_manager=ANY,
+                                       task_finished_cb=node.check_shutdown)
 
     @patch('golem.node.Node')
     def test_single_peer(self, mock_node: MagicMock, *_):

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -907,7 +907,7 @@ class TestOptNode(TempDirFixture):
         self.node = Node(**self.node_kwargs)
         self.node.quit = Mock()
 
-        self.node.check_shutdown()
+        self.node._is_task_in_progress()
 
         assert self.node.quit.not_called
 
@@ -918,7 +918,7 @@ class TestOptNode(TempDirFixture):
         self.node.quit = Mock()
         self.node._is_task_in_progress = Mock(return_value=True)
 
-        self.node.check_shutdown()
+        self.node._is_task_in_progress()
 
         assert self.node.quit.not_called
 
@@ -929,6 +929,6 @@ class TestOptNode(TempDirFixture):
         self.node.quit = Mock()
         self.node._is_task_in_progress = Mock(return_value=False)
 
-        self.node.check_shutdown()
+        self.node._is_task_in_progress()
 
         assert self.node.quit.called


### PR DESCRIPTION
- Added new setting `in_shutdown`
- On `init()` from `Client` this setting gets set to `False`
- Added new rpc call `graceful_shutdown` to be called from cli / gui and control the `in_shutdown` setting
- Added `golemcli account shutdown` to call rpc
- As provider `in_shutdown` disables new tasks like the setting `accept_tasks`
- As requestor, `in_shutdown` raises an error like "out of eth"
- Added handler `node.check_shutdown` to be called from `taskcomputer` and `taskmanager` when a task is done.
- Check `subtask` timeouts before `task` timeouts in `taskmanager`