### PR TITLE
Reverted unicode fixes for windows logs

### DIFF
--- a/golem/utils.py
+++ b/golem/utils.py
@@ -1,6 +1,5 @@
 import logging
 import socket
-import sys
 
 import semantic_version
 
@@ -15,35 +14,6 @@ def find_free_net_port():
     s = socket.socket()
     s.bind(('', 0))            # Bind to a free port provided by the host.
     return s.getsockname()[1]  # Return the port assigned.
-
-
-class UnicodeRecord(logging.LogRecord):
-    ENCODING = 'utf-8'
-
-    @classmethod
-    def from_record(cls, record):
-        # based on logging.makeLogRecord
-        u_record = cls(None, None, "", 0, "", (), None, None)
-        u_record.__dict__.update(record.__dict__)
-        return u_record
-
-    def getMessage(self):
-        if sys.platform == "win32" and isinstance(self.msg, str):
-            self.msg = self.msg.encode(self.ENCODING, 'replace')
-        return super(UnicodeRecord, self).getMessage()
-
-
-class UnicodeFormatter(logging.Formatter):
-    """This formatter is a workaround for a bug in logging module which causes
-    problems when logging bytestrings with special characters.
-    SEE: tests.test_logging.TestLogging.test_unicode_formatter
-    """
-    def format(self, record):
-        u_record = UnicodeRecord.from_record(record)
-        s = super(UnicodeFormatter, self).format(u_record)
-        if not isinstance(s, str):
-            s = s.decode('utf-8', 'replace')
-        return s
 
 
 def pubkeytoaddr(pubkey: str) -> str:

--- a/loggingconfig.py
+++ b/loggingconfig.py
@@ -18,11 +18,9 @@ LOGGING = {
     'disable_existing_loggers': False,
     'formatters': {
         'simple': {
-            '()': 'golem.utils.UnicodeFormatter',
             'format': '%(levelname)-8s [%(name)-35s] %(message)s',
         },
         'date': {
-            '()': 'golem.utils.UnicodeFormatter',
             'format': '%(asctime)s %(levelname)-8s %(name)-35s %(message)s',
             'datefmt': '%Y-%m-%d %H:%M:%S',
         },


### PR DESCRIPTION
Since they seem fixed in python3.

Original PR: #910

This removes the `b''` surrounding each log line on windows.