### PR TITLE
Remove perf from subtask info

### DIFF
--- a/apps/blender/task/blenderrendertask.py
+++ b/apps/blender/task/blenderrendertask.py
@@ -489,7 +489,6 @@ class BlenderRenderTask(FrameRenderingTask):
         self.subtasks_given[subtask_id] = copy(extra_data)
         self.subtasks_given[subtask_id]['subtask_id'] = subtask_id
         self.subtasks_given[subtask_id]['status'] = SubtaskStatus.starting
-        self.subtasks_given[subtask_id]['perf'] = perf_index
         self.subtasks_given[subtask_id]['node_id'] = node_id
         self.subtasks_given[subtask_id]['parts'] = parts
         self.subtasks_given[subtask_id]['res_x'] = self.res_x

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -526,7 +526,6 @@ class CoreTask(Task):
         new_subtask = self.subtasks_given[subtask_id]
 
         new_subtask['node_id'] = old_subtask_info['node_id']
-        new_subtask['perf'] = old_subtask_info['perf']
         new_subtask['ctd']['performance'] = \
             old_subtask_info['ctd']['performance']
 

--- a/apps/dummy/task/dummytask.py
+++ b/apps/dummy/task/dummytask.py
@@ -89,7 +89,6 @@ class DummyTask(CoreTask):
 
         self.subtasks_given[sid] = copy(ctd['extra_data'])
         self.subtasks_given[sid]["status"] = SubtaskStatus.starting
-        self.subtasks_given[sid]["perf"] = perf_index
         self.subtasks_given[sid]["node_id"] = node_id
         self.subtasks_given[sid]["result_extension"] = self.RESULT_EXT
         self.subtasks_given[sid]["shared_data_files"] = \

--- a/apps/lux/task/luxrendertask.py
+++ b/apps/lux/task/luxrendertask.py
@@ -220,7 +220,6 @@ class LuxTask(renderingtask.RenderingTask):
         subtask_id = self.create_subtask_id()
         self.subtasks_given[subtask_id] = copy(extra_data)
         self.subtasks_given[subtask_id]['status'] = SubtaskStatus.starting
-        self.subtasks_given[subtask_id]['perf'] = perf_index
         self.subtasks_given[subtask_id]['node_id'] = node_id
         self.subtasks_given[subtask_id]['res_x'] = self.res_x
         self.subtasks_given[subtask_id]['res_y'] = self.res_y

--- a/tests/apps/blender/verification/test_verificator_integration.py
+++ b/tests/apps/blender/verification/test_verificator_integration.py
@@ -40,7 +40,6 @@ class TestVerificatorModuleIntegration(TempDirFixture):
         self.subtask_info['frames'] = [1]
         self.subtask_info['start_task'] = 1
         self.subtask_info['subtask_id'] = '250771152547690738285326338136457465'
-        self.subtask_info['perf'] = 713.176
         self.subtask_info['crop_window'] = (0.0, 1.0, 0.0, 1.0)
         self.subtask_info['output_format'] = 'PNG'
         self.subtask_info['all_frames'] = [1]


### PR DESCRIPTION
Looks unused and I think it's duplicated with `performance` in ComputeTaskDefinition