### PR TITLE
More short node_ids, part 3

### DIFF
--- a/apps/blender/task/blenderrendertask.py
+++ b/apps/blender/task/blenderrendertask.py
@@ -26,7 +26,7 @@ from apps.rendering.task.framerenderingtask import FrameRenderingTask, \
 from apps.rendering.task.renderingtask import PREVIEW_EXT, PREVIEW_X, PREVIEW_Y
 from apps.rendering.task.renderingtaskstate import RenderingTaskDefinition, \
     RendererDefaults
-from golem.core.common import to_unicode
+from golem.core.common import short_node_id, to_unicode
 from golem.core.fileshelper import has_ext
 from golem.docker.task_thread import DockerTaskThread
 from golem.resource.dirmanager import DirManager
@@ -38,7 +38,7 @@ from golem_verificator.blender_verifier import BlenderVerifier
 # https://github.com/golemfactory/golem/issues/2059
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 
-logger = logging.getLogger("apps.blender")
+logger = logging.getLogger(__name__)
 
 
 class BlenderDefaults(RendererDefaults):
@@ -483,9 +483,13 @@ class BlenderRenderTask(FrameRenderingTask):
                       }
 
         subtask_id = self.create_subtask_id()
-        logger.debug('Created new subtask for task. task_id=%r, subtask_id=%r'
-                     ', node_id=%r',
-                     self.header.task_id, subtask_id, node_id)
+        logger.debug(
+            'Created new subtask for task. '
+            'task_id=%s, subtask_id=%s, node_id=%s',
+            self.header.task_id,
+            subtask_id,
+            short_node_id(node_id)
+        )
         self.subtasks_given[subtask_id] = copy(extra_data)
         self.subtasks_given[subtask_id]['subtask_id'] = subtask_id
         self.subtasks_given[subtask_id]['status'] = SubtaskStatus.starting

--- a/apps/blender/task/blenderrendertask.py
+++ b/apps/blender/task/blenderrendertask.py
@@ -488,7 +488,7 @@ class BlenderRenderTask(FrameRenderingTask):
             'task_id=%s, subtask_id=%s, node_id=%s',
             self.header.task_id,
             subtask_id,
-            short_node_id(node_id)
+            short_node_id(node_id or '')
         )
         self.subtasks_given[subtask_id] = copy(extra_data)
         self.subtasks_given[subtask_id]['subtask_id'] = subtask_id

--- a/golem/network/transport/tcpserver.py
+++ b/golem/network/transport/tcpserver.py
@@ -3,6 +3,7 @@ import time
 from typing import Callable, Dict, List, Optional, Set
 
 from golem.clientconfigdescriptor import ClientConfigDescriptor
+from golem.core.common import node_info_str
 from golem.core.types import Kwargs
 from golem.core.hostaddress import ip_address_private, ip_network_contains, \
     ipv4_networks
@@ -12,13 +13,7 @@ from .session import BasicSession
 from .tcpnetwork import TCPNetwork, TCPListeningInfo, TCPListenInfo, \
     SocketAddress, TCPConnectInfo
 
-logger = logging.getLogger('golem.network.transport.tcpserver')
-
-
-def shorten_key_id(key_id):
-    if not isinstance(key_id, str):
-        return key_id
-    return key_id[:16] + "..." + key_id[-16:]
+logger = logging.getLogger(__name__)
 
 
 class TCPServer:
@@ -164,8 +159,8 @@ class PendingConnectionsServer(TCPServer):
         if not sockets:
             return False
 
