### PR TITLE
Fix CLI's `settings show` and `min_price`, `max_price` formatting

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -812,7 +812,13 @@ class Client(HardwarePresetsMixin):
         return str(key) if key else None
 
     def get_settings(self):
-        return DictSerializer.dump(self.config_desc)
+        settings = DictSerializer.dump(self.config_desc, typed=False)
+
+        for key, value in settings.items():
+            if ConfigApprover.is_big_int(key):
+                settings[key] = str(value)
+
+        return settings
 
     def get_setting(self, key):
         if not hasattr(self.config_desc, key):

--- a/golem/clientconfigdescriptor.py
+++ b/golem/clientconfigdescriptor.py
@@ -83,7 +83,10 @@ class ConfigApprover(object):
     to_int_opt = {
         'seed_port', 'num_cores', 'opt_peer_num', 'p2p_session_timeout',
         'task_session_timeout', 'pings_interval', 'max_results_sending_delay',
-        'min_price', 'max_price', 'key_difficulty'
+        'key_difficulty',
+    }
+    to_big_int_opt = {
+        'min_price', 'max_price',
     }
     to_float_opt = {
         'getting_peers_interval', 'getting_tasks_interval', 'computing_trust',
@@ -99,6 +102,7 @@ class ConfigApprover(object):
         """
         self._actions = [
             (self.to_int_opt, self._to_int),
+            (self.to_big_int_opt, self._to_int),
             (self.to_float_opt, self._to_float),
             (self.max_opt, self._max_value)
         ]
@@ -122,8 +126,16 @@ class ConfigApprover(object):
         return self.config_desc
 
     @classmethod
-    def is_numeric(cls, name):
-        return name in cls.to_int_opt or name in cls.to_float_opt
+    def is_numeric(cls, name: str) -> bool:
+        return (
+            name in cls.to_int_opt or
+            name in cls.to_float_opt or
+            name in cls.to_big_int_opt
+        )
+
+    @classmethod
+    def is_big_int(cls, name: str) -> bool:
+        return name in cls.to_big_int_opt
 
     @staticmethod
     def _to_int(val, name):

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1147,11 +1147,10 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         self.assertNotEqual(c.get_setting('node_name'), newer_node_name)
 
         settings = c.get_settings()
-        settings['node_name'] = newer_node_name
-        with self.assertRaises(KeyError):
-            c.update_settings(settings)
+        self.assertIsInstance(settings['min_price'], str)
+        self.assertIsInstance(settings['max_price'], str)
 
-        del settings['py/object']
+        settings['node_name'] = newer_node_name
         c.update_settings(settings)
         self.assertEqual(c.get_setting('node_name'), newer_node_name)
 


### PR DESCRIPTION
- `Client.get_settings` returns `min_price` and `max_price` as strings
- `min_price` and `max_price` are displayed in CLI as `<value> / 10 ^ 18`

Resolves #2653