### PR TITLE
change the Concent Integration test datadir report so that it can be …

### DIFF
--- a/scripts/concent_integration_tests/params.py
+++ b/scripts/concent_integration_tests/params.py
@@ -9,7 +9,7 @@ def get_datadir(role: str):
     if not datadir:
         datadir = tempfile.mkdtemp(prefix='golem-{}-'.format(role.lower()))
         os.environ[env_key] = datadir
-        print("{} data directory: {}".format(role.capitalize(), datadir))
+        print("{}={}".format(env_key, datadir))
     return datadir
 
 


### PR DESCRIPTION
…immediately used as the input to run the nodes again more easily