### PR TITLE
TaskManager.task_needs_computation

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -1534,7 +1534,7 @@ class MaskUpdateService(LoopingCallService):
         logger.info('Updating masks')
         # Using list() because tasks could be changed by another thread
         for task_id, task in list(self._task_manager.tasks.items()):
-            if not task.needs_computation():
+            if not self._task_manager.task_needs_computation(task_id):
                 continue
             task_state = self._task_manager.query_task_state(task_id)
             if task_state.elapsed_time < self._interval:

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -375,6 +375,8 @@ class TaskManager(TaskEventListener):
             return None, False, False
 
         if not self.task_needs_computation(task_id):
+            logger.info(f'Task does not need computation; '
+                        f'provider: {node_name} - {node_id}')
             return None, False, False
 
         extra_data = task.query_extra_data(

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -327,6 +327,16 @@ class TaskManager(TaskEventListener):
                                      op=TaskOp.WORK_OFFER_RECEIVED,
                                      persist=False)
 
+    def task_needs_computation(self, task_id: str) -> bool:
+        if self.tasks_states[task_id].status not in self.activeStatus:
+            logger.info(f'task is not active: {task_id}')
+            return False
+        task = self.tasks[task_id]
+        if not task.needs_computation():
+            logger.info(f'no more computation needed: {task_id}')
+            return False
+        return True
+
     def get_next_subtask(
             self, node_id, node_name, task_id, estimated_performance, price,
             max_resource_size, max_memory_size, num_cores=0, address=""):
@@ -364,17 +374,7 @@ class TaskManager(TaskEventListener):
         if task.header.max_price < price:
             return None, False, False
 
-        def needs_computation():
-            ids = f'provider: {node_name} - {node_id}, task_id: {task_id}'
-            if self.tasks_states[task_id].status not in self.activeStatus:
-                logger.info(f'task is not active; {ids}')
-                return False
-            if not task.needs_computation():
-                logger.info(f'no more computation needed; {ids}')
-                return False
-            return True
-
-        if not needs_computation():
+        if not self.task_needs_computation(task_id):
             return None, False, False
 
         extra_data = task.query_extra_data(


### PR DESCRIPTION
Refactored nested function into a public method. Used it in MaskUpdateService instead of Task.needs_computation(). This will prevent updating masks for timed-out tasks.