### PR TITLE
Convert GNT to GNTB asap

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -187,6 +187,7 @@ class Client(HardwarePresetsMixin):
             start_port=start_geth_port,
             address=geth_address,
         )
+        self.transaction_system.start()
 
         self.funds_locker = FundsLocker(self.transaction_system,
                                         Path(self.datadir))

--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -2,13 +2,12 @@ import calendar
 import logging
 import time
 from collections import defaultdict
-from typing import Dict, List, Optional
+from typing import Dict, List
 from threading import Lock
 
 from sortedcontainers import SortedListWithKey
-from ethereum.utils import normalize_address, denoms
+from ethereum.utils import denoms
 from pydispatch import dispatcher
-import requests
 
 import golem_sci
 from golem.core.variables import PAYMENT_DEADLINE

--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -56,10 +56,12 @@ class PaymentProcessor:
         self._inprogress: Dict[str, List[Payment]] = {}  # Sent transactions.
         self.load_from_db()
 
-    def get_reserved_eth(self) -> int:
+    @property
+    def reserved_eth(self) -> int:
         return self._eth_reserved + self.ETH_BATCH_PAYMENT_BASE
 
-    def get_reserved_gntb(self) -> int:
+    @property
+    def reserved_gntb(self) -> int:
         return self._gntb_reserved
 
     def get_gas_cost_per_payment(self) -> int:

--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -2,7 +2,6 @@ import calendar
 import logging
 import time
 from collections import defaultdict
-from datetime import datetime
 from typing import Dict, List, Optional
 from threading import Lock
 
@@ -12,15 +11,12 @@ from pydispatch import dispatcher
 import requests
 
 import golem_sci
-from golem_sci.gntconverter import GNTConverter
-from golem.core.service import LoopingCallService
 from golem.core.variables import PAYMENT_DEADLINE
 from golem.model import db, Payment, PaymentStatus
 from golem.utils import encode_hex
 
 log = logging.getLogger("golem.pay")
 
-DONATE_URL_TEMPLATE = "http://188.165.227.180:4000/donate/{}"
 # We reserve 30 minutes for the payment to go through
 PAYMENT_MAX_DELAY = PAYMENT_DEADLINE - 30 * 60
 
@@ -28,24 +24,6 @@ PAYMENT_MAX_DELAY = PAYMENT_DEADLINE - 30 * 60
 def get_timestamp() -> int:
     """This is platform independent timestamp, needed for payments logic"""
     return calendar.timegm(time.gmtime())
-
-
-def tETH_faucet_donate(addr):
-    addr = normalize_address(addr)
-    request = DONATE_URL_TEMPLATE.format(addr.hex())
-    response = requests.get(request)
-    if response.status_code != 200:
-        log.error("tETH Faucet error code {}".format(response.status_code))
-        return False
-    response = response.json()
-    if response['paydate'] == 0:
-        log.warning("tETH Faucet warning {}".format(response['message']))
-        return False
-    # The paydate is not actually very reliable, usually some day in the past.
-    paydate = datetime.fromtimestamp(response['paydate'])
-    amount = int(response['amount']) / denoms.ether
-    log.info("Faucet: {:.6f} ETH on {}".format(amount, paydate))
-    return True
 
 
 def _make_batch_payments(payments: List[Payment]) -> List[golem_sci.Payment]:
@@ -59,91 +37,30 @@ def _make_batch_payments(payments: List[Payment]) -> List[golem_sci.Payment]:
 
 
 # pylint: disable=too-many-instance-attributes
-class PaymentProcessor(LoopingCallService):
+class PaymentProcessor:
     # Minimal number of confirmations before we treat transactions as done
-    REQUIRED_CONFIRMATIONS = 12
+    REQUIRED_CONFIRMATIONS = 6
 
     CLOSURE_TIME_DELAY = 2
     # Don't try to use more than 75% of block gas limit
     BLOCK_GAS_LIMIT_RATIO = 0.75
 
-    def __init__(self,
-                 sci,
-                 faucet=False) -> None:
+    def __init__(self, sci) -> None:
         self.ETH_BATCH_PAYMENT_BASE = \
             sci.GAS_PRICE * sci.GAS_BATCH_PAYMENT_BASE
         self._sci = sci
-        self._gnt_converter = GNTConverter(sci)
-        self.__eth_balance: Optional[int] = None
-        self.__gnt_balance: Optional[int] = None
-        self.__gntb_balance: Optional[int] = None
-        self.__eth_reserved = 0
-        self.__gntb_reserved = 0
+        self._eth_reserved = 0
+        self._gntb_reserved = 0
         self._awaiting_lock = Lock()
         self._awaiting = SortedListWithKey(key=lambda p: p.processed_ts)
         self._inprogress: Dict[str, List[Payment]] = {}  # Sent transactions.
-        self.__faucet = faucet
         self.load_from_db()
-        self._last_gnt_update = None
-        self._last_eth_update = None
-        self._last_balance_log = 0
-        super().__init__(13)
 
-    def balance_known(self):
-        return self.__gnt_balance is not None and \
-            self.__gntb_balance is not None and \
-            self.__eth_balance is not None
+    def get_reserved_eth(self) -> int:
+        return self._eth_reserved + self.ETH_BATCH_PAYMENT_BASE
 
