### PR TITLE
pubkeytoaddr should return checksum'd address

### DIFF
--- a/golem/transactions/ethereum/ethereumincomeskeeper.py
+++ b/golem/transactions/ethereum/ethereumincomeskeeper.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 
 
 class EthereumIncomesKeeper(IncomesKeeper):
-    BLOCK_NUMBER_DB_KEY = 'eth_incomes_keeper_block_number'
+    BLOCK_NUMBER_DB_KEY = 'eth_incomes_keeper_block_number_v2'
     BLOCK_NUMBER_BUFFER = 50
 
     def __init__(self, sci) -> None:

--- a/golem/utils.py
+++ b/golem/utils.py
@@ -3,7 +3,7 @@ import socket
 
 import semantic_version
 
-from eth_utils import decode_hex, encode_hex
+from eth_utils import decode_hex, encode_hex, to_checksum_address
 from ethereum.utils import sha3
 
 logger = logging.getLogger(__name__)
@@ -17,7 +17,7 @@ def find_free_net_port():
 
 
 def pubkeytoaddr(pubkey: str) -> str:
-    return encode_hex(sha3(decode_hex(pubkey))[12:])
+    return to_checksum_address(encode_hex(sha3(decode_hex(pubkey))[12:]))
 
 
 def tee_target(prefix, proc, input_stream, path, stream):

--- a/tests/golem/test_utils.py
+++ b/tests/golem/test_utils.py
@@ -1,5 +1,7 @@
+import os
 import unittest
 
+from eth_utils import encode_hex, is_checksum_address
 import faker
 import semantic_version
 
@@ -46,3 +48,9 @@ class IsVersionCompatibleTest(unittest.TestCase):
 
     def test_invalid(self):
         self.assertFalse(utils.is_version_compatible(fake.word(), self.spec))  # noqa pylint: disable=no-member
+
+
+def test_pubkeytoaddr():
+    pubkey = encode_hex(os.urandom(64))
+    addr = utils.pubkeytoaddr(pubkey)
+    assert is_checksum_address(addr)


### PR DESCRIPTION
`IncomesKeeper` doesn't work well without it.
Changing `BLOCK_NUMBER_DB_KEY` will trigger listening to old events which will correctly mark awaiting incomes as confirmed.