### PR TITLE
Implement provider ordering algorithm

### DIFF
--- a/golem/marketplace/__init__.py
+++ b/golem/marketplace/__init__.py
@@ -1,1 +1,8 @@
 from rust.golem import marketplace__order_providers as order_providers  # noqa pylint: disable=no-name-in-module,import-error
+
+
+class Offer:
+    def __init__(self, scaled_price: float) -> None:
+        self.scaled_price = scaled_price
+        self.reputation = 0.0
+        self.quality = (0.0, 0.0, 0.0, 0.0)

--- a/rust/golem/src/marketplace.rs
+++ b/rust/golem/src/marketplace.rs
@@ -1,31 +1,97 @@
+// Price sensitivity factor. 0 <= ALPHA <= 1
+const ALPHA: f64 = 0.67;
+// Distrust factor. 1 <= D
+const D: f64 = 5.0;
+// History forgetting factor. 0 < PSI < 1
+const PSI: f64 = 0.9;
+
+pub struct Quality {
+    pub s: f64,
+    pub t: f64,
+    pub f: f64,
+    pub r: f64,
+}
+
 pub struct Offer {
-    price: f64,
+    pub scaled_price: f64,
+    pub reputation: f64,
+    pub quality: Quality,
 }
 
-impl Offer {
-    pub fn new(price: f64) -> Offer {
-        Offer { price }
-    }
+pub fn order_providers(offers: Vec<Offer>) -> Vec<usize> {
+    order_providers_impl(offers, ALPHA, PSI, D)
 }
 
-pub fn order_providers(offers: &[Offer]) -> Vec<usize> {
-    let mut perm: Vec<usize> = (0..offers.len()).collect();
-    perm.sort_by(|lhs, rhs| offers[*lhs].price.partial_cmp(&offers[*rhs].price).unwrap());
-    perm
+fn order_providers_impl(offers: Vec<Offer>, alpha: f64, psi: f64, d: f64) -> Vec<usize> {
+    let q_star = (1.0 + 1.0 / (1.0 - psi)) / (d + 1.0 / (1.0 - psi));
+    let score = |offer: &Offer| -> f64 {
+        let q = (1.0 + offer.quality.s)
+            / (d + offer.quality.s + offer.quality.t + offer.quality.f + offer.quality.r)
+            / q_star;
+        alpha * offer.scaled_price + (1.0 - alpha) * offer.reputation * q
+    };
+    let mut perm: Vec<(usize, f64)> = (0..offers.len())
+        .map(|ind| (ind, score(&offers[ind])))
+        .collect();
+    perm.sort_by(|lhs, rhs| rhs.1.partial_cmp(&lhs.1).unwrap());
+    perm.iter().map(|(ind, _)| *ind).collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    fn gen_offers() -> Vec<Offer> {
+        return vec![
+            Offer {
+                scaled_price: 2.0,
+                reputation: 10.0,
+                quality: Quality {
+                    s: 0.0,
+                    t: 0.0,
+                    f: 0.0,
+                    r: 0.0,
+                },
+            },
+            Offer {
+                scaled_price: 2.2,
+                reputation: 20.0,
+                quality: Quality {
+                    s: 0.0,
+                    t: 0.0,
+                    f: 0.0,
+                    r: 0.0,
+                },
+            },
+            Offer {
+                scaled_price: 1.7,
+                reputation: 17.0,
+                quality: Quality {
+                    s: 0.0,
+                    t: 0.0,
+                    f: 0.0,
+                    r: 0.0,
+                },
+            },
+            Offer {
+                scaled_price: 4.4,
+                reputation: 14.0,
+                quality: Quality {
+                    s: 0.0,
+                    t: 0.0,
+                    f: 0.0,
+                    r: 0.0,
+                },
+            },
+        ];
+    }
     #[test]
-    fn order_providers_sanity() {
-        let offer0 = Offer { price: 2.0 };
-        let offer1 = Offer { price: 2.2 };
-        let offer2 = Offer { price: 1.7 };
-        let offer3 = Offer { price: 4.4 };
-        assert_eq!(
-            order_providers(&vec![offer0, offer1, offer2, offer3]),
-            vec![2, 0, 1, 3]
-        );
+    fn order_providers_price_preference() {
+        let offers = gen_offers();
+        assert_eq!(order_providers_impl(offers, 1.0, PSI, D), vec![3, 1, 0, 2]);
+    }
+    #[test]
+    fn order_providers_reputation_preference() {
+        let offers = gen_offers();
+        assert_eq!(order_providers_impl(offers, 0.0, PSI, D), vec![1, 2, 3, 0]);
     }
 }

--- a/tests/golem/marketplace/test_marketplace.py
+++ b/tests/golem/marketplace/test_marketplace.py
@@ -1,5 +1,10 @@
-from golem.marketplace import order_providers
+from golem.marketplace import order_providers, Offer
 
 
 def test_order_providers():
-    assert order_providers([2.0, 1.8, 5.0, 4.4]) == [1, 0, 3, 2]
+    offer0 = Offer(scaled_price=2.0)
+    offer1 = Offer(scaled_price=1.8)
+    offer2 = Offer(scaled_price=4.4)
+    res = order_providers([offer0, offer1, offer2])
+    # Actual order is not important, just that it is a permutation
+    assert sorted(res) == list(range(3))


### PR DESCRIPTION
Straight from the marketplace doc. Using `scaled_price` which is `price / max_price` as it's the only context `price` is used in the algorithm and this way we don't need to pass `max_price` along.
Also writing tests for it seems awkward