### PR TITLE
Fix TaskManager dependency on derived class

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -632,7 +632,7 @@ class Client(HardwarePresetsMixin):
                 task.header.mask = Mask()
 
             estimated_fee = self.transaction_system.eth_for_batch_payment(
-                task.total_tasks)
+                task.get_total_tasks())
             task_manager.add_new_task(task, estimated_fee=estimated_fee)
 
             client_options = self.task_server.get_share_options(task_id, None)

--- a/golem/client.py
+++ b/golem/client.py
@@ -632,7 +632,7 @@ class Client(HardwarePresetsMixin):
                 task.header.mask = Mask()
 
             estimated_fee = self.transaction_system.eth_for_batch_payment(
-                task.get_total_tasks())
+                task.total_tasks)
             task_manager.add_new_task(task, estimated_fee=estimated_fee)
 
             client_options = self.task_server.get_share_options(task_id, None)

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -250,7 +250,7 @@ def _inform_subsystems(client, task, packager_result):
         task.header.mask = masking.Mask()
 
     estimated_fee = client.transaction_system.eth_for_batch_payment(
-        task.total_tasks)
+        task.get_total_tasks())
     client.task_manager.add_new_task(task, estimated_fee=estimated_fee)
 
     client_options = client.task_server.get_share_options(task_id, None)

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -44,6 +44,11 @@ class TaskTypeInfo(object):
     def for_purpose(self, purpose: TaskPurpose) -> 'TaskTypeInfo':
         return self
 
+    @classmethod
+    # pylint:disable=unused-argument
+    def get_preview(cls, task, single=False):
+        pass
+
 
 # TODO change types to enums - for now it gets
 # evt.comp.task.test.status Error WAMP message serialization
@@ -326,6 +331,13 @@ class TaskBuilder(abc.ABC):
         """
         pass
 
+    # TODO: Backward compatibility only. The rendering tasks should
+    # move to overriding their own TaskDefinitions instead of
+    # overriding `build_dictionary. Issue #2424`
+    @staticmethod
+    def build_dictionary(definition: TaskDefinition) -> dict:
+        return definition.to_dict()
+
 
 class TaskEventListener(object):
     def __init__(self):
@@ -601,6 +613,10 @@ class Task(abc.ABC):
         Copy results of a single subtask from another task
         """
         raise NotImplementedError()
+
+    @abc.abstractmethod
+    def to_dictionary(self):
+        pass
 
     @abc.abstractmethod
     def should_accept_client(self, node_id):

--- a/tests/apps/core/benchmark/test_benchmarkrunner.py
+++ b/tests/apps/core/benchmark/test_benchmarkrunner.py
@@ -74,6 +74,9 @@ class DummyTask(Task):
     def should_accept_client(self, node_id):
         pass
 
+    def to_dictionary(self):
+        pass
+
 
 class BenchmarkRunnerFixture(TempDirFixture):
     def _success(self):


### PR DESCRIPTION
`to_dictionary` method was not defined for abstract Task class (golem/task/taskmanager.py:1028)
`get_preview` method was not defined for abstract TaskTypeInfo class (golem/task/taskmanager.py:1024)
`build_dictionary` method was not defined for abstract TaskBuilder class (golem/task/taskmanager.py:164)

Fix Golem Client to use Task API properly

This fixes Golem Client to use appropriate API method from Task class instead
of accessing property that is only defined in a CoreTask (Task
derived class). Task base class does not have the `total_tasks
property. This code caused problems when deriving Task from scratch.