### PR TITLE
Client.{create,restart}_task: restore returning task id

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -738,7 +738,11 @@ class Client(HardwarePresetsMixin):
                  on failure
         """
         try:
-            _, task_id = self.enqueue_new_task(t_dict)
+            deferred, task_id = self.enqueue_new_task(t_dict)
+            # We want to return quickly from create_task without waiting for
+            # deferred completion.
+            deferred.addErrback(
+                lambda err: logger.error("Cannot create task: %r", err))
             return task_id, None
         except Exception as ex:  # pylint: disable=broad-except
             logger.error("Cannot create task %r: %s", t_dict, str(ex))

--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -112,8 +112,8 @@ class Tasks:
     @command(argument=id_req, help="Restart a task")
     def restart(self, id):
         deferred = Tasks.client.restart_task(id)
-        ok, error = sync_wait(deferred)
-        if not ok:
+        new_task_id, error = sync_wait(deferred)
+        if not new_task_id:
             return error
         return None
 

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -538,7 +538,7 @@ class TestTasks(TempDirFixture):
 
     def test_restart_success(self):
         with client_ctx(Tasks, self.client):
-            self.client.restart_task.return_value = True, 'whatever'
+            self.client.restart_task.return_value = 'new_task_id', 'whatever'
             tasks = Tasks()
             result = tasks.restart('task_id')
             self.assertIsNone(result)
@@ -546,7 +546,7 @@ class TestTasks(TempDirFixture):
 
     def test_restart_error(self):
         with client_ctx(Tasks, self.client):
-            self.client.restart_task.return_value = False, 'error'
+            self.client.restart_task.return_value = None, 'error'
             tasks = Tasks()
             result = tasks.restart('task_id')
             self.assertEqual(result, 'error')

--- a/tests/golem/interface/test_client_commands.py
+++ b/tests/golem/interface/test_client_commands.py
@@ -538,18 +538,18 @@ class TestTasks(TempDirFixture):
 
     def test_restart_success(self):
         with client_ctx(Tasks, self.client):
-            self.client.restart_task.return_value = 'new_task_id', 'whatever'
+            self.client.restart_task.return_value = 'new_task_id', None
             tasks = Tasks()
             result = tasks.restart('task_id')
-            self.assertIsNone(result)
+            self.assertEqual(result, 'new_task_id')
             self.client.restart_task.assert_called_once_with('task_id')
 
     def test_restart_error(self):
         with client_ctx(Tasks, self.client):
             self.client.restart_task.return_value = None, 'error'
             tasks = Tasks()
-            result = tasks.restart('task_id')
-            self.assertEqual(result, 'error')
+            with self.assertRaises(CommandException):
+                tasks.restart('task_id')
             self.client.restart_task.assert_called_once_with('task_id')
 
     def test_create(self) -> None:
@@ -582,6 +582,7 @@ class TestTasks(TempDirFixture):
             with patch(patched_open, mock_open(
                 read_data='{"name": "Golem task"}'
             )):
+                client.create_task.return_value = ('task_id', None)
                 tasks.create("foo")
                 task_def = json.loads('{"name": "Golem task"}')
                 client.create_task.assert_called_with(task_def)

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -507,7 +507,7 @@ class TestClient(TestWithDatabase, TestWithReactor):
 
         def add_task(*_args, **_kwargs):
             resource_manager_result = 'res_hash', ['res_file_1']
-            result = resource_manager_result, 'res_file_1', 'package_hash'
+            result = resource_manager_result, 'res_file_1', 'package_hash', 0
             return done_deferred(result)
 
         self.client.resource_server = Mock(

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -539,12 +539,12 @@ class TestClient(TestWithDatabase, TestWithReactor):
             'type': 'Dummy',
         }
 
-        task_id, error = sync_wait(self.client.create_task(task_dict))
+        task_id, error = self.client.create_task(task_dict)
 
         assert task_id
         assert not error
 
-        new_task_id, error = sync_wait(self.client.restart_task(task_id))
+        new_task_id, error = self.client.restart_task(task_id)
         assert new_task_id
         assert not error
         assert len(task_manager.tasks_states) == 2
@@ -1023,13 +1023,13 @@ class TestClientRPCMethods(TestWithDatabase, LogTestCase):
             side_effect=add_task)
         c.p2pservice.get_estimated_network_size.return_value = 0
 
-        deferred = c.enqueue_new_task(t_dict)
+        deferred, task_id = c.enqueue_new_task(t_dict)
         task = sync_wait(deferred)
         assert isinstance(task, Task)
         assert task.header.task_id
+        assert task.header.task_id == task_id
         assert c.resource_server.add_task.called
 
-        task_id = task.header.task_id
         c.task_server.task_manager.tasks[task_id] = task
         c.task_server.task_manager.tasks_states[task_id] = TaskState()
         frames = c.get_subtasks_frames(task_id)

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -539,23 +539,15 @@ class TestClient(TestWithDatabase, TestWithReactor):
             'type': 'Dummy',
         }
 
-        created, error = self.client.create_task(task_dict)
+        task_id, error = sync_wait(self.client.create_task(task_dict))
 
-        assert created
+        assert task_id
         assert not error
 
-        time.sleep(1)
-        task_id = list(task_manager.tasks_states)[0]
-
-        created, error = sync_wait(self.client.restart_task(task_id))
-        assert created
+        new_task_id, error = sync_wait(self.client.restart_task(task_id))
+        assert new_task_id
         assert not error
         assert len(task_manager.tasks_states) == 2
-        new_task_id = None
-        for i in task_manager.tasks_states.keys():
-            if i != task_id:
-                new_task_id = i
-                return
 
         assert task_id != new_task_id
         assert task_manager.tasks_states[


### PR DESCRIPTION
Also:
- test_restart_task should no longer cause failures on windows of #2701
- fixes #2953