### PR TITLE
Remove scipy dependency

### DIFF
--- a/apps/rendering/resources/imgverifier.py
+++ b/apps/rendering/resources/imgverifier.py
@@ -4,88 +4,8 @@ import math
 
 from apps.rendering.resources.imgrepr import (ImgRepr, PILImgRepr)
 
-from golem_verificator.verifier import SubtaskVerificationState
-
-from ssim import compute_ssim
 
 logger = logging.getLogger("apps.rendering")
-
-
-class ImgStatistics(object):
-    def __init__(self, base_img: ImgRepr, img: ImgRepr):
-        if base_img.get_size() != img.get_size():
-            raise ValueError('base_img and img are of different sizes.')
-
-        self.img = img
-        self.ssim = compute_ssim(base_img.to_pil(), self.img.to_pil())
-        self.mse, self.norm_mse = \
-            self._calculate_color_normalized_mse(base_img, self.img)
-        self.mse_bw, norm_mse_bw = \
-            self._calculate_greyscale_normalized_mse(base_img, self.img)
-        self.psnr = self._calculate_psnr(self.mse)
-
-    @property
-    def name(self) -> str:
-        name = None
-        if isinstance(self.img, PILImgRepr):
-            name = self.img.get_name()
-
-        return name
-
-    def _calculate_greyscale_normalized_mse(self, img1: ImgRepr, img2: ImgRepr):
-        (res_x, res_y) = img1.get_size()
-
-        img1_bw = img1.to_pil().convert('L')  # makes it greyscale
-        img2_bw = img2.to_pil().convert('L')  # makes it greyscale
-
-        import numpy
-        npimg1 = numpy.array(img1_bw)
-        npimg2 = numpy.array(img2_bw)
-
-        npimg1 = npimg1.astype(numpy.float32, copy=False)
-        npimg2 = npimg2.astype(numpy.float32, copy=False)
-
-        mse_bw = 0
-        for i in range(len(npimg1)):
-            for j in range(len(npimg1[0])):
-                mse_bw += (npimg1[i][j] - npimg2[i][j]) \
-                          * (npimg1[i][j] - npimg2[i][j])
-
-        mse_bw /= res_x * res_y
-
-        # max value of pixel is 255
-        max_possible_mse = res_x * res_y * 255
-        norm_mse = mse_bw / max_possible_mse
-
-        return mse_bw, norm_mse
-
-    def _calculate_color_normalized_mse(self, img1, img2):
-        mse = 0
-        (res_x, res_y) = img1.get_size()
-
-        for i in range(0, res_x):
-            for j in range(0, res_y):
-                [r1, g1, b1] = img1.get_pixel((i, j))
-                [r2, g2, b2] = img2.get_pixel((i, j))
-                mse += (r1 - r2) * (r1 - r2) + \
-                       (g1 - g2) * (g1 - g2) + \
-                       (b1 - b2) * (b1 - b2)
-
-        mse /= res_x * res_y * 3
-
-        # max value of pixel is 255
-        max_possible_mse = res_x * res_y * 3 * 255
-        norm_mse = mse / max_possible_mse
-
-        return mse, norm_mse
-
-    def _calculate_psnr(self, mse, max_=255):
-        if mse <= 0 or max_ <= 0:
-            raise ValueError("MSE & MAX_ must be higher than 0")
-        return 20 * math.log10(max_) - 10 * math.log10(mse)
-
-    def get_stats(self):
-        return self.ssim, self.mse, self.norm_mse, self.mse_bw, self.psnr
 
 
 class ImgVerifier(object):
@@ -136,19 +56,3 @@ class ImgVerifier(object):
 
         crop_window = (start[0], start[0] + dx, start[1], start[1] + dy)
         return crop_window
-
-    def is_valid_against_reference(self,
-                                   imgStat, reference_imgStat,
-                                   acceptance_ratio=0.75, maybe_ratio=0.65):
-
-        if not isinstance(imgStat, ImgStatistics) \
-                and not isinstance(reference_imgStat, ImgStatistics):
-            raise TypeError("imgStatistics be instance of ImgStatistics")
-
-        if imgStat.ssim > acceptance_ratio * reference_imgStat.ssim:
-            return SubtaskVerificationState.VERIFIED
-
-        if imgStat.ssim > maybe_ratio * reference_imgStat.ssim:
-            return SubtaskVerificationState.UNKNOWN
-
-        return SubtaskVerificationState.WRONG_ANSWER

--- a/apps/rendering/resources/imgverifier.py
+++ b/apps/rendering/resources/imgverifier.py
@@ -2,7 +2,7 @@ from __future__ import division
 import logging
 import math
 
-from apps.rendering.resources.imgrepr import (ImgRepr, PILImgRepr)
+from apps.rendering.resources.imgrepr import PILImgRepr
 
 
 logger = logging.getLogger("apps.rendering")

--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -297,7 +297,7 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
                            'performance info is available')
             return 1.0
 
-        rank = len(list(filter(lambda x: x < perf))) / len(hosts_perf)
+        rank = sum(1 for x in hosts_perf if x < perf) / len(hosts_perf)
         logger.info(f'Performance for env `{env_id}`: rank({perf}) = {rank}')
         return rank
 

--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -9,7 +9,6 @@ from threading import Lock
 from typing import Callable, Any, Dict
 
 from golem_messages import message
-from scipy.stats import stats
 
 from golem.config.active import P2P_SEEDS
 from golem.core import simplechallenge
@@ -298,7 +297,7 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
                            'performance info is available')
             return 1.0
 
-        rank = stats.percentileofscore(hosts_perf, perf, kind='strict') / 100
+        rank = len(list(filter(lambda x: x < perf))) / len(hosts_perf)
         logger.info(f'Performance for env `{env_id}`: rank({perf}) = {rank}')
         return rank
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -81,7 +81,6 @@ pyOpenSSL==17.1.0
 pyparsing==2.2.0
 PyQRCode==1.2.1
 pysha3==1.0.2
-pyssim==0.4
 PyTrie==0.3
 pytz==2018.4
 PyYAML==3.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -89,7 +89,6 @@ raven==6.6.0
 repoze.lru==0.7
 requests==2.18.4
 rlp==0.6.0
-scipy==0.19.1
 scrypt==0.8.6
 sdnotify==0.3.2
 secp256k1==0.13.2

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -40,7 +40,6 @@ incremental==17.5.0
 OpenEXR
 pycparser==2.17
 numpy==1.13.1
-scipy==0.19.1
 pyssim
 enforce==0.3.4
 miniupnpc<2.1,>=2.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -40,7 +40,6 @@ incremental==17.5.0
 OpenEXR
 pycparser==2.17
 numpy==1.13.1
-pyssim
 enforce==0.3.4
 miniupnpc<2.1,>=2.0
 token_bucket==0.2.0

--- a/scripts/pyinstaller/hooks/hook-scipy.py
+++ b/scripts/pyinstaller/hooks/hook-scipy.py
@@ -1,3 +1,0 @@
-from PyInstaller.utils.hooks import collect_submodules
-
-hiddenimports = collect_submodules('scipy')


### PR DESCRIPTION
The `scipy` dependency is responsible for almost a half of the Golem dependencies size (in terms of disk space - all requirements take `437M`, `scipy` - `183M`).
It appears that there is only one place, where one one-line scipy function was used.
This PR removes the dependency.
