### PR TITLE
Move repeated code to a common base in TaskCore

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -260,6 +260,8 @@ class CoreTask(Task):
             raise Exception("Subtask {} has wrong type".format(subtask_id))
 
         subtask["status"] = SubtaskStatus.finished
+        node_id = self.subtasks_given[subtask_id]['node_id']
+        TaskClient.assert_exists(node_id, self.counting_nodes).accept()
 
     @handle_key_error
     def verify_subtask(self, subtask_id):

--- a/apps/dummy/task/dummytask.py
+++ b/apps/dummy/task/dummytask.py
@@ -101,8 +101,6 @@ class DummyTask(CoreTask):
 
     def accept_results(self, subtask_id, result_files):
         super().accept_results(subtask_id, result_files)
-        node_id = self.subtasks_given[subtask_id]['node_id']
-        TaskClient.assert_exists(node_id, self.counting_nodes).accept()
         self.num_tasks_received += 1
 
     def __get_result_file_name(self, subtask_id: str) -> str:

--- a/apps/dummy/task/dummytask.py
+++ b/apps/dummy/task/dummytask.py
@@ -15,7 +15,6 @@ from apps.dummy.task.dummytaskstate import DummyTaskDefaults, DummyTaskOptions
 from apps.dummy.task.dummytaskstate import DummyTaskDefinition
 from apps.dummy.task.verifier import DummyTaskVerifier
 from golem.task.taskbase import Task
-from golem.task.taskclient import TaskClient
 from golem.task.taskstate import SubtaskStatus
 
 logger = logging.getLogger("apps.dummy")

--- a/apps/lux/task/luxrendertask.py
+++ b/apps/lux/task/luxrendertask.py
@@ -425,8 +425,6 @@ class LuxTask(renderingtask.RenderingTask):
         for tr_file in result_files:
             if has_ext(tr_file, ".flm"):
                 self.collected_file_names[num_start] = tr_file
-                node_id = self.subtasks_given[subtask_id]['node_id']
-                TaskClient.assert_exists(node_id, self.counting_nodes).accept()
                 self.num_tasks_received += 1
             elif not has_ext(tr_file, '.log'):
                 self.subtasks_given[subtask_id]['preview_file'] = tr_file

--- a/apps/lux/task/luxrendertask.py
+++ b/apps/lux/task/luxrendertask.py
@@ -27,7 +27,6 @@ from golem.core.common import timeout_to_deadline, get_golem_path, to_unicode
 from golem.core.fileshelper import common_dir, find_file_with_ext, has_ext
 from golem.resource import dirmanager
 from golem.resource.dirmanager import DirManager
-from golem.task.taskclient import TaskClient
 from golem.task.localcomputer import LocalComputer, ComputerAdapter
 from golem.task.taskstate import SubtaskStatus
 

--- a/apps/rendering/task/framerenderingtask.py
+++ b/apps/rendering/task/framerenderingtask.py
@@ -20,7 +20,6 @@ from apps.rendering.task.renderingtaskstate import RendererDefaults
 from golem_verificator.rendering_verifier import FrameRenderingVerifier
 from golem.core.common import update_dict, to_unicode
 from golem.task.taskbase import ResultType
-from golem.task.taskclient import TaskClient
 from golem.task.taskstate import SubtaskStatus, TaskStatus, SubtaskState
 
 logger = logging.getLogger("apps.rendering")

--- a/apps/rendering/task/framerenderingtask.py
+++ b/apps/rendering/task/framerenderingtask.py
@@ -187,8 +187,6 @@ class FrameRenderingTask(RenderingTask):
 
     def accept_results(self, subtask_id, result_files):
         super().accept_results(subtask_id, result_files)
-        node_id = self.subtasks_given[subtask_id]['node_id']
-        TaskClient.assert_exists(node_id, self.counting_nodes).accept()
         num_start = self.subtasks_given[subtask_id]['start_task']
         parts = self.subtasks_given[subtask_id]['parts']
         num_end = self.subtasks_given[subtask_id]['end_task']

--- a/tests/apps/core/task/test_coretask.py
+++ b/tests/apps/core/task/test_coretask.py
@@ -486,7 +486,8 @@ class TestCoreTask(LogTestCase, TestDirFixture):
 
         # this one should be ok
         c.subtasks_given["SUBTASK1"] = {
-            "status": SubtaskStatus.downloading
+            "status": SubtaskStatus.downloading,
+            "node_id": "NODE_ID",
         }
         c.accept_results("SUBTASK1", None)
 


### PR DESCRIPTION
Move repetitive piece of code to a common base.
This isn't non functional change for Lux, but I think way is more appropriate and Lux is going away anyway.