### PR TITLE
Log an info message when a task finishes

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -713,13 +713,14 @@ class TaskManager(TaskEventListener):
                     self.tasks_states[task_id].status = TaskStatus.computing
                 else:
                     if self.tasks[task_id].verify_task():
-                        logger.debug("Task %r accepted", task_id)
+                        logger.info("Task finished! task_id=%r", task_id)
                         self.tasks_states[task_id].status =\
                             TaskStatus.finished
                         self.notice_task_updated(task_id,
                                                  op=TaskOp.FINISHED)
                     else:
-                        logger.debug("Task %r not accepted", task_id)
+                        logger.warning("Task finished but was not accepted. "
+                                       "task_id=%r", task_id)
                         self.notice_task_updated(task_id,
                                                  op=TaskOp.NOT_ACCEPTED)
             verification_finished()

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -624,16 +624,16 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
 
         self.tm.notice_task_updated = Mock()
         self.tm.subtask2task_mapping[subtask_id] = task_id
-        
+
         task_obj = self.tm.tasks[task_id] = Mock()
-        task_obj.computation_finished = lambda a, b, c, cb: cb() 
-        task_obj.finished_computation = Mock(return_value=True) 
-        task_obj.verify_task = Mock(return_value=False) 
-        
+        task_obj.computation_finished = lambda a, b, c, cb: cb()
+        task_obj.finished_computation = Mock(return_value=True)
+        task_obj.verify_task = Mock(return_value=False)
+
         task_state = self.tm.tasks_states[task_id] = Mock()
-        task_state.status = TaskStatus.computing 
+        task_state.status = TaskStatus.computing
         task_state.subtask_states = dict()
-        
+
         subtask_state = task_state.subtask_states[subtask_id] = Mock()
         subtask_state.subtask_status = SubtaskStatus.downloading
 
@@ -643,11 +643,13 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
                                            mock_finished)
 
         # THEN
-        expected_warn = f"Task finished but was not accepted. task_id='{task_id}'"
+        expected_warn = f"Task finished but was not accepted. " \
+                        f"task_id='{task_id}'"
         assert any(expected_warn in s for s in log.output)
         assert self.tm.notice_task_updated.call_count == 2
-        self.tm.notice_task_updated.assert_called_with(task_id, op=TaskOp.NOT_ACCEPTED)
-        mock_finished.assert_called_once
+        self.tm.notice_task_updated.assert_called_with(
+            task_id, op=TaskOp.NOT_ACCEPTED)
+        mock_finished.assert_called_once()
 
     @patch('golem.task.taskmanager.TaskManager.dump_task')
     def test_task_result_incoming(self, dump_mock):

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -614,6 +614,41 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
                  ("task4", None, TaskOp.FINISHED)])
         del handler
 
+    def test_computed_task_received_failure(self):
+        # GIVEN
+        task_id = "unittest_task_id"
+        subtask_id = "unittest_subtask_id"
+        result = Mock()
+        result_type = Mock()
+        mock_finished = Mock()
+
+        self.tm.notice_task_updated = Mock()
+        self.tm.subtask2task_mapping[subtask_id] = task_id
+        
+        task_obj = self.tm.tasks[task_id] = Mock()
+        task_obj.computation_finished = lambda a, b, c, cb: cb() 
+        task_obj.finished_computation = Mock(return_value=True) 
+        task_obj.verify_task = Mock(return_value=False) 
+        
+        task_state = self.tm.tasks_states[task_id] = Mock()
+        task_state.status = TaskStatus.computing 
+        task_state.subtask_states = dict()
+        
+        subtask_state = task_state.subtask_states[subtask_id] = Mock()
+        subtask_state.subtask_status = SubtaskStatus.downloading
+
+        # WHEN
+        with self.assertLogs(logger, level="DEBUG") as log:
+            self.tm.computed_task_received(subtask_id, result, result_type,
+                                           mock_finished)
+
+        # THEN
+        expected_warn = f"Task finished but was not accepted. task_id='{task_id}'"
+        assert any(expected_warn in s for s in log.output)
+        assert self.tm.notice_task_updated.call_count == 2
+        self.tm.notice_task_updated.assert_called_with(task_id, op=TaskOp.NOT_ACCEPTED)
+        mock_finished.assert_called_once
+
     @patch('golem.task.taskmanager.TaskManager.dump_task')
     def test_task_result_incoming(self, dump_mock):
         subtask_id = "xxyyzz"


### PR DESCRIPTION
Can be used in integration tests and when debugging a task with users.