### PR TITLE
Use Ethereum address for incomes

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -1073,7 +1073,7 @@ class Client(HardwarePresetsMixin):
 
             return {
                 "subtask": to_unicode(o.subtask),
-                "payer": to_unicode(o.sender_node),
+                "payer": to_unicode(o.payer_address),
                 "value": to_unicode(o.value),
                 "status": to_unicode(status),
                 "transaction": to_unicode(o.transaction),

--- a/golem/database/database.py
+++ b/golem/database/database.py
@@ -51,7 +51,7 @@ class GolemSqliteDatabase(peewee.SqliteDatabase):
 
 class Database:
 
-    SCHEMA_VERSION = 16
+    SCHEMA_VERSION = 18
 
     def __init__(self,  # noqa pylint: disable=too-many-arguments
                  db: peewee.Database,
@@ -77,7 +77,7 @@ class Database:
         if not version:
             self._create_tables()
         elif schemas_dir and version < self.SCHEMA_VERSION:
-            self._migrate_schema(version, to_version=self.SCHEMA_VERSION)
+            self._migrate_schema(version, self.SCHEMA_VERSION)
 
     def close(self):
         if not self.db.is_closed():

--- a/golem/database/schemas/017_schema.py
+++ b/golem/database/schemas/017_schema.py
@@ -1,0 +1,31 @@
+# pylint: disable=no-member
+# pylint: disable=unused-argument
+# pylint: disable=too-few-public-methods
+import peewee as pw
+from golem.model import Income
+from golem.utils import pubkeytoaddr
+
+SCHEMA_VERSION = 17
+
+
+def _fill_payer_address():
+    while True:
+        entries = \
+            Income.select().where(Income.payer_address.is_null()).limit(50)
+        if not entries:
+            break
+        for entry in entries:
+            entry.payer_address = pubkeytoaddr(entry.sender_node)[2:]
+            entry.save()
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_fields(
+        'income',
+        payer_address=pw.CharField(max_length=255, null=True),
+    )
+    migrator.python(_fill_payer_address)
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.remove_fields('income', 'payer_address')

--- a/golem/database/schemas/018_schema.py
+++ b/golem/database/schemas/018_schema.py
@@ -1,0 +1,15 @@
+# pylint: disable=no-member
+# pylint: disable=unused-argument
+# pylint: disable=too-few-public-methods
+SCHEMA_VERSION = 18
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_not_null('income', 'payer_address')
+    migrator.remove_index('income', 'sender_node', 'subtask')
+    migrator.remove_fields('income', 'sender_node')
+    migrator.add_index('income', 'payer_address', 'subtask')
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.drop_not_null('income', 'payer_address')

--- a/golem/model.py
+++ b/golem/model.py
@@ -238,7 +238,7 @@ class Payment(BaseModel):
 
 
 class Income(BaseModel):
-    sender_node = CharField()
+    payer_address = CharField()
     subtask = CharField()
     value = HexIntegerField()
     accepted_ts = IntegerField(null=True)
@@ -248,7 +248,7 @@ class Income(BaseModel):
 
     class Meta:
         database = db
-        primary_key = CompositeKey('sender_node', 'subtask')
+        primary_key = CompositeKey('payer_address', 'subtask')
 
     def __repr__(self):
         return "<Income: {!r} v:{:.3f} accepted_ts:{!r} tid:{!r}>"\

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -28,7 +28,7 @@ from golem.task.benchmarkmanager import BenchmarkManager
 from golem.task.taskbase import TaskHeader, Task
 from golem.task.taskconnectionshelper import TaskConnectionsHelper
 from golem.task.taskstate import TaskOp
-from golem.utils import decode_hex
+from golem.utils import decode_hex, pubkeytoaddr
 
 from .result.resultmanager import ExtractedPackage
 from .server import resources
@@ -226,7 +226,7 @@ class TaskServer(
         if subtask_id not in self.results_to_send:
             value = self.task_manager.comp_task_keeper.get_value(task_id)
             self.client.transaction_system.incomes_keeper.expect(
-                sender_node_id=header.task_owner.key,
+                payer_address=pubkeytoaddr(header.task_owner.key),
                 subtask_id=subtask_id,
                 value=value,
             )
@@ -415,7 +415,7 @@ class TaskServer(
         logger.debug("Subtask %r result accepted", subtask_id)
         self.task_result_sent(subtask_id)
         self.client.transaction_system.incomes_keeper.update_awaiting(
-            sender_node_id,
+            pubkeytoaddr(sender_node_id),
             subtask_id,
             accepted_ts,
         )
@@ -425,7 +425,10 @@ class TaskServer(
         logger.debug("Subtask %r settled by the Concent", subtask_id)
         self.task_result_sent(subtask_id)
         self.client.transaction_system.incomes_keeper.settled(
-            sender_node_id, subtask_id, settled_ts)
+            pubkeytoaddr(sender_node_id),
+            subtask_id,
+            settled_ts,
+        )
 
     def subtask_failure(self, subtask_id, err):
         logger.info("Computation for task %r failed: %r.", subtask_id, err)

--- a/golem/transactions/incomeskeeper.py
+++ b/golem/transactions/incomeskeeper.py
@@ -9,7 +9,6 @@ from pydispatch import dispatcher
 
 from golem.core.variables import PAYMENT_DEADLINE
 from golem.model import Income
-from golem.utils import pubkeytoaddr
 
 logger = logging.getLogger("golem.transactions.incomeskeeper")
 
@@ -35,12 +34,11 @@ class IncomesKeeper:
             amount: int,
             closure_time: int) -> None:
         expected = Income.select().where(
+            Income.payer_address == sender,
             Income.accepted_ts > 0,
             Income.accepted_ts <= closure_time,
             Income.transaction.is_null(),
             Income.settled_ts.is_null())
-        expected = \
-            [e for e in expected if pubkeytoaddr(e.sender_node) == sender]
 
         expected_value = sum([e.value for e in expected])
         if expected_value == 0:
@@ -79,17 +77,17 @@ class IncomesKeeper:
             value=amount,
         )
 
-    def expect(self, sender_node_id, subtask_id, value):
+    def expect(self, payer_address: str, subtask_id: str, value: int):
         logger.debug(
-            "expect(%r, %r, %r)",
-            sender_node_id,
+            "Expected income - payer: %s, subtask: %s, value: %f",
+            payer_address,
             subtask_id,
-            value
+            value / denoms.ether,
         )
         return Income.create(
-            sender_node=sender_node_id,
+            payer_address=payer_address,
             subtask=subtask_id,
-            value=value
+            value=value,
         )
 
     @staticmethod
@@ -111,9 +109,9 @@ class IncomesKeeper:
         )
 
     @staticmethod
-    def settled(sender_node, subtask_id, settled_ts):
+    def settled(payer_address: str, subtask_id: str, settled_ts: int):
         try:
-            income = Income.get(sender_node=sender_node, subtask=subtask_id)
+            income = Income.get(payer_address=payer_address, subtask=subtask_id)
         except Income.DoesNotExist:
             logger.error(
                 "Income.DoesNotExist subtask_id: %r", subtask_id)
@@ -128,9 +126,10 @@ class IncomesKeeper:
             sender_addr: str,
             subtask_id: str,
             value: int) -> None:
