### PR TITLE
Prevent provider locking in TaskComputer

### DIFF
--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -168,6 +168,8 @@ class TaskComputer(object):
         self.reset()
 
     def task_computed(self, task_thread):
+        self.reset()
+
         if task_thread.end_time is None:
             task_thread.end_time = time.time()
 
@@ -228,8 +230,6 @@ class TaskComputer(object):
 
         dispatcher.send(signal='golem.monitor', event='computation_time_spent',
                         success=was_success, value=work_time_to_be_paid)
-
-        self.counting_task = None
 
     def run(self):
         """ Main loop of task computer """

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -327,12 +327,13 @@ class TestTaskThread(DatabaseFixture):
         tc = TaskComputer("ABC", ts, use_docker_manager=False)
         tc.counting_task = True
         tc.waiting_for_task = None
-        tt = self._new_task_thread(tc)
 
+        tt = self._new_task_thread(tc)
         tt.run()
+
         self.assertGreater(tt.end_time - tt.start_time, 0)
         self.assertLess(tt.end_time - tt.start_time, 20)
-        self.assertTrue(tc.counting_task)
+        self.assertFalse(tc.counting_task)
 
     def test_fail(self):
         first_error = Exception("First error message")


### PR DESCRIPTION
If a `KeyError` is raised in `TaskComputer.task_computed`, the provider may never set their `counting_task` property to `None` (a.k.a. providers stuck in `Computing` state)