### PR TITLE
make `concent_enabled` key optional for `TaskManager.create_task` dictionary

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -788,7 +788,7 @@ class Client(HardwarePresetsMixin):
                 dictionary=dictionary, minimal=True
             )
         except Exception as e:
-            return on_error(to_unicode(e))
+            return on_error("{}: {}".format(type(e), to_unicode(e)))
 
         self.task_test_result = json.dumps(
             {"status": TaskTestStatus.started, "error": True})

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -150,7 +150,7 @@ class TaskManager(TaskEventListener):
         definition = builder_type.build_definition(task_type, dictionary,
                                                    minimal)
         definition.task_id = CoreTask.create_task_id(self.keys_auth.public_key)
-        definition.concent_enabled = dictionary['concent_enabled']
+        definition.concent_enabled = dictionary.get('concent_enabled', False)
         builder = builder_type(self.node, definition, self.dir_manager)
 
         return builder.build()

--- a/golem/tools/assertlogs.py
+++ b/golem/tools/assertlogs.py
@@ -81,8 +81,12 @@ class _AssertLogsContext(_BaseTestCaseContext):
                 .format(logging.getLevelName(self.level), self.logger.name))
         elif len(self.watcher.records) > 0 and not self.assert_logs:
             self._raiseFailure(
-                "logs of level {} or higher triggered on {}"
-                .format(logging.getLevelName(self.level), self.logger_name))
+                "logs of level {} or higher triggered on {}.\n{}"
+                .format(
+                    logging.getLevelName(self.level),
+                    self.logger_name,
+                    self.watcher.output)
+            )
 
 
 class LogTestCase(unittest.TestCase):

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1422,18 +1422,18 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
 
     def test_run_test_task_params(self, *_):
         with mock.patch(
-                'apps.blender.task.blenderrendertask.'
-                'BlenderTaskTypeInfo.for_purpose',
-                mock.Mock(),
+            'apps.blender.task.blenderrendertask.'
+            'BlenderTaskTypeInfo.for_purpose',
+            mock.Mock(),
         ),\
-             mock.patch('golem.client.TaskTester.run', mock.Mock()),\
-             self.assertNoLogs():
-                self.client._run_test_task(
-                    {
-                        'type': 'blender',
-                        'resources': ['_.blend'],
-                        'subtasks': 1,
-                    })
+        mock.patch('golem.client.TaskTester.run', mock.Mock()),\
+        self.assertNoLogs():
+            self.client._run_test_task(
+                {
+                    'type': 'blender',
+                    'resources': ['_.blend'],
+                    'subtasks': 1,
+                })
 
     @classmethod
     def __new_incoming_peer(cls):

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1368,6 +1368,14 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
         self.client.task_server.acl.disallow.assert_called_once_with(
             'node_id', persist=True)
 
+    def _check_task_tester_result(self):
+        self.assertIsInstance(self.client.task_test_result, str)
+        test_result = json.loads(self.client.task_test_result)
+        self.assertEqual(test_result, {
+            "status": TaskTestStatus.started,
+            "error": True
+        })
+
     def test_run_test_task_success(self, *_):
         result = {'result': 'result'}
         estimated_memory = 1234
@@ -1375,13 +1383,7 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
         more = {'more': 'more'}
 
         def _run(_self: TaskTester):
-            self.assertIsInstance(self.client.task_test_result, str)
-            test_result = json.loads(self.client.task_test_result)
-            self.assertEqual(test_result, {
-                "status": TaskTestStatus.started,
-                "error": True
-            })
-
+            self._check_task_tester_result()
             _self.success_callback(result, estimated_memory, time_spent, **more)
 
         with patch.object(self.client.task_server.task_manager, 'create_task'),\
@@ -1403,13 +1405,7 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
         more = {'more': 'more'}
 
         def _run(_self: TaskTester):
-            self.assertIsInstance(self.client.task_test_result, str)
-            test_result = json.loads(self.client.task_test_result)
-            self.assertEqual(test_result, {
-                "status": TaskTestStatus.started,
-                "error": True
-            })
-
+            self._check_task_tester_result()
             _self.error_callback(*error, **more)
 
         with patch.object(self.client.task_server.task_manager, 'create_task'),\
@@ -1423,6 +1419,21 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
             "error": error,
             "more": more
         })
+
+    def test_run_test_task_params(self, *_):
+        with mock.patch(
+                'apps.blender.task.blenderrendertask.'
+                'BlenderTaskTypeInfo.for_purpose',
+                mock.Mock(),
+        ),\
+             mock.patch('golem.client.TaskTester.run', mock.Mock()),\
+             self.assertNoLogs():
+                self.client._run_test_task(
+                    {
+                        'type': 'blender',
+                        'resources': ['_.blend'],
+                        'subtasks': 1,
+                    })
 
     @classmethod
     def __new_incoming_peer(cls):


### PR DESCRIPTION
partially_resolves: https://github.com/golemfactory/golem/issues/3350
complements: https://github.com/golemfactory/golem-electron/pull/446