### PR TITLE
Better management of locked funds

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -987,11 +987,13 @@ class Client(HardwarePresetsMixin):
         balances = self.transaction_system.get_balance()
         gnt_total = balances['gnt_available'] + balances['gnt_nonconverted']
         return {
-            'gnt': str(gnt_total),
             'av_gnt': str(balances['gnt_available']),
-            'eth': str(balances['eth_available']),
+            'gnt': str(gnt_total),
             'gnt_lock': str(balances['gnt_locked']),
+            'gnt_nonconverted': str(balances['gnt_nonconverted']),
+            'eth': str(balances['eth_available']),
             'eth_lock': str(balances['eth_locked']),
+            'block_number': str(balances['block_number']),
             'last_gnt_update': str(balances['gnt_update_time']),
             'last_eth_update': str(balances['eth_update_time']),
         }

--- a/golem/interface/client/account.py
+++ b/golem/interface/client/account.py
@@ -38,7 +38,6 @@ class Account:
         gnt_available = int(balance['av_gnt'])
         gnt_nonconverted = int(balance['gnt_nonconverted'])
         eth_balance = int(balance['eth'])
-        gnt_reserved = gnt_balance - gnt_available
         gnt_locked = int(balance['gnt_lock'])
         eth_locked = int(balance['eth_lock'])
 
@@ -52,7 +51,7 @@ class Account:
                 eth_available=_fmt(eth_balance, unit="ETH"),
                 eth_locked=_fmt(eth_locked, unit="ETH"),
                 gnt_available=_fmt(gnt_available),
-                gnt_locked=_fmt(gnt_reserved),
+                gnt_locked=_fmt(gnt_locked),
                 gnt_unadopted=_fmt(gnt_nonconverted),
             )
         )

--- a/golem/interface/client/account.py
+++ b/golem/interface/client/account.py
@@ -33,17 +33,10 @@ class Account:
         payment_address = sync_wait(client.get_payment_address())
 
         balance = sync_wait(client.get_balance())
-        if balance is None:
-            balance = {
-                'gnt': 0,
-                'av_gnt': 0,
-                'eth': 0,
-                'gnt_lock': 0,
-                'eth_lock': 0
-            }
 
         gnt_balance = int(balance['gnt'])
         gnt_available = int(balance['av_gnt'])
+        gnt_nonconverted = int(balance['gnt_nonconverted'])
         eth_balance = int(balance['eth'])
         gnt_reserved = gnt_balance - gnt_available
         gnt_locked = int(balance['gnt_lock'])
@@ -56,12 +49,11 @@ class Account:
             provider_reputation=int(computing_trust * 100),
             finances=dict(
                 eth_address=payment_address,
-                total_balance=_fmt(gnt_balance),
-                available_balance=_fmt(gnt_available),
-                reserved_balance=_fmt(gnt_reserved),
-                eth_balance=_fmt(eth_balance, unit="ETH"),
-                gnt_locked=_fmt(gnt_locked),
+                eth_available=_fmt(eth_balance, unit="ETH"),
                 eth_locked=_fmt(eth_locked, unit="ETH"),
+                gnt_available=_fmt(gnt_available),
+                gnt_locked=_fmt(gnt_reserved),
+                gnt_unadopted=_fmt(gnt_nonconverted),
             )
         )
 

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -731,7 +731,6 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             self.task_server.client.transaction_system.concent_deposit(
                 required=amount,
                 expected=expected,
-                reserved=self.task_server.client.funds_locker.sum_locks()[0],
                 cb=ask_for_verification,
             )
 

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -146,7 +146,11 @@ class EthereumTransactionSystem(TransactionSystem):
         if eth > eth_available:
             raise NotEnoughFunds(eth, eth_available, 'ETH')
 
-        log.info("Locking %f GNT and ETH for %d payments", gnt, num)
+        log.info(
+            "Locking %f GNT and ETH for %d payments",
+            gnt / denoms.ether,
+            num,
+        )
         self._gntb_locked += gnt
         self._payments_locked += num
 
