### PR TITLE
#1625 Send failure messages to golem monitor

### DIFF
--- a/golem/monitor/model/subtaskfailedmodel.py
+++ b/golem/monitor/model/subtaskfailedmodel.py
@@ -1,0 +1,15 @@
+from .modelbase import BasicModel
+
+
+# pylint:disable=too-few-public-methods
+class SubtaskFailedModel(BasicModel):
+
+    # pylint:disable=too-many-arguments
+    def __init__(self, cliid, sessid, hardware, performance_values, task_id,
+                 subtask_id, reason):
+        super().__init__('SubtaskFailed', cliid, sessid)
+        self.hardware = hardware
+        self.performance_values = performance_values
+        self.task_id = task_id
+        self.subtask_id = subtask_id
+        self.reason = reason

--- a/golem/monitor/monitor.py
+++ b/golem/monitor/monitor.py
@@ -16,6 +16,7 @@ from .model.balancemodel import BalanceModel
 from .model.loginlogoutmodel import LoginModel, LogoutModel
 from .model.nodemetadatamodel import NodeInfoModel, NodeMetadataModel
 from .model.paymentmodel import ExpenditureModel, IncomeModel
+from .model.subtaskfailedmodel import SubtaskFailedModel
 from .model.taskcomputersnapshotmodel import TaskComputerSnapshotModel
 from .transport.sender import DefaultJSONSender as Sender
 
@@ -164,6 +165,20 @@ class SystemMonitor(object):
 
     def on_logout(self):
         self.sender_thread.send(LogoutModel(self.meta_data))
+
+    # pylint:disable=too-many-arguments
+    def on_compute_task_failed(self, hardware, performances,
+                               task_id, subtask_id, reason):
+        msg = SubtaskFailedModel(
+            self.meta_data.cliid,
+            self.meta_data.sessid,
+            hardware,
+            performances,
+            task_id,
+            subtask_id,
+            reason
+        )
+        self.sender_thread.send(msg)
 
     def on_stats_snapshot(self, known_tasks, supported_tasks, stats):
         msg = statssnapshotmodel.StatsSnapshotModel(

--- a/golem/resource/resourcehandshake.py
+++ b/golem/resource/resourcehandshake.py
@@ -295,6 +295,8 @@ class ResourceHandshakeSessionMixin:
         logger.info("Resource handshake error (%r): %r", key_id, error)
         self._block_peer(key_id)
         self._finalize_handshake(key_id)
+        self.task_server.notify_monitor_task_failed(
+            reason=f'Resource handshake error ({key_id}): {error}')
         self.task_server.task_computer.session_closed()
         self.dropped()
 

--- a/tests/golem/resource/test_resourcehandshake.py
+++ b/tests/golem/resource/test_resourcehandshake.py
@@ -393,6 +393,7 @@ class TestResourceHandshakeSessionMixin(TempDirFixture):
         assert session._block_peer.called
         assert session._finalize_handshake.called
         assert session.task_server.task_computer.session_closed.called
+        assert session.task_server.notify_monitor_task_failed.called
         assert not session.disconnect.called
 
     def test_handshake_timeout(self, *_):


### PR DESCRIPTION
New golem.monitor message SubtaskFailedModel was added to report failures to golem-monitor.
This message is reported when subtask fails to computate (errors in communication, errors in taskthread),
but not when it's just rejected from computation.

All reporting goes through taskserver.notify_monitor_task_failed, which adds performance and hardware stats
to the report.

In the best situation SubtaskFailedModel should contain both task_id and subtask_id, but in some situations
one or both might be missing due to insufficient data at hand (e.g. resource handshake errors).

Change-Id: Ifc9adb4fb2638d15b55c0c7873ea859e2390f91d