-    def eth_balance(self, refresh=False):
-        if self.__eth_balance is None or refresh:
-            balance = self._sci.get_eth_balance(self._sci.get_eth_address())
-            if balance is not None:
-                self.__eth_balance = balance
-                self._last_eth_update = time.mktime(
-                    datetime.today().timetuple())
-            else:
-                log.warning("Failed to retrieve ETH balance")
-        return (self.__eth_balance, self._last_eth_update)
-
-    def gnt_balance(self, refresh=False):
-        if self.__gnt_balance is None or self.__gntb_balance is None or refresh:
-            gnt_balance = self._sci.get_gnt_balance(
-                self._sci.get_eth_address())
-            if gnt_balance is not None:
-                self.__gnt_balance = \
-                    gnt_balance + self._gnt_converter.get_gate_balance()
-            else:
-                log.warning("Failed to retrieve GNT balance")
-
-            gntb_balance = self._sci.get_gntb_balance(
-                self._sci.get_eth_address())
-            if gntb_balance is not None:
-                self.__gntb_balance = gntb_balance
-            else:
-                log.warning("Failed to retrieve GNTB balance")
-
-            if self.__gnt_balance is not None and \
-               self.__gntb_balance is not None:
-                self._last_gnt_update = time.mktime(
-                    datetime.today().timetuple())
-
-        return (self.__gnt_balance + self.__gntb_balance,
-                self._last_gnt_update)
-
-    def _eth_reserved(self):
-        return self.__eth_reserved + self.ETH_BATCH_PAYMENT_BASE
-
-    def _eth_available(self):
-        """ Returns available ETH balance for new payments fees."""
-        eth_balance, _ = self.eth_balance()
-        return eth_balance - self._eth_reserved()
-
-    def _gnt_reserved(self):
-        return self.__gntb_reserved
-
-    def _gnt_available(self):
-        gnt_balance, _ = self.gnt_balance()
-        return gnt_balance - self.__gntb_reserved
+    def get_reserved_gntb(self) -> int:
+        return self._gntb_reserved
 
     def get_gas_cost_per_payment(self) -> int:
         gas_price = \
@@ -183,30 +100,19 @@ class PaymentProcessor(LoopingCallService):
 
             self._awaiting.add(payment)
 
-        self.__gntb_reserved += payment.value
-        self.__eth_reserved += self.get_gas_cost_per_payment()
+        self._gntb_reserved += payment.value
+        self._eth_reserved += self.get_gas_cost_per_payment()
 
-        log.info("GNT: available {:.6f}, reserved {:.6f}".format(
-            self._gnt_available() / denoms.ether,
-            self.__gntb_reserved / denoms.ether))
-
-        if self.__gntb_balance is not None and (self.__gnt_balance or 0) > 0:
-            if self.__gntb_reserved > self.__gntb_balance:
-                if not self._gnt_converter.is_converting():
-                    log.info(
-                        'Will convert %f GNT to be ready for payments',
-                        self.__gnt_balance / denoms.ether,
-                    )
-                    self._gnt_converter.convert(self.__gnt_balance)
+        log.info("GNTB reserved %.6f", self._gntb_reserved / denoms.ether)
 
     def __get_next_batch(
             self,
             payments: List[Payment],
             closure_time: int) -> int:
-        gntb_balance = self.__gntb_balance
-        if not gntb_balance:
+        gntb_balance = self._sci.get_gntb_balance(self._sci.get_eth_address())
+        eth_balance = self._sci.get_eth_balance(self._sci.get_eth_address())
+        if not gntb_balance or not eth_balance:
             return 0
-        eth_balance, _ = self.eth_balance()
         eth_balance = eth_balance - self.ETH_BATCH_PAYMENT_BASE
         ind = 0
         eth_per_payment = self.get_gas_cost_per_payment()
@@ -249,21 +155,10 @@ class PaymentProcessor(LoopingCallService):
                 log.info("Next sendout in {} s".format(deadline - now))
                 return False
 
-            if self._gnt_converter.is_converting():
-                log.info('Waiting for GNT-GNTB conversion')
-                return False
-
             payments_count = self.__get_next_batch(
                 self._awaiting.copy(),
                 now - self.CLOSURE_TIME_DELAY,
             )
-            if payments_count < len(self._awaiting) and self.__gnt_balance:
-                log.info(
-                    'Will convert %r GNT before sending out payments',
-                    self.__gnt_balance / denoms.ether,
-                )
-                self._gnt_converter.convert(self.__gnt_balance)
-                return False
             if payments_count == 0:
                 return False
             payments = self._awaiting[:payments_count]
@@ -298,9 +193,9 @@ class PaymentProcessor(LoopingCallService):
 
         # Remove from reserved, because we monitor the pending block.
         # TODO: Maybe we should only monitor the latest block? issue #2414
-        self.__gntb_reserved -= value
+        self._gntb_reserved -= value
         with self._awaiting_lock:
-            self.__eth_reserved = \
+            self._eth_reserved = \
                 len(self._awaiting) * self.get_gas_cost_per_payment()
         return True
 
@@ -367,68 +262,7 @@ class PaymentProcessor(LoopingCallService):
             for p in payments:
                 self.add(p)
 
-    def get_ether_from_faucet(self):
-        eth_balance, _ = self.eth_balance(True)
-        if eth_balance is None:
-            return False
-
-        if self.__faucet and eth_balance < 0.01 * denoms.ether:
-            log.info("Requesting tETH")
-            tETH_faucet_donate(self._sci.get_eth_address())
-            return False
-        return True
-
-    def get_gnt_from_faucet(self):
-        gnt_balance, _ = self.gnt_balance(True)
-        if gnt_balance is None:
-            return False
-
-        if self.__faucet and gnt_balance < 100 * denoms.ether:
-            # During GNT-GNTB convertion gnt_balance will be zero, but we don't
-            # want to request GNT from faucet again
-            if self._gnt_converter.is_converting():
-                return False
-            log.info("Requesting GNT from faucet")
-            self._sci.request_gnt_from_faucet()
-            return False
-        return True
-
-    def _send_balance_snapshot(self):
-        dispatcher.send(
-            signal='golem.monitor',
-            event='balance_snapshot',
-            eth_balance=self.__eth_balance,
-            gnt_balance=self.__gnt_balance,
-            gntb_balance=self.__gntb_balance
-        )
-
-    def _run(self):
-        if self._sci.is_synchronized() and \
-                self.get_ether_from_faucet() and \
-                self.get_gnt_from_faucet():
-
-            if time.time() - self._last_balance_log > 60:
-                log.info("ETH: %.10f,  GNT: %.3f,  GNTB: %.3f",
-                         self.__eth_balance / denoms.ether,
-                         self.__gnt_balance / denoms.ether,
-                         self.__gntb_balance / denoms.ether)
-                self._last_balance_log = time.time()
-
+    def run(self) -> None:
+        if self._sci.is_synchronized():
             self.monitor_progress()
             self.sendout()