@@ -163,7 +167,11 @@ class EthereumTransactionSystem(TransactionSystem):
                 self._payments_locked,
 
             ))
-        log.info("Unlocking %f GNT and ETH for %d payments", gnt, num)
+        log.info(
+            "Unlocking %f GNT and ETH for %d payments",
+            gnt / denoms.ether,
+            num,
+        )
         self._gntb_locked -= gnt
         self._payments_locked -= num
 

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -3,7 +3,7 @@ import time
 from enum import Enum
 from datetime import datetime
 from pathlib import Path
-from typing import List
+from typing import Any, Dict, List
 
 from ethereum.utils import privtoaddr, denoms
 from eth_utils import encode_hex, is_address, to_checksum_address
@@ -15,7 +15,7 @@ from golem.ethereum.node import NodeProcess
 from golem.ethereum.paymentprocessor import PaymentProcessor
 from golem.transactions.ethereum.ethereumincomeskeeper \
     import EthereumIncomesKeeper
-from golem.transactions.ethereum import exceptions
+from golem.transactions.ethereum.exceptions import NotEnoughFunds
 from golem.transactions.transactionsystem import TransactionSystem
 
 log = logging.getLogger('golem.pay')
@@ -73,6 +73,8 @@ class EthereumTransactionSystem(TransactionSystem):
         self._gntb_balance: int = 0
         self._last_eth_update = None
         self._last_gnt_update = None
+        self._payments_locked: int = 0
+        self._gntb_locked: int = 0
         self._is_stopped = False
 
     def stop(self):
@@ -87,7 +89,8 @@ class EthereumTransactionSystem(TransactionSystem):
         log.info("Synchronizing balances")
         while not self._is_stopped:
             self._refresh_balances()
-            if self._balance_known():
+            if self._last_eth_update is not None and \
+               self._last_gnt_update is not None:
                 log.info("Balances synchronized")
                 return
             log.info("Waiting for initial GNT/ETH balances...")
@@ -102,18 +105,72 @@ class EthereumTransactionSystem(TransactionSystem):
         """ Human readable Ethereum address for incoming payments."""
         return self._sci.get_eth_address()
 
-    def get_balance(self):
-        if not self._balance_known():
-            return None, None, None, None, None
-        gnt_total = self._gnt_balance + self._gntb_balance
-        gnt_av = gnt_total - self.payment_processor.reserved_gntb
-        return gnt_total, gnt_av, self._eth_balance, \
-            self._last_gnt_update, self._last_eth_update
+    def get_available_eth(self) -> int:
+        return max(self._eth_balance - self.get_locked_eth(), 0)
 
