### PR TITLE
Disable sentry logger early (b0.16.0)

### DIFF
--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -208,6 +208,8 @@ def config_logging(suffix='', datadir=None, loglevel=None, config_desc=None):
         return  # Avoid consequent errors
     logging.captureWarnings(True)
 
+    from golem.tools.talkback import enable_sentry_logger
+    enable_sentry_logger(False)
     import txaio
     txaio.use_twisted()
     from ethereum import slogging


### PR DESCRIPTION
Sentry logger is currently enabled between calling `config_logging` and starting the client.