### PR TITLE
FundsLocker doesnt need to clean old locks

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -193,7 +193,6 @@ class Client(HardwarePresetsMixin):
 
         self.funds_locker = FundsLocker(self.transaction_system,
                                         Path(self.datadir))
-        self._services.append(self.funds_locker)
 
         self.use_docker_manager = use_docker_manager
         self.connect_to_known_hosts = connect_to_known_hosts


### PR DESCRIPTION
Old tasks are periodically removed in `Client` which results in removing the locks as well. Unless I'm missing something `FundsLocker` shouldn't take care of old locks on its own.
