### PR TITLE
Fix verification paths to work again on windows

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -76,8 +76,8 @@ class TaskManager(TaskEventListener):
         pass
 
     def __init__(
-            self, node_name, node, keys_auth, listen_address="", listen_port=0,
-            root_path="ComputerRes", use_distributed_resources=True,
+            self, node_name, node, keys_auth, root_path,
+            use_distributed_resources=True,
             tasks_dir="tasks", task_persistence=True,
             apps_manager=AppsManager(), finished_cb=None):
         super().__init__()
@@ -96,8 +96,8 @@ class TaskManager(TaskEventListener):
         self.tasks_states: Dict[str, TaskState] = {}
         self.subtask2task_mapping: Dict[str, str] = {}
 
-        self.listen_address = listen_address
-        self.listen_port = listen_port
+        self.listen_address = ""
+        self.listen_port = 0
 
         self.task_persistence = task_persistence
 

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -76,8 +76,8 @@ class TaskManager(TaskEventListener):
         pass
 
     def __init__(
-            self, node_name, node, keys_auth, listen_address="",
-            listen_port=0, root_path="res", use_distributed_resources=True,
+            self, node_name, node, keys_auth, listen_address="", listen_port=0,
+            root_path="ComputerRes", use_distributed_resources=True,
             tasks_dir="tasks", task_persistence=True,
             apps_manager=AppsManager(), finished_cb=None):
         super().__init__()

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -1036,7 +1036,7 @@ class TaskServer(
     #############################
     @staticmethod
     def __get_task_manager_root(datadir):
-        return os.path.join(datadir, "res")
+        return os.path.join(datadir, "ComputerRes")
 
     def _set_conn_established(self):
         self.conn_established_for_type.update({

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -30,12 +30,15 @@ class TempDirFixture(unittest.TestCase):
                 # to avoid issues with mounting directories in Docker containers
                 cls.root_dir = os.path.join(get_local_datadir('tests'))
                 os.makedirs(cls.root_dir, exist_ok=True)
+            elif is_windows():
+                import win32api
+                base_dir = get_local_datadir('default')
+                cls.root_dir = os.path.join(base_dir, 'ComputerRes', 'tests')
+                os.makedirs(cls.root_dir, exist_ok=True)
+                cls.root_dir = win32api.GetLongPathName(cls.root_dir)
             else:
                 # Select nice root temp dir exactly once.
                 cls.root_dir = tempfile.mkdtemp(prefix='golem-tests-')
-                if is_windows():
-                    import win32api
-                    cls.root_dir = win32api.GetLongPathName(cls.root_dir)
 
     # Concurrent tests will fail
     # @classmethod

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -31,7 +31,7 @@ class TempDirFixture(unittest.TestCase):
                 cls.root_dir = os.path.join(get_local_datadir('tests'))
                 os.makedirs(cls.root_dir, exist_ok=True)
             elif is_windows():
-                import win32api
+                import win32api  # noqa pylint: disable=import-error
                 base_dir = get_local_datadir('default')
                 cls.root_dir = os.path.join(base_dir, 'ComputerRes', 'tests')
                 os.makedirs(cls.root_dir, exist_ok=True)

--- a/tests/apps/blender/benchmark/test_blenderbenchmark.py
+++ b/tests/apps/blender/benchmark/test_blenderbenchmark.py
@@ -12,6 +12,7 @@ from apps.rendering.benchmark.renderingbenchmark import RenderingBenchmark
 from apps.rendering.task.renderingtaskstate import RenderingTaskDefinition
 from golem import testutils
 from golem.docker.manager import DockerManager
+from golem.docker.task_thread import DockerTaskThread
 from golem.network.p2p.node import Node
 from golem.resource.dirmanager import DirManager
 from golem.task.taskbase import Task
@@ -49,6 +50,12 @@ class TestBenchmarkRunner(testutils.TempDirFixture):
 
     @pytest.mark.slow
     def test_run(self):
+        dm = DockerTaskThread.docker_manager = DockerManager.install()
+        dm.update_config(
+            status_callback=mock.Mock(),
+            done_callback=mock.Mock(),
+            work_dir=self.new_path,
+            in_background=True)
         benchmark = BlenderBenchmark()
         task_definition = benchmark.task_definition
 
@@ -66,7 +73,6 @@ class TestBenchmarkRunner(testutils.TempDirFixture):
         success = mock.MagicMock()
         error = mock.MagicMock()
 
-        DockerManager.install()
         self.br = BenchmarkRunner(task, self.path, success, error, benchmark)
         self.br.run()
         if self.br.tt:

--- a/tests/apps/blender/verification/test_verificator_integration.py
+++ b/tests/apps/blender/verification/test_verificator_integration.py
@@ -1,24 +1,24 @@
 import logging
 import os
 import time
-from unittest import skip
+from unittest import skip, mock
 
 from twisted.internet.defer import Deferred
 
 from apps.blender.blender_reference_generator import BlenderReferenceGenerator
+from apps.blender.blenderenvironment import BlenderEnvironment
 from apps.blender.task.blenderrendertask import BlenderRenderTask
 from golem_verificator.common.ci import ci_skip
 from golem.core.common import get_golem_path
+from golem.core.deferred import sync_wait
 from golem.docker.image import DockerImage
+from golem.docker.manager import DockerManager
+from golem.docker.task_thread import DockerTaskThread
+from golem.environments.environmentsmanager import EnvironmentsManager
 from golem.task.localcomputer import ComputerAdapter
 from golem.testutils import TempDirFixture
-from golem.core.deferred import sync_wait
-
-logger = logging.getLogger(__name__)
 
 
-# FIXME: Verificator module doesn't work correctly with Docker
-@skip('Temporarily disabled')
 @ci_skip
 class TestVerificatorModuleIntegration(TempDirFixture):
 
@@ -27,6 +27,12 @@ class TestVerificatorModuleIntegration(TempDirFixture):
     def setUp(self):
         # pylint: disable=R0915
         super().setUp()
+        dm = DockerTaskThread.docker_manager = DockerManager.install()
+        dm.update_config(
+            status_callback=mock.Mock(),
+            done_callback=mock.Mock(),
+            work_dir=self.new_path,
+            in_background=True)
         self.blender_reference_generator = BlenderReferenceGenerator()
         self.golem_dir = get_golem_path()
         self.resources = ['tests/apps/blender/verification/test_data/bmw.blend']

--- a/tests/golem/task/test_localcomputer.py
+++ b/tests/golem/task/test_localcomputer.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from golem_messages.message import ComputeTaskDef
 
+from golem.docker.manager import DockerManager
+from golem.docker.task_thread import DockerTaskThread
 from golem.task.localcomputer import LocalComputer
 from golem.task.taskbase import Task
 from golem.tools.ci import ci_skip
@@ -29,6 +31,12 @@ class TestLocalComputer(TestDirFixture):
 
     def test_computer(self):
 
+        dm = DockerTaskThread.docker_manager = DockerManager.install()
+        dm.update_config(
+            status_callback=mock.Mock(),
+            done_callback=mock.Mock(),
+            work_dir=self.new_path,
+            in_background=True)
         files = self.additional_dir_content([1])
         lc = LocalComputer(root_path=self.path,
                            success_callback=self._success_callback,
@@ -39,6 +47,7 @@ class TestLocalComputer(TestDirFixture):
         assert self.last_error is not None
         assert self.last_result is None
         assert self.error_counter == 1
+        assert self.success_counter == 0
 
         lc = LocalComputer(root_path=self.path,
                            success_callback=self._success_callback,


### PR DESCRIPTION
- Update tests to install and set env for the DockerManager
- Update task_server and task_manager default path from `res` to `ComputerRes`