### PR TITLE
Start VM means `start` not `restart`

### DIFF
--- a/golem/docker/commands/docker_machine.py
+++ b/golem/docker/commands/docker_machine.py
@@ -6,14 +6,15 @@ class DockerMachineCommandHandler(DockerCommandHandler):
     commands: CommandDict = dict(
         create=['docker-machine', 'create'],
         rm=['docker-machine', 'rm', '-y'],
-        start=['docker-machine', 'restart'],
+        start=['docker-machine', 'start'],
         stop=['docker-machine', 'stop'],
         active=['docker-machine', 'active'],
         list=['docker-machine', 'ls', '-q'],
         env=['docker-machine', 'env'],
         status=['docker-machine', 'status'],
         inspect=['docker-machine', 'inspect'],
-        regenerate_certs=['docker-machine', 'regenerate-certs', '--force']
+        regenerate_certs=['docker-machine', 'regenerate-certs', '--force'],
+        restart=['docker-machine', 'restart'],
     )
 
     commands.update(DockerCommandHandler.commands)

--- a/golem/docker/hypervisor/docker_machine.py
+++ b/golem/docker/hypervisor/docker_machine.py
@@ -133,7 +133,7 @@ Ensure that you try the following before reporting an issue:
             return self._set_env(retried=True)
 
         try:
-            self.command('start', self._vm_name)
+            self.command('restart', self._vm_name)
         except subprocess.CalledProcessError as e:
             logger.warning("DockerMachine:"
                            " failed to restart the VM: %s -- %s",


### PR DESCRIPTION
Changed the handling of `start` command in DockerMachineCommandHandler so that it calls `docker-machine start` instead of `restart`. It was not working correctly because Hyper-V driver for docker-machine tries to connect to a VM via SSH before stopping it and this would hang up forever if the VM is not running in the first place.

Added a separate `restart` command which is used in `_recover()`.