### PR TITLE
Graceful shutdown fixes

### DIFF
--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -220,15 +220,10 @@ class RenderingTask(CoreTask):
         else:
             return ''
 
-    def short_extra_data_repr(self, extra_data=None):
-        _extra_data = extra_data
-        if _extra_data is None:
-            # FIXME Use real data? Issue #2460
-            _extra_data = self.query_extra_data_for_test_task()['extra_data']
-        return "path_root: {path_root}, start_task: {start_task}, " \
-               "end_task: {end_task}, total_tasks: {total_tasks}, " \
-               "outfilebasename: {outfilebasename}, " \
-               "scene_file: {scene_file}".format(**_extra_data)
+    def short_extra_data_repr(self, extra_data):
+        l = extra_data
+        return "path_root: {path_root}, start_task: {start_task}, end_task: {end_task}, total_tasks: {total_tasks}, " \
+               "outfilebasename: {outfilebasename}, scene_file: {scene_file}".format(**l)
 
     def _open_preview(self, mode="RGB", ext=PREVIEW_EXT):
         """ If preview file doesn't exist create a new empty one with given mode and extension.

--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -221,12 +221,14 @@ class RenderingTask(CoreTask):
             return ''
 
     def short_extra_data_repr(self, extra_data=None):
-        if extra_data is not None:
-            l = extra_data
-        else:
-            l = self.query_extra_data_for_test_task()['extra_data']
-        return "path_root: {path_root}, start_task: {start_task}, end_task: {end_task}, total_tasks: {total_tasks}, " \
-               "outfilebasename: {outfilebasename}, scene_file: {scene_file}".format(**l)
+        _extra_data = extra_data
+        if _extra_data is None:
+            # FIXME Use real data? Issue #2460
+            _extra_data = self.query_extra_data_for_test_task()['extra_data']
+        return "path_root: {path_root}, start_task: {start_task}, " \
+               "end_task: {end_task}, total_tasks: {total_tasks}, " \
+               "outfilebasename: {outfilebasename}, " \
+               "scene_file: {scene_file}".format(**_extra_data)
 
     def _open_preview(self, mode="RGB", ext=PREVIEW_EXT):
         """ If preview file doesn't exist create a new empty one with given mode and extension.

--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -220,8 +220,11 @@ class RenderingTask(CoreTask):
         else:
             return ''
 
-    def short_extra_data_repr(self, extra_data):
-        l = extra_data
+    def short_extra_data_repr(self, extra_data=None):
+        if extra_data is not None:
+            l = extra_data
+        else:
+            l = self.query_extra_data_for_test_task()['extra_data']
         return "path_root: {path_root}, start_task: {start_task}, end_task: {end_task}, total_tasks: {total_tasks}, " \
                "outfilebasename: {outfilebasename}, scene_file: {scene_file}".format(**l)
 

--- a/golem/interface/client/account.py
+++ b/golem/interface/client/account.py
@@ -5,6 +5,7 @@ import zxcvbn
 from decimal import Decimal
 from ethereum.utils import denoms
 
+from golem.node import ShutdownResponse
 from golem.core.deferred import sync_wait
 from golem.interface.command import Argument, command, group
 
@@ -116,8 +117,9 @@ class Account:
     def shutdown(self) -> str:  # pylint: disable=no-self-use
 
         result = sync_wait(Account.client.graceful_shutdown())
+        readable_result = repr(ShutdownResponse(result))
 
-        return "Graceful shutdown triggered result: {}".format(result)
+        return "Graceful shutdown triggered result: {}".format(readable_result)
 
 
 def _fmt(value: int, unit: str = "GNT") -> str:

--- a/golem/node.py
+++ b/golem/node.py
@@ -131,8 +131,6 @@ class Node(object):  # pylint: disable=too-few-public-methods
 
         def _quit():
             reactor = self._reactor
-            if self.client:
-                self.client.quit()
             if reactor.running:
                 reactor.callFromThread(reactor.stop)
 

