### PR TITLE
Remove unnecessary getter from TransactionSystem

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -31,9 +31,13 @@ from golem.config.active import EthereumConfig
 from golem.config.presets import HardwarePresetsMixin
 from golem.core import variables
 from golem.core.async import AsyncRequest, async_run
-from golem.core.common import get_timestamp_utc, to_unicode, \
-    string_to_timeout, \
-    deadline_to_timeout
+from golem.core.common import (
+    deadline_to_timeout,
+    datetime_to_timestamp_utc,
+    get_timestamp_utc,
+    string_to_timeout,
+    to_unicode,
+)
 from golem.core.fileshelper import du
 from golem.core.hardware import HardwarePresets
 from golem.core.keysauth import KeysAuth
@@ -1036,7 +1040,22 @@ class Client(HardwarePresetsMixin):
         return self.transaction_system.get_payments_list()
 
     def get_incomes_list(self):
-        return self.transaction_system.get_incoming_payments()
+        incomes = self.transaction_system.get_incomes_list()
+
+        def item(o):
+            status = "confirmed" if o.transaction else "awaiting"
+
+            return {
+                "subtask": to_unicode(o.subtask),
+                "payer": to_unicode(o.sender_node),
+                "value": to_unicode(o.value),
+                "status": to_unicode(status),
+                "transaction": to_unicode(o.transaction),
+                "created": datetime_to_timestamp_utc(o.created_date),
+                "modified": datetime_to_timestamp_utc(o.modified_date)
+            }
+
+        return [item(income) for income in incomes]
 
     def get_withdraw_gas_cost(
             self,

--- a/golem/transactions/transactionsystem.py
+++ b/golem/transactions/transactionsystem.py
@@ -1,8 +1,7 @@
 from typing import List, Iterable, Tuple, Optional
 
-from golem.core.common import datetime_to_timestamp_utc, to_unicode
 from golem.core.service import LoopingCallService
-from golem.model import Payment, PaymentStatus, PaymentDetails
+from golem.model import Payment, PaymentDetails
 
 from .paymentskeeper import PaymentsKeeper
 from .incomeskeeper import IncomesKeeper
@@ -73,28 +72,6 @@ class TransactionSystem(LoopingCallService):
         :return list: list of dictionaries describing incomes
         """
         return self.incomes_keeper.get_list_of_all_incomes()
-
-    def get_incoming_payments(self):
-        """Returns preprocessed list of pending & confirmed incomes.
-        It's optimised for electron GUI.
-        """
-        incomes = self.incomes_keeper.get_list_of_all_incomes()
-
-        def item(o):
-            status = PaymentStatus.confirmed if o.transaction \
-                else PaymentStatus.awaiting
-
-            return {
-                "subtask": to_unicode(o.subtask),
-                "payer": to_unicode(o.sender_node),
-                "value": to_unicode(o.value),
-                "status": to_unicode(status.name),
-                "transaction": to_unicode(o.transaction),
-                "created": datetime_to_timestamp_utc(o.created_date),
-                "modified": datetime_to_timestamp_utc(o.modified_date)
-            }
-
-        return [item(income) for income in incomes]
 
     def get_nodes_with_overdue_payments(self) -> List[str]:
         overdue_incomes = self.incomes_keeper.update_overdue_incomes()

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -129,8 +129,9 @@ class TestClient(TestWithDatabase, TestWithReactor):
             use_docker_manager=False,
             use_monitor=False
         )
-        assert self.client.get_incomes_list() == \
-            self.client.transaction_system.get_incoming_payments.return_value
+        self.client.get_incomes_list()
+        self.client.transaction_system.get_incomes_list.\
+            assert_called_once_with()
 
     def test_withdraw(self, *_):
         keys_auth = Mock()


### PR DESCRIPTION
This method was responsible for the presentation layer, so no need for it to exist in `TransactionSystem`