### PR TITLE
Fixed 'estimated_memory' issue

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -615,6 +615,7 @@ class CoreTaskBuilder(TaskBuilder):
         definition.subtask_timeout = string_to_timeout(
             dictionary['subtask_timeout'])
         definition.output_file = cls.get_output_path(dictionary, definition)
+        definition.estimated_memory = dictionary.get('estimated_memory', 0)
 
         return definition
 

--- a/golem/client.py
+++ b/golem/client.py
@@ -645,10 +645,10 @@ class Client(HardwarePresetsMixin):
         except Exception as e:
             return on_error(to_unicode(e))
 
-        self.task_tester = TaskTester(task, self.datadir, on_success, on_error)
-        self.task_tester.run()
         self.task_test_result = json.dumps(
             {"status": TaskTestStatus.started, "error": True})
+        self.task_tester = TaskTester(task, self.datadir, on_success, on_error)
+        self.task_tester.run()
 
     def abort_test_task(self):
         logger.debug('Aborting test task ...')

--- a/golem/client.py
+++ b/golem/client.py
@@ -619,13 +619,15 @@ class Client(HardwarePresetsMixin):
 
     def _run_test_task(self, t_dict):
 
-        def on_success(*args, **kwargs):
+        def on_success(result, estimated_memory, time_spent, **kwargs):
             logger.info('Test task succes "%r"', t_dict)
             self.task_tester = None
             self.task_test_result = json.dumps(
                 {
                     "status": TaskTestStatus.success,
-                    "error": args,
+                    "result": result,
+                    "estimated_memory": estimated_memory,
+                    "time_spent": time_spent,
                     "more": kwargs
                 })
 

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -38,6 +38,7 @@ from golem.task.taskbase import Task
 from golem.task.taskserver import TaskServer
 from golem.task.taskstate import TaskState, TaskStatus, SubtaskStatus, \
     TaskTestStatus
+from golem.task.tasktester import TaskTester
 from golem.tools.assertlogs import LogTestCase
 from golem.tools.testwithdatabase import TestWithDatabase
 from golem.tools.testwithreactor import TestWithReactor
@@ -1383,6 +1384,62 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         self.client.block_node('node_id')
         self.client.task_server.acl.disallow.assert_called_once_with(
             'node_id', persist=True)
+
+    def test_run_test_task_success(self, *_):
+        result = {'result': 'result'}
+        estimated_memory = 1234
+        time_spent = 1.234
+        more = {'more': 'more'}
+
+        def _run(_self: TaskTester):
+            self.assertIsInstance(self.client.task_test_result, str)
+            test_result = json.loads(self.client.task_test_result)
+            self.assertEqual(test_result, {
+                "status": TaskTestStatus.started,
+                "error": True
+            })
+
+            _self.success_callback(result, estimated_memory, time_spent, **more)
+
+        with patch.object(self.client.task_server.task_manager, 'create_task'),\
+                patch('golem.client.TaskTester.run', _run):
+            self.client._run_test_task({})
+
+        self.assertIsInstance(self.client.task_test_result, str)
+        test_result = json.loads(self.client.task_test_result)
+        self.assertEqual(test_result, {
+            "status": TaskTestStatus.success,
+            "result": result,
+            "estimated_memory": estimated_memory,
+            "time_spent": time_spent,
+            "more": more
+        })
+
+    def test_run_test_task_error(self, *_):
+        error = ['error', 'error']
+        more = {'more': 'more'}
+
+        def _run(_self: TaskTester):
+            self.assertIsInstance(self.client.task_test_result, str)
+            test_result = json.loads(self.client.task_test_result)
+            self.assertEqual(test_result, {
+                "status": TaskTestStatus.started,
+                "error": True
+            })
+
+            _self.error_callback(*error, **more)
+
+        with patch.object(self.client.task_server.task_manager, 'create_task'),\
+                patch('golem.client.TaskTester.run', _run):
+            self.client._run_test_task({})
+
+        self.assertIsInstance(self.client.task_test_result, str)
+        test_result = json.loads(self.client.task_test_result)
+        self.assertEqual(test_result, {
+            "status": TaskTestStatus.error,
+            "error": error,
+            "more": more
+        })
 
     @classmethod
     def __new_incoming_peer(cls):


### PR DESCRIPTION
Memory usage estimated by test task was obscurely returned in `error` list. It was also never used when creating tasks.