### PR TITLE
Removing resources methods from Options

### DIFF
--- a/apps/core/task/coretaskstate.py
+++ b/apps/core/task/coretaskstate.py
@@ -75,10 +75,10 @@ class TaskDefinition(object):
                 output_file, err)
 
     def add_to_resources(self):
-        self.options.add_to_resources(self.resources)
+        pass
 
     def remove_from_resources(self):
-        self.options.remove_from_resources(self.resources)
+        pass
 
     def make_preset(self):
         """ Create preset that can be shared with different tasks
@@ -153,9 +153,3 @@ class Options(object):
     def __init__(self):
         self.environment = Environment()
         self.name = ''
-
-    def add_to_resources(self, resources):
-        pass
-
-    def remove_from_resources(self, resources):
-        pass

--- a/tests/apps/core/task/test_coretaskstate.py
+++ b/tests/apps/core/task/test_coretaskstate.py
@@ -30,8 +30,6 @@ class TestOptions(TestCase):
         opt = Options()
         assert isinstance(opt.environment, Environment)
         assert opt.name == ""
-        opt.add_to_resources([])
-        opt.remove_from_resources([])
 
 
 class TestCoreTaskStateStyle(TestCase, PEP8MixIn):


### PR DESCRIPTION
Options class had some legacy methods dealing with resources. They were not used anywhere and this functionality was moved to TaskDefinition. 
This PR refactores them out.