### PR TITLE
Different retry logic for Geth requests

### DIFF
--- a/golem/ethereum/node.py
+++ b/golem/ethereum/node.py
@@ -62,12 +62,12 @@ class NodeProcess(object):
         log.info('GETH: connecting to remote RPC interface at %s', addr)
         return ProviderProxy(HTTPProvider(addr))
 
-    def _handle_remote_rpc_provider_failure(self, exc):
+    def _handle_remote_rpc_provider_failure(self):
         from golem.core.async import async_run, AsyncRequest
-        log.warning('GETH: reconnecting to another provider (%r)', exc)
+        log.warning('GETH: reconnecting to another provider')
         self.provider_proxy.provider = None
 
         request = AsyncRequest(self.start)
         async_run(request).addErrback(
-            lambda err: self._handle_remote_rpc_provider_failure(err)
+            lambda err: self._handle_remote_rpc_provider_failure()
         )

--- a/golem/ethereum/web3/middleware.py
+++ b/golem/ethereum/web3/middleware.py
@@ -1,10 +1,14 @@
+import logging
 import socket
 
 from types import MethodType
 
 from web3.exceptions import CannotHandleRequest
 
-MAX_ERRORS = 3
+logger = logging.getLogger(__name__)
+
+MAX_ERRORS = 20
+RETRIES = 3
 
 
 class RemoteRPCErrorMiddlewareBuilder:
@@ -15,7 +19,8 @@ class RemoteRPCErrorMiddlewareBuilder:
 
     def __init__(self,
                  error_listener: MethodType,
-                 max_errors: int = MAX_ERRORS) -> None:
+                 max_errors: int = MAX_ERRORS,
+                 retries: int = RETRIES) -> None:
         """
         :param error_listener: Function to execute when the maximum number of
         consecutive errors is reached
@@ -23,26 +28,30 @@ class RemoteRPCErrorMiddlewareBuilder:
         """
         self._max_errors = max_errors
         self._cur_errors = 0
+        self._retries = retries
         self._err_listener = error_listener
 
     def build(self, make_request, _web3):
         """ Returns the middleware function """
 
         def middleware(method, params):
-            try:
-                result = make_request(method, params)
-            except (ConnectionError, ValueError,
-                    socket.error, CannotHandleRequest) as exc:
-
-                self._cur_errors += 1
-                if self._cur_errors >= self._max_errors:
+            while True:
+                try:
+                    result = make_request(method, params)
+                except (ConnectionError, ValueError,
+                        socket.error, CannotHandleRequest) as exc:
+                    logger.warning(
+                        'GETH: request failure, retrying: %s',
+                        exc,
+                    )
+                    self._cur_errors += 1
+                    if self._cur_errors >= self._max_errors:
+                        raise
+                    if self._cur_errors % self._retries == 0:
+                        self._err_listener()
+                else:
                     self.reset()
-                    self._err_listener(exc)
-                raise
-
-            else:
-                self.reset()
-                return result
+                    return result
 
         return middleware
 

--- a/tests/golem/ethereum/test_ethereum_node.py
+++ b/tests/golem/ethereum/test_ethereum_node.py
@@ -29,7 +29,7 @@ class TestPublicNodeList(TestCase):
 
         node.provider_proxy.provider = Mock()
         node.addr_list = []
-        node._handle_remote_rpc_provider_failure(Exception('test exception'))
+        node._handle_remote_rpc_provider_failure()
 
         assert node.provider_proxy.provider is None
         assert node.start.called

--- a/tests/golem/ethereum/web3/test_middleware.py
+++ b/tests/golem/ethereum/web3/test_middleware.py
@@ -42,6 +42,11 @@ class TestMiddleware(unittest.TestCase):
         make_request = Mock(side_effect=ConnectionError)
         middleware = builder.build(make_request, _web3=None)
 
+        middleware(Mock(), None)
+        assert listener.call_count == 1
+
+        middleware(Mock(), None)
+        assert listener.call_count == 2
+
         with self.assertRaises(ConnectionError):
             middleware(Mock(), None)
-        assert listener.call_count == 2

--- a/tests/golem/ethereum/web3/test_middleware.py
+++ b/tests/golem/ethereum/web3/test_middleware.py
@@ -34,14 +34,14 @@ class TestMiddleware(unittest.TestCase):
 
     def test_unrecoverable_errors(self):
         listener = Mock()
-        builder = RemoteRPCErrorMiddlewareBuilder(listener, max_errors=2)
+        builder = RemoteRPCErrorMiddlewareBuilder(
+            listener,
+            max_errors=5,
+            retries=2,
+        )
         make_request = Mock(side_effect=ConnectionError)
         middleware = builder.build(make_request, _web3=None)
 
         with self.assertRaises(ConnectionError):
             middleware(Mock(), None)
-        assert not listener.called
-
-        with self.assertRaises(ConnectionError):
-            middleware(Mock(), None)
-        assert listener.called
+        assert listener.call_count == 2


### PR DESCRIPTION
Every `RETRIES` times change the Geth server up to `MAX_ERRORS` when it fails completely.