### PR TITLE
Remove sync from EthereumTransactionSystem

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -269,7 +269,7 @@ class Client(HardwarePresetsMixin):
 
     @report_calls(Component.client, 'sync')
     def sync(self):
-        self.transaction_system.sync()
+        pass
 
     @report_calls(Component.client, 'start', stage=Stage.pre)
     def start(self):

--- a/golem/transactions/ethereum/ethereumtransactionsystem.py
+++ b/golem/transactions/ethereum/ethereumtransactionsystem.py
@@ -81,25 +81,20 @@ class EthereumTransactionSystem(TransactionSystem):
         self._last_gnt_update = None
         self._payments_locked: int = 0
         self._gntb_locked: int = 0
-        self._is_stopped = False
+
+        self._refresh_balances()
+        log.info(
+            "Initial balances: %f GNTB, %f GNT, %f ETH",
+            self._gntb_balance / denoms.ether,
+            self._gnt_balance / denoms.ether,
+            self._eth_balance / denoms.ether,
+        )
 
     def stop(self):
         super().stop()
-        self._is_stopped = True
         self.payment_processor.sendout(0)
         self.incomes_keeper.stop()
         self._sci.stop()
-
-    def sync(self) -> None:
-        log.info("Synchronizing balances")
-        while not self._is_stopped:
-            self._refresh_balances()
-            if self._last_eth_update is not None and \
-               self._last_gnt_update is not None:
-                log.info("Balances synchronized")
-                return
-            log.info("Waiting for initial GNT/ETH balances...")
-            time.sleep(1)
 
     def add_payment_info(self, *args, **kwargs):
         payment = super().add_payment_info(*args, **kwargs)

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -188,20 +188,6 @@ class TestClient(TestWithDatabase, TestWithReactor):
         self.assertIsInstance(payment_address, str)
         self.assertTrue(len(payment_address) > 0)
 
-    def test_sync(self, *_):
-        self.client = Client(
-            datadir=self.path,
-            app_config=Mock(),
-            config_desc=ClientConfigDescriptor(),
-            keys_auth=(Mock(_private_key='a' * 32)),
-            database=Mock(),
-            connect_to_known_hosts=False,
-            use_docker_manager=False,
-            use_monitor=False
-        )
-        self.client.sync()
-        self.assertTrue(self.client.transaction_system.sync.called)
-
     def test_remove_resources(self, *_):
         self.client = Client(
             datadir=self.path,

--- a/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
+++ b/tests/golem/transactions/ethereum/test_ethereumtransactionsystem.py
@@ -30,6 +30,9 @@ class TestEthereumTransactionSystem(TestWithDatabase, LogTestCase,
         self.sci.get_gate_address.return_value = None
         self.sci.get_block_number.return_value = 1223
         self.sci.get_current_gas_price.return_value = 10 ** 9
+        self.sci.get_eth_balance.return_value = 0
+        self.sci.get_gnt_balance.return_value = 0
+        self.sci.get_gntb_balance.return_value = 0
         self.sci.GAS_PER_PAYMENT = 20000
         self.ets = self._make_ets()
 


### PR DESCRIPTION
That fixes an issue where `FundsLocker` tries to restore locks at startup but the balances are not known yet so it fails.
But also I think this `sync` approach was not great in general.