### PR TITLE
* bump `golem-messages to 2.9.3` -> fixes the potential inadvertent setting of `TTC.concent_enabled=True` for concent-disabled requestors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ eth-keys==0.1.0b4
 eth-tester==0.1.0b15
 eth-utils==0.7.4
 ethereum==1.6.1
-Golem-Messages==2.9.1
+Golem-Messages==2.9.3
 Golem-Smart-Contracts-Interface==1.1.0
 Golem-Verificator==1.0.7
 h2==3.0.1

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -53,7 +53,7 @@ token_bucket==0.2.0
 py-cpuinfo==3.3.0
 humanize==0.5.1
 raven
-Golem-Messages==2.9.1
+Golem-Messages==2.9.3
 Golem-Smart-Contracts-Interface==1.1.0
 Golem-Verificator==1.0.7
 html2text==2018.1.9

--- a/tests/golem/task/test_concent_logic.py
+++ b/tests/golem/task/test_concent_logic.py
@@ -288,3 +288,17 @@ class ReactToWantToComputeTaskTestCase(unittest.TestCase):
         self.msg.concent_enabled = False
         self.task_session.concent_service.enabled = True
         self.assert_allowed(send_mock)
+
+    def test_concent_disabled_wtct_concent_flag_none(self, send_mock):
+        self.msg.concent_enabled = None
+        self.task_session.concent_service.enabled = False
+        self.task_session.task_manager.get_next_subtask.return_value = (
+            factories.tasks.ComputeTaskDefFactory(),
+            False,
+            True
+        )
+        self.task_session._react_to_want_to_compute_task(self.msg)
+        send_mock.assert_called()
+        ttc = send_mock.call_args_list[2][0][0]
+        self.assertIsInstance(ttc, message.tasks.TaskToCompute)
+        self.assertFalse(ttc.concent_enabled)

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -449,6 +449,7 @@ class TestTaskSession(ConcentMessageMixin, LogTestCase,
         ts.task_manager = MagicMock()
         ts.task_computer = Mock()
         ts.task_server = Mock()
+        ts.concent_service.enabled = False
         ts.send = Mock()
 
         env = Mock()
@@ -819,7 +820,8 @@ class ForceReportComputedTaskTestCase(testutils.DatabaseFixture,
     def test_send_report_computed_task_concent_success(self):
         wtr = factories.taskserver.WaitingTaskResultFactory(
             task_id=self.task_id, subtask_id=self.subtask_id, owner=self.n)
-        self._mock_task_to_compute(self.task_id, self.subtask_id, self.node_id)
+        self._mock_task_to_compute(self.task_id, self.subtask_id, self.node_id,
+                                   concent_enabled=True)
         self.ts.send_report_computed_task(
             wtr, wtr.owner.pub_addr, wtr.owner.pub_port, "0x00", self.n)
 
@@ -837,7 +839,8 @@ class ForceReportComputedTaskTestCase(testutils.DatabaseFixture,
             task_id=self.task_id, subtask_id=self.subtask_id, owner=self.n,
             result=result, result_type=ResultType.FILES
         )
-        self._mock_task_to_compute(self.task_id, self.subtask_id, self.node_id)
+        self._mock_task_to_compute(self.task_id, self.subtask_id, self.node_id,
+                                   concent_enabled=True)
 
         self.ts.send_report_computed_task(
             wtr, wtr.owner.pub_addr, wtr.owner.pub_port, "0x00", self.n)


### PR DESCRIPTION
+ regression test