-        expected = Income.select().where(Income.subtask_id == subtask_id)
-        expected = \
-            [e for e in expected if pubkeytoaddr(e.sender_node) == sender_addr]
+        expected = Income.select().where(
+            Income.payer_address == sender_addr,
+            Income.subtask_id == subtask_id,
+        )
         if not expected:
             logger.info(
                 "Received forced subtask payment but there's no entry for "
@@ -151,9 +150,13 @@ class IncomesKeeper:
             income.value = value
         income.save()
 
-    def update_awaiting(self, sender_node, subtask_id, accepted_ts):
+    def update_awaiting(
+            self,
+            payer_address: str,
+            subtask_id: str,
+            accepted_ts: int):
         try:
-            income = Income.get(sender_node=sender_node, subtask=subtask_id)
+            income = Income.get(payer_address=payer_address, subtask=subtask_id)
         except Income.DoesNotExist:
             logger.error(
                 "Income.DoesNotExist subtask_id: %r",
@@ -173,7 +176,7 @@ class IncomesKeeper:
         # TODO: pagination. issue #2402
         return Income.select(
             Income.created_date,
-            Income.sender_node,
+            Income.payer_address,
             Income.subtask,
             Income.transaction,
             Income.value

--- a/tests/factories/model.py
+++ b/tests/factories/model.py
@@ -9,7 +9,7 @@ class Income(Factory):
     class Meta:
         model = model.Income
 
-    sender_node = Faker('binary', length=64)
+    payer_address = '0x' + 40 * '3'
     subtask = Faker('uuid4')
     value = Faker('pyint')
 


### PR DESCRIPTION
Instead of `sender_node_id`.
Had to use two migration steps because peewee_migrate doesn't handle adding `not_null` constraint very well.