### PR TITLE
Fix Golem Client to use Task API properly

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -632,7 +632,7 @@ class Client(HardwarePresetsMixin):
                 task.header.mask = Mask()
 
             estimated_fee = self.transaction_system.eth_for_batch_payment(
-                task.total_tasks)
+                task.get_total_tasks())
             task_manager.add_new_task(task, estimated_fee=estimated_fee)
 
             client_options = self.task_server.get_share_options(task_id, None)


### PR DESCRIPTION
This fixes Golem Client to use appropriate API method from Task class instead
of accessing property that is only defined in a CoreTask (Task
derived class). Task base class does not have the `total_tasks
property. This code caused problems when deriving Task from scratch.