### PR TITLE
monitor messages debug added

### DIFF
--- a/golem/monitor/transport/httptransport.py
+++ b/golem/monitor/transport/httptransport.py
@@ -14,8 +14,10 @@ class DefaultHttpSender(object):
 
     def _post(self, headers, payload):
         try:
+            log.debug(f'sending msg {payload}')
             r = requests.post(self.url, data=payload, headers=headers,
                               timeout=self.timeout)
+            log.debug(f'result {r}')
             return r.status_code == 200
         except requests.exceptions.RequestException as e:
             delta = time.time() - self.last_exception_time

--- a/tests/golem/core/test_hardware_presets.py
+++ b/tests/golem/core/test_hardware_presets.py
@@ -54,8 +54,12 @@ class TestHardwarePresets(testutils.DatabaseFixture):
 
     def test_update_config(self):
         # given
-        HardwarePreset.create(name='foo', cpu_cores=1, memory=1200000,
-                              disk=2000000)
+        cpu_cores = 1
+        memory = 1200000
+        disk = 2000000
+
+        HardwarePreset.create(name='foo', cpu_cores=cpu_cores, memory=memory,
+                              disk=disk)
 
         # when
         config_changed = HardwarePresets.update_config('foo', self.config)
@@ -63,9 +67,9 @@ class TestHardwarePresets(testutils.DatabaseFixture):
         # then
         assert not config_changed
         assert self.config.hardware_preset_name == 'foo'
-        assert self.config.num_cores == 1
-        assert self.config.max_memory_size == 1200000
-        assert self.config.max_resource_size == 2000000
+        assert self.config.num_cores == HardwarePresets.cpu_cores(cpu_cores)
+        assert self.config.max_memory_size == HardwarePresets.memory(memory)
+        assert self.config.max_resource_size == HardwarePresets.disk(disk)
 
     def test_update_config_upper_bounds(self):
         # given

--- a/tests/golem/core/test_hardware_presets.py
+++ b/tests/golem/core/test_hardware_presets.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from golem import testutils
 from golem.appconfig import DEFAULT_HARDWARE_PRESET_NAME as DEFAULT, \
     CUSTOM_HARDWARE_PRESET_NAME as CUSTOM, MIN_MEMORY_SIZE, MIN_DISK_SPACE, \
@@ -88,15 +90,29 @@ class TestHardwarePresets(testutils.DatabaseFixture):
 
     def test_update_config_not_changed(self):
         # given
-        HardwarePreset.create(name='foo', cpu_cores=1, memory=1200000,
-                              disk=2000000)
+        cpu_cores = HardwarePresets.cpu_cores(1)
+        memory = HardwarePresets.memory(1200000)
+        disk = HardwarePresets.disk(2000000)
+
+        HardwarePreset.create(name='foo', cpu_cores=cpu_cores, memory=memory,
+                              disk=disk)
 
         # then
-        assert not HardwarePresets.update_config(DEFAULT, self.config)
-        assert not HardwarePresets.update_config(DEFAULT, self.config)
-        assert not HardwarePresets.update_config(DEFAULT, self.config)
-        assert HardwarePresets.update_config(CUSTOM, self.config)
-        assert not HardwarePresets.update_config(CUSTOM, self.config)
-        assert HardwarePresets.update_config(DEFAULT, self.config)
-        assert HardwarePresets.update_config('foo', self.config)
-        assert not HardwarePresets.update_config('foo', self.config)
+        with mock.patch(
+            'golem.core.hardware.HardwarePresets.cpu_cores',
+            return_value=cpu_cores
+        ), mock.patch(
+            'golem.core.hardware.HardwarePresets.memory',
+            return_value=memory
+        ), mock.patch(
+            'golem.core.hardware.HardwarePresets.disk',
+            return_value=disk
+        ):
+            assert not HardwarePresets.update_config(DEFAULT, self.config)
+            assert not HardwarePresets.update_config(DEFAULT, self.config)
+            assert not HardwarePresets.update_config(DEFAULT, self.config)
+            assert HardwarePresets.update_config(CUSTOM, self.config)
+            assert not HardwarePresets.update_config(CUSTOM, self.config)
+            assert HardwarePresets.update_config(DEFAULT, self.config)
+            assert HardwarePresets.update_config('foo', self.config)
+            assert not HardwarePresets.update_config('foo', self.config)

