### PR TITLE
Deadline already passed

### DIFF
--- a/golem/task/exceptions.py
+++ b/golem/task/exceptions.py
@@ -9,6 +9,7 @@ class KwargsError(Exception):
             kwargs=self.kwargs,
         )
 
+
 class TaskError(KwargsError):
     pass
 

--- a/golem/task/exceptions.py
+++ b/golem/task/exceptions.py
@@ -1,0 +1,17 @@
+class KwargsError(Exception):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args)
+        self.kwargs = kwargs
+
+    def __str__(self):
+        return "{parent} {kwargs}".format(
+            parent=super().__str__(),
+            kwargs=self.kwargs,
+        )
+
+class TaskError(KwargsError):
+    pass
+
+
+class TaskHeaderError(TaskError):
+    pass

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -151,7 +151,7 @@ class TaskFixedHeader(object):  # pylint: disable=too-many-instance-attributes
         task_owner = th_dict_repr.get('task_owner')
 
         try:
-            node_name = task_owner['node_name']
+            node_name = task_owner['node_name']  # type: ignore
         except (TypeError, KeyError):
             node_name = task_owner
 

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -153,8 +153,8 @@ class TaskFixedHeader(object):  # pylint: disable=too-many-instance-attributes
         task_owner = th_dict_repr.get('task_owner')
 
         try:
-            node_name = task_owner['node_name']  # type: ignore
-        except (TypeError, KeyError):
+            node_name = task_owner.get('node_name')  # type: ignore
+        except AttributeError:
             raise exceptions.TaskHeaderError(
                 'Task owner missing',
                 task_id=task_id,

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -184,13 +184,14 @@ class TaskFixedHeader(object):  # pylint: disable=too-many-instance-attributes
                 deadline=th_dict_repr['deadline'],
             )
 
-        if th_dict_repr['deadline'] < common.get_timestamp_utc():
+        now = common.get_timestamp_utc()
+        if th_dict_repr['deadline'] < now:
             raise exceptions.TaskHeaderError(
                 "Deadline already passed",
                 task_id=task_id,
                 node_name=node_name,
                 deadline=th_dict_repr['deadline'],
-                now=common.get_timestamp_utc(),
+                now=now,
             )
 
         if not isinstance(th_dict_repr['subtask_timeout'], int):

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -155,18 +155,15 @@ class TaskFixedHeader(object):  # pylint: disable=too-many-instance-attributes
         try:
             node_name = task_owner['node_name']  # type: ignore
         except (TypeError, KeyError):
-            node_name = task_owner
+            raise exceptions.TaskHeaderError(
+                'Task owner missing',
+                task_id=task_id,
+                task_owner=task_owner,
+            )
 
         if not isinstance(task_id, str):
             raise exceptions.TaskHeaderError(
                 'Task ID missing',
-                task_id=task_id,
-                node_name=node_name,
-            )
-
-        if not isinstance(task_owner, dict):
-            raise exceptions.TaskHeaderError(
-                'Task owner missing',
                 task_id=task_id,
                 node_name=node_name,
             )

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+import functools
 import itertools
 import logging
 import os
@@ -130,18 +131,34 @@ class TaskServer(
             signal='golem.taskmanager'
         )
 
