### PR TITLE
Show precise balance in CLI

### DIFF
--- a/golem/interface/client/account.py
+++ b/golem/interface/client/account.py
@@ -44,12 +44,12 @@ class Account:
         gnt_balance = balance['gnt']
         gnt_available = balance['av_gnt']
         eth_balance = balance['eth']
-        gnt_balance = float(gnt_balance)
-        gnt_available = float(gnt_available)
-        eth_balance = float(eth_balance)
+        gnt_balance = int(gnt_balance)
+        gnt_available = int(gnt_available)
+        eth_balance = int(eth_balance)
         gnt_reserved = gnt_balance - gnt_available
-        gnt_locked = float(balance['gnt_lock'])
-        eth_locked = float(balance['eth_lock'])
+        gnt_locked = int(balance['gnt_lock'])
+        eth_locked = int(balance['eth_lock'])
 
         return dict(
             node_name=node['node_name'],
@@ -117,4 +117,8 @@ class Account:
 
 
 def _fmt(value: float, unit: str = "GNT") -> str:
-    return "{:.6f} {}".format(value / denoms.ether, unit)
+    full = value // denoms.ether
+    decimals = '.' + str(value % denoms.ether).zfill(18).rstrip('0')
+    if decimals == '.':
+        decimals = ''
+    return "{}{} {}".format(full, decimals, unit)

--- a/golem/interface/client/account.py
+++ b/golem/interface/client/account.py
@@ -41,12 +41,9 @@ class Account:
                 'eth_lock': 0
             }
 
-        gnt_balance = balance['gnt']
-        gnt_available = balance['av_gnt']
-        eth_balance = balance['eth']
-        gnt_balance = int(gnt_balance)
-        gnt_available = int(gnt_available)
-        eth_balance = int(eth_balance)
+        gnt_balance = int(balance['gnt'])
+        gnt_available = int(balance['av_gnt'])
+        eth_balance = int(balance['eth'])
         gnt_reserved = gnt_balance - gnt_available
         gnt_locked = int(balance['gnt_lock'])
         eth_locked = int(balance['eth_lock'])
@@ -116,7 +113,7 @@ class Account:
         return sync_wait(Account.client.withdraw(amount, destination, currency))
 
 
-def _fmt(value: float, unit: str = "GNT") -> str:
+def _fmt(value: int, unit: str = "GNT") -> str:
     full = value // denoms.ether
     decimals = '.' + str(value % denoms.ether).zfill(18).rstrip('0')
     if decimals == '.':

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -65,13 +65,13 @@ class TestAccount(unittest.TestCase):
                 'requestor_reputation': 2,
                 'Golem_ID': 'deadbeef',
                 'finances': {
-                    'available_balance': '2.000000 GNT',
+                    'available_balance': '2 GNT',
                     'eth_address': 'f0f0f0ababab',
-                    'eth_balance': '1.000000 ETH',
-                    'reserved_balance': '1.000000 GNT',
-                    'total_balance': '3.000000 GNT',
-                    'gnt_locked': '0.010000 GNT',
-                    'eth_locked': '0.020000 ETH'
+                    'eth_balance': '1 ETH',
+                    'reserved_balance': '1 GNT',
+                    'total_balance': '3 GNT',
+                    'gnt_locked': '0.01 GNT',
+                    'eth_locked': '0.02 ETH'
                 },
             }
 


### PR DESCRIPTION
Fixes #2735
Sample output:
```
  available_balance: 938.303333333333333332 GNT
  eth_address: '0xA84CA4E4119F677431a51DB85F3567f2B59B4C2A'
  eth_balance: 0.019257347 ETH
  eth_locked: 0.00054 ETH
  gnt_locked: 0 GNT
  reserved_balance: 0 GNT
  total_balance: 938.303333333333333332 GNT
```