--- a/tests/golem/core/test_hardware_presets.py
+++ b/tests/golem/core/test_hardware_presets.py
@@ -1,4 +1,4 @@
-from unittest import mock
+from unittest.mock import patch
 
 from golem import testutils
 from golem.appconfig import DEFAULT_HARDWARE_PRESET_NAME as DEFAULT, \
@@ -9,6 +9,9 @@ from golem.core.hardware import HardwarePresets
 from golem.model import HardwarePreset
 
 
+@patch('golem.core.hardware.cpu_cores_available', return_value=[1] * 7)
+@patch('golem.core.hardware.memory_available', return_value=7e7)
+@patch('golem.core.hardware.free_partition_space', return_value=7e9)
 class TestHardwarePresets(testutils.DatabaseFixture):
 
     def setUp(self):
@@ -16,17 +19,41 @@ class TestHardwarePresets(testutils.DatabaseFixture):
         HardwarePresets.initialize(self.tempdir)
         self.config = ClientConfigDescriptor()
 
-    def test_initialize(self):
+    def test_initialize(self, *_):
         assert HardwarePreset.get(name=DEFAULT)
         assert HardwarePreset.get(name=CUSTOM)
 
-    def test_caps(self):
+    def test_caps(self, *_):
         caps = HardwarePresets.caps()
-        assert caps['cpu_cores'] > 0
-        assert caps['memory'] > 0
-        assert caps['disk'] > 0
+        assert caps['cpu_cores'] == 7
+        assert caps['memory'] == 7e7
+        assert caps['disk'] == 7e9
 
-    def test_update_config_to_default(self):
+    def test_cpu_cores(self, *_):
+        assert HardwarePresets.cpu_cores(-1) == MIN_CPU_CORES
+        assert HardwarePresets.cpu_cores(0) == MIN_CPU_CORES
+        assert HardwarePresets.cpu_cores(1) == 1
+        assert HardwarePresets.cpu_cores(7) == 7
+        assert HardwarePresets.cpu_cores(8) == 7
+        assert HardwarePresets.cpu_cores(1e9) == 7
+
+    def test_memory(self, *_):
+        assert HardwarePresets.memory(-1) == MIN_MEMORY_SIZE
+        assert HardwarePresets.memory(1e6) == MIN_MEMORY_SIZE
+        assert HardwarePresets.memory(2**20) == 2 ** 20
+        assert HardwarePresets.memory(1e7) == 1e7
+        assert HardwarePresets.memory(7e7) == 7e7
+        assert HardwarePresets.memory(9e9) == 7e7
+
+    def test_disk(self, *_):
+        assert HardwarePresets.disk(-1) == MIN_DISK_SPACE
+        assert HardwarePresets.disk(1e6) == MIN_DISK_SPACE
+        assert HardwarePresets.disk(2**20) == 2 ** 20
+        assert HardwarePresets.disk(1e7) == 1e7
+        assert HardwarePresets.disk(7e9) == 7e9
+        assert HardwarePresets.disk(9e19) == 7e9
+
+    def test_update_config_to_default(self, *_):
         # given
         _, default_preset = HardwarePresets.values(DEFAULT)
 
@@ -40,9 +67,9 @@ class TestHardwarePresets(testutils.DatabaseFixture):
         assert self.config.max_memory_size == default_preset['memory']
         assert self.config.max_resource_size == default_preset['disk']
 
-    def test_update_config_lower_bounds(self):
+    def test_update_config_lower_bounds(self, *_):
         # given
-        HardwarePreset.create(name='min', cpu_cores=-7, memory=3, disk=2)
+        HardwarePreset.create(name='min', cpu_cores=-7, memory=-1, disk=-1)
 
         # when
         config_changed = HardwarePresets.update_config('min', self.config)
