### PR TITLE
Removal NAT type retrieval

### DIFF
--- a/golem/core/hostaddress.py
+++ b/golem/core/hostaddress.py
@@ -139,10 +139,10 @@ def get_external_address(source_port=0):
     :return (str, int, str): tuple with host public address, public port that is
     mapped to local <source_port> and this host nat type
     """
-    nat_type, external_ip, external_port = stun.get_ip_info(source_port=source_port)
-    logger.debug("NAT %r, external_ip [%r] External_port %r",
-                 nat_type, external_ip, external_port)
-    return external_ip, external_port, nat_type
+    external_ip, external_port = stun.get_ip_info(source_port=source_port)
+    logger.debug("external_ip [%r] external_port %r",
+                 external_ip, external_port)
+    return external_ip, external_port
 
 def get_host_address(seed_addr=None, use_ipv6=False):
     """

--- a/golem/network/p2p/node.py
+++ b/golem/network/p2p/node.py
@@ -47,7 +47,7 @@ class Node(DictSerializable):
         self.prv_addresses = get_host_addresses(use_ipv6)
 
         if not self.pub_addr:
-            self.pub_addr, _, self.nat_type = get_external_address()
+            self.pub_addr, _ = get_external_address()
 
         if not self.prv_addr:
             if self.pub_addr in self.prv_addresses:

--- a/tests/golem/core/test_hostaddress.py
+++ b/tests/golem/core/test_hostaddress.py
@@ -126,20 +126,17 @@ class TestHostAddress(unittest.TestCase):
 
     def test_get_external_address_live(self):
         """ Test getting host public address with STUN protocol """
-        nats = ["Blocked", "Open Internet", "Full Cone", "Symmetric UDP Firewall",
-                "Restric NAT", "Restric Port NAT", "Symmetric NAT"]
-        address, port, nat = get_external_address()
+        address, port = get_external_address()
         self.assertTrue(is_ip_address(address), "Incorrect IP address: {}".format(address))
         self.assertIsInstance(port, int, "Incorrect port type")
         self.assertTrue(0 < port < 65535, "Incorrect port number")
-        self.assertIn(nat, nats, "Incorrect nat type")
 
     @patch('golem.network.stun.pystun.get_ip_info')
     def test_get_external_address_argument(self, stun):
-        stun.return_value = ('2607:f0d0:1002:51::4', 1234, "Open Internet")
-        address, port, nat = get_external_address(9876)
+        stun.return_value = ('2607:f0d0:1002:51::4', 1234)
+        address, port = get_external_address(9876)
         assert stun.called_once_with(9876)
-        address, port, nat = get_external_address()
+        address, port = get_external_address()
         assert stun.called_once_with(0)
 
     @patch('golem.core.hostaddress.socket.gethostname')

--- a/tests/golem/task/dummy/runner.py
+++ b/tests/golem/task/dummy/runner.py
@@ -58,7 +58,7 @@ def report(msg):
 
 def override_ip_info(*_, **__):
     from golem.network.stun.pystun import OpenInternet
-    return OpenInternet, '1.2.3.4', 40102
+    return '1.2.3.4', 40102
 
 
 def create_client(datadir):


### PR DESCRIPTION
NAT type is not in use, yet it's retrieval takes significant amount of time resulting in a start up slowdown. 