### PR TITLE
remove support for Concent's `receive-out-of-band` endpoint

### DIFF
--- a/golem/network/concent/client.py
+++ b/golem/network/concent/client.py
@@ -336,8 +336,7 @@ class ConcentClientService(threading.Thread):
             return
 
         try:
-            # mypy, why u so silly?
-            res = receive_from_concent(  # type: ignore
+            res = receive_from_concent(
                 signing_key=self.keys_auth._private_key,  # noqa pylint: disable=protected-access
                 public_key=self.keys_auth.public_key,
                 concent_variant=self.variant,

--- a/golem/network/concent/client.py
+++ b/golem/network/concent/client.py
@@ -155,12 +155,6 @@ def receive_from_concent(
     return response.content or None
 
 
-receive_out_of_band = functools.partial(
-    receive_from_concent,
-    path='/api/v1/receive-out-of-band/',
-)
-
-
 class ConcentRequest(msg_datastructures.FrozenDict):
     ITEMS = {
         'key': '',
@@ -341,23 +335,22 @@ class ConcentClientService(threading.Thread):
         if not self.enabled:
             return
 
-        for receive_function in (receive_from_concent, receive_out_of_band):
-            try:
-                # mypy, why u so silly?
-                res = receive_function(  # type: ignore
-                    signing_key=self.keys_auth._private_key,  # noqa pylint: disable=protected-access
-                    public_key=self.keys_auth.public_key,
-                    concent_variant=self.variant,
-                )
-            except exceptions.ConcentError as e:
-                logger.warning("Can't receive message from Concent: %s", e)
-                self._grace_sleep()
-                return
-            except Exception:  # pylint: disable=broad-except
-                logger.exception('receive_from_concent() failed')
-                self._grace_sleep()
-                return
-            self.react_to_concent_message(res)
+        try:
+            # mypy, why u so silly?
+            res = receive_from_concent(  # type: ignore
+                signing_key=self.keys_auth._private_key,  # noqa pylint: disable=protected-access
+                public_key=self.keys_auth.public_key,
+                concent_variant=self.variant,
+            )
+        except exceptions.ConcentError as e:
+            logger.warning("Can't receive message from Concent: %s", e)
+            self._grace_sleep()
+            return
+        except Exception:  # pylint: disable=broad-except
+            logger.exception('receive_from_concent() failed')
+            self._grace_sleep()
+            return
+        self.react_to_concent_message(res)
 
     @staticmethod
     def process_synchronous_response(

--- a/scripts/concent_acceptance_tests/additional_verification/test_verification.py
+++ b/scripts/concent_acceptance_tests/additional_verification/test_verification.py
@@ -65,7 +65,7 @@ class SubtaskResultsVerifyFiletransferTest(SubtaskResultsVerifyBaseTest):
         verification_start = time.time()
 
         while time.time() < verification_start + self.TIMEOUT:
-            response = self.provider_receive_oob()
+            response = self.provider_receive()
             if response:
                 self.assertIsInstance(response,
                                       concent_msg.SubtaskResultsSettled)
@@ -92,7 +92,7 @@ class SubtaskResultsVerifyFiletransferTest(SubtaskResultsVerifyBaseTest):
         verification_start = time.time()
 
         while time.time() < verification_start + self.TIMEOUT:
-            response = self.provider_receive_oob()
+            response = self.provider_receive()
             if response:
                 self.assertIsInstance(response,
                                       tasks_msg.SubtaskResultsRejected)

--- a/scripts/concent_acceptance_tests/base.py
+++ b/scripts/concent_acceptance_tests/base.py
@@ -139,10 +139,6 @@ class ConcentBaseTest:
         receive_and_load,
         receive_function=client.receive_from_concent,
     )
-    receive_out_of_band = functools.partialmethod(
-        receive_and_load,
-        receive_function=client.receive_out_of_band,
-    )
 
     def provider_receive(self):
         return self.receive_from_concent(
@@ -152,24 +148,8 @@ class ConcentBaseTest:
             public_key=self.provider_pub_key,
         )
 
-    def provider_receive_oob(self):
-        return self.receive_out_of_band(
-            actor='Provider',
-            signing_key=self.provider_priv_key,
-            private_key=self.provider_priv_key,
-            public_key=self.provider_pub_key,
-        )
-
     def requestor_receive(self):
         return self.receive_from_concent(
-            actor='Requestor',
-            signing_key=self.requestor_keys.raw_privkey,
-            private_key=self.requestor_keys.raw_privkey,
-            public_key=self.requestor_keys.raw_pubkey
-        )
-
-    def requestor_receive_oob(self):
-        return self.receive_out_of_band(
             actor='Requestor',
             signing_key=self.requestor_keys.raw_privkey,
             private_key=self.requestor_keys.raw_privkey,

--- a/scripts/concent_acceptance_tests/force_payment/test_payment.py
+++ b/scripts/concent_acceptance_tests/force_payment/test_payment.py
@@ -172,7 +172,7 @@ class RequestorDoesntPayTestCase(SCIBaseTest):
             subtask_results_accepted_list=LOA,
         )
         response_provider = self.provider_load_response(self.provider_send(fp))
-        response_requestor = self.requestor_receive_oob()
+        response_requestor = self.requestor_receive()
         roles = message.concents.ForcePaymentCommitted.Actor
         for response in (response_provider, response_requestor):
             self.assertIsInstance(

--- a/tests/golem/network/concent/test_concent_client.py
+++ b/tests/golem/network/concent/test_concent_client.py
@@ -182,7 +182,6 @@ class TestReceiveFromConcent(TestCase):
 
 
 @mock.patch('twisted.internet.reactor', create=True)
-@mock.patch('golem.network.concent.client.receive_out_of_band')
 @mock.patch('golem.network.concent.client.receive_from_concent')
 @mock.patch('golem.network.concent.client.send_to_concent')
 class TestConcentClientService(testutils.TempDirFixture):

--- a/tests/golem/network/concent/test_concent_client.py
+++ b/tests/golem/network/concent/test_concent_client.py
@@ -286,16 +286,10 @@ class TestConcentClientService(testutils.TempDirFixture):
         'golem.network.concent.client.ConcentClientService'
         '.react_to_concent_message'
     )
-    def test_receive(self, react_mock, _send_mock, receive_mock, roob_mock, *_):
+    def test_receive(self, react_mock, _send_mock, receive_mock, *_):
         receive_mock.return_value = content = 'rcv_content'
-        roob_mock.return_value = content_oob = 'oob_content'
         self.concent_service.receive()
         receive_mock.assert_called_once_with(
-            signing_key=self.concent_service.keys_auth._private_key,
-            public_key=self.concent_service.keys_auth.public_key,
-            concent_variant=self.concent_service.variant,
-        )
-        roob_mock.assert_called_once_with(
             signing_key=self.concent_service.keys_auth._private_key,
             public_key=self.concent_service.keys_auth.public_key,
             concent_variant=self.concent_service.variant,
@@ -303,7 +297,6 @@ class TestConcentClientService(testutils.TempDirFixture):
         react_mock.assert_has_calls(
             (
                 mock.call(content),
-                mock.call(content_oob),
             ),
         )
 


### PR DESCRIPTION
(it has been unified with `receive`)

closes #3296 