### PR TITLE
Use Ethereum address for incomes

### DIFF
--- a/golem/database/database.py
+++ b/golem/database/database.py
@@ -51,7 +51,7 @@ class GolemSqliteDatabase(peewee.SqliteDatabase):
 
 class Database:
 
-    SCHEMA_VERSION = 17
+    SCHEMA_VERSION = 19
 
     def __init__(self,  # noqa pylint: disable=too-many-arguments
                  db: peewee.Database,

--- a/golem/database/schemas/018_schema.py
+++ b/golem/database/schemas/018_schema.py
@@ -1,0 +1,31 @@
+# pylint: disable=no-member
+# pylint: disable=unused-argument
+# pylint: disable=too-few-public-methods
+import peewee as pw
+from golem.model import Income
+from golem.utils import pubkeytoaddr
+
+SCHEMA_VERSION = 18
+
+
+def _fill_payer_address():
+    while True:
+        entries = \
+            Income.select().where(Income.payer_address.is_null()).limit(50)
+        if not entries:
+            break
+        for entry in entries:
+            entry.payer_address = pubkeytoaddr(entry.sender_node)[2:]
+            entry.save()
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_fields(
+        'income',
+        payer_address=pw.CharField(max_length=255, null=True),
+    )
+    migrator.python(_fill_payer_address)
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.remove_fields('income', 'payer_address')

--- a/golem/database/schemas/019_schema.py
+++ b/golem/database/schemas/019_schema.py
@@ -1,0 +1,12 @@
+# pylint: disable=no-member
+# pylint: disable=unused-argument
+# pylint: disable=too-few-public-methods
+SCHEMA_VERSION = 19
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_not_null('income', 'payer_address')
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.drop_not_null('income', 'payer_address')

--- a/golem/model.py
+++ b/golem/model.py
@@ -238,6 +238,7 @@ class Payment(BaseModel):
 class Income(BaseModel):
     sender_node = CharField()
     subtask = CharField()
+    payer_address = CharField()
     value = HexIntegerField()
     accepted_ts = IntegerField(null=True)
     transaction = CharField(null=True)

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -28,7 +28,7 @@ from golem.task.benchmarkmanager import BenchmarkManager
 from golem.task.taskbase import TaskHeader, Task
 from golem.task.taskconnectionshelper import TaskConnectionsHelper
 from golem.task.taskstate import TaskOp
-from golem.utils import decode_hex
+from golem.utils import decode_hex, pubkeytoaddr
 
 from .result.resultmanager import ExtractedPackage
 from .server import resources
@@ -226,8 +226,9 @@ class TaskServer(
         if subtask_id not in self.results_to_send:
             value = self.task_manager.comp_task_keeper.get_value(task_id)
             self.client.transaction_system.incomes_keeper.expect(
-                sender_node_id=header.task_owner.key,
+                sender_node=header.task_owner.key,
                 subtask_id=subtask_id,
+                payer_address=pubkeytoaddr(header.task_owner.key),
                 value=value,
             )
 

--- a/golem/transactions/incomeskeeper.py
+++ b/golem/transactions/incomeskeeper.py
@@ -9,9 +9,8 @@ from pydispatch import dispatcher
 
 from golem.core.variables import PAYMENT_DEADLINE
 from golem.model import Income
-from golem.utils import pubkeytoaddr
 
-logger = logging.getLogger("golem.transactions.incomeskeeper")
+logger = logging.getLogger(__name__)
 
 
 class IncomesKeeper:
@@ -35,12 +34,11 @@ class IncomesKeeper:
             amount: int,
             closure_time: int) -> None:
         expected = Income.select().where(
+            Income.payer_address == sender,
             Income.accepted_ts > 0,
             Income.accepted_ts <= closure_time,
             Income.transaction.is_null(),
             Income.settled_ts.is_null())
-        expected = \
-            [e for e in expected if pubkeytoaddr(e.sender_node) == sender]
 
         expected_value = sum([e.value for e in expected])
         if expected_value == 0:
@@ -79,21 +77,29 @@ class IncomesKeeper:
             value=amount,
         )
 
