### PR TITLE
Fix fundslocker to use Task API properly

### DIFF
--- a/golem/ethereum/fundslocker.py
+++ b/golem/ethereum/fundslocker.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class TaskFundsLock:  # pylint: disable=too-few-public-methods
     def __init__(self, task):
         self.price = task.subtask_price
-        self.num_tasks = task.total_tasks
+        self.num_tasks = task.get_total_tasks()
         self.task_deadline = task.header.deadline
 
     @property


### PR DESCRIPTION
This fixes fundslocker to use appropriate API method from Task class instead
of accessing property that is only defined in a CoreTask (Task
derived class). Task base class does not have the `total_tasks`
property. This code caused problems when deriving Task from scratch.