### PR TITLE
Added total task cost (GNT) and fee (ETH) to comp.tasks

### DIFF
--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -1,4 +1,5 @@
 from enum import Enum, auto
+import time
 from typing import Optional
 
 from golem.core.common import to_unicode
@@ -21,6 +22,12 @@ class TaskState(object):
         self.package_path = None
         self.package_size = None
         self.extra_data = {}
+        self.last_update_time = time.time()
+
+    def __setattr__(self, key, value):
+        super().__setattr__(key, value)
+        if key == 'status':
+            self.last_update_time = time.time()
 
     def __repr__(self):
         return '<TaskStatus: %r %.2f>' % (self.status, self.progress)
@@ -29,6 +36,7 @@ class TaskState(object):
         return {
             'time_started': self.time_started,
             'time_remaining': self.remaining_time,
+            'last_updated': getattr(self, 'last_update_time', None),
             'status': self.status.value
         }
 

--- a/golem/transactions/transactionsystem.py
+++ b/golem/transactions/transactionsystem.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Iterable, Tuple
 
 from golem.core.common import datetime_to_timestamp_utc, to_unicode
 from golem.core.service import LoopingCallService
@@ -56,6 +56,16 @@ class TransactionSystem(LoopingCallService):
         :return list: list of dictionaries describing payments
         """
         return self.payments_keeper.get_list_of_all_payments()
+
+    def get_total_payment_for_subtasks(self, subtask_ids: Iterable[str]) \
+            -> Tuple[int, int]:
+        """
+        Get total value and total fee for confirmed payments for the given
+        subtask IDs
+        :param subtask_ids: subtask IDs
+        :return: (total_value, total_fee)
+        """
+        return self.payments_keeper.get_total_payment_for_subtasks(subtask_ids)
 
     def get_incomes_list(self):
         """ Return list of all expected and received incomes

--- a/tests/factories/model.py
+++ b/tests/factories/model.py
@@ -1,13 +1,32 @@
-import factory
+from factory import Factory, Faker, SubFactory
 
 from golem import model
+from . import p2p
 # pylint: disable=too-few-public-methods
 
 
-class Income(factory.Factory):
+class Income(Factory):
     class Meta:
         model = model.Income
 
-    sender_node = factory.Faker('binary', length=64)
-    subtask = factory.Faker('uuid4')
-    value = factory.Faker('pyint')
+    sender_node = Faker('binary', length=64)
+    subtask = Faker('uuid4')
+    value = Faker('pyint')
+
+
+class PaymentDetails(Factory):
+    class Meta:
+        model = model.PaymentDetails
+
+    node_info = SubFactory(p2p.Node)
+    fee = Faker('pyint')
+
+
+class Payment(Factory):
+    class Meta:
+        model = model.Payment
+
+    subtask = Faker('uuid4')
+    payee = Faker('binary', length=20)
+    value = Faker('pyint')
+    details = SubFactory(PaymentDetails)

--- a/tests/golem/task/test_taskstate.py
+++ b/tests/golem/task/test_taskstate.py
@@ -1,10 +1,12 @@
+import time
 import unittest
 
 from freezegun import freeze_time
 
 from golem.core.common import timeout_to_deadline, deadline_to_timeout, \
     get_timestamp_utc
-from golem.task.taskstate import SubtaskState, SubtaskStatus
+from golem.task.taskstate import SubtaskState, SubtaskStatus, TaskState, \
+    TaskStatus
 
 
 class TestSubtaskState(unittest.TestCase):
@@ -66,3 +68,19 @@ class TestSubtaskState(unittest.TestCase):
         assert ss_dict['node_performance'] == "180"
         assert ss_dict['node_ip_address'] == "10.10.10.1"
         assert ss_dict['node_port'] == 1311
+
+
+class TestTaskState(unittest.TestCase):
+
+    @freeze_time(as_arg=True)
+    def test_last_update_time(  # pylint: disable=no-self-argument
+            frozen_time, self):
+        ts = TaskState()
+        self.assertEqual(ts.last_update_time, time.time())
+
+        frozen_time.tick()  # pylint: disable=no-member
+        ts.status = TaskStatus.finished
+        self.assertEqual(ts.last_update_time, time.time())
+
+        ts_dict = ts.to_dictionary()
+        self.assertEqual(ts_dict.get('last_updated'), time.time())

--- a/tests/golem/transactions/test_paymentskeeper.py
+++ b/tests/golem/transactions/test_paymentskeeper.py
@@ -14,6 +14,7 @@ from golem.transactions.paymentskeeper import PaymentsDatabase, PaymentInfo, \
     logger, PaymentsKeeper
 from golem.transactions.ethereum.ethereumpaymentskeeper import EthAccountInfo
 from golem.tools.ci import ci_skip
+from tests.factories.model import Payment as PaymentFactory
 
 
 @ci_skip  # Windows gives random failures #1738
@@ -153,6 +154,62 @@ class TestPaymentsKeeper(TestWithDatabase):
         self.assertEqual(len(all_payments), 6)
         assert pk.get_payment("xxyyzz") == 2023
         assert pk.get_payment("not existing") == 0
+
+
+class TestGetTotalPaymentForSubtasks(TestWithDatabase):
+
+    def setUp(self):
+        super().setUp()
+        self.pd = PaymentsDatabase()
+
+    @staticmethod
+    def _create_payment(**kwargs):
+        payment = PaymentFactory(**kwargs)
+        payment.save(force_insert=True)
+        return payment
+
+    def test_no_payments(self):
+        result = self.pd.get_total_payment_for_subtasks(('id1',))
+        self.assertEqual(result, (0, 0))
+
+    def test_wrong_id(self):
+        self._create_payment(subtask='id1', status=PaymentStatus.confirmed)
+        result = self.pd.get_total_payment_for_subtasks(('id2',))
+        self.assertEqual(result, (0, 0))
+
+    def test_awaiting_status(self):
+        self._create_payment(subtask='id1', status=PaymentStatus.awaiting)
+        result = self.pd.get_total_payment_for_subtasks(('id1',))
+        self.assertEqual(result, (0, 0))
+
+    def test_sent_status(self):
+        self._create_payment(subtask='id1', status=PaymentStatus.sent)
+        result = self.pd.get_total_payment_for_subtasks(('id1',))
+        self.assertEqual(result, (0, 0))
+
+    def test_single_payment(self):
+        payment = self._create_payment(
+            subtask='id1',
+            status=PaymentStatus.confirmed)
+        result = self.pd.get_total_payment_for_subtasks(('id1',))
+        self.assertEqual(
+            result,
+            (payment.value, payment.details.fee))  # pylint: disable=no-member
+
+    def test_multiple_payments(self):
+        p1 = self._create_payment(
+            subtask='id1',
+            status=PaymentStatus.confirmed)
+        p2 = self._create_payment(
+            subtask='id2',
+            status=PaymentStatus.confirmed)
+        self._create_payment(
+            subtask='id3',
+            status=PaymentStatus.confirmed)
+        result = self.pd.get_total_payment_for_subtasks(('id1', 'id2'))
+        exp_value = p1.value + p2.value
+        exp_fee = p1.details.fee + p2.details.fee  # pylint: disable=no-member
+        self.assertEqual(result, (exp_value, exp_fee))
 
 
 class TestAccountInfo(TempDirFixture):


### PR DESCRIPTION
Modified `comp.task` and `comp.tasks` to include two new fields:
* `cost` - total cost of the task (GNT)
* `fee` - total transaction fee for the task (ETH)

**Only confirmed transactions are counted.**

Closes #2895