### PR TITLE
Replace golem.utils.encode_hex

### DIFF
--- a/golem/core/keysauth.py
+++ b/golem/core/keysauth.py
@@ -8,11 +8,11 @@ from hashlib import sha256
 from typing import Optional, Tuple, Union
 
 import ethereum.keys
+from eth_utils import encode_hex, decode_hex
 from ethereum.keys import decode_keystore_json, make_keystore_json
 from golem_messages.cryptography import ECCx, mk_privkey, ecdsa_verify, \
     privtopub
 
-from golem.utils import encode_hex, decode_hex
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +97,7 @@ class KeysAuth:
         self._private_key = prv
         self.ecc = ECCx(prv)
         self.public_key = pub
-        self.key_id = encode_hex(pub)
+        self.key_id = encode_hex(pub)[2:]
         self.difficulty = KeysAuth.get_difficulty(self.key_id)
 
     @staticmethod

--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -6,6 +6,7 @@ from typing import Dict, List
 from threading import Lock
 
 from sortedcontainers import SortedListWithKey
+from eth_utils import encode_hex
 from ethereum.utils import denoms
 from pydispatch import dispatcher
 from twisted.internet import threads
@@ -13,7 +14,6 @@ from twisted.internet import threads
 import golem_sci
 from golem.core.variables import PAYMENT_DEADLINE
 from golem.model import db, Payment, PaymentStatus
-from golem.utils import encode_hex
 
 log = logging.getLogger("golem.pay")
 
@@ -32,7 +32,7 @@ def _make_batch_payments(payments: List[Payment]) -> List[golem_sci.Payment]:
         payees[p.payee] += p.value
     res = []
     for payee, amount in payees.items():
-        res.append(golem_sci.Payment('0x' + encode_hex(payee), amount))
+        res.append(golem_sci.Payment(encode_hex(payee), amount))
     return res
 
 

--- a/golem/model.py
+++ b/golem/model.py
@@ -59,7 +59,7 @@ class RawCharField(CharField):
     """ Char field without auto utf-8 encoding."""
 
     def db_value(self, value):
-        return str(encode_hex(value)[2:])
+        return encode_hex(value)[2:]
 
     def python_value(self, value):
         return decode_hex(value)

--- a/golem/model.py
+++ b/golem/model.py
@@ -7,6 +7,7 @@ import sys
 # Type is used for old-style (pre Python 3.6) type annotation
 from typing import Optional, Type  # pylint: disable=unused-import
 