-    def eth_for_batch_payment(self, num_payments: int) -> int:
+    def get_locked_eth(self) -> int:
+        eth = self.payment_processor.reserved_eth + \
+            self._eth_for_batch_payment(self._payments_locked)
+        if self._payments_locked > 0 and \
+           self.payment_processor.reserved_eth == 0:
+            eth += self._eth_base_for_batch_payment()
+        return eth
+
+    def get_available_gnt(self) -> int:
+        return max(self._gntb_balance - self.get_locked_gnt(), 0)
+
+    def get_locked_gnt(self) -> int:
+        return self._gntb_locked + self.payment_processor.reserved_gntb
+
+    def get_balance(self) -> Dict[str, Any]:
+        return {
+            'gnt_available': self.get_available_gnt(),
+            'gnt_locked': self.get_locked_gnt(),
+            'gnt_nonconverted': self._gnt_balance,
+            'gnt_update_time': self._last_gnt_update,
+            'eth_available': self.get_available_eth(),
+            'eth_locked': self.get_locked_eth(),
+            'eth_update_time': self._last_eth_update,
+        }
+
+    def lock_funds_for_payments(self, price: int, num: int) -> None:
+        gnt = price * num
+        if gnt > self.get_available_gnt():
+            raise NotEnoughFunds(gnt, self.get_available_gnt(), 'GNT')
+
+        eth = self._eth_for_batch_payment(num)
+        if self._payments_locked == 0 and \
+           self.payment_processor.reserved_eth == 0:
+            eth += self._eth_base_for_batch_payment()
+        eth_available = self.get_available_eth()
+        if eth > eth_available:
+            raise NotEnoughFunds(eth, eth_available, 'ETH')
+
+        log.info("Locking %f GNT and ETH for %d payments", gnt, num)
+        self._gntb_locked += gnt
+        self._payments_locked += num
+
+    def unlock_funds_for_payments(self, price: int, num: int) -> None:
+        gnt = price * num
+        if gnt > self._gntb_locked:
+            raise Exception("Can't unlock {} GNT, locked: {}".format(
+                gnt / denoms.ether,
+                self._gntb_locked / denoms.ether,
+            ))
+        if num > self._payments_locked:
+            raise Exception("Can't unlock {} payments, locked: {}".format(
+                num,
+                self._payments_locked,
+
+            ))
+        log.info("Unlocking %f GNT and ETH for %d payments", gnt, num)
+        self._gntb_locked -= gnt
+        self._payments_locked -= num
+
+    def _eth_for_batch_payment(self, num_payments: int) -> int:
         return self.payment_processor.get_gas_cost_per_payment() * num_payments
 
-    def eth_base_for_batch_payment(self):
+    def _eth_base_for_batch_payment(self) -> int:
         return self.payment_processor.ETH_BATCH_PAYMENT_BASE
 
     def get_withdraw_gas_cost(
@@ -133,16 +190,17 @@ class EthereumTransactionSystem(TransactionSystem):
             self,
             amount: int,
             destination: str,
-            currency: str,
-            lock: int = 0) -> List[str]:
+            currency: str) -> List[str]:
         if not is_address(destination):
             raise ValueError("{} is not valid ETH address".format(destination))
 
-        pp = self.payment_processor
         if currency == 'ETH':
