### PR TITLE
Rename computation_finished to subtask_finished.

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -206,7 +206,7 @@ class CoreTask(Task):
     def computation_failed(self, subtask_id):
         self._mark_subtask_failed(subtask_id)
 
-    def computation_finished(self, subtask_id, task_result,
+    def subtask_finished(self, subtask_id, task_result,
                              result_type=ResultType.DATA,
                              verification_finished=None):
         if not self.should_accept(subtask_id):

--- a/apps/rendering/task/framerenderingtask.py
+++ b/apps/rendering/task/framerenderingtask.py
@@ -134,10 +134,10 @@ class FrameRenderingTask(RenderingTask):
             self._update_task_preview()
 
     @CoreTask.handle_key_error
-    def computation_finished(self, subtask_id, task_result,
+    def subtask_finished(self, subtask_id, task_result,
                              result_type=ResultType.DATA,
                              verification_finished=None):
-        super(FrameRenderingTask, self).computation_finished(
+        super(FrameRenderingTask, self).subtask_finished(
             subtask_id,
             task_result,
             result_type,

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -440,7 +440,7 @@ class Task(abc.ABC):
         return False
 
     @abc.abstractmethod
-    def computation_finished(self, subtask_id, task_result,
+    def subtask_finished(self, subtask_id, task_result,
                              result_type=ResultType.DATA,
                              verification_finished=None):
         """ Inform about finished subtask

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -716,7 +716,7 @@ class TaskManager(TaskEventListener):
                                                  op=TaskOp.NOT_ACCEPTED)
             verification_finished()
 
-        self.tasks[task_id].computation_finished(
+        self.tasks[task_id].subtask_finished(
             subtask_id, result, result_type, verification_finished_
         )
 

--- a/tests/apps/blender/task/test_blenderrendertask.py
+++ b/tests/apps/blender/task/test_blenderrendertask.py
@@ -129,7 +129,7 @@ class TestBlenderFrameTask(TempDirFixture):
         assert extra_data2.ctd is not None
 
         self.bt.computation_failed(extra_data1.ctd['subtask_id'])
-        self.bt.computation_finished(extra_data1.ctd['subtask_id'], [],
+        self.bt.subtask_finished(extra_data1.ctd['subtask_id'], [],
                                      ResultType.DATA)
         assert self.bt.subtasks_given[extra_data1.ctd['subtask_id']][
             'status'] == \
@@ -161,7 +161,7 @@ class TestBlenderFrameTask(TempDirFixture):
         with mock.patch('golem_verificator.rendering_verifier.'
                         'RenderingVerifier.start_verification',
                         side_effect=verification_finished1):
-            self.bt.computation_finished(
+            self.bt.subtask_finished(
                 extra_data3.ctd['subtask_id'],
                 [file1],
                 ResultType.FILES,
@@ -193,7 +193,7 @@ class TestBlenderFrameTask(TempDirFixture):
         with mock.patch('golem_verificator.rendering_verifier.'
                         'RenderingVerifier.start_verification',
                         side_effect=verification_finished2):
-            self.bt.computation_finished(
+            self.bt.subtask_finished(
                 extra_data4.ctd['subtask_id'],
                 [file2],
                 ResultType.FILES,

--- a/tests/apps/core/benchmark/test_benchmarkrunner.py
+++ b/tests/apps/core/benchmark/test_benchmarkrunner.py
@@ -22,7 +22,7 @@ class DummyTask(Task):
     def finished_computation(self):
         pass
 
-    def computation_finished(self, subtask_id, task_result, result_type,
+    def subtask_finished(self, subtask_id, task_result, result_type,
                              verification_finished):
         pass
 

--- a/tests/golem/docker/test_docker_dummy_task.py
+++ b/tests/golem/docker/test_docker_dummy_task.py
@@ -119,7 +119,7 @@ class TestDockerDummyTask(DockerTaskTestCase[DummyTask, DummyTaskBuilder]):
 
         # assert good results - should pass
         self.assertEqual(task.num_tasks_received, 0)
-        task.computation_finished(ctd['subtask_id'], [str(output)],
+        task.subtask_finished(ctd['subtask_id'], [str(output)],
                                   result_type=ResultType.FILES,
                                   verification_finished=success)
 
@@ -137,7 +137,7 @@ class TestDockerDummyTask(DockerTaskTestCase[DummyTask, DummyTaskBuilder]):
         # assert bad results - should fail
         bad_output = output.parent / "badfile.result"
         ctd = task.query_extra_data(10000.).ctd
-        task.computation_finished(ctd['subtask_id'], [str(bad_output)],
+        task.subtask_finished(ctd['subtask_id'], [str(bad_output)],
                                   result_type=ResultType.FILES,
                                   verification_finished=failure)
         reactor.iterate()

--- a/tests/golem/docker/test_docker_luxrender_task.py
+++ b/tests/golem/docker/test_docker_luxrender_task.py
@@ -158,7 +158,7 @@ class TestDockerLuxrenderTask(
 
         # assert good results - should pass
         self.assertEqual(task.num_tasks_received, 0)
-        task.computation_finished(subtask_id,
+        task.subtask_finished(subtask_id,
                                   [str(new_flm_file), str(new_preview_file)],
                                   result_type=ResultType.FILES,
                                   verification_finished=success)
@@ -184,7 +184,7 @@ class TestDockerLuxrenderTask(
         # assert bad results - should fail
         bad_flm_file = new_flm_file.parent / "badfile.flm"
         task.VERIFICATION_QUEUE._reset()
-        task.computation_finished(ctd['subtask_id'],
+        task.subtask_finished(ctd['subtask_id'],
                                   [str(bad_flm_file), str(new_preview_file)],
                                   result_type=ResultType.FILES,
                                   verification_finished=failure)

--- a/tests/golem/task/dummy/task.py
+++ b/tests/golem/task/dummy/task.py
@@ -213,7 +213,7 @@ class DummyTask(Task):
         return computation.check_pow(int(result, 16), input_data,
                                      self.task_params.difficulty)
 
-    def computation_finished(self, subtask_id, task_result,
+    def subtask_finished(self, subtask_id, task_result,
                              result_type=ResultType.DATA,
                              verification_finished=None):
         with self._lock:
@@ -236,7 +236,7 @@ class DummyTask(Task):
 
     def computation_failed(self, subtask_id):
         print('DummyTask.computation_failed called')
-        self.computation_finished(subtask_id, None)
+        self.subtask_finished(subtask_id, None)
 
     def restart(self):
         print('DummyTask.restart called')

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -467,7 +467,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             def needs_computation(self):
                 return sum(self.finished.values()) != len(self.finished)
 
-            def computation_finished(self, subtask_id, task_result,
+            def subtask_finished(self, subtask_id, task_result,
                                      result_type=ResultType.DATA,
                                      verification_finished=None):
                 if not self.restarted[subtask_id]:


### PR DESCRIPTION
Refactor a confusing method name very similiar to "finished_computation"
which is a method used to determine task completion.