### PR TITLE
Remove unnecessary short_desc

### DIFF
--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -72,7 +72,6 @@ class DockerTaskThread(TaskThread):
                  docker_images: List[Union[DockerImage, Dict, Tuple]],
                  src_code: str,
                  extra_data: Dict,
-                 short_desc: str,
                  dir_mapping: DockerDirMapping,
                  timeout: int,
                  check_mem: bool = False) -> None:
@@ -81,7 +80,7 @@ class DockerTaskThread(TaskThread):
             raise AttributeError("docker images is None")
         super(DockerTaskThread, self).__init__(
             subtask_id, src_code, extra_data,
-            short_desc, dir_mapping.resources, dir_mapping.temporary,
+            dir_mapping.resources, dir_mapping.temporary,
             timeout)
 
         # Find available image

--- a/golem/task/localcomputer.py
+++ b/golem/task/localcomputer.py
@@ -189,7 +189,6 @@ class LocalComputer:
             ctd['docker_images'],
             ctd['src_code'],
             ctd['extra_data'],
-            ctd['short_description'],
             dir_mapping,
             0,
             check_mem=self.check_mem,

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -129,7 +129,6 @@ class TaskComputer(object):
                     subtask['docker_images'],
                     subtask['src_code'],
                     subtask['extra_data'],
-                    subtask['short_description'],
                     subtask['deadline'])
                 return True
             return False
@@ -359,7 +358,7 @@ class TaskComputer(object):
             self.reset()
 
     def __compute_task(self, subtask_id, docker_images,
-                       src_code, extra_data, short_desc, subtask_deadline):
+                       src_code, extra_data, subtask_deadline):
         task_id = self.assigned_subtasks[subtask_id]['task_id']
         task_header = self.task_server.task_keeper.task_headers.get(task_id)
 
@@ -394,11 +393,11 @@ class TaskComputer(object):
             dir_mapping = DockerTaskThread.generate_dir_mapping(resource_dir,
                                                                 temp_dir)
             tt = DockerTaskThread(subtask_id, docker_images,
-                                  src_code, extra_data, short_desc,
+                                  src_code, extra_data,
                                   dir_mapping, task_timeout)
         elif self.support_direct_computation:
             tt = PyTaskThread(subtask_id, src_code,
-                              extra_data, short_desc, resource_dir, temp_dir,
+                              extra_data, resource_dir, temp_dir,
                               task_timeout)
         else:
             logger.error("Cannot run PyTaskThread in this version")
@@ -425,11 +424,9 @@ class TaskComputer(object):
 
 
 class AssignedSubTask(object):
-    def __init__(self, src_code, extra_data, short_desc, owner_address,
-                 owner_port):
+    def __init__(self, src_code, extra_data, owner_address, owner_port):
         self.src_code = src_code
         self.extra_data = extra_data
-        self.short_desc = short_desc
         self.owner_address = owner_address
         self.owner_port = owner_port
 
@@ -437,18 +434,16 @@ class AssignedSubTask(object):
 class PyTaskThread(TaskThread):
     # pylint: disable=too-many-arguments
     def __init__(self, subtask_id, src_code,
-                 extra_data, short_desc, res_path, tmp_path, timeout):
+                 extra_data, res_path, tmp_path, timeout):
         super(PyTaskThread, self).__init__(
-            subtask_id, src_code, extra_data,
-            short_desc, res_path, tmp_path, timeout)
+            subtask_id, src_code, extra_data, res_path, tmp_path, timeout)
         self.vm = PythonProcVM()
 
 
 class PyTestTaskThread(PyTaskThread):
     # pylint: disable=too-many-arguments
     def __init__(self, subtask_id, src_code,
-                 extra_data, short_desc, res_path, tmp_path, timeout):
+                 extra_data, res_path, tmp_path, timeout):
         super(PyTestTaskThread, self).__init__(
-            subtask_id, src_code, extra_data,
-            short_desc, res_path, tmp_path, timeout)
+            subtask_id, src_code, extra_data, res_path, tmp_path, timeout)
         self.vm = PythonTestVM()

--- a/golem/task/taskthread.py
+++ b/golem/task/taskthread.py
@@ -27,7 +27,6 @@ class TaskThread(threading.Thread):
                  subtask_id: str,
                  src_code: str,
                  extra_data: Dict,
-                 short_desc: str,
                  res_path: str,
                  tmp_path: str,
                  timeout: float = 0) -> None:
@@ -37,7 +36,6 @@ class TaskThread(threading.Thread):
         self.subtask_id = subtask_id
         self.src_code = src_code
         self.extra_data = extra_data
-        self.short_desc = short_desc
         self.result = None
         self.done = False
         self.res_path = res_path
@@ -74,9 +72,6 @@ class TaskThread(threading.Thread):
 
     def get_subtask_id(self):
         return self.subtask_id
-
-    def get_task_short_desc(self):
-        return self.short_desc
 
     def get_progress(self):
         with self.lock:

--- a/tests/golem/docker/test_docker_task_thread.py
+++ b/tests/golem/docker/test_docker_task_thread.py
@@ -39,7 +39,7 @@ class TestDockerTaskThread(TestDockerJob, TestWithDatabase):
             dir_mapping = DockerTaskThread.generate_dir_mapping(
                 self.resources_dir, self.output_dir)
             DockerTaskThread("subtask_id", None,
-                             script, None, "test task thread",
+                             script, None,
                              dir_mapping, timeout=30)
 
         def test():

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -304,7 +304,6 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
             docker_images=[],
             src_code='print("test")',
             extra_data=mock.Mock(),
-            short_desc='test',
             subtask_deadline=time.time() + 3600
         )
 
@@ -379,7 +378,6 @@ class TestTaskThread(DatabaseFixture):
         return PyTaskThread(subtask_id="xxyyzz",
                             src_code=src_code,
                             extra_data={},
-                            short_desc="hello thread",
                             res_path=os.path.dirname(files[0]),
                             tmp_path=os.path.dirname(files[1]),
                             timeout=20)


### PR DESCRIPTION
This isn't used anywhere.
Also imo short description should be associated with environment, not with a particular task instance making this redundant anyway.