### PR TITLE
Fix GNT lock in FundsLocker

### DIFF
--- a/golem/transactions/ethereum/fundslocker.py
+++ b/golem/transactions/ethereum/fundslocker.py
@@ -11,9 +11,13 @@ logger = logging.getLogger(__name__)
 
 class TaskFundsLock:  # pylint: disable=too-few-public-methods
     def __init__(self, task):
-        self.gnt_lock = task.price
+        self.price = task.subtask_price
         self.num_tasks = task.total_tasks
         self.task_deadline = task.header.deadline
+
+    @property
+    def gnt_lock(self):
+        return self.price * self.num_tasks
 
 
 class FundsLocker(LoopingCallService):

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -950,7 +950,7 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
             get_resources=Mock(return_value=[]),
             total_tasks=5,
             get_price=Mock(return_value=900),
-            price=1000,
+            subtask_price=1000,
         )
 
         c.enqueue_new_task(task)
@@ -961,7 +961,7 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         task_mock.total_tasks = 3
         price = task_mock.header.max_price * task_mock.total_tasks
         task_mock.get_price.return_value = price
-        task_mock.price = 1000
+        task_mock.subtask_price = 1000
         c.task_server.task_manager.create_task.return_value = task_mock
         c.concent_service = Mock()
         c.concent_service.enabled = True

--- a/tests/golem/transactions/ethereum/test_fundslocker.py
+++ b/tests/golem/transactions/ethereum/test_fundslocker.py
@@ -28,7 +28,7 @@ class TestFundsLocker(TempDirFixture):
         task_deadline = timeout_to_deadline(3600)
         task = mock.MagicMock()
         task.header.task_id = "abc"
-        task.price = 320
+        task.subtask_price = 320
         task.total_tasks = 10
         task.header.deadline = task_deadline
         fl.lock_funds(task)
@@ -36,7 +36,7 @@ class TestFundsLocker(TempDirFixture):
 
         def test_params(tfl):
             assert isinstance(tfl, TaskFundsLock)
-            assert tfl.gnt_lock == 320
+            assert tfl.gnt_lock == 320 * 10
             assert tfl.num_tasks == 10
             assert tfl.task_deadline == task_deadline
 
@@ -61,25 +61,26 @@ class TestFundsLocker(TempDirFixture):
         fl = FundsLocker(self.ts, self.new_path)
         task = mock.MagicMock()
         task.header.task_id = "abc"
-        task.price = val1
+        task.subtask_price = val1
         task.total_tasks = tasks1
         task.header.deadline = timeout_to_deadline(3600)
         fl.lock_funds(task)
         task.header.task_id = "def"
-        task.price = val2
+        task.subtask_price = val2
         task.total_tasks = tasks2
         fl.lock_funds(task)
         task.header.task_id = "ghi"
-        task.price = val3
+        task.subtask_price = val3
         task.total_tasks = tasks3
         fl.lock_funds(task)
         task.header.task_id = "jkl"
-        task.price = val4
+        task.subtask_price = val4
         task.total_tasks = tasks4
         fl.lock_funds(task)
         gnt, eth = fl.sum_locks()
         assert eth == 13000 * (tasks1 + tasks2 + tasks3 + tasks4) + 3000
-        assert gnt == val1 + val2 + val3 + val4
+        assert \
+            gnt == val1 * tasks1 + val2 * tasks2 + val3 * tasks3 + val4 * tasks4
 
     @mock.patch("golem.transactions.ethereum.fundslocker.time")
     def test_remove_old(self, time_mock):
@@ -102,28 +103,28 @@ class TestFundsLocker(TempDirFixture):
         # new fund locker should restore tasks
         fl2 = FundsLocker(self.ts, self.new_path)
         assert len(fl2.task_lock) == 4
-        assert fl2.task_lock['abc'].gnt_lock == 320
+        assert fl2.task_lock['abc'].gnt_lock == 320 * 10
 
     @staticmethod
     def _add_tasks(fl):
         task = mock.MagicMock()
         task.header.task_id = "abc"
-        task.price = 320
+        task.subtask_price = 320
         task.total_tasks = 10
         task.header.deadline = timeout_to_deadline(0.5)
         fl.lock_funds(task)
         task.header.task_id = "def"
-        task.price = 140
+        task.subtask_price = 140
         task.total_tasks = 7
         task.header.deadline = timeout_to_deadline(2)
         fl.lock_funds(task)
         task.header.task_id = "ghi"
-        task.price = 10
+        task.subtask_price = 10
         task.total_tasks = 4
         task.header.deadline = timeout_to_deadline(0.2)
         fl.lock_funds(task)
         task.header.task_id = "jkl"
-        task.price = 13
+        task.subtask_price = 13
         task.total_tasks = 1
         task.header.deadline = timeout_to_deadline(3.5)
         fl.lock_funds(task)


### PR DESCRIPTION
Current GNT lock value depends on the number of the unfinished tasks which is being updated but not taken into calculations after #2774. This PR fixes that.