@@ -54,14 +81,10 @@ class TestHardwarePresets(testutils.DatabaseFixture):
         assert self.config.max_memory_size == MIN_MEMORY_SIZE
         assert self.config.max_resource_size == MIN_DISK_SPACE
 
-    def test_update_config(self):
+    def test_update_config(self, *_):
         # given
-        cpu_cores = 1
-        memory = 1200000
-        disk = 2000000
-
-        HardwarePreset.create(name='foo', cpu_cores=cpu_cores, memory=memory,
-                              disk=disk)
+        HardwarePreset.create(name='foo', cpu_cores=1, memory=1200000,
+                              disk=2000000)
 
         # when
         config_changed = HardwarePresets.update_config('foo', self.config)
@@ -69,11 +92,11 @@ class TestHardwarePresets(testutils.DatabaseFixture):
         # then
         assert not config_changed
         assert self.config.hardware_preset_name == 'foo'
-        assert self.config.num_cores == HardwarePresets.cpu_cores(cpu_cores)
-        assert self.config.max_memory_size == HardwarePresets.memory(memory)
-        assert self.config.max_resource_size == HardwarePresets.disk(disk)
+        assert self.config.num_cores == 1
+        assert self.config.max_memory_size == 1200000
+        assert self.config.max_resource_size == 2000000
 
-    def test_update_config_upper_bounds(self):
+    def test_update_config_upper_bounds(self, *_):
         # given
         HardwarePreset.create(name='max', cpu_cores=1e9, memory=1e18, disk=1e18)
         caps = HardwarePresets.caps()
@@ -88,31 +111,17 @@ class TestHardwarePresets(testutils.DatabaseFixture):
         assert self.config.max_memory_size == caps['memory']
         assert self.config.max_resource_size == caps['disk']
 
-    def test_update_config_not_changed(self):
+    def test_update_config_not_changed(self, *_):
         # given
-        cpu_cores = HardwarePresets.cpu_cores(1)
-        memory = HardwarePresets.memory(1200000)
-        disk = HardwarePresets.disk(2000000)
-
-        HardwarePreset.create(name='foo', cpu_cores=cpu_cores, memory=memory,
-                              disk=disk)
+        HardwarePreset.create(name='foo', cpu_cores=1, memory=1200000,
+                              disk=2000000)
 
         # then
-        with mock.patch(
-            'golem.core.hardware.HardwarePresets.cpu_cores',
-            return_value=cpu_cores
-        ), mock.patch(
-            'golem.core.hardware.HardwarePresets.memory',
-            return_value=memory
-        ), mock.patch(
-            'golem.core.hardware.HardwarePresets.disk',
-            return_value=disk
-        ):
-            assert not HardwarePresets.update_config(DEFAULT, self.config)
-            assert not HardwarePresets.update_config(DEFAULT, self.config)
-            assert not HardwarePresets.update_config(DEFAULT, self.config)
-            assert HardwarePresets.update_config(CUSTOM, self.config)
-            assert not HardwarePresets.update_config(CUSTOM, self.config)
-            assert HardwarePresets.update_config(DEFAULT, self.config)
-            assert HardwarePresets.update_config('foo', self.config)
-            assert not HardwarePresets.update_config('foo', self.config)
+        assert not HardwarePresets.update_config(DEFAULT, self.config)
+        assert not HardwarePresets.update_config(DEFAULT, self.config)
+        assert not HardwarePresets.update_config(DEFAULT, self.config)
+        assert HardwarePresets.update_config(CUSTOM, self.config)
+        assert not HardwarePresets.update_config(CUSTOM, self.config)
+        assert HardwarePresets.update_config(DEFAULT, self.config)
+        assert HardwarePresets.update_config('foo', self.config)
+        assert not HardwarePresets.update_config('foo', self.config)


### PR DESCRIPTION
enables monitor messages preview for debugging purposes

just change this in `loggingconfig.py`:
```
    'handlers': {
        'console': {
            'class': 'logging.StreamHandler',
            'level': 'DEBUG',
```
and add
```
        'golem.monitor.transport': {
            'level': 'DEBUG',
            'propagate': True,
        },
```
