### PR TITLE
Modified task cost & fee information

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -171,10 +171,6 @@ class CoreTask(Task):
         self.tmp_dir = None
         self.max_pending_client_results = max_pending_client_results
 
-    @property
-    def price(self) -> int:
-        return self.subtask_price * self.total_tasks
-
     @staticmethod
     def create_task_id(public_key: bytes) -> str:
         return generate_id(public_key)

--- a/golem/client.py
+++ b/golem/client.py
@@ -937,6 +937,12 @@ class Client(HardwarePresetsMixin):
         subtask_ids = list(task_state.subtask_states.keys())
         task_dict['cost'], task_dict['fee'] = \
             self.transaction_system.get_total_payment_for_subtasks(subtask_ids)
+
+        # Convert to string because RPC serializer fails on big numbers
+        for k in ('cost', 'fee', 'estimated_cost', 'estimated_fee'):
+            if task_dict[k] is not None:
+                task_dict[k] = str(task_dict[k])
+
         return task_dict
 
     def get_tasks(self, task_id: Optional[str] = None) \

--- a/golem/client.py
+++ b/golem/client.py
@@ -615,7 +615,9 @@ class Client(HardwarePresetsMixin):
             else:
                 task.header.mask = Mask()
 
-            task_manager.add_new_task(task)
+            estimated_fee = self.transaction_system.eth_for_batch_payment(
+                task.total_tasks)
+            task_manager.add_new_task(task, estimated_fee=estimated_fee)
 
             client_options = self.task_server.get_share_options(task_id, None)
             client_options.timeout = deadline_to_timeout(task.header.deadline)

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -299,6 +299,10 @@ class Task(abc.ABC):
         return '<Task: %r>' % (self.header,)
 
     @property
+    def price(self) -> int:
+        return self.subtask_price * self.get_total_tasks()
+
+    @property
     def subtask_price(self):
         from golem.task import taskkeeper
         return taskkeeper.compute_subtask_value(

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -147,7 +147,7 @@ class TaskManager(TaskEventListener):
         task_type = self.task_types[definition.task_type.lower()]
         return task_type.task_builder_type.build_dictionary(definition)
 
-    def add_new_task(self, task):
+    def add_new_task(self, task: Task, estimated_fee: int = 0) -> None:
         task_id = task.header.task_id
         if task_id in self.tasks:
             raise RuntimeError("Task {} has been already added"
@@ -169,6 +169,8 @@ class TaskManager(TaskEventListener):
         ts.outputs = task.get_output_names()
         ts.total_subtasks = task.get_total_tasks()
         ts.time_started = time.time()
+        ts.estimated_cost = task.price
+        ts.estimated_fee = estimated_fee
 
         self.tasks[task_id] = task
         self.tasks_states[task_id] = ts

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -23,6 +23,8 @@ class TaskState(object):
         self.package_size = None
         self.extra_data = {}
         self.last_update_time = time.time()
+        self.estimated_cost = 0
+        self.estimated_fee = 0
 
     def __setattr__(self, key, value):
         super().__setattr__(key, value)
@@ -37,7 +39,9 @@ class TaskState(object):
             'time_started': self.time_started,
             'time_remaining': self.remaining_time,
             'last_updated': getattr(self, 'last_update_time', None),
-            'status': self.status.value
+            'status': self.status.value,
+            'estimated_cost': getattr(self, 'estimated_cost', None),
+            'estimated_fee': getattr(self, 'estimated_fee', None)
         }
 
 

--- a/golem/transactions/transactionsystem.py
+++ b/golem/transactions/transactionsystem.py
@@ -1,4 +1,4 @@
-from typing import List, Iterable, Tuple
+from typing import List, Iterable, Tuple, Optional
 
 from golem.core.common import datetime_to_timestamp_utc, to_unicode
 from golem.core.service import LoopingCallService
@@ -58,12 +58,13 @@ class TransactionSystem(LoopingCallService):
         return self.payments_keeper.get_list_of_all_payments()
 
     def get_total_payment_for_subtasks(self, subtask_ids: Iterable[str]) \
-            -> Tuple[int, int]:
+            -> Tuple[Optional[int], Optional[int]]:
         """
-        Get total value and total fee for confirmed payments for the given
-        subtask IDs
+        Get total value and total fee for payments for the given subtask IDs
+        **if all payments for the given subtasks are sent**
         :param subtask_ids: subtask IDs
-        :return: (total_value, total_fee)
+        :return: (total_value, total_fee) if all payments are sent,
+                (None, None) otherwise
         """
         return self.payments_keeper.get_total_payment_for_subtasks(subtask_ids)
 

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -55,6 +55,9 @@ class TaskMock(Task):
     def query_extra_data(self, *args, **kwargs):
         return self.query_extra_data_return_value
 
+    def get_total_tasks(self):
+        return 0
+
     def __getstate__(self):
         state = super(TaskMock, self).__getstate__()
         del state['query_extra_data_return_value']
@@ -405,6 +408,9 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
                 e = self.ExtraData(False, ctd)
                 return e
 
+            def get_total_tasks(self):
+                return 0
+
             def needs_computation(self):
                 return sum(self.finished.values()) != len(self.finished)
 
@@ -644,13 +650,14 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
         assert self.tm.get_subtasks("TASK 1") == ["SUBTASK 1"]
 
     def test_resource_send(self):
+        # pylint: disable=abstract-class-instantiated
         from pydispatch import dispatcher
         self.tm.task_persistence = True
         owner = Node(node_name="ABC",
                      pub_addr="10.10.10.10",
                      pub_port=1023,
                      key="abcde")
-        t = Task(
+        t = TaskMock(
             TaskHeader(task_id="xyz", environment="DEFAULT", task_owner=owner),
             "print 'hello world'", None)
         listener_mock = Mock()
@@ -812,7 +819,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             prv_port=40103, pub_addr="1.2.3.4", pub_port=40103,
             p2p_prv_port=40102, p2p_pub_port=40102
         )
-        task = Task(
+        task = TaskMock(
             header=TaskHeader(
                 task_id="task_id",
                 environment="environment",


### PR DESCRIPTION
* Changed `get_total_payment_for_subtasks`:
  - return `(None, None)` instead of `(0, 0)` as empty result
  - include 'sent' payments, not only 'confirmed'
  - return Nones if not all tasks are sent (no partial sums)
* Added `estimated_cost` & `estimated_fee` to `TaskStatus`