--- a/golem/node.py
+++ b/golem/node.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import IntEnum
 import functools
 import logging
 import time
@@ -30,10 +30,10 @@ from golem.terms import TermsOfUse
 logger = logging.getLogger(__name__)
 
 
-class ShutdownResponse(Enum):
-    quit = "quit"
-    off = "off"
-    on = "on"
+class ShutdownResponse(IntEnum):
+    quit = 0
+    off = 1
+    on = 2
 
 
 # pylint: disable=too-many-instance-attributes

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -748,7 +748,7 @@ class TaskManager(TaskEventListener):
                     t.get_total_tasks(),
                     t.get_active_tasks(),
                     t.get_progress(),
-                    t.short_extra_data_repr(2200.0)
+                    t.short_extra_data_repr(None)
                 )  # FIXME in short_extra_data_repr should there be extra data
                 # Issue #2460
                 tasks_progresses[task_id] = ltss

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -748,7 +748,7 @@ class TaskManager(TaskEventListener):
                     t.get_total_tasks(),
                     t.get_active_tasks(),
                     t.get_progress(),
-                    t.short_extra_data_repr(None)
+                    t.short_extra_data_repr()
                 )  # FIXME in short_extra_data_repr should there be extra data
                 # Issue #2460
                 tasks_progresses[task_id] = ltss

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -738,7 +738,8 @@ class TaskManager(TaskEventListener):
 
         for t in list(self.tasks.values()):
             task_id = t.header.task_id
-            task_status = self.tasks_states[task_id].status
+            task_state = self.tasks_states[task_id]
+            task_status = task_state.status
             in_progress = not TaskStatus.is_completed(task_status)
             logger.info('Collecting progress %r %r %r',
                         task_id, task_status, in_progress)
@@ -748,7 +749,7 @@ class TaskManager(TaskEventListener):
                     t.get_total_tasks(),
                     t.get_active_tasks(),
                     t.get_progress(),
-                    t.short_extra_data_repr()
+                    t.short_extra_data_repr(task_state.extra_data)
                 )  # FIXME in short_extra_data_repr should there be extra data
                 # Issue #2460
                 tasks_progresses[task_id] = ltss

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -841,11 +841,9 @@ class TestOptNode(TempDirFixture):
         reactor.running = True
 
         self.node = Node(**self.node_kwargs)
-        self.node.client = Mock()
         self.node._reactor.callFromThread = call_now
 
         self.node.quit()
-        assert self.node.client.quit.called
         assert self.node._reactor.stop.called
 
     @patch('golem.node.Database')
@@ -862,7 +860,6 @@ class TestOptNode(TempDirFixture):
         result = self.node.graceful_shutdown()
         assert result == ShutdownResponse.quit
         assert self.node._is_task_in_progress.called
-        assert self.node.client.quit.called
         assert self.node._reactor.stop.called
 
     def test_graceful_shutdown_off(self, *_):


### PR DESCRIPTION
Small fixes for the reported errors by @Krigpl :
```
  File "/home/admin_imapp/golem_repos/golem/golem/task/taskmanager.py", line 751, in get_progresses
    t.short_extra_data_repr(2200.0)
  File "/home/admin_imapp/golem_repos/golem/apps/rendering/task/renderingtask.py", line 226, in short_extra_data_repr
    "outfilebasename: {outfilebasename}, scene_file: {scene_file}".format(**l)
builtins.TypeError: format() argument after ** must be a mapping, not float
```
Added default of `None` and a query for data inside `short_extra_data_repr()`.
This also relates to #2460

```
  File "/home/admin_imapp/golem_repos/golem/golem/transactions/ethereum/ethereumtransactionsystem.py", line 79, in stop
    super().stop()
  File "/home/admin_imapp/golem_repos/golem/golem/core/service.py", line 62, in stop
    raise RuntimeError("service not started")
builtins.RuntimeError: service not started
```
Turned out `node.quit()` was calling `client.quit()` twice, removed one of them.