### PR TITLE
Fix silent fail in dirmanager.symlink_or_copy

### DIFF
--- a/golem/resource/dirmanager.py
+++ b/golem/resource/dirmanager.py
@@ -1,3 +1,4 @@
+import errno
 import logging
 import os
 import shutil
@@ -12,6 +13,9 @@ logger = logging.getLogger(__name__)
 # the solution would be to replicate code_dir behaviour from dummytask
 # in lux task
 def symlink_or_copy(source, target):
+    if not os.path.exists(source):
+        raise FileNotFoundError(
+            errno.ENOENT, os.strerror(errno.ENOENT), source)
     try:
         os.symlink(source, target)
     except OSError:


### PR DESCRIPTION
When `source` does not exist the following code will silently fail:

```
        os.symlink(source, target)
```

resulting in a no-op. In some cases it emerges only on provider side with a meaningless error message making things hard to debug. The proposed patch is a fail-fast approach.