+from eth_utils import decode_hex, encode_hex
 from ethereum.utils import denoms
 from golem_messages import message
 from peewee import (Field, BooleanField, CharField, CompositeKey, DateTimeField,
@@ -17,7 +18,6 @@ from golem.core.simpleserializer import DictSerializable
 from golem.database import GolemSqliteDatabase
 from golem.network.p2p.node import Node
 from golem.ranking.helper.trust_const import NEUTRAL_TRUST
-from golem.utils import decode_hex, encode_hex
 
 # Indicates how many KnownHosts can be stored in the DB
 MAX_STORED_HOSTS = 4
@@ -59,7 +59,7 @@ class RawCharField(CharField):
     """ Char field without auto utf-8 encoding."""
 
     def db_value(self, value):
-        return str(encode_hex(value))
+        return str(encode_hex(value)[2:])
 
     def python_value(self, value):
         return decode_hex(value)

--- a/golem/network/concent/helpers.py
+++ b/golem/network/concent/helpers.py
@@ -4,6 +4,7 @@ import logging
 import time
 import typing
 
+from eth_utils import decode_hex
 from ethereum.utils import privtoaddr
 from golem_messages import constants as msg_constants
 from golem_messages import cryptography
@@ -11,7 +12,6 @@ from golem_messages import exceptions as msg_exceptions
 from golem_messages import message
 
 from golem.network import history
-from golem.utils import decode_hex
 
 
 logger = logging.getLogger(__name__)

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -7,6 +7,7 @@ import typing
 import random
 from collections import Counter
 
+from eth_utils import decode_hex
 from golem_messages import message, helpers
 from golem_messages.constants import MTD
 from semantic_version import Version
@@ -17,7 +18,6 @@ from golem.core.async import AsyncRequest, async_run
 from golem.core.idgenerator import check_id_seed
 from golem.core.variables import NUM_OF_RES_TRANSFERS_NEEDED_FOR_VER
 from golem.environments.environment import SupportStatus, UnsupportReason
-from golem.utils import decode_hex
 from .taskbase import TaskHeader
 
 logger = logging.getLogger('golem.task.taskkeeper')

--- a/golem/transactions/ethereum/ethereumpaymentskeeper.py
+++ b/golem/transactions/ethereum/ethereumpaymentskeeper.py
@@ -1,9 +1,8 @@
 import logging
 
+from eth_utils import encode_hex
 from ethereum.utils import normalize_address
 
-
-from golem.utils import encode_hex
 
 logger = logging.getLogger(__name__)
 
@@ -44,7 +43,7 @@ class EthereumAddress(object):
 
     def get_str_addr(self):
         if self.address:
-            return "0x{}".format(encode_hex(self.address))
+            return encode_hex(self.address)
         return None
 
     def __eq__(self, other):

--- a/golem/transactions/incomeskeeper.py
+++ b/golem/transactions/incomeskeeper.py
@@ -4,7 +4,6 @@ import logging
 import time
 from typing import List
 
-from eth_utils import encode_hex
 from ethereum.utils import denoms
 from pydispatch import dispatcher
 
@@ -29,7 +28,12 @@ class IncomesKeeper:
         # TODO Check for unpaid incomes and ask Concent for them. issue #2194
         pass
 
-    def received_batch_transfer(self, tx_hash, sender, amount, closure_time):
+    def received_batch_transfer(
+            self,
+            tx_hash: str,
+            sender: str,
+            amount: int,
+            closure_time: int) -> None:
         expected = Income.select().where(
             Income.accepted_ts > 0,
             Income.accepted_ts <= closure_time,
@@ -70,7 +74,7 @@ class IncomesKeeper:
         dispatcher.send(
             signal='golem.monitor',
             event='income',
-            addr=encode_hex(sender),
+            addr=sender,
             value=amount
         )
 

--- a/golem/transactions/incomeskeeper.py
+++ b/golem/transactions/incomeskeeper.py
@@ -4,12 +4,13 @@ import logging
 import time
 from typing import List
 
+from eth_utils import encode_hex
 from ethereum.utils import denoms
 from pydispatch import dispatcher
 
 from golem.core.variables import PAYMENT_DEADLINE
 from golem.model import Income
-from golem.utils import encode_hex, pubkeytoaddr
+from golem.utils import pubkeytoaddr
 
 logger = logging.getLogger("golem.transactions.incomeskeeper")
 

--- a/golem/transactions/paymentskeeper.py
+++ b/golem/transactions/paymentskeeper.py
@@ -1,9 +1,10 @@
 import logging
 from datetime import datetime
 
+from eth_utils import encode_hex
+
 from golem.core.common import to_unicode, datetime_to_timestamp_utc
 from golem.model import Payment
-from golem.utils import encode_hex
 
 logger = logging.getLogger(__name__)
 

--- a/golem/utils.py
+++ b/golem/utils.py
@@ -1,10 +1,10 @@
-import binascii
 import logging
 import socket
 import sys
 
 import semantic_version
 
+from eth_utils import decode_hex, encode_hex
 from ethereum.utils import sha3
 
 logger = logging.getLogger(__name__)
@@ -46,30 +46,8 @@ class UnicodeFormatter(logging.Formatter):
         return s
 
 
-def decode_hex(s):
-    if isinstance(s, str):
-        if s.startswith('0x'):
-            s = s[2:]
-        return bytes.fromhex(s)
-    if isinstance(s, (bytes, bytearray)):
-        if s[0] == b'0' and s[1] == b'x':
-            s = s[2:]
-        return binascii.unhexlify(s)
-    raise TypeError(f'Value {s} must be an instance of str or bytes: {type(s)}')
-
-
-def encode_hex(b):
-    if isinstance(b, str):
-        b = bytes(b, 'utf-8')
-    if isinstance(b, (bytes, bytearray)):
-        if b[0] == b'0' and b[1] == b'x':
-            b = b[2:]
-        return str(binascii.hexlify(b), 'utf-8')
-    raise TypeError('Value must be an instance of str or bytes')
-
-
 def pubkeytoaddr(pubkey: str) -> str:
-    return '0x' + encode_hex(sha3(decode_hex(pubkey))[12:])
+    return encode_hex(sha3(decode_hex(pubkey))[12:])
 
 
 def tee_target(prefix, proc, input_stream, path, stream):

--- a/tests/apps/core/task/test_coretask.py
+++ b/tests/apps/core/task/test_coretask.py
@@ -18,7 +18,6 @@ from golem.task.taskbase import ResultType, TaskEventListener
 from golem.task.taskstate import SubtaskStatus
 from golem.tools.assertlogs import LogTestCase
 from golem.tools.testdirfixture import TestDirFixture
-from golem.utils import decode_hex
 
 
 class TestCoreTask(LogTestCase, TestDirFixture):
@@ -163,7 +162,7 @@ class TestCoreTask(LogTestCase, TestDirFixture):
 
     def test_create_task_id(self):
         # when
-        task_id = CoreTask.create_task_id(decode_hex(b'beefdeadbeef'))
+        task_id = CoreTask.create_task_id(b'\xbe\xef\xde\xad\xbe\xef')
 
         # then
         self.assertRegex(task_id, "^[-0-9a-f]{23}-beefdeadbeef$")
@@ -171,7 +170,7 @@ class TestCoreTask(LogTestCase, TestDirFixture):
     def test_create_subtask_id(self):
         # given
         t = self._get_core_task()
-        t.header.task_id = CoreTask.create_task_id(decode_hex(b'beefdeadbeef'))
+        t.header.task_id = CoreTask.create_task_id(b'\xbe\xef\xde\xad\xbe\xef')
 
         # when
         subtask_id = t.create_subtask_id()

--- a/tests/golem/core/test_keygen.py
+++ b/tests/golem/core/test_keygen.py
@@ -1,12 +1,12 @@
 from unittest import TestCase
 
-from golem.utils import encode_hex
+from eth_utils import encode_hex
 
 from golem_messages.cryptography import privtopub, mk_privkey
 
 
 def key_in_hex(key):
-    return encode_hex(key)
+    return encode_hex(key)[2:]
 
 
 class TestKeygenHelper(TestCase):

--- a/tests/golem/core/test_keysauth.py
+++ b/tests/golem/core/test_keysauth.py
@@ -12,8 +12,7 @@ from golem.core.keysauth import (
     KeysAuth, get_random, get_random_float, sha2, WrongPassword)
 from golem.core.simpleserializer import CBORSerializer
 from golem.tools.testwithreactor import TestWithReactor
-from golem.utils import decode_hex
-from golem.utils import encode_hex
+from eth_utils import decode_hex, encode_hex
 
 
 class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
@@ -168,17 +167,17 @@ class TestKeysAuth(testutils.PEP8MixIn, testutils.TempDirFixture):
             assert args[0][0].startswith('Cannot verify signature: ')
 
     def test_fixed_sign_verify(self):  # pylint: disable=too-many-locals
-        public_key = b"cdf2fa12bef915b85d94a9f210f2e432542f249b8225736d923fb0" \
-                     b"7ac7ce38fa29dd060f1ea49c75881b6222d26db1c8b0dd1ad4e934" \
-                     b"263cc00ed03f9a781444"
-        private_key = b"1aab847dd0aa9c3993fea3c858775c183a588ac328e5deb9ceeee" \
-                      b"3b4ac6ef078"
+        public_key = "0xcdf2fa12bef915b85d94a9f210f2e432542f249b8225736d923fb0"\
+                     "7ac7ce38fa29dd060f1ea49c75881b6222d26db1c8b0dd1ad4e934"  \
+                     "263cc00ed03f9a781444"
+        private_key = "0x1aab847dd0aa9c3993fea3c858775c183a588ac328e5deb9ceeee"\
+                      "3b4ac6ef078"
 
         ek = self._create_keysauth()
 
         ek.public_key = decode_hex(public_key)
         ek._private_key = decode_hex(private_key)
-        ek.key_id = encode_hex(ek.public_key)
+        ek.key_id = encode_hex(ek.public_key)[2:]
         ek.ecc = ECCx(ek._private_key)
 
         msg = message.WantToComputeTask(node_name='node_name',

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -5,6 +5,7 @@ import time
 import unittest.mock as mock
 import uuid
 
+from eth_utils import encode_hex
 from twisted.internet.tcp import EISCONN
 
 from golem.clientconfigdescriptor import ClientConfigDescriptor
@@ -18,7 +19,6 @@ from golem.network.p2p.peersession import PeerSession
 from golem.network.transport.tcpnetwork import SocketAddress
 from golem.task.taskconnectionshelper import TaskConnectionsHelper
 from golem.tools.testwithreactor import TestDatabaseWithReactor
-from golem.utils import encode_hex
 
 
 class TestP2PService(TestDatabaseWithReactor):
@@ -88,7 +88,7 @@ class TestP2PService(TestDatabaseWithReactor):
 
     def test_add_to_peer_keeper(self):
         node = Node()
-        node.key = encode_hex(urandom(64))
+        node.key = encode_hex(urandom(64))[2:]
         m_test2 = mock.MagicMock()
         m_test3 = mock.MagicMock()
         self.service.peers["TEST3"] = m_test3
@@ -118,7 +118,7 @@ class TestP2PService(TestDatabaseWithReactor):
 
     def test_remove_old_peers(self):
         node = mock.MagicMock()
-        node.key = encode_hex(urandom(64))
+        node.key = encode_hex(urandom(64))[2:]
         node.key_id = node.key
 
         self.service.last_peers_request = time.time() + 10
@@ -139,12 +139,12 @@ class TestP2PService(TestDatabaseWithReactor):
         sa = SocketAddress('127.0.0.1', 11111)
 
         node = mock.MagicMock()
-        node.key = encode_hex(urandom(64))
+        node.key = encode_hex(urandom(64))[2:]
         node.key_id = node.key
         node.address = sa
 
         node2 = mock.MagicMock()
-        node2.key = encode_hex(urandom(64))
+        node2.key = encode_hex(urandom(64))[2:]
         node2.key_id = node2.key
         node2.address = sa
 
@@ -168,7 +168,7 @@ class TestP2PService(TestDatabaseWithReactor):
         assert len(self.service.peers) == 2
 
     def test_add_known_peer(self):
-        key_id = encode_hex(urandom(64))
+        key_id = encode_hex(urandom(64))[2:]
         nominal_seeds = len(self.service.seeds)
 
         node = Node(
@@ -226,7 +226,7 @@ class TestP2PService(TestDatabaseWithReactor):
 
     def test_sync_free_peers(self):
         node = Node(
-            key=encode_hex(urandom(64)),
+            key=encode_hex(urandom(64))[2:],
             pub_addr='127.0.0.1',
             p2p_pub_port=10000
         )
@@ -330,7 +330,7 @@ class TestP2PService(TestDatabaseWithReactor):
         m2.transport.getPeer.return_value.port = "11432"
         m2.transport.getPeer.return_value.host = "127.0.0.1"
         ps2 = PeerSession(m2)
-        key_id2 = encode_hex(urandom(64))
+        key_id2 = encode_hex(urandom(64))[2:]
         ps2.key_id = key_id2
         self.service.add_peer(ps2)
         self.service.get_diagnostics(DiagnosticsOutputFormat.json)

--- a/tests/golem/network/p2p/test_peerkeeper.py
+++ b/tests/golem/network/p2p/test_peerkeeper.py
@@ -5,9 +5,9 @@ import uuid
 
 import sys
 
+from eth_utils import encode_hex
 from golem.network.p2p.peerkeeper import PeerKeeper, K_SIZE, CONCURRENCY, \
     node_id_distance
-from golem.utils import encode_hex
 from golem import testutils
 
 
@@ -38,7 +38,7 @@ class TestPeerKeeper(unittest.TestCase, testutils.PEP8MixIn):
         self.n_bytes = K_SIZE // 8
         self.key = random_key(self.n_bytes)
         self.key_num = key_to_number(self.key)
-        self.peer_keeper = PeerKeeper(encode_hex(self.key))
+        self.peer_keeper = PeerKeeper(encode_hex(self.key)[2:])
 
     def test_neighbours(self):
         keys = set(random_key(self.n_bytes) for _ in range(64))
@@ -100,7 +100,7 @@ class TestPeerKeeper(unittest.TestCase, testutils.PEP8MixIn):
 
 class MockPeer:
     def __init__(self, key):
-        self.key = encode_hex(key)
+        self.key = encode_hex(key)[2:]
         self.key_num = int(self.key, 16)
         self.address = random.randrange(1, 2 ** 32 - 1)
         self.port = random.randrange(1000, 65535)

--- a/tests/golem/task/dummy/task.py
+++ b/tests/golem/task/dummy/task.py
@@ -2,6 +2,7 @@ import random
 from os import path
 from threading import Lock
 
+from eth_utils import encode_hex
 from golem_messages.message import ComputeTaskDef
 
 from golem.appconfig import MIN_PRICE
@@ -9,7 +10,6 @@ from golem.core.common import timeout_to_deadline
 from golem.core.idgenerator import generate_id, generate_new_id_from_id
 from golem.network.p2p.node import Node
 from golem.task.taskbase import Task, TaskHeader, ResultType
-from golem.utils import encode_hex
 
 
 class DummyTaskParameters(object):
@@ -59,7 +59,7 @@ class DummyTask(Task):
         task_id = generate_id(public_key)
         owner_address = ''
         owner_port = 0
-        owner_key_id = encode_hex(public_key)
+        owner_key_id = encode_hex(public_key)[2:]
         environment = self.ENVIRONMENT_NAME
         header = TaskHeader(
             task_id,

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -5,6 +5,7 @@ import time
 from unittest import TestCase
 import unittest.mock as mock
 
+from eth_utils import encode_hex
 from golem_messages import factories as msg_factories
 from golem_messages.message import ComputeTaskDef
 
@@ -22,7 +23,6 @@ from golem.task.taskkeeper import TaskHeaderKeeper, CompTaskKeeper,\
 from golem.testutils import PEP8MixIn
 from golem.testutils import TempDirFixture
 from golem.tools.assertlogs import LogTestCase
-from golem.utils import encode_hex
 
 
 def async_run(request, success=None, error=None):
@@ -474,7 +474,7 @@ def get_dict_task_header(key_id_seed="kkk"):
         "task_id": generate_id(key_id),
         "task_owner": {
             "node_name": "Bob's node",
-            "key": encode_hex(key_id),
+            "key": encode_hex(key_id)[2:],
             "pub_addr": "10.10.10.10",
             "pub_port": 10101
         },

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -5,6 +5,7 @@ from collections import deque
 from math import ceil
 from unittest.mock import Mock, MagicMock, patch, ANY
 
+from eth_utils import encode_hex
 from golem_messages.message import ComputeTaskDef
 from golem_messages import factories as msg_factories
 from requests import HTTPError
@@ -31,7 +32,6 @@ from golem.task.tasksession import TaskSession
 from golem.task.taskstate import TaskState, TaskOp
 from golem.tools.assertlogs import LogTestCase
 from golem.tools.testwithreactor import TestDatabaseWithReactor
-from golem.utils import encode_hex
 
 from tests.factories.resultpackage import ExtractedPackageFactory
 
@@ -41,7 +41,7 @@ def get_example_task_header(key_id):
         "task_id": generate_id(key_id),
         "environment": "DEFAULT",
         "task_owner": dict(
-            key=encode_hex(key_id),
+            key=encode_hex(key_id)[2:],
             node_name="ABC",
             prv_port=40103,
             prv_addr='10.0.0.10',

--- a/tests/golem/test_model.py
+++ b/tests/golem/test_model.py
@@ -14,22 +14,22 @@ class TestPayment(DatabaseFixture):
         self.assertGreaterEqual(datetime.now(), p.modified_date)
 
     def test_create(self):
-        p = m.Payment(payee="DEF", subtask="xyz", value=5,
+        p = m.Payment(payee=b"\xDE", subtask="xyz", value=5,
                       status=m.PaymentStatus.awaiting)
         self.assertEqual(p.save(force_insert=True), 1)
 
         with self.assertRaises(IntegrityError):
-            m.Payment.create(payee="DEF", subtask="xyz", value=5,
+            m.Payment.create(payee=b"\xDE", subtask="xyz", value=5,
                              status=m.PaymentStatus.awaiting)
-        m.Payment.create(payee="DEF", subtask="xyz2", value=4,
+        m.Payment.create(payee=b"\xDE", subtask="xyz2", value=4,
                          status=m.PaymentStatus.confirmed)
-        m.Payment.create(payee="DEF2", subtask="xyz4", value=5,
+        m.Payment.create(payee=b"\xDE\xF2", subtask="xyz4", value=5,
                          status=m.PaymentStatus.sent)
 
         self.assertEqual(3, len([payment for payment in m.Payment.select()]))
 
     def test_status_base_type(self):
-        payee = 'xx'
+        payee = b"\xab"
         subtask = 'zz'
         m.Payment.create(payee=payee, subtask=subtask, value=5,
                          status=m.PaymentStatus.awaiting.value)
@@ -38,19 +38,19 @@ class TestPayment(DatabaseFixture):
 
     def test_invalid_status(self):
         with self.assertRaises(TypeError):
-            m.Payment.create(payee="XX", subtask="zz", value=5, status=667)
+            m.Payment.create(payee=b"\xab", subtask="zz", value=5, status=667)
 
     def test_invalid_value_type(self):
         with self.assertRaises(TypeError):
-            m.Payment.create(payee="XX", subtask="float", value=5.5,
+            m.Payment.create(payee=b"\xab", subtask="float", value=5.5,
                              status=m.PaymentStatus.sent)
         with self.assertRaises(TypeError):
-            m.Payment.create(payee="XX", subtask="str", value="500",
+            m.Payment.create(payee=b"\xab", subtask="str", value="500",
                              status=m.PaymentStatus.sent)
 
     def test_payment_details(self):
-        p1 = m.Payment(payee="me", subtask="T1000", value=123456)
-        p2 = m.Payment(payee="you", subtask="T900", value=654321)
+        p1 = m.Payment(payee=b"\xab", subtask="T1000", value=123456)
+        p2 = m.Payment(payee=b"\xcd", subtask="T900", value=654321)
         self.assertNotEqual(p1.payee, p2.payee)
         self.assertNotEqual(p1.subtask, p2.subtask)
         self.assertNotEqual(p1.value, p2.value)
@@ -64,7 +64,7 @@ class TestPayment(DatabaseFixture):
     def test_payment_big_value(self):
         value = 10000 * 10**18
         assert value > 2**64
-        m.Payment.create(payee="me", subtask="T1000", value=value,
+        m.Payment.create(payee=b"\xab", subtask="T1000", value=value,
                          status=m.PaymentStatus.sent)
 
     def test_payment_details_serialization(self):

--- a/tests/golem/transactions/ethereum/test_ethereumabi.py
+++ b/tests/golem/transactions/ethereum/test_ethereumabi.py
@@ -1,8 +1,7 @@
 import unittest
 
+from eth_utils import encode_hex
 from ethereum.abi import encode_abi
-
-from golem.utils import encode_hex
 
 
 class TestEthereumAbi(unittest.TestCase):
@@ -12,7 +11,7 @@ class TestEthereumAbi(unittest.TestCase):
             ['uint32', 'uint32[]', 'bytes10', 'bytes'],
             [int(0x123), [int(0x456), int(0x789)],
              b"1234567890", b"Hello, world!"]
-        ))
+        ))[2:]
         data = "0000000000000000000000000000000000000000000000000000000000000" \
                "1230000000000000000000000000000000000000000000000000000000000" \
                "0000803132333435363738393000000000000000000000000000000000000" \

--- a/tests/golem/transactions/ethereum/test_paymentprocessor.py
+++ b/tests/golem/transactions/ethereum/test_paymentprocessor.py
@@ -57,7 +57,7 @@ class PaymentProcessorInternalTest(DatabaseFixture):
         value = 10
         payment = Payment.create(
             subtask=str(uuid.uuid4()),
-            payee=encode_hex(urandom(32)),
+            payee=urandom(20),
             value=value,
         )
 
@@ -70,7 +70,7 @@ class PaymentProcessorInternalTest(DatabaseFixture):
     def test_load_from_db_sent(self):
         tx_hash = encode_hex(urandom(32))
         value = 10
-        payee = encode_hex(urandom(32))
+        payee = urandom(20)
         sent_payment = Payment.create(
             subtask=str(uuid.uuid4()),
             payee=payee,

--- a/tests/golem/transactions/test_paymentskeeper.py
+++ b/tests/golem/transactions/test_paymentskeeper.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 
+from eth_utils import encode_hex
 from peewee import IntegrityError
 from os import urandom
 
@@ -12,7 +13,6 @@ from golem.tools.assertlogs import LogTestCase
 from golem.transactions.paymentskeeper import PaymentsDatabase, PaymentInfo, \
     logger, PaymentsKeeper
 from golem.transactions.ethereum.ethereumpaymentskeeper import EthAccountInfo
-from golem.utils import encode_hex
 from golem.tools.ci import ci_skip
 
 
@@ -57,7 +57,7 @@ class TestPaymentsDatabase(LogTestCase, TestWithDatabase):
         pi3 = deepcopy(pi)
         pi3.subtask_id = "bbbxxx"
         pi4 = deepcopy(pi)
-        pi4.computer.eth_account.address = "GHI"
+        pi4.computer.eth_account.address = b"GHI"
         pi4.subtask_id = "ghighi"
         with self.assertLogs(logger, level='WARNING') as l:
             self.assertIsNone(pd.get_state(pi4))


### PR DESCRIPTION
No need for our own implementation is there's already one existing.
NOTE: `eth_utils.encode_hex` prepends `0x` while `golem.utils` doesn't.