### PR TITLE
Fix fundslocker to use Task API properly

### DIFF
--- a/golem/ethereum/fundslocker.py
+++ b/golem/ethereum/fundslocker.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 class TaskFundsLock:
     def __init__(self, task):
         self.price = task.subtask_price
-        self.num_tasks = task.total_tasks
+        self.num_tasks = task.get_total_tasks()
         self.task_deadline = task.header.deadline
 
     @property

--- a/tests/golem/ethereum/test_fundslocker.py
+++ b/tests/golem/ethereum/test_fundslocker.py
@@ -17,7 +17,7 @@ def make_mock_task(*_, task_id: str = 'tid', subtask_price: int = 100,
     task.header.deadline = timeout_to_deadline(timeout)
     task.header.task_id = task_id
     task.subtask_price = subtask_price
-    task.get_total_tasks = mock.Mock(return_value=total_tasks)
+    task.get_total_tasks.return_value = total_tasks
     return task
 
 

--- a/tests/golem/ethereum/test_fundslocker.py
+++ b/tests/golem/ethereum/test_fundslocker.py
@@ -17,7 +17,7 @@ def make_mock_task(*_, task_id: str = 'tid', subtask_price: int = 100,
     task.header.deadline = timeout_to_deadline(timeout)
     task.header.task_id = task_id
     task.subtask_price = subtask_price
-    task.total_tasks = total_tasks
+    task.get_total_tasks = mock.Mock(return_value=total_tasks)
     return task
 
 
@@ -36,13 +36,13 @@ class TestFundsLocker(TempDirFixture):
         task = make_mock_task(task_id="abc", subtask_price=320, total_tasks=10)
         fl.lock_funds(task)
         self.ts.lock_funds_for_payments.assert_called_once_with(
-            task.subtask_price, task.total_tasks)
+            task.subtask_price, task.get_total_tasks())
         tfl = fl.task_lock[task.header.task_id]
 
         def test_params(tfl):
             assert isinstance(tfl, TaskFundsLock)
-            assert tfl.gnt_lock == task.subtask_price * task.total_tasks
-            assert tfl.num_tasks == task.total_tasks
+            assert tfl.gnt_lock == task.subtask_price * task.get_total_tasks()
+            assert tfl.num_tasks == task.get_total_tasks()
             assert tfl.task_deadline == task.header.deadline
 
         test_params(tfl)
@@ -163,4 +163,4 @@ class TestFundsLocker(TempDirFixture):
         self.ts.lock_funds_for_payments.assert_called_with(task.subtask_price,
                                                            num)
         assert fl.task_lock[task.header.task_id].num_tasks == \
-            task.total_tasks + num
+            task.get_total_tasks() + num

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -798,7 +798,7 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
         task = Mock(
             header=task_header,
             get_resources=Mock(return_value=[]),
-            total_tasks=5,
+            get_total_tasks=Mock(return_value=5),
             get_price=Mock(return_value=900),
             subtask_price=1000,
             spec=Task,
@@ -810,8 +810,8 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
         task_mock = MagicMock()
         task_mock.header.max_price = 1 * 10**18
         task_mock.header.subtask_timeout = 158
-        task_mock.total_tasks = 3
-        price = task_mock.header.max_price * task_mock.total_tasks
+        task_mock.get_total_tasks = mock.Mock(return_value=3)
+        price = task_mock.header.max_price * task_mock.get_total_tasks()
         task_mock.get_price.return_value = price
         task_mock.subtask_price = 1000
         c.task_server.task_manager.create_task.return_value = task_mock

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -810,7 +810,7 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
         task_mock = MagicMock()
         task_mock.header.max_price = 1 * 10**18
         task_mock.header.subtask_timeout = 158
-        task_mock.get_total_tasks = mock.Mock(return_value=3)
+        task_mock.get_total_tasks.return_value = 3
         price = task_mock.header.max_price * task_mock.get_total_tasks()
         task_mock.get_price.return_value = price
         task_mock.subtask_price = 1000


### PR DESCRIPTION
This fixes fundslocker to use appropriate API method from Task class instead
of accessing property that is only defined in a CoreTask (Task
derived class). Task base class does not have the `total_tasks
property. This code caused problems when deriving Task from scratch.