-            eth = self._eth_balance - pp.reserved_eth
-            if amount > eth - lock:
-                raise exceptions.NotEnoughFunds(amount, eth - lock, currency)
+            if amount > self.get_available_eth():
+                raise NotEnoughFunds(
+                    amount,
+                    self.get_available_eth(),
+                    currency,
+                )
             log.info(
                 "Withdrawing %f ETH to %s",
                 amount / denoms.ether,
@@ -151,21 +209,14 @@ class EthereumTransactionSystem(TransactionSystem):
             return [self._sci.transfer_eth(destination, amount)]
 
         if currency == 'GNT':
-            total_gnt = \
-                self._gnt_balance + self._gntb_balance - pp.reserved_gntb
-            if amount > total_gnt - lock:
-                raise exceptions.NotEnoughFunds(
+            if amount > self.get_available_gnt():
+                raise NotEnoughFunds(
                     amount,
-                    total_gnt - lock,
+                    self.get_available_gnt(),
                     currency,
                 )
-            # This can happen during unfinished GNT-GNTB conversion,
-            # so we should wait until it finishes
-            if amount > self._gntb_balance:
-                raise Exception('Cannot withdraw right now, '
-                                'background operations in progress')
             log.info(
-                "Withdrawing %f GNTB to %s",
+                "Withdrawing %f GNT to %s",
                 amount / denoms.ether,
                 destination,
             )
@@ -174,16 +225,9 @@ class EthereumTransactionSystem(TransactionSystem):
         raise ValueError('Unknown currency {}'.format(currency))
 
     def concent_balance(self) -> int:
-        return self._sci.get_deposit_value(
-            account_address=self._sci.get_eth_address(),
-        )
+        return self._sci.get_deposit_value(self._sci.get_eth_address())
 
-    def concent_deposit(
-            self,
-            required: int,
-            expected: int,
-            reserved: int,
-            cb=None) -> None:
+    def concent_deposit(self, required: int, expected: int, cb=None) -> None:
         if cb is None:
             def noop():
                 pass
@@ -194,10 +238,9 @@ class EthereumTransactionSystem(TransactionSystem):
             return
         required -= current
         expected -= current
-        gntb_balance = self._gntb_balance
-        gntb_balance -= reserved
+        gntb_balance = self.get_available_gnt()
         if gntb_balance < required:
-            raise exceptions.NotEnoughFunds(required, gntb_balance, 'GNTB')
+            raise NotEnoughFunds(required, gntb_balance, 'GNTB')
         max_possible_amount = min(expected, gntb_balance)
         tx_hash = self._sci.deposit_payment(max_possible_amount)
         log.info(
@@ -215,7 +258,7 @@ class EthereumTransactionSystem(TransactionSystem):
         self._sci.on_transaction_confirmed(tx_hash, transaction_receipt)
 
     def _get_funds_from_faucet(self) -> None:
-        if not self._faucet or not self._balance_known():
+        if not self._faucet:
             return
         if self._eth_balance < 0.01 * denoms.ether:
             log.info("Requesting tETH from faucet")
@@ -229,10 +272,6 @@ class EthereumTransactionSystem(TransactionSystem):
                 self._gnt_faucet_requested = True
         else:
             self._gnt_faucet_requested = False
-
-    def _balance_known(self) -> bool:
-        return self._last_eth_update is not None and \
-            self._last_gnt_update is not None
 
     def _refresh_balances(self) -> None:
         now = time.mktime(datetime.today().timetuple())
@@ -251,8 +290,6 @@ class EthereumTransactionSystem(TransactionSystem):
             log.warning('Failed to update balances: %r', e)
 
     def _try_convert_gnt(self) -> None:  # pylint: disable=too-many-branches
-        if not self._balance_known():
-            return
         if self._gnt_conversion_status == ConversionStatus.UNFINISHED:
             if self._gnt_balance > 0:
                 self._gnt_conversion_status = ConversionStatus.NONE

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -106,7 +106,7 @@ class EthereumTransactionSystem(TransactionSystem):
         return self._sci.get_eth_address()
 
     def get_available_eth(self) -> int:
-        return max(self._eth_balance - self.get_locked_eth(), 0)
+        return self._eth_balance - self.get_locked_eth()
 
     def get_locked_eth(self) -> int:
         eth = self.payment_processor.reserved_eth + \
@@ -114,10 +114,10 @@ class EthereumTransactionSystem(TransactionSystem):
         if self._payments_locked > 0 and \
            self.payment_processor.reserved_eth == 0:
             eth += self._eth_base_for_batch_payment()
-        return eth
+        return min(eth, self._eth_balance)
 
     def get_available_gnt(self) -> int:
-        return max(self._gntb_balance - self.get_locked_gnt(), 0)
+        return self._gntb_balance - self.get_locked_gnt()
 
     def get_locked_gnt(self) -> int:
         return self._gntb_locked + self.payment_processor.reserved_gntb

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -127,9 +127,10 @@ class EthereumTransactionSystem(TransactionSystem):
             'gnt_available': self.get_available_gnt(),
             'gnt_locked': self.get_locked_gnt(),
             'gnt_nonconverted': self._gnt_balance,
-            'gnt_update_time': self._last_gnt_update,
             'eth_available': self.get_available_eth(),
             'eth_locked': self.get_locked_eth(),
+            'block_number': self._sci.get_block_number(),
+            'gnt_update_time': self._last_gnt_update,
             'eth_update_time': self._last_eth_update,
         }
 

--- a/golem/transactions/ethereum/exceptions.py
+++ b/golem/transactions/ethereum/exceptions.py
@@ -6,7 +6,7 @@ class EthereumError(Exception):
 
 
 class NotEnoughFunds(EthereumError):
-    def __init__(self, required: int, available: int, extension="GNT"):
+    def __init__(self, required: int, available: int, extension="GNT") -> None:
         super().__init__()
         self.required = required
         self.available = available

--- a/golem/transactions/ethereum/exceptions.py
+++ b/golem/transactions/ethereum/exceptions.py
@@ -1,14 +1,19 @@
+from ethereum.utils import denoms
+
+
 class EthereumError(Exception):
     pass
 
 
 class NotEnoughFunds(EthereumError):
-    def __init__(self, required=None, available=None, extension="GNT"):
+    def __init__(self, required: int, available: int, extension="GNT"):
         super().__init__()
         self.required = required
         self.available = available
         self.extension = extension
 
     def __str__(self):
-        return "Not enough %s available. Required: %d, available: %d" % \
-               (self.extension, self.required, self.available)
+        return "Not enough %s available. Required: %f, available: %f" % \
+               (self.extension,
+                self.required / denoms.ether,
+                self.available / denoms.ether)

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -52,6 +52,7 @@ class TestAccount(unittest.TestCase):
         client.get_balance.return_value = {
             'gnt': 3 * denoms.ether,
             'av_gnt': 2 * denoms.ether,
+            'gnt_nonconverted': 0,
             'eth': denoms.ether,
             'gnt_lock': 0.01 * denoms.ether,
             'eth_lock': 0.02 * denoms.ether
@@ -65,13 +66,12 @@ class TestAccount(unittest.TestCase):
                 'requestor_reputation': 2,
                 'Golem_ID': 'deadbeef',
                 'finances': {
-                    'available_balance': '2 GNT',
                     'eth_address': 'f0f0f0ababab',
-                    'eth_balance': '1 ETH',
-                    'reserved_balance': '1 GNT',
-                    'total_balance': '3 GNT',
+                    'eth_available': '1 ETH',
+                    'eth_locked': '0.02 ETH',
+                    'gnt_available': '2 GNT',
                     'gnt_locked': '0.01 GNT',
-                    'eth_locked': '0.02 ETH'
+                    'gnt_unadopted': '0 GNT',
                 },
             }
 

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1056,16 +1056,21 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
             'eth_available': 2,
             'eth_locked': 1,
             'eth_update_time': None,
+            'block_number': 222,
         }
         c.transaction_system.get_balance.return_value = result
         balance = sync_wait(c.get_balance())
-        assert balance == {'gnt': "2",
-                           'av_gnt': "2",
-                           'eth': "2",
-                           'gnt_lock': "1",
-                           'eth_lock': "1",
-                           'last_gnt_update': "None",
-                           'last_eth_update': "None"}
+        assert balance == {
+            'gnt': "2",
+            'av_gnt': "2",
+            'eth': "2",
+            'gnt_nonconverted': "0",
+            'gnt_lock': "1",
+            'eth_lock': "1",
+            'last_gnt_update': "None",
+            'last_eth_update': "None",
+            'block_number': "222",
+        }
         assert all(isinstance(entry, str) for entry in balance)
 
     def test_run_benchmark(self, *_):

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -28,7 +28,6 @@ from golem.core.common import timeout_to_string
 from golem.core.deferred import sync_wait
 from golem.core.simpleserializer import DictSerializer
 from golem.environments.environment import Environment as DefaultEnvironment
-from golem.model import Performance
 from golem.network.p2p.node import Node
 from golem.network.p2p.peersession import PeerSessionInfo
 from golem.report import StatusPublisher
@@ -169,7 +168,7 @@ class TestClient(TestWithDatabase, TestWithReactor):
                     use_monitor=False,
                 )
                 self.client.withdraw('123', '0xdead', 'ETH')
