### PR TITLE
Disable benchmark computation on each test

### DIFF
--- a/tests/golem/docker/test_docker_task_thread.py
+++ b/tests/golem/docker/test_docker_task_thread.py
@@ -28,6 +28,8 @@ class TestDockerTaskThread(TestDockerJob, TestWithDatabase):
         task_server = Mock()
         task_server.config_desc = ClientConfigDescriptor()
         task_server.client.datadir = self.test_dir
+        task_server.benchmark_manager = Mock()
+        task_server.benchmark_manager.benchmarks_needed.return_value = False
         task_server.client.get_node_name.return_value = "test_node"
         task_server.get_task_computer_root.return_value = \
             task_server.client.datadir


### PR DESCRIPTION
It speeds up each test run by ~60 seconds. 