### PR TITLE
Add directory support to resultpackage module

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -116,7 +116,7 @@ class CoreTask(Task):
 
         # resources stuff
         self.task_resources = list(
-            set(filter(os.path.isfile, task_definition.resources)))
+            set(filter(os.path.exists, task_definition.resources)))
         if resource_size is None:
             self.resource_size = 0
             for resource in self.task_resources:

--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -170,8 +170,7 @@ class DockerTaskThread(TaskThread):
 
     def _task_computed(self, estm_mem: Optional[int]) -> None:
         out_files = [
-            str(path) for path in self.dir_mapping.output.glob("**/*")
-            if path.is_file()
+            str(path) for path in self.dir_mapping.output.glob("*")
         ]
         self.result = {
             "data": out_files,

--- a/golem/task/result/resultpackage.py
+++ b/golem/task/result/resultpackage.py
@@ -153,7 +153,8 @@ class ZipPackager(Packager):
                     ZipPackager.zip_append(archive, os.path.join(root, d),
                                            os.path.join(subdirectory, d))
                 for f in files:
-                    archive.write(os.path.join(root, f), os.path.join(subdirectory, f))
+                    archive.write(os.path.join(root, f),
+                                  os.path.join(subdirectory, f))
                 break
         elif os.path.isfile(path):
             archive.write(path, os.path.join(subdirectory, basename))

--- a/golem/task/result/resultpackage.py
+++ b/golem/task/result/resultpackage.py
@@ -109,7 +109,6 @@ class Packager(object):
     def write_cbor_file(self, obj, file_name, cbor_data):
         pass
 
-
 class ZipPackager(Packager):
 
     ZIP_MODE = zipfile.ZIP_STORED  # no compression
@@ -130,7 +129,7 @@ class ZipPackager(Packager):
         return zipfile.ZipFile(output_path, mode='w', compression=self.ZIP_MODE)
 
     def write_disk_file(self, obj, file_path, file_name):
-        obj.write(file_path, file_name)
+        ZipPackager.zip_append(obj, file_path)
 
     def write_cbor_file(self, obj, file_name, cbord_data):
         obj.writestr(file_name, cbord_data)
@@ -140,6 +139,25 @@ class ZipPackager(Packager):
         if file_path.lower().endswith('.zip'):
             return file_path
         return file_path + '.zip'
+
+    @staticmethod
+    def zip_append(ob, path, rel=""):
+        basename = os.path.basename(path)
+        if os.path.isdir(path):
+            if rel == "":
+                rel = basename
+            ob.write(path, os.path.join(rel))
+            for root, dirs, files in os.walk(path):
+                for d in dirs:
+                    ZipPackager.zip_append(ob, os.path.join(root, d),
+                                           os.path.join(rel, d))
+                for f in files:
+                    ob.write(os.path.join(root, f), os.path.join(rel, f))
+                break
+        elif os.path.isfile(path):
+            ob.write(path, os.path.join(rel, basename))
+        else:
+            pass
 
 
 class EncryptingPackager(Packager):

--- a/golem/task/result/resultpackage.py
+++ b/golem/task/result/resultpackage.py
@@ -109,6 +109,7 @@ class Packager(object):
     def write_cbor_file(self, obj, file_name, cbor_data):
         pass
 
+
 class ZipPackager(Packager):
 
     ZIP_MODE = zipfile.ZIP_STORED  # no compression

--- a/golem/task/result/resultpackage.py
+++ b/golem/task/result/resultpackage.py
@@ -158,7 +158,8 @@ class ZipPackager(Packager):
         elif os.path.isfile(path):
             archive.write(path, os.path.join(subdirectory, basename))
         else:
-            pass
+            raise RuntimeError("Packaging supports only \
+                    directories and files, unsupported object: {}".format(path))
 
 
 class EncryptingPackager(Packager):

--- a/golem/task/result/resultpackage.py
+++ b/golem/task/result/resultpackage.py
@@ -130,7 +130,7 @@ class ZipPackager(Packager):
         return zipfile.ZipFile(output_path, mode='w', compression=self.ZIP_MODE)
 
     def write_disk_file(self, obj, file_path, file_name):
-        ZipPackager.zip_append(obj, file_path)
+        ZipPackager.zip_append(obj, file_path.rstrip('/'))
 
     def write_cbor_file(self, obj, file_name, cbord_data):
         obj.writestr(file_name, cbord_data)

--- a/golem/task/result/resultpackage.py
+++ b/golem/task/result/resultpackage.py
@@ -142,21 +142,21 @@ class ZipPackager(Packager):
         return file_path + '.zip'
 
     @staticmethod
-    def zip_append(ob, path, rel=""):
+    def zip_append(archive, path, subdirectory=""):
         basename = os.path.basename(path)
         if os.path.isdir(path):
-            if rel == "":
-                rel = basename
-            ob.write(path, os.path.join(rel))
+            if subdirectory == "":
+                subdirectory = basename
+            archive.write(path, os.path.join(subdirectory))
             for root, dirs, files in os.walk(path):
                 for d in dirs:
-                    ZipPackager.zip_append(ob, os.path.join(root, d),
-                                           os.path.join(rel, d))
+                    ZipPackager.zip_append(archive, os.path.join(root, d),
+                                           os.path.join(subdirectory, d))
                 for f in files:
-                    ob.write(os.path.join(root, f), os.path.join(rel, f))
+                    archive.write(os.path.join(root, f), os.path.join(subdirectory, f))
                 break
         elif os.path.isfile(path):
-            ob.write(path, os.path.join(rel, basename))
+            archive.write(path, os.path.join(subdirectory, basename))
         else:
             pass
 

--- a/tests/golem/task/result/test_resultpackage.py
+++ b/tests/golem/task/result/test_resultpackage.py
@@ -130,14 +130,16 @@ class TestZipDirectoryPackager(TempDirFixture):
             directory2_path,
         ]
 
