### PR TITLE
Bump pycryptodome version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -69,7 +69,7 @@ py-ubjson==0.11.0
 pyasn1==0.4.1
 pyasn1-modules==0.2.1
 pycparser==2.17
-pycryptodome==3.5.1
+pycryptodome==3.6.6
 PyDispatcher==2.0.5
 pyelliptic==1.5.10
 pyethash==0.1.27


### PR DESCRIPTION
There is a vulnerabilit in 3.5.1 (https://nvd.nist.gov/vuln/detail/CVE-2018-15560). It shouldn't affect us, but it's better to keep libraries up to date (just in case). 