-                ets.withdraw.assert_called_once_with(123, '0xdead', 'ETH', 0)
+                ets.withdraw.assert_called_once_with(123, '0xdead', 'ETH')
 
     def test_get_withdraw_gas_cost(self, *_):
         keys_auth = Mock()
@@ -872,7 +871,6 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         client.monitor = Mock()
 
         self.client = client
-        print(self.client.funds_locker.sum_locks())
 
     def tearDown(self):
         self.client.quit()
@@ -976,7 +974,6 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
         c.transaction_system.concent_deposit.assert_called_once_with(
             required=mock.ANY,
             expected=mock.ANY,
-            reserved=c.funds_locker.sum_locks()[0],
         )
         c.funds_locker.persist = False
 
@@ -1048,29 +1045,25 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
 
     def test_get_balance(self, *_):
         c = self.client
-        print(c.funds_locker.sum_locks())
-        result = (None, None, None, None, None)
 
         c.transaction_system = Mock()
-        c.transaction_system.get_balance.return_value = result
 
-        balance = sync_wait(c.get_balance())
-
-        assert balance is None
-
-        result = (None, 1, None, None, None)
-        c.transaction_system.get_balance.return_value = result
-        balance = sync_wait(c.get_balance())
-        assert balance is None
-
-        result = (1, 1, None, None, None)
+        result = {
+            'gnt_available': 2,
+            'gnt_locked': 1,
+            'gnt_nonconverted': 0,
+            'gnt_update_time': None,
+            'eth_available': 2,
+            'eth_locked': 1,
+            'eth_update_time': None,
+        }
         c.transaction_system.get_balance.return_value = result
         balance = sync_wait(c.get_balance())