-    def sync_network(self):
-        super().sync_network(timeout=self.last_message_time_threshold)
-        self._sync_pending()
-        self.__send_waiting_results()
-        self.task_computer.run()
-        self.task_connections_helper.sync()
-        self._sync_forwarded_session_requests()
-        self.__remove_old_tasks()
-        self.__remove_old_sessions()
-        concent.process_messages_received_from_concent(
-            concent_service=self.client.concent_service,
+    def sync_network(self, timeout=None):
+        if timeout is None:
+            timeout = self.last_message_time_threshold
+        jobs = (
+            functools.partial(
+                super().sync_network,
+                timeout=timeout,
+            ),
+            self._sync_pending,
+            self.__send_waiting_results,
+            self.task_computer.run,
+            self.task_connections_helper.sync,
+            self._sync_forwarded_session_requests,
+            self.__remove_old_tasks,
+            self.__remove_old_sessions,
+            functools.partial(
+                concent.process_messages_received_from_concent,
+                concent_service=self.client.concent_service,
+            ),
         )
+
+        for job in jobs:
+            try:
+                logger.debug("TServer sync running: job=%r", job)
+                job()
+            except Exception:  # pylint: disable=broad-except
+                logger.exception("TaskServer.sync_network job %r failed", job)
+
         if next(tmp_cycler) == 0:
             logger.debug('TASK SERVER TASKS DUMP: %r', self.task_manager.tasks)
             logger.debug('TASK SERVER TASKS STATES: %r',

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -32,6 +32,7 @@ from golem.task.taskconnectionshelper import TaskConnectionsHelper
 from golem.task.taskstate import TaskOp
 from golem.utils import decode_hex, pubkeytoaddr
 
+from . import exceptions
 from .result.resultmanager import ExtractedPackage
 from .server import resources
 from .server import concent
@@ -337,8 +338,11 @@ class TaskServer(
 
             return self.task_keeper.add_task_header(header)
 
-        except ValueError:
-            logger.warning("Wrong task header received", exc_info=True)
+        except exceptions.TaskHeaderError as e:
+            logger.warning("Wrong task header received: %s", e)
+            return False
+        except Exception:  # pylint: disable=broad-except
+            logger.exception("Task header validation failed")
             return False
 
     def verify_header_sig(self, header: TaskHeader):

--- a/tests/golem/task/test_taskbase.py
+++ b/tests/golem/task/test_taskbase.py
@@ -9,6 +9,7 @@ from golem.core.common import timeout_to_deadline, get_timestamp_utc
 from golem.core.idgenerator import generate_id
 from golem.core.simpleserializer import CBORSerializer
 from golem.network.p2p.node import Node
+from golem.task import exceptions
 from golem.task.taskbase import Task, TaskBuilder, TaskHeader
 from golem.tools.assertlogs import LogTestCase
 from golem.utils import encode_hex
@@ -80,62 +81,90 @@ class TestTaskHeader(TestCase):
 
     def test_validate_illegal_deadline(self):
         self.th_dict_repr['fixed_header']['deadline'] = datetime.now()
-        with self.assertRaisesRegex(ValueError, "Deadline is not a timestamp"):
+        with self.assertRaisesRegex(
+            exceptions.TaskHeaderError,
+            "Deadline is not a timestamp"
+        ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_validate_deadline_passed(self):
         self.th_dict_repr['fixed_header']['deadline'] = get_timestamp_utc() - 10
-        with self.assertRaisesRegex(ValueError, "Deadline already passed"):
+        with self.assertRaisesRegex(
+            exceptions.TaskHeaderError,
+            "Deadline already passed"
+        ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_validate_illegal_timeout(self):
         self.th_dict_repr['fixed_header']['subtask_timeout'] = "abc"
         with self.assertRaisesRegex(
-            ValueError, "Subtask timeout is not a number"
+            exceptions.TaskHeaderError,
+            "Subtask timeout is not a number"
         ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_validate_negative_timeout(self):
         self.th_dict_repr['fixed_header']['subtask_timeout'] = -131
         with self.assertRaisesRegex(
-            ValueError, "Subtask timeout is less than 0"
+            exceptions.TaskHeaderError,
+            "Subtask timeout is less than 0",
         ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_validate_no_fixed_header(self):
         del self.th_dict_repr['fixed_header']
-        with self.assertRaisesRegex(ValueError, "Fixed header is missing"):
+        with self.assertRaisesRegex(
+            exceptions.TaskHeaderError,
+            "Fixed header is missing"
+        ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_validate_no_task_id(self):
         del self.th_dict_repr['fixed_header']['task_id']
-        with self.assertRaisesRegex(ValueError, "Task ID missing"):
+        with self.assertRaisesRegex(
+            exceptions.TaskHeaderError,
+            "Task ID missing",
+        ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_validate_no_task_owner(self):
         del self.th_dict_repr['fixed_header']['task_owner']
-        with self.assertRaisesRegex(ValueError, "Task owner missing"):
+        with self.assertRaisesRegex(
+            exceptions.TaskHeaderError,
+            "Task owner missing",
+        ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_validate_no_task_owner_node_name(self):
         del self.th_dict_repr['fixed_header']['task_owner']['node_name']
-        with self.assertRaisesRegex(ValueError, "node name missing"):
+        with self.assertRaisesRegex(
+            exceptions.TaskHeaderError,
+            "node name missing",
+        ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_validate_no_subtasks_count(self):
         del self.th_dict_repr['fixed_header']['subtasks_count']
-        with self.assertRaisesRegex(ValueError, r"^Subtasks count is missing"):
+        with self.assertRaisesRegex(
+            exceptions.TaskHeaderError,
+            r"^Subtasks count is missing"
+        ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_validate_subtasks_count_invalid_type(self):
         self.th_dict_repr['fixed_header']['subtasks_count'] = None
-        with self.assertRaisesRegex(ValueError, r"^Subtasks count is missing"):
+        with self.assertRaisesRegex(
+            exceptions.TaskHeaderError,
+            r"^Subtasks count is missing",
+        ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_validate_subtasks_count_too_low(self):
         self.th_dict_repr['fixed_header']['subtasks_count'] = -1
-        with self.assertRaisesRegex(ValueError,
-                                    r"^Subtasks count is less than 1 \(-1\)"):
+        with self.assertRaisesRegex(
+            exceptions.TaskHeaderError,
+            r"^Subtasks count is less than 1 {.*'subtasks_count': -1.*}$",
+        ):
             TaskHeader.validate(self.th_dict_repr)
 
     def test_from_dict_no_subtasks_count(self):

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1,4 +1,4 @@
-# pylint: disable=protected-access
+# pylint: disable=protected-access, too-many-lines
 import os
 import random
 import uuid


### PR DESCRIPTION
fixes: #3230

1. Harden TaskServer.sync_network() to ensure that all jobs are attempted even when previous one fails
1. Use custom exception for TaskHeader validation errors and don't include their tracebacks in logs