-    def expect(self, sender_node_id, subtask_id, value):
-        logger.debug(
-            "expect(%r, %r, %r)",
-            sender_node_id,
+    @staticmethod
+    def expect(
+            sender_node: str,
+            subtask_id: str,
+            payer_address: str,
+            value: int) -> Income:
+        logger.info(
+            "Expected income - sender_node: %s, subtask: %s, "
+            "payer: %s, value: %f",
+            sender_node,
             subtask_id,
-            value
+            payer_address,
+            value / denoms.ether,
         )
         return Income.create(
-            sender_node=sender_node_id,
+            sender_node=sender_node,
             subtask=subtask_id,
-            value=value
+            payer_address=payer_address,
+            value=value,
         )
 
     @staticmethod
-    def reject(subtask_id):
+    def reject(subtask_id: str) -> None:
         try:
             income = Income.get(subtask=subtask_id, accepted_ts=None,
                                 overdue=False)
@@ -111,7 +117,10 @@ class IncomesKeeper:
         )
 
     @staticmethod
-    def settled(sender_node, subtask_id, settled_ts):
+    def settled(
+            sender_node: str,
+            subtask_id: str,
+            settled_ts: int) -> None:
         try:
             income = Income.get(sender_node=sender_node, subtask=subtask_id)
         except Income.DoesNotExist:
@@ -128,9 +137,10 @@ class IncomesKeeper:
             sender_addr: str,
             subtask_id: str,
             value: int) -> None:
-        expected = Income.select().where(Income.subtask_id == subtask_id)
-        expected = \
-            [e for e in expected if pubkeytoaddr(e.sender_node) == sender_addr]
+        expected = Income.select().where(
+            Income.payer_address == sender_addr,
+            Income.subtask_id == subtask_id,
+        )
         if not expected:
             logger.info(
                 "Received forced subtask payment but there's no entry for "
@@ -151,7 +161,11 @@ class IncomesKeeper:
             income.value = value
         income.save()
 
-    def update_awaiting(self, sender_node, subtask_id, accepted_ts):
+    @staticmethod
+    def update_awaiting(
+            sender_node: str,
+            subtask_id: str,
+            accepted_ts: int) -> None:
         try:
             income = Income.get(sender_node=sender_node, subtask=subtask_id)
         except Income.DoesNotExist:

--- a/tests/factories/model.py
+++ b/tests/factories/model.py
@@ -10,6 +10,7 @@ class Income(Factory):
         model = model.Income
 
     sender_node = Faker('binary', length=64)
+    payer_address = '0x' + 40 * '3'
     subtask = Faker('uuid4')
     value = Faker('pyint')
 

--- a/tests/golem/network/concent/test_concent_client.py
+++ b/tests/golem/network/concent/test_concent_client.py
@@ -467,8 +467,9 @@ class OverdueIncomeTestCase(testutils.DatabaseFixture):
                 sync=True,
             )
             self.incomes_keeper.expect(
-                sender_node_id='requestor_id',
+                sender_node='requestor_id',
                 subtask_id=msg.subtask_id,
+                payer_address='0x1234',
                 value=msg.task_to_compute.price,  # pylint: disable=no-member
             )
             self.incomes_keeper.update_awaiting(

--- a/tests/golem/network/concent/test_received_handler.py
+++ b/tests/golem/network/concent/test_received_handler.py
@@ -397,8 +397,9 @@ class ForceSubtaskResultsResponseTest(TaskServerMessageHandlerTestBase):
             ForceSubtaskResultsResponseFactory.with_accepted()
 
         IncomesKeeper().expect(
-            sender_node_id=msg.task_to_compute.requestor_id,
+            sender_node=msg.task_to_compute.requestor_id,
             subtask_id=msg.subtask_id,
+            payer_address='0xdead',
             value=42
         )
         self.assertIsNone(Income.get(subtask=msg.subtask_id).accepted_ts)
@@ -806,8 +807,9 @@ class SubtaskResultsSettledTest(TaskServerMessageHandlerTestBase):
         srs = msg_factories.concents.SubtaskResultsSettledFactory()
         self.task_server.client.node.key = srs.task_to_compute.provider_id
         IncomesKeeper().expect(
-            sender_node_id=srs.task_to_compute.requestor_id,
+            sender_node=srs.task_to_compute.requestor_id,
             subtask_id=srs.subtask_id,
+            payer_address='0xdead',
             value=42
         )
         self.assertIsNone(Income.get(subtask=srs.subtask_id).settled_ts)

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -33,6 +33,7 @@ from golem.task.tasksession import TaskSession
 from golem.task.taskstate import TaskState, TaskOp
 from golem.tools.assertlogs import LogTestCase
 from golem.tools.testwithreactor import TestDatabaseWithReactor
+from golem.utils import pubkeytoaddr
 
 from tests.factories.p2p import Node as NodeFactory
 from tests.factories.resultpackage import ExtractedPackageFactory
@@ -229,8 +230,9 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         self.assertEqual(wtr.already_sending, False)
         incomes_keeper = ts.client.transaction_system.incomes_keeper
         incomes_keeper.expect.assert_called_once_with(
-            sender_node_id=keys_auth.key_id,
+            sender_node=keys_auth.key_id,
             subtask_id=subtask_id2,
+            payer_address=pubkeytoaddr(keys_auth.key_id),
             value=1,
         )
 
@@ -251,8 +253,8 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         ts.task_manager.comp_task_keeper.receive_subtask(ttc)
         model.Income.create(
             sender_node=keys_auth.public_key,
-            task=ctd['task_id'],
             subtask=ctd['subtask_id'],
+            payer_address=pubkeytoaddr(keys_auth.key_id),
             value=1
         )
 

--- a/tests/golem/transactions/test_incomeskeeper.py
+++ b/tests/golem/transactions/test_incomeskeeper.py
@@ -39,15 +39,16 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
         random.seed(__name__)
         self.incomes_keeper = IncomesKeeper()
 
-    def _test_expect_income(self, sender_node_id, subtask_id, value):
+    def _test_expect_income(self, sender_node, subtask_id, payer_addr, value):
         self.incomes_keeper.expect(
-            sender_node_id=sender_node_id,
+            sender_node=sender_node,
             subtask_id=subtask_id,
+            payer_address=payer_addr,
             value=value
         )
         with db.atomic():
             expected_income = Income.get(
-                sender_node=sender_node_id,
+                sender_node=sender_node,
                 subtask=subtask_id,
             )
         assert expected_income.value == value
@@ -55,7 +56,8 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
         assert expected_income.transaction is None
 
     def test_received_batch_transfer_closure_time(self):
-        sender_node_id = '0x' + 64 * 'a'
+        sender_node = 64 * 'a'
+        payer_address = '0x' + 40 * '9'
         subtask_id1 = 'sample_subtask_id1'
         value1 = MAX_INT + 10
         accepted_ts1 = 1337
@@ -65,13 +67,15 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
 
         assert Income.select().count() == 0
         self._test_expect_income(
-            sender_node_id=sender_node_id,
+            sender_node=sender_node,
             subtask_id=subtask_id1,
+            payer_addr=payer_address,
             value=value1,
         )
         self._test_expect_income(
-            sender_node_id=sender_node_id,
+            sender_node=sender_node,
             subtask_id=subtask_id2,
+            payer_addr=payer_address,
             value=value2,
         )
         assert Income.select().count() == 2
@@ -83,50 +87,52 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
         # incomes not accepted, so this in no op
         self.incomes_keeper.received_batch_transfer(
             transaction_id,
-            pubkeytoaddr(sender_node_id),
+            payer_address,
             value1,
             accepted_ts2,
         )
-        income1 = Income.get(sender_node=sender_node_id, subtask=subtask_id1)
+        income1 = Income.get(sender_node=sender_node, subtask=subtask_id1)
         assert income1.transaction is None
-        income2 = Income.get(sender_node=sender_node_id, subtask=subtask_id2)
+        income2 = Income.get(sender_node=sender_node, subtask=subtask_id2)
         assert income2.transaction is None
 
         # now we accept both
         self.incomes_keeper.update_awaiting(
-            sender_node_id,
+            sender_node,
             subtask_id1,
             accepted_ts1,
         )
         self.incomes_keeper.update_awaiting(
-            sender_node_id,
+            sender_node,
             subtask_id2,
             accepted_ts2,
         )
         self.incomes_keeper.received_batch_transfer(
             transaction_id1,
-            pubkeytoaddr(sender_node_id),
+            payer_address,
             value1,
             accepted_ts1,
         )
-        income1 = Income.get(sender_node=sender_node_id, subtask=subtask_id1)
+        income1 = Income.get(sender_node=sender_node, subtask=subtask_id1)
         assert transaction_id1[2:] == income1.transaction
-        income2 = Income.get(sender_node=sender_node_id, subtask=subtask_id2)
+        income2 = Income.get(sender_node=sender_node, subtask=subtask_id2)
         assert income2.transaction is None
         self.incomes_keeper.received_batch_transfer(
             transaction_id2,
-            pubkeytoaddr(sender_node_id),
+            payer_address,
             value2,
             accepted_ts2,
         )
-        income1 = Income.get(sender_node=sender_node_id, subtask=subtask_id1)
+        income1 = Income.get(sender_node=sender_node, subtask=subtask_id1)
         assert transaction_id1[2:] == income1.transaction
-        income2 = Income.get(sender_node=sender_node_id, subtask=subtask_id2)
+        income2 = Income.get(sender_node=sender_node, subtask=subtask_id2)
         assert transaction_id2[2:] == income2.transaction
 
     def test_received_batch_transfer_two_senders(self):
-        sender_node_id1 = '0x' + 64 * 'a'
-        sender_node_id2 = '0x' + 64 * 'b'
+        sender_node1 = 64 * 'a'
+        sender_node2 = 64 * 'b'
+        payer_address1 = '0x' + 40 * '1'
+        payer_address2 = '0x' + 40 * '2'
         subtask_id1 = 'sample_subtask_id1'
         subtask_id2 = 'sample_subtask_id2'
         value1 = MAX_INT + 10
@@ -134,13 +140,15 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
 
         assert Income.select().count() == 0
         self._test_expect_income(
-            sender_node_id=sender_node_id1,
+            sender_node=sender_node1,
             subtask_id=subtask_id1,
+            payer_addr=payer_address1,
             value=value1,
         )
         self._test_expect_income(
-            sender_node_id=sender_node_id2,
+            sender_node=sender_node2,
             subtask_id=subtask_id2,
+            payer_addr=payer_address2,
             value=value2,
         )
         assert Income.select().count() == 2
@@ -151,35 +159,35 @@ class TestIncomesKeeper(TestWithDatabase, PEP8MixIn):
         closure_time2 = 2137
 
         self.incomes_keeper.update_awaiting(
-            sender_node_id1,
+            sender_node1,
             subtask_id1,
             closure_time1,
         )
         self.incomes_keeper.received_batch_transfer(
             transaction_id1,
-            pubkeytoaddr(sender_node_id1),
+            payer_address1,
             value1,
             closure_time1,
         )
-        income1 = Income.get(sender_node=sender_node_id1, subtask=subtask_id1)
+        income1 = Income.get(sender_node=sender_node1, subtask=subtask_id1)
         assert transaction_id1[2:] == income1.transaction
-        income2 = Income.get(sender_node=sender_node_id2, subtask=subtask_id2)
+        income2 = Income.get(sender_node=sender_node2, subtask=subtask_id2)
         assert income2.transaction is None
 
         self.incomes_keeper.update_awaiting(
-            sender_node_id2,
+            sender_node2,
             subtask_id2,
             closure_time2,
         )
         self.incomes_keeper.received_batch_transfer(
             transaction_id2,
-            pubkeytoaddr(sender_node_id2),
+            payer_address2,
             value2,
             closure_time2,
         )
-        income1 = Income.get(sender_node=sender_node_id1, subtask=subtask_id1)
+        income1 = Income.get(sender_node=sender_node1, subtask=subtask_id1)
         assert transaction_id1[2:] == income1.transaction
-        income2 = Income.get(sender_node=sender_node_id2, subtask=subtask_id2)
+        income2 = Income.get(sender_node=sender_node2, subtask=subtask_id2)
         assert transaction_id2[2:] == income2.transaction
 
     @staticmethod


### PR DESCRIPTION
Two migrations as `add_not_null` constraint doesn't work very well if done in the same migration.