-        logger.info("Connecting to peer %r using addresses: %r",
-                    shorten_key_id(node.key),
+        logger.info("Connecting to peer. node=%s, adresses=%r",
+                    node_info_str(node.node_name, node.key),
                     [str(socket) for socket in sockets])
 
         pc = PendingConnection(request_type,

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -183,7 +183,7 @@ class CompTaskKeeper:
 
     def add_request(self, theader: TaskHeader, price: int):
         # price is task_header.max_price
-        logger.debug('CT.add_request()')
+        logger.debug('CT.add_request(%r, %d)', theader, price)
         if price < 0:
             raise ValueError("Price should be greater or equal zero")
         task_id = theader.task_id

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -18,7 +18,7 @@ from twisted.internet.threads import deferToThread
 from apps.appsmanager import AppsManager
 from apps.core.task.coretask import CoreTask, AcceptClientVerdict
 from golem.core.common import get_timestamp_utc, HandleForwardedError, \
-    HandleKeyError, node_info_str, to_unicode, update_dict
+    HandleKeyError, node_info_str, short_node_id, to_unicode, update_dict
 from golem.manager.nodestatesnapshot import LocalTaskStateSnapshot
 from golem.network.transport.tcpnetwork import SocketAddress
 from golem.resource.dirmanager import DirManager

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -17,8 +17,8 @@ from twisted.internet.threads import deferToThread
 
 from apps.appsmanager import AppsManager
 from apps.core.task.coretask import CoreTask, AcceptClientVerdict
-from golem.core.common import HandleKeyError, get_timestamp_utc, \
-    to_unicode, update_dict, HandleForwardedError
+from golem.core.common import get_timestamp_utc, HandleForwardedError, \
+    HandleKeyError, node_info_str, to_unicode, update_dict
 from golem.manager.nodestatesnapshot import LocalTaskStateSnapshot
 from golem.network.transport.tcpnetwork import SocketAddress
 from golem.resource.dirmanager import DirManager
@@ -452,12 +452,13 @@ class TaskManager(TaskEventListener):
 
         verdict = task.should_accept_client(node_id)
         if verdict == AcceptClientVerdict.SHOULD_WAIT:
-            logger.warning("Waiting for results from %s on %s", node_id,
-                           task_id)
+            logger.warning("Waiting for results from %s on %s",
+                           short_node_id(node_id), task_id)
             return True
         elif verdict == AcceptClientVerdict.REJECTED:
-            logger.warning("Client %s has failed on subtask within task %s"
-                           " and is banned from it", node_id, task_id)
+            logger.warning("Client has failed on subtask within this task"
+                           " and is banned from it. node_id=%s, task_id=%s",
+                           short_node_id(node_id), task_id)
 
         return False
 
@@ -478,7 +479,8 @@ class TaskManager(TaskEventListener):
             node_id, node_name, task_id, price,
         )
         if not self.is_my_task(task_id):
-            logger.info("Cannot find task in my tasks. task_id=%r", task_id)
+            logger.info("Cannot find task in my tasks. task_id=%s, provider=%s",
+                        task_id, node_info_str(node_name, node_id))
             return False
 
         task = self.tasks[task_id]
@@ -487,8 +489,11 @@ class TaskManager(TaskEventListener):
             return False
 
         if not self.task_needs_computation(task_id):
-            logger.info('Task does not need computation. provider=%r - %r',
-                        node_name, node_id)
+            logger.info(
+                'Task does not need computation. task_id=%s, provider=%s',
+                task_id,
+                node_info_str(node_name, node_id)
+            )
             return False
 
         return True

--- a/tests/golem/docker/test_docker_task.py
+++ b/tests/golem/docker/test_docker_task.py
@@ -107,7 +107,8 @@ class DockerTaskTestCase(
     def _run_task(self, task: Task, timeout: int = 60 * 5, *_) \
             -> Optional[DockerTaskThread]:
         task_id = task.header.task_id
-        extra_data = task.query_extra_data(1.0)
+        node_id = '0xdeadbeef'
+        extra_data = task.query_extra_data(1.0, 0, node_id)
         ctd = extra_data.ctd
         ctd['deadline'] = timeout_to_deadline(timeout)
 
@@ -120,8 +121,9 @@ class DockerTaskTestCase(
                 use_docker_manager=False,
                 concent_variant={'url': None, 'pubkey': None},
             )
-        with patch('golem.client.node_info_str'):
-            self.node.client = self.node._client_factory(Mock())
+        mock_keys_auth = Mock()
+        mock_keys_auth.key_id = node_id
+        self.node.client = self.node._client_factory(mock_keys_auth)
         self.node.client.start = Mock()
         self.node._run()
 


### PR DESCRIPTION
Small improvements to logs:
- use `short_node_id` or `node_info_str` where possible
- make logs in the same function more consistent in data printed.