### PR TITLE
Migrate task definition pickles from 0.17.1

### DIFF
--- a/apps/core/task/coretaskstate.py
+++ b/apps/core/task/coretaskstate.py
@@ -133,9 +133,10 @@ class TaskDefinition(object):
         subtask_timeout = timeout_to_string(self.subtask_timeout)
         output_path = self.build_output_path()
 
-        result = {
+        return {
             'id': self.task_id,
             'type': self.task_type,
+            'compute_on': self.compute_on,
             'name': self.task_name,
             'timeout': task_timeout,
             'subtask_timeout': subtask_timeout,
@@ -145,10 +146,8 @@ class TaskDefinition(object):
             'options': {
                 'output_path': output_path
             },
-            'compute_on': self.compute_on,
             'concent_enabled': self.concent_enabled,
         }
-        return result
 
     def build_output_path(self) -> str:
         return self.output_file.rsplit(path.sep, 1)[0]

--- a/apps/core/task/coretaskstate.py
+++ b/apps/core/task/coretaskstate.py
@@ -1,7 +1,9 @@
 from os import path, remove
 
 from ethereum.utils import denoms
+import semantic_version
 
+import golem
 from golem.core.common import timeout_to_string
 from golem.environments.environment import Environment
 from golem.task.taskstate import TaskState
@@ -53,6 +55,30 @@ class TaskDefinition(object):
         self.compute_on = "cpu"
 
         self.concent_enabled: bool = False
+
+    def __getstate__(self):
+        return golem.__version__, self.__dict__
+
+    def __setstate__(self, state):
+        if not isinstance(state, tuple):
+            pickled_version, attributes = '0.17.1', state
+        else:
+            pickled_version, attributes = state
+
+        s_pickled_version = semantic_version.Version(pickled_version)
+        if s_pickled_version < semantic_version.Version('0.18.0'):
+            # Defaults for attributes that could be missing in pickles
+            # from 0.17.1  #3405
+            migration_defaults = (
+                ('compute_on', 'cpu'),
+                ('concent_enabled', False),
+            )
+            for key, default_value in migration_defaults:
+                if key not in attributes:
+                    attributes[key] = default_value
+
+        for key in attributes:
+            setattr(self, key, attributes[key])
 
     def is_valid(self):
         if not path.exists(self.main_program_file):
@@ -119,21 +145,9 @@ class TaskDefinition(object):
             'options': {
                 'output_path': output_path
             },
+            'compute_on': self.compute_on,
+            'concent_enabled': self.concent_enabled,
         }
-
-        # Safe getattrs for attributes that could be missing in pickles
-        # from 0.17.1
-        new_attributes = (
-            ('compute_on', 'compute_on', 'cpu'),
-            ('concent_enabled', 'concent_enabled', False),
-        )
-        for key, attribute, default in new_attributes:
-            try:
-                result[key] = getattr(self, attribute)
-            except AttributeError:
-                result[key] = default
-                setattr(self, attribute, default)
-
         return result
 
     def build_output_path(self) -> str:


### PR DESCRIPTION
fixes: #3300 

Migrate task definitions pickled in *0.17.1*. It's ad hoc solution for release only. Full solution suggested in #3405