+        directory2_path = directory2_path.rstrip('/')
+        directory3_path = directory3_path.rstrip('/')
         self.expected_results = [
             os.path.basename(file_path),
-            os.path.basename(directory_path),
-            os.path.basename(directory2_path),
+            os.path.basename(directory_path) + '/',
+            os.path.basename(directory2_path) + '/',
+            os.path.join(os.path.basename(directory2_path),
+                         os.path.basename(directory3_path)) + '/',
             os.path.join(os.path.basename(directory2_path),
                          os.path.basename(directory3_file_path)),
-            os.path.join(os.path.basename(directory2_path),
-                         os.path.basename(directory3_path)),
             os.path.join(os.path.basename(directory2_path),
                          os.path.basename(directory3_path),
                          os.path.basename(directory3_file_path))
@@ -158,7 +160,7 @@ class TestZipDirectoryPackager(TempDirFixture):
         zp.create(self.out_path, self.disk_files, None)
         files, _ = zp.extract(self.out_path)
 
-        self.assertTrue(len(files) == len(self.expected_results))
+        self.assertTrue(set(files) == set(self.expected_results))
 
 class TestEncryptingPackager(PackageDirContentsFixture):
 

--- a/tests/golem/task/result/test_resultpackage.py
+++ b/tests/golem/task/result/test_resultpackage.py
@@ -1,6 +1,7 @@
 import uuid
 import os
 
+from pathlib import Path
 from unittest.mock import Mock
 
 from golem.core.fileencrypt import FileEncryptor
@@ -130,19 +131,13 @@ class TestZipDirectoryPackager(TempDirFixture):
             directory2_path,
         ]
 
-        directory2_path = directory2_path.rstrip('/')
-        directory3_path = directory3_path.rstrip('/')
         self.expected_results = [
             os.path.basename(file_path),
-            os.path.basename(directory_path) + '/',
-            os.path.basename(directory2_path) + '/',
-            os.path.join(os.path.basename(directory2_path),
-                         os.path.basename(directory3_path)) + '/',
-            os.path.join(os.path.basename(directory2_path),
-                         os.path.basename(directory3_file_path)),
-            os.path.join(os.path.basename(directory2_path),
-                         os.path.basename(directory3_path),
-                         os.path.basename(directory3_file_path))
+            os.path.basename(directory_path),
+            os.path.relpath(directory2_path, res_dir),
+            os.path.relpath(directory3_path, res_dir),
+            os.path.relpath(directory2_file_path, res_dir),
+            os.path.relpath(directory3_file_path, res_dir)
         ]
 
         self.res_dir = res_dir
@@ -159,7 +154,7 @@ class TestZipDirectoryPackager(TempDirFixture):
         zp = ZipPackager()
         zp.create(self.out_path, self.disk_files, None)
         files, _ = zp.extract(self.out_path)
-
+        files = [str(Path(f)) for f in files]
         self.assertTrue(set(files) == set(self.expected_results))
 
 class TestEncryptingPackager(PackageDirContentsFixture):

--- a/tests/golem/task/result/test_resultpackage.py
+++ b/tests/golem/task/result/test_resultpackage.py
@@ -82,6 +82,7 @@ class TestZipPackager(PackageDirContentsFixture):
 
         self.assertTrue(len(files) == len(self.all_files))
 
+# pylint: disable=too-many-instance-attributes
 class TestZipDirectoryPackager(TempDirFixture):
     def setUp(self):
         super().setUp()
@@ -97,16 +98,14 @@ class TestZipDirectoryPackager(TempDirFixture):
         self.dir_manager = dir_manager
         self.task_id = task_id
         self.secret = FileEncryptor.gen_secret(10, 20)
-        
+
         # Create directory structure:
-        '''
-            |-- directory
-            |-- directory2
-            |   |-- directory3
-            |   |   `-- file.txt
-            |   `-- file.txt
-            `-- file.txt
-        '''
+        #    |-- directory
+        #    |-- directory2
+        #    |   |-- directory3
+        #    |   |   `-- file.txt
+        #    |   `-- file.txt
+        #    `-- file.txt
 
         file_path = os.path.join(res_dir, "file.txt")
         directory_path = os.path.join(res_dir, "directory")
@@ -157,7 +156,7 @@ class TestZipDirectoryPackager(TempDirFixture):
     def testExtract(self):
         zp = ZipPackager()
         zp.create(self.out_path, self.disk_files, None)
-        files, out_dir = zp.extract(self.out_path)
+        files, _ = zp.extract(self.out_path)
 
         self.assertTrue(len(files) == len(self.expected_results))
 


### PR DESCRIPTION
This allows specifying a directory in "resources" key in task
definition, e.g.:

```
{
    ...
        "resources": [
            '/home/user/task_data'
        ]
    ...
}
```

All files and subdirectories will be zipped under 'task_data' directory
inside a package.