### PR TITLE
Docker resources permissions

### DIFF
--- a/golem/docker/job.py
+++ b/golem/docker/job.py
@@ -139,7 +139,7 @@ class DockerJob(object):
             },
             posix_path(self.resources_dir): {
                 "bind": self.RESOURCES_DIR,
-                "mode": "ro"
+                "mode": "rw"
             },
             posix_path(self.output_dir): {
                 "bind": self.OUTPUT_DIR,

--- a/golem/docker/job.py
+++ b/golem/docker/job.py
@@ -154,6 +154,12 @@ class DockerJob(object):
         else:
             environment = dict(LOCAL_USER_ID=os.getuid())
 
+        environment.update(
+            WORK_DIR=self.WORK_DIR,
+            RESOURCES_DIR=self.RESOURCES_DIR,
+            OUTPUT_DIR=self.OUTPUT_DIR
+        )
+
         docker_env = EnvironmentsManager().get_environment_by_image(self.image)
 
         if docker_env:

--- a/tests/golem/docker/test_docker_job.py
+++ b/tests/golem/docker/test_docker_job.py
@@ -198,7 +198,7 @@ class TestBaseDockerJob(TestDockerJob):
             self.assertTrue(work_mount["RW"])
             self.assertIsNotNone(resources_mount)
             self.assertEqual(resources_mount["Source"], resource_dir)
-            self.assertFalse(resources_mount["RW"])
+            self.assertTrue(resources_mount["RW"])
             self.assertIsNotNone(output_mount)
             self.assertEqual(output_mount["Source"], output_dir)
             self.assertTrue(output_mount["RW"])


### PR DESCRIPTION
I added also a commit expanding docker enviroment variables. I understand that it introduces some inconsistency because `/golem/job/params.py` exist in parallel, but it's not trivial to replace `DockerJob.prepare` method. 