### PR TITLE
Change default ethereum logging level

### DIFF
--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -211,7 +211,11 @@ def config_logging(suffix='', datadir=None, loglevel=None, config_desc=None):
     import txaio
     txaio.use_twisted()
     from ethereum import slogging
-    slogging.configure(':debug')
+    if config_desc and config_desc.debug_third_party:
+        slogging.configure(':debug')
+    else:
+        slogging.configure(':warning')
+
     from twisted.python import log
     observer = log.PythonLoggingObserver(loggerName='twisted')
     observer.start()


### PR DESCRIPTION
To get rid of annoying `DEBUG:eth.chain.tx	deserialized tx tx=b'103006db'` messages,