### PR TITLE
nvidia-docker packaging (pyinstaller)

### DIFF
--- a/scripts/pyinstaller/hooks/hook-golem.py
+++ b/scripts/pyinstaller/hooks/hook-golem.py
@@ -6,11 +6,16 @@ hiddenimports = collect_submodules('golem') + \
 
 datas = [
     ('loggingconfig.py', '.'),
+    ('apps/entrypoint.sh', 'apps/'),
     ('apps/*.ini', 'apps/'),
+    ('apps/core/resources/images/nvgpu.Dockerfile',
+     'apps/core/resources/images/'),
     ('apps/rendering/benchmark/minilight/cornellbox.ml.txt',
      'apps/rendering/benchmark/minilight/'),
     ('apps/rendering/resources/scripts/runner.py',
      'apps/rendering/resources/scripts/'),
+    ('apps/blender/resources/images/blender_nvgpu.Dockerfile',
+     'apps/blender/resources/images/'),
     ('apps/blender/resources/scripts/blendercrop.py.template',
      'apps/blender/resources/scripts/'),
     ('apps/blender/resources/scripts/docker_blendertask.py',


### PR DESCRIPTION
The built bundle will now include nvgpu dockerfiles and the entrypoint script. This allows Golem to build the required docker images.