-        assert balance == {'gnt': "1",
-                           'av_gnt': "1",
-                           'eth': "None",
-                           'gnt_lock': "0",
-                           'eth_lock': "0",
+        assert balance == {'gnt': "2",
+                           'av_gnt': "2",
+                           'eth': "2",
+                           'gnt_lock': "1",
+                           'eth_lock': "1",
                            'last_gnt_update': "None",
                            'last_eth_update': "None"}
         assert all(isinstance(entry, str) for entry in balance)

--- a/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
+++ b/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
@@ -3,6 +3,7 @@ import unittest
 from unittest.mock import patch, Mock, ANY, PropertyMock
 
 from eth_utils import encode_hex
+from ethereum.utils import denoms
 import golem_sci
 import requests
 
@@ -107,9 +108,9 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
         assert cost == self.sci.GAS_WITHDRAW * gas_price
 
     def test_withdraw(self):
-        eth_balance = 40 * 10 ** 18
-        gnt_balance = 10 * 10 ** 18
-        gntb_balance = 20 * 10 ** 18
+        eth_balance = 40 * denoms.ether
+        gnt_balance = 10 * denoms.ether
+        gntb_balance = 20 * denoms.ether
         self.sci.get_eth_balance.return_value = eth_balance
         self.sci.get_gnt_balance.return_value = gnt_balance
         self.sci.get_gntb_balance.return_value = gntb_balance
@@ -190,8 +191,8 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
         self.sci.reset_mock()
 
     def test_locking_funds(self):
-        eth_balance = 10 * 10 ** 18
-        gnt_balance = 1000 * 10 ** 18
+        eth_balance = 10 * denoms.ether
+        gnt_balance = 1000 * denoms.ether
         self.sci.get_eth_balance.return_value = eth_balance
         self.sci.get_gntb_balance.return_value = gnt_balance
         self.ets._refresh_balances()
@@ -199,7 +200,7 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
         assert self.ets.get_locked_eth() == 0
         assert self.ets.get_locked_gnt() == 0
 
-        price = 5 * 10 ** 18
+        price = 5 * denoms.ether
         num = 3
 
         self.ets.lock_funds_for_payments(price, num)
@@ -225,11 +226,11 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
             self.ets.unlock_funds_for_payments(1, 1)
 
     def test_convert_gnt(self):
-        amount = 1000 * 10 ** 18
+        amount = 1000 * denoms.ether
         gate_addr = '0x' + 40 * '2'
         self.sci.get_gate_address.return_value = None
         self.sci.get_gnt_balance.return_value = amount
-        self.sci.get_eth_balance.return_value = 10 ** 18
+        self.sci.get_eth_balance.return_value = denoms.ether
         self.sci.get_current_gas_price.return_value = 0
         self.sci.GAS_OPEN_GATE = 10
         self.sci.GAS_GNT_TRANSFER = 2
@@ -254,14 +255,14 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
         self.sci.transfer_from_gate.assert_not_called()
 
     def test_unfinished_gnt_conversion(self):
-        amount = 1000 * 10 ** 18
+        amount = 1000 * denoms.ether
         gate_addr = '0x' + 40 * '2'
         self.sci.get_current_gas_price.return_value = 0
         self.sci.GAS_TRANSFER_FROM_GATE = 5
         self.sci.get_gate_address.return_value = gate_addr
         self.sci.get_gnt_balance.side_effect = \
             lambda addr: amount if addr == gate_addr else 0
-        self.sci.get_eth_balance.return_value = 10 ** 18
+        self.sci.get_eth_balance.return_value = denoms.ether
         with patch('golem.transactions.ethereum.ethereumtransactionsystem.'
                    'new_sci', return_value=self.sci),\
             patch('golem.transactions.ethereum.ethereumtransactionsystem.'
@@ -300,7 +301,7 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
     def test_concent_deposit_done(self):
         self.sci.get_deposit_value.return_value = 0
         self.ets._gntb_balance = 20
-        self.ets._eth_balance = 10 ** 18
+        self.ets._eth_balance = denoms.ether
         self.ets.lock_funds_for_payments(1, 1)
         self.ets.concent_deposit(
             required=10,

--- a/tests/golem/transactions/ethereum/test_exceptions.py
+++ b/tests/golem/transactions/ethereum/test_exceptions.py
@@ -1,13 +1,15 @@
 from unittest import TestCase
 
+from ethereum.utils import denoms
+
 from golem.transactions.ethereum.exceptions import NotEnoughFunds
 
 
 class TestNotEnoughFunds(TestCase):
     def test_exception(self):
         try:
-            raise NotEnoughFunds(10, 2)
+            raise NotEnoughFunds(10 * denoms.ether, 2 * denoms.ether)
         except NotEnoughFunds as err:
-            expected_str = "Not enough GNT available. Required: 10, " \
-                           "available: 2"
+            expected_str = "Not enough GNT available. Required: 10.000000, " \
+                           "available: 2.000000"
             assert expected_str in str(err)

--- a/tests/golem/transactions/ethereum/test_fundslocker.py
+++ b/tests/golem/transactions/ethereum/test_fundslocker.py
@@ -67,9 +67,15 @@ class TestFundsLocker(TempDirFixture):
         self._add_tasks(fl)
 
         # new fund locker should restore tasks
+        self.ts.reset_mock()
         fl2 = FundsLocker(self.ts, self.new_path)
         assert len(fl2.task_lock) == 4
         assert fl2.task_lock['abc'].gnt_lock == 320 * 10
+        assert self.ts.lock_funds_for_payments.call_count == 4
+        assert self.ts.lock_funds_for_payments.call_args_list[0][0] == (320, 10)
+        assert self.ts.lock_funds_for_payments.call_args_list[1][0] == (140, 7)
+        assert self.ts.lock_funds_for_payments.call_args_list[2][0] == (10, 4)
+        assert self.ts.lock_funds_for_payments.call_args_list[3][0] == (13, 1)
 
     @staticmethod
     def _add_tasks(fl):


### PR DESCRIPTION
Transaction system manages locked funds, not `FundsLocker`. `FundsLocker` is now just a simple class managing number of locked subtasks of a task.
This way everything funds related belongs in a single place - `TransactionSystem`.
No need to provide `locked` arguments in methods like `withdraw` or `concent_deposit`.
No need to remember about `FundsLocker` when querying for balance.