-
-    def stop(self):
-        self.sendout(0)
-        super().stop()
-
-    def sync(self) -> None:
-        log.info("Synchronizing balances")
-        self._sci.wait_until_synchronized()
-        while True:
-            self.eth_balance(True)
-            self.gnt_balance(True)
-            if self.balance_known():
-                log.info("Balances synchronized")
-                return
-            log.info("Waiting for initial GNT/ETH balances...")
-            time.sleep(1)

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -1,10 +1,14 @@
+from datetime import datetime
 import logging
+import time
 from typing import List
 
 from ethereum.utils import privtoaddr, denoms
 from eth_utils import encode_hex, is_address
+import requests
 
 from golem_sci import new_sci, chains
+from golem_sci.gntconverter import GNTConverter
 from golem.ethereum.node import NodeProcess
 from golem.ethereum.paymentprocessor import PaymentProcessor
 from golem.transactions.ethereum.ethereumincomeskeeper \
@@ -13,6 +17,25 @@ from golem.transactions.ethereum.exceptions import NotEnoughFunds
 from golem.transactions.transactionsystem import TransactionSystem
 
 log = logging.getLogger('golem.pay')
+
+DONATE_URL_TEMPLATE = "http://188.165.227.180:4000/donate/{}"
+
+
+def tETH_faucet_donate(addr: str):
+    request = DONATE_URL_TEMPLATE.format(addr)
+    response = requests.get(request)
+    if response.status_code != 200:
+        log.error("tETH Faucet error code {}".format(response.status_code))
+        return False
+    response = response.json()
+    if response['paydate'] == 0:
+        log.warning("tETH Faucet warning {}".format(response['message']))
+        return False
+    # The paydate is not actually very reliable, usually some day in the past.
+    paydate = datetime.fromtimestamp(response['paydate'])
+    amount = int(response['amount']) / denoms.ether
+    log.info("Faucet: {:.6f} ETH on {}".format(amount, paydate))
+    return True
 
 
 class EthereumTransactionSystem(TransactionSystem):
@@ -38,26 +61,37 @@ class EthereumTransactionSystem(TransactionSystem):
             lambda tx: tx.sign(node_priv_key),
             chains.MAINNET if mainnet else chains.RINKEBY,
         )
-        self.payment_processor = PaymentProcessor(
-            sci=self._sci,
-            faucet=not mainnet,
-        )
+        self._gnt_converter = GNTConverter(self._sci)
+        self._faucet = not mainnet
+        self.payment_processor = PaymentProcessor(self._sci)
 
         super().__init__(
             incomes_keeper=EthereumIncomesKeeper(self._sci),
         )
 
-        self.payment_processor.start()
+        self._eth_balance: Optional[int] = None
+        self._gnt_balance: Optional[int] = None
+        self._gntb_balance: Optional[int] = None
+        self._last_eth_update = None
+        self._last_gnt_update = None
 
     def stop(self):
-        if self.payment_processor.running:
-            self.payment_processor.stop()
+        super().stop()
+        self.payment_processor.sendout(0)
         self.incomes_keeper.stop()
         self._sci.stop()
         self._node.stop()
 
     def sync(self) -> None:
-        self.payment_processor.sync()
+        log.info("Synchronizing balances")
+        self._sci.wait_until_synchronized()
+        while True:
+            self._refresh_balances()
+            if self._balance_known():
+                log.info("Balances synchronized")
+                return
+            log.info("Waiting for initial GNT/ETH balances...")
+            time.sleep(1)
 
     def add_payment_info(self, *args, **kwargs):
         payment = super().add_payment_info(*args, **kwargs)
@@ -69,12 +103,12 @@ class EthereumTransactionSystem(TransactionSystem):
         return self._sci.get_eth_address()
 
     def get_balance(self):
-        if not self.payment_processor.balance_known():
+        if not self._balance_known():
             return None, None, None, None, None
-        gnt, last_gnt_update = self.payment_processor.gnt_balance()
-        av_gnt = self.payment_processor._gnt_available()
-        eth, last_eth_update = self.payment_processor.eth_balance()
-        return gnt, av_gnt, eth, last_gnt_update, last_eth_update
+        gnt_total = self._gnt_balance + self._gntb_balance
+        gnt_av = gnt_total - self.payment_processor.get_reserved_gntb()
+        return gnt_total, gnt_av, self._eth_balance, \
+            self._last_gnt_update, self._last_eth_update
 
     def eth_for_batch_payment(self, num_payments: int) -> int:
         return self.payment_processor.get_gas_cost_per_payment() * num_payments
@@ -87,8 +121,7 @@ class EthereumTransactionSystem(TransactionSystem):
         if currency == 'ETH':
             return 21000 * gas_price
         if currency == 'GNT':
-            total_gnt = \
-                self.payment_processor._gnt_available()  # pylint: disable=W0212
+            total_gnt = self._gnt_balance + self._gntb_balance
             gnt = self._sci.get_gnt_balance(self._sci.get_eth_address())
             gntb = total_gnt - gnt
             if gnt >= amount:
@@ -110,7 +143,7 @@ class EthereumTransactionSystem(TransactionSystem):
 
         pp = self.payment_processor
         if currency == 'ETH':
-            eth = pp._eth_available()  # pylint: disable=W0212
+            eth = self._eth_balance - pp.get_reserved_eth()
             if amount > eth - lock:
                 raise NotEnoughFunds(amount, eth - lock, currency)
             log.info(
@@ -121,7 +154,7 @@ class EthereumTransactionSystem(TransactionSystem):
             return [self._sci.transfer_eth(destination, amount)]
 
         if currency == 'GNT':
-            total_gnt = pp._gnt_available()  # pylint: disable=W0212
+            total_gnt = self._gnt_balance + self._gntb_balance
             if amount > total_gnt - lock:
                 raise NotEnoughFunds(amount, total_gnt - lock, currency)
             gnt = self._sci.get_gnt_balance(self._sci.get_eth_address())
@@ -156,3 +189,63 @@ class EthereumTransactionSystem(TransactionSystem):
             return res
 
         raise ValueError('Unknown currency {}'.format(currency))
+
+    def _get_ether_from_faucet(self) -> None:
+        if not self._faucet:
+            return
+        if self._eth_balance < 0.01 * denoms.ether:
+            log.info("Requesting tETH from faucet")
+            tETH_faucet_donate(self._sci.get_eth_address())
+
+    def _get_gnt_from_faucet(self) -> None:
+        if not self._faucet or self._eth_balance < 0.001 * denoms.ether:
+            return
+        if self._gnt_balance + self._gntb_balance < 100 * denoms.ether:
+            log.info("Requesting GNT from faucet")
+            self._sci.request_gnt_from_faucet()
+
+    def _balance_known(self) -> bool:
+        return self._last_eth_update is not None and \
+            self._last_gnt_update is not None
+
+    def _refresh_balances(self) -> None:
+        addr = self._sci.get_eth_address()
+
+        eth_balance = self._sci.get_eth_balance(addr)
+        if eth_balance is not None:
+            self._eth_balance = eth_balance
+            self._last_eth_update = time.mktime(datetime.today().timetuple())
+        else:
+            log.warning("Failed to retrieve ETH balance")
+
+        gnt_balance = self._sci.get_gnt_balance(addr)
+        if gnt_balance is not None:
+            self._gnt_balance = \
+                gnt_balance + self._gnt_converter.get_gate_balance()
+        else:
+            log.warning("Failed to retrieve GNT balance")
+
+        gntb_balance = self._sci.get_gntb_balance(addr)
+        if gntb_balance is not None:
+            self._gntb_balance = gntb_balance
+            # Update the last update time if both GNT and GNTB were updated
+            if gnt_balance is not None:
+                self._last_gnt_update = \
+                    time.mktime(datetime.today().timetuple())
+        else:
+            log.warning("Failed to retrieve GNTB balance")
+
+    def _run(self) -> None:
+        self._refresh_balances()
+        self._get_ether_from_faucet()
+        self._get_gnt_from_faucet()
+
+        if self._balance_known() and not self._gnt_converter.is_converting():
+            if self._gnt_balance > 0 and self._eth_balance > 0:
+                log.info(
+                    "Converting %f GNT to GNTB",
+                    self._gnt_balance / denoms.ether,
+                )
+                self._gnt_converter.convert(self._gnt_balance)
+
+        self.payment_processor.run()

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -23,11 +23,11 @@ DONATE_URL_TEMPLATE = "http://188.165.227.180:4000/donate/{}"
 
 def tETH_faucet_donate(addr: str):
     request = DONATE_URL_TEMPLATE.format(addr)
-    response = requests.get(request)
-    if response.status_code != 200:
-        log.error("tETH Faucet error code {}".format(response.status_code))
+    resp = requests.get(request)
+    if resp.status_code != 200:
+        log.error("tETH Faucet error code {}".format(resp.status_code))
         return False
-    response = response.json()
+    response = resp.json()
     if response['paydate'] == 0:
         log.warning("tETH Faucet warning {}".format(response['message']))
         return False

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -106,7 +106,7 @@ class EthereumTransactionSystem(TransactionSystem):
         if not self._balance_known():
             return None, None, None, None, None
         gnt_total = self._gnt_balance + self._gntb_balance
-        gnt_av = gnt_total - self.payment_processor.get_reserved_gntb()
+        gnt_av = gnt_total - self.payment_processor.reserved_gntb
         return gnt_total, gnt_av, self._eth_balance, \
             self._last_gnt_update, self._last_eth_update
 
@@ -143,7 +143,7 @@ class EthereumTransactionSystem(TransactionSystem):
 
         pp = self.payment_processor
         if currency == 'ETH':
-            eth = self._eth_balance - pp.get_reserved_eth()
+            eth = self._eth_balance - pp.reserved_eth
             if amount > eth - lock:
                 raise NotEnoughFunds(amount, eth - lock, currency)
             log.info(

--- a/golem/transactions/transactionsystem.py
+++ b/golem/transactions/transactionsystem.py
@@ -1,13 +1,14 @@
 from typing import List
 
 from golem.core.common import datetime_to_timestamp_utc, to_unicode
+from golem.core.service import LoopingCallService
 from golem.model import Payment, PaymentStatus, PaymentDetails
 
 from .paymentskeeper import PaymentsKeeper
 from .incomeskeeper import IncomesKeeper
 
 
-class TransactionSystem(object):
+class TransactionSystem(LoopingCallService):
     """ Transaction system.
     Keeps information about budget, expected payments, etc. """
 
@@ -25,6 +26,8 @@ class TransactionSystem(object):
 
         # Keeps information about received payments
         self.incomes_keeper = incomes_keeper
+
+        super().__init__(13)
 
     def add_payment_info(self, task_id, subtask_id, value, account_info):
         """ Add to payment keeper information about new payment for subtask.

--- a/tests/golem/task/dummy/runner.py
+++ b/tests/golem/task/dummy/runner.py
@@ -83,9 +83,8 @@ def create_client(datadir):
     database = Database(
         db, fields=DB_FIELDS, models=DB_MODELS, db_dir=datadir)
 
-    with mock.patch('golem.transactions.ethereum.ethereumtransactionsystem.'
-                    'PaymentProcessor') as pp:
-        _configure_mock_payment_processor(pp.return_value)
+    with mock.patch('golem.client.EthereumTransactionSystem') as ets:
+        _configure_mock_ets(ets.return_value)
         return Client(datadir=datadir,
                       app_config=app_config,
                       config_desc=config_desc,
@@ -96,13 +95,17 @@ def create_client(datadir):
                       use_docker_manager=False)
 
 
-def _configure_mock_payment_processor(pp):
-    pp.ETH_BATCH_PAYMENT_BASE = 0.01 * denoms.ether
-    pp.get_gas_cost_per_payment.return_value = 0.001 * denoms.ether
-    pp.gnt_balance.return_value = 5000 * denoms.ether, time.time()
-    pp.eth_balance.return_value = 300 * denoms.ether, time.time()
-    pp._eth_available.return_value = 5000 * denoms.ether
-    pp._gnt_available.return_value = 3000 * denoms.ether
+def _configure_mock_ets(ets):
+    ets.get_balance.return_value = (
+        1000 * denoms.ether,
+        1000 * denoms.ether,
+        1000 * denoms.ether,
+        time.time(),
+        time.time(),
+    )
+    ets.eth_for_batch_payment.return_value = 0.0001 * denoms.ether
+    ets.eth_base_for_batch_payment.return_value = 0.001 * denoms.ether
+    ets.get_payment_address = '0x' + 40 * 'a'
 
 
 def run_requesting_node(datadir, num_subtasks=3):

--- a/tests/golem/task/dummy/runner.py
+++ b/tests/golem/task/dummy/runner.py
@@ -105,7 +105,7 @@ def _configure_mock_ets(ets):
     )
     ets.eth_for_batch_payment.return_value = 0.0001 * denoms.ether
     ets.eth_base_for_batch_payment.return_value = 0.001 * denoms.ether
-    ets.get_payment_address = '0x' + 40 * 'a'
+    ets.get_payment_address.return_value = '0x' + 40 * 'a'
 
 
 def run_requesting_node(datadir, num_subtasks=3):

--- a/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
+++ b/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
@@ -33,29 +33,26 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
     @patch('golem.core.service.LoopingCallService.running',
            new_callable=PropertyMock)
     def test_stop(self, mock_is_service_running):
-        ets_pkg = 'golem.transactions.ethereum.ethereumtransactionsystem.'
-
-        def _init(self, *args, **kwargs):
-            self.rpcport = 65001
-            self._NodeProcess__ps = None
-            self.web3 = Mock()
-
         with patch('twisted.internet.task.LoopingCall.start'), \
                 patch('twisted.internet.task.LoopingCall.stop'), \
-                patch(ets_pkg + 'new_sci'), \
-                patch(ets_pkg + 'GNTConverter'), \
-                patch(ets_pkg + 'PaymentProcessor'), \
-                patch(ets_pkg + 'NodeProcess'):
+                patch('golem.transactions.ethereum.ethereumtransactionsystem.'
+                      'new_sci'), \
+                patch('golem.transactions.ethereum.ethereumtransactionsystem.'
+                      'GNTConverter'), \
+                patch('golem.transactions.ethereum.ethereumtransactionsystem.'
+                      'PaymentProcessor'), \
+                patch('golem.transactions.ethereum.ethereumtransactionsystem.'
+                      'NodeProcess'):
 
             mock_is_service_running.return_value = False
             e = EthereumTransactionSystem(self.tempdir, PRIV_KEY)
-            e._node.start.assert_called_once_with(None)
+            e._node.start.assert_called_once_with(None)  # noqa pylint:disable=no-member
             e.start()
 
             mock_is_service_running.return_value = True
             e.stop()
-            e._node.stop.assert_called_once_with()
-            e.payment_processor.sendout.assert_called_once_with(0)
+            e._node.stop.assert_called_once_with()  # pylint:disable=no-member
+            e.payment_processor.sendout.assert_called_once_with(0)  # noqa pylint:disable=no-member
 
     @patch('golem.transactions.ethereum.ethereumtransactionsystem.NodeProcess',
            Mock())

--- a/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
+++ b/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
@@ -1,10 +1,10 @@
-import requests
 from os import urandom
 import unittest
 from unittest.mock import patch, Mock, ANY, PropertyMock
 
 from eth_utils import encode_hex
 import golem_sci
+import requests
 
 from golem import testutils
 from golem.tools.assertlogs import LogTestCase
@@ -33,7 +33,6 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
     @patch('golem.core.service.LoopingCallService.running',
            new_callable=PropertyMock)
     def test_stop(self, mock_is_service_running):
-        pkg = 'golem.ethereum.'
         ets_pkg = 'golem.transactions.ethereum.ethereumtransactionsystem.'
 
         def _init(self, *args, **kwargs):
@@ -46,17 +45,16 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
                 patch(ets_pkg + 'new_sci'), \
                 patch(ets_pkg + 'GNTConverter'), \
                 patch(ets_pkg + 'PaymentProcessor'), \
-                patch(pkg + 'node.NodeProcess.start'), \
-                patch(pkg + 'node.NodeProcess.stop'):
+                patch(ets_pkg + 'NodeProcess'):
 
             mock_is_service_running.return_value = False
             e = EthereumTransactionSystem(self.tempdir, PRIV_KEY)
-            assert e._node.start.called
+            e._node.start.assert_called_once_with(None)
             e.start()
 
             mock_is_service_running.return_value = True
             e.stop()
-            assert e._node.stop.called
+            e._node.stop.assert_called_once_with()
             e.payment_processor.sendout.assert_called_once_with(0)
 
     @patch('golem.transactions.ethereum.ethereumtransactionsystem.NodeProcess',

--- a/tests/golem/transactions/ethereum/test_paymentprocessor.py
+++ b/tests/golem/transactions/ethereum/test_paymentprocessor.py
@@ -5,8 +5,6 @@ import unittest
 import unittest.mock as mock
 from os import urandom
 
-import requests
-
 import golem_sci
 from eth_utils import encode_hex
 from ethereum.utils import denoms, privtoaddr
@@ -17,7 +15,6 @@ from twisted.internet.task import Clock
 from golem.core.common import timestamp_to_datetime
 from golem.ethereum.paymentprocessor import (
     PaymentProcessor,
-    tETH_faucet_donate,
     PAYMENT_MAX_DELAY,
 )
 from golem.model import Payment, PaymentStatus, PaymentDetails
@@ -42,10 +39,6 @@ class PaymentStatusTest(unittest.TestCase):
         s = PaymentStatus(1)
         assert s == PaymentStatus.awaiting
 
-    def test_status2(self):
-        s = PaymentStatus.awaiting
-        assert s == PaymentStatus.awaiting
-
 
 class PaymentProcessorInternalTest(DatabaseFixture):
     """ In this suite we test internal logic of PaymentProcessor. The final
@@ -60,17 +53,13 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         self.sci.GAS_PER_PAYMENT = 300
         self.sci.GAS_BATCH_PAYMENT_BASE = 30
         self.sci.get_eth_balance.return_value = 0
-        self.sci.get_gnt_balance.return_value = 0
         self.sci.get_gntb_balance.return_value = 0
         self.sci.get_eth_address.return_value = self.addr
-        self.sci.get_gate_address.return_value = None
         self.sci.get_current_gas_price.return_value = self.sci.GAS_PRICE
         latest_block = mock.Mock()
         latest_block.gas_limit = 10 ** 10
         self.sci.get_latest_block.return_value = latest_block
-        # FIXME: PaymentProcessor should be started and stopped! #2455
         self.pp = PaymentProcessor(self.sci)
-        self.pp._loopingCall.clock = Clock()  # Disable looping call.
         self.pp._gnt_converter = mock.Mock()
         self.pp._gnt_converter.is_converting.return_value = False
         self.pp._gnt_converter.get_gate_balance.return_value = 0
@@ -116,41 +105,9 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         }
         self.assertEqual(expected, self.pp._inprogress)
 
-    def test_eth_balance(self):
-        expected_balance = random.randint(0, 2**128 - 1)
-        self.sci.get_eth_balance.return_value = expected_balance
-        b, _ = self.pp.eth_balance()
-        assert b == expected_balance
-        b, _ = self.pp.eth_balance()
-        assert b == expected_balance
-        self.sci.get_eth_balance.assert_called_once_with(self.addr)
-
-    def test_gnt_balance(self):
-        expected_balance = 13
-        self.sci.get_gnt_balance.return_value = expected_balance
-        self.sci.get_gntb_balance.return_value = 0
-        b, _ = self.pp.gnt_balance()
-        assert b == expected_balance
-        self.sci.get_gnt_balance.return_value = 16
-        b, _ = self.pp.gnt_balance()
-        assert b == expected_balance
-        self.sci.get_gnt_balance.assert_called_once()
-
-    def test_eth_balance_refresh(self):
-        expected_balance = random.randint(0, 2**128 - 1)
-        self.sci.get_eth_balance.return_value = expected_balance
-        b, _ = self.pp.eth_balance()
-        assert b == expected_balance
-        self.sci.get_eth_balance.assert_called_once_with(self.addr)
-        b, _ = self.pp.eth_balance(refresh=True)
-        assert b == expected_balance
-        assert self.sci.get_eth_balance.call_count == 2
-
-    def test_available_eth(self):
-        eth = random.randint(1, 10 * denoms.ether)
-        self.sci.get_eth_balance.return_value = eth
-        eth_available = eth - self.pp.ETH_BATCH_PAYMENT_BASE
-        assert self.pp._eth_available() == eth_available
+    def test_reserved_eth(self):
+        assert self.pp.get_reserved_eth() == \
+            self.sci.GAS_BATCH_PAYMENT_BASE * self.sci.GAS_PRICE
 
     def test_add_invalid_payment_status(self):
         a1 = urandom(20)
@@ -164,12 +121,6 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         with self.assertRaises(RuntimeError):
             self.pp.add(p1)
 
-    @mock.patch('golem.ethereum.paymentprocessor.tETH_faucet_donate')
-    def test_faucet(self, donate):
-        self.pp._PaymentProcessor__faucet = True
-        self.pp.get_ether_from_faucet()
-        donate.assert_called_once_with(self.addr)
-
     def test_monitor_progress(self):
         inprogress = self.pp._inprogress
 
@@ -181,22 +132,16 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         self.sci.get_gntb_balance.return_value = balance_gntb
         self.pp.CLOSURE_TIME_DELAY = 0
 
-        assert self.pp._gnt_reserved() == 0
-        assert self.pp._gnt_available() == balance_gntb
-        assert self.pp._eth_reserved() == self.pp.ETH_BATCH_PAYMENT_BASE
-        eth_available = balance_eth - self.pp.ETH_BATCH_PAYMENT_BASE
-        assert self.pp._eth_available() == eth_available
+        assert self.pp.get_reserved_gntb() == 0
+        assert self.pp.get_reserved_eth() == self.pp.ETH_BATCH_PAYMENT_BASE
 
         gnt_value = 10**17
         p = Payment.create(subtask="p1", payee=urandom(20), value=gnt_value)
         self.pp.add(p)
-        assert self.pp._gnt_reserved() == gnt_value
-        assert self.pp._gnt_available() == balance_gntb - gnt_value
+        assert self.pp.get_reserved_gntb() == gnt_value
         eth_reserved = \
             self.pp.ETH_BATCH_PAYMENT_BASE + self.pp.get_gas_cost_per_payment()
-        assert self.pp._eth_reserved() == eth_reserved
-        eth_available = balance_eth - eth_reserved
-        assert self.pp._eth_available() == eth_available
+        assert self.pp.get_reserved_eth() == eth_reserved
 
         tx_hash = '0xdead'
         self.sci.batch_transfer.return_value = tx_hash
@@ -218,25 +163,13 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         assert len(inprogress) == 1
         assert tx_hash in inprogress
         assert inprogress[tx_hash] == [p]
-        gb, _ = self.pp.gnt_balance(True)
-        assert gb == balance_gntb - gnt_value
-        eb, _ = self.pp.eth_balance(True)
-        assert eb == balance_eth_after_sendout
-        assert self.pp._gnt_reserved() == 0
-        assert self.pp._gnt_available() == balance_gntb - gnt_value
-        assert self.pp._eth_reserved() == \
-            self.pp.ETH_BATCH_PAYMENT_BASE
-        assert self.pp._eth_available() == \
-            balance_eth_after_sendout - self.pp.ETH_BATCH_PAYMENT_BASE
+        assert self.pp.get_reserved_gntb() == 0
+        assert self.pp.get_reserved_eth() == self.pp.ETH_BATCH_PAYMENT_BASE
 
         self.pp.monitor_progress()
         assert len(inprogress) == 1
-        assert self.pp._gnt_reserved() == 0
-        assert self.pp._gnt_available() == balance_gntb - gnt_value
-        assert self.pp._eth_reserved() == \
-            self.pp.ETH_BATCH_PAYMENT_BASE
-        assert self.pp._eth_available() == \
-            balance_eth_after_sendout - self.pp.ETH_BATCH_PAYMENT_BASE
+        assert self.pp.get_reserved_gntb() == 0
+        assert self.pp.get_reserved_eth() == self.pp.ETH_BATCH_PAYMENT_BASE
 
         tx_block_number = 1337
         self.sci.get_block_number.return_value = tx_block_number
@@ -260,7 +193,7 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         self.assertEqual(p.details.block_number, tx_block_number)
         self.assertEqual(p.details.block_hash, 64 * 'f')
         self.assertEqual(p.details.fee, 55001 * self.sci.GAS_PRICE)
-        self.assertEqual(self.pp._gnt_reserved(), 0)
+        self.assertEqual(self.pp.get_reserved_gntb(), 0)
 
     def test_failed_transaction(self):
         inprogress = self.pp._inprogress
@@ -310,7 +243,7 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         self.assertEqual(p.details.block_number, tx_block_number)
         self.assertEqual(p.details.block_hash, 64 * 'f')
         self.assertEqual(p.details.fee, 55001 * self.sci.GAS_PRICE)
-        self.assertEqual(self.pp._gnt_reserved(), 0)
+        self.assertEqual(self.pp.get_reserved_gntb(), 0)
 
     def test_payment_timestamp(self):
         self.sci.get_eth_balance.return_value = denoms.ether
@@ -325,64 +258,6 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         with freeze_time(timestamp_to_datetime(new_ts)):
             self.pp.add(p)
         self.assertEqual(ts, p.processed_ts)
-
-    def test_get_ether_and_gnt_failure(self):
-        self.pp.monitor_progress = mock.Mock()
-        self.sci.is_synchronized.return_value = True
-        self.pp.sendout = mock.Mock()
-
-        self.pp.get_gnt_from_faucet = mock.Mock(return_value=False)
-        self.pp.get_ether_from_faucet = mock.Mock(return_value=False)
-
-        self.pp._run()
-        assert not self.pp.monitor_progress.called
-        assert not self.pp.sendout.called
-
-    def test_get_gnt_failure(self):
-        self.pp.monitor_progress = mock.Mock()
-        self.sci.is_synchronized.return_value = True
-        self.pp.sendout = mock.Mock()
-
-        self.pp.get_gnt_from_faucet = mock.Mock(return_value=False)
-        self.pp.get_ether_from_faucet = mock.Mock(return_value=True)
-
-        self.pp._run()
-        assert not self.pp.monitor_progress.called
-        assert not self.pp.sendout.called
-
-    def test_get_ether_and_gnt_succces(self):
-        self.pp.monitor_progress = mock.Mock()
-        self.sci.is_synchronized.return_value = True
-        self.pp.sendout = mock.Mock()
-
-        self.pp._run()
-        assert self.pp.monitor_progress.called
-        assert self.pp.sendout.called
-
-    def test_get_ether_sci_failure(self):
-        # given
-        self.pp.monitor_progress = mock.Mock()
-        self.sci.is_synchronized.return_value = True
-        self.pp.sendout = mock.Mock()
-
-        self.pp._PaymentProcessor__faucet = True
-
-        self.sci.get_eth_balance.return_value = None
-        self.sci.get_gnt_balance.return_value = None
-        self.sci.get_gntb_balance.return_value = None
-
-        # when
-        self.pp._run()
-
-        # then
-        assert not self.pp.monitor_progress.called
-        assert not self.pp.sendout.called
-
-    def test_sendout_on_stop(self):
-        self.pp.sendout = mock.Mock()
-        self.pp.start()
-        self.pp.stop()
-        self.pp.sendout.assert_called_once_with(0)
 
 
 def make_awaiting_payment(value=None, ts=None):
@@ -427,19 +302,6 @@ class InteractionWithSmartContractInterfaceTest(DatabaseFixture):
         for expected, actual in zip(payments, called_payments):
             assert expected.payee == actual.payee
             assert expected.amount == actual.amount
-
-    def test_faucet(self):
-        self.pp._PaymentProcessor__faucet = True
-
-        self.sci.get_gnt_balance.return_value = 1000 * denoms.ether
-        self.sci.get_gntb_balance.return_value = 1000 * denoms.ether
-        self.assertTrue(self.pp.get_gnt_from_faucet())
-        self.sci.request_from_faucet.assert_not_called()
-
-        self.sci.get_gnt_balance.return_value = 0
-        self.sci.get_gntb_balance.return_value = 0
-        self.assertFalse(self.pp.get_gnt_from_faucet())
-        self.sci.request_gnt_from_faucet.assert_called_once()
 
     def test_batch_transfer(self):
         deadline = PAYMENT_MAX_DELAY
@@ -541,7 +403,6 @@ class InteractionWithSmartContractInterfaceTest(DatabaseFixture):
             self.sci.batch_transfer.reset_mock()
 
         self.sci.get_gntb_balance.return_value = 5 * denoms.ether
-        self.pp.gnt_balance(refresh=True)
         with freeze_time(timestamp_to_datetime(10000)):
             self.pp.sendout(0)
             self._assert_batch_transfer_called_with(
@@ -572,7 +433,6 @@ class InteractionWithSmartContractInterfaceTest(DatabaseFixture):
             self.sci.batch_transfer.reset_mock()
 
         self.sci.get_gntb_balance.return_value = 10 * denoms.ether
-        self.pp.gnt_balance(refresh=True)
         with freeze_time(timestamp_to_datetime(10000)):
             self.pp.sendout(0)
             self._assert_batch_transfer_called_with(
@@ -602,7 +462,6 @@ class InteractionWithSmartContractInterfaceTest(DatabaseFixture):
             self.sci.batch_transfer.reset_mock()
 
         self.sci.get_eth_balance.return_value = denoms.ether
-        self.pp.eth_balance(refresh=True)
         with freeze_time(timestamp_to_datetime(10000)):
             self.pp.sendout(0)
             self._assert_batch_transfer_called_with(
@@ -668,35 +527,3 @@ class InteractionWithSmartContractInterfaceTest(DatabaseFixture):
                 [scip1],
                 1)
             self.sci.batch_transfer.reset_mock()
-
-
-class FaucetTest(unittest.TestCase):
-
-    @mock.patch('requests.get')
-    def test_error_code(self, get):
-        addr = urandom(20)
-        response = mock.Mock(spec=requests.Response)
-        response.status_code = 500
-        get.return_value = response
-        assert tETH_faucet_donate(addr) is False
-
-    @mock.patch('requests.get')
-    def test_error_msg(self, get):
-        addr = urandom(20)
-        response = mock.Mock(spec=requests.Response)
-        response.status_code = 200
-        response.json.return_value = {'paydate': 0, 'message': "Ooops!"}
-        get.return_value = response
-        assert tETH_faucet_donate(addr) is False
-
-    @mock.patch('requests.get')
-    def test_success(self, get):
-        addr = urandom(20)
-        response = mock.Mock(spec=requests.Response)
-        response.status_code = 200
-        response.json.return_value = {'paydate': 1486605259,
-                                      'amount': 999999999999999}
-        get.return_value = response
-        assert tETH_faucet_donate(addr) is True
-        assert get.call_count == 1
-        assert encode_hex(addr)[2:] in get.call_args[0][0]

--- a/tests/golem/transactions/ethereum/test_paymentprocessor.py
+++ b/tests/golem/transactions/ethereum/test_paymentprocessor.py
@@ -106,7 +106,7 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         self.assertEqual(expected, self.pp._inprogress)
 
     def test_reserved_eth(self):
-        assert self.pp.get_reserved_eth() == \
+        assert self.pp.reserved_eth == \
             self.sci.GAS_BATCH_PAYMENT_BASE * self.sci.GAS_PRICE
 
     def test_add_invalid_payment_status(self):
@@ -132,16 +132,16 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         self.sci.get_gntb_balance.return_value = balance_gntb
         self.pp.CLOSURE_TIME_DELAY = 0
 
-        assert self.pp.get_reserved_gntb() == 0
-        assert self.pp.get_reserved_eth() == self.pp.ETH_BATCH_PAYMENT_BASE
+        assert self.pp.reserved_gntb == 0
+        assert self.pp.reserved_eth == self.pp.ETH_BATCH_PAYMENT_BASE
 
         gnt_value = 10**17
         p = Payment.create(subtask="p1", payee=urandom(20), value=gnt_value)
         self.pp.add(p)
-        assert self.pp.get_reserved_gntb() == gnt_value
+        assert self.pp.reserved_gntb == gnt_value
         eth_reserved = \
             self.pp.ETH_BATCH_PAYMENT_BASE + self.pp.get_gas_cost_per_payment()
-        assert self.pp.get_reserved_eth() == eth_reserved
+        assert self.pp.reserved_eth == eth_reserved
 
         tx_hash = '0xdead'
         self.sci.batch_transfer.return_value = tx_hash
@@ -163,13 +163,13 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         assert len(inprogress) == 1
         assert tx_hash in inprogress
         assert inprogress[tx_hash] == [p]
-        assert self.pp.get_reserved_gntb() == 0
-        assert self.pp.get_reserved_eth() == self.pp.ETH_BATCH_PAYMENT_BASE
+        assert self.pp.reserved_gntb == 0
+        assert self.pp.reserved_eth == self.pp.ETH_BATCH_PAYMENT_BASE
 
         self.pp.monitor_progress()
         assert len(inprogress) == 1
-        assert self.pp.get_reserved_gntb() == 0
-        assert self.pp.get_reserved_eth() == self.pp.ETH_BATCH_PAYMENT_BASE
+        assert self.pp.reserved_gntb == 0
+        assert self.pp.reserved_eth == self.pp.ETH_BATCH_PAYMENT_BASE
 
         tx_block_number = 1337
         self.sci.get_block_number.return_value = tx_block_number
@@ -193,7 +193,7 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         self.assertEqual(p.details.block_number, tx_block_number)
         self.assertEqual(p.details.block_hash, 64 * 'f')
         self.assertEqual(p.details.fee, 55001 * self.sci.GAS_PRICE)
-        self.assertEqual(self.pp.get_reserved_gntb(), 0)
+        self.assertEqual(self.pp.reserved_gntb, 0)
 
     def test_failed_transaction(self):
         inprogress = self.pp._inprogress
@@ -243,7 +243,7 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         self.assertEqual(p.details.block_number, tx_block_number)
         self.assertEqual(p.details.block_hash, 64 * 'f')
         self.assertEqual(p.details.fee, 55001 * self.sci.GAS_PRICE)
-        self.assertEqual(self.pp.get_reserved_gntb(), 0)
+        self.assertEqual(self.pp.reserved_gntb, 0)
 
     def test_payment_timestamp(self):
         self.sci.get_eth_balance.return_value = denoms.ether

--- a/tests/golem/transactions/ethereum/test_paymentprocessor.py
+++ b/tests/golem/transactions/ethereum/test_paymentprocessor.py
@@ -6,11 +6,10 @@ import unittest.mock as mock
 from os import urandom
 
 import golem_sci
+from golem_sci.interface import TransactionReceipt
 from eth_utils import encode_hex
 from ethereum.utils import denoms, privtoaddr
 from freezegun import freeze_time
-from golem_sci.interface import TransactionReceipt
-from twisted.internet.task import Clock
 
 from golem.core.common import timestamp_to_datetime
 from golem.ethereum.paymentprocessor import (


### PR DESCRIPTION
The idea is to convert GNT to GNTB as soon as it is possible and make the rest of the system not aware of GNT at all and only operate on GNTB which makes a lot of stuff easier (eg. deposits to Concent).

I removed a bunch of stuff from PaymentProcessor and moved some stuff to EthereumTransactionSystem. This removes some dependencies and makes PaymentProcessor closer to have only one responsibility.
