### PR TITLE
Reorganize modules

### DIFF
--- a/rust/golem/src/bindings/marketplace.rs
+++ b/rust/golem/src/bindings/marketplace.rs
@@ -1,5 +1,3 @@
-extern crate cpython;
-
 use cpython::{FromPyObject, ObjectProtocol, PyObject, PyResult, Python};
 
 use marketplace;

--- a/rust/golem/src/bindings/marketplace.rs
+++ b/rust/golem/src/bindings/marketplace.rs
@@ -1,0 +1,23 @@
+extern crate cpython;
+
+use cpython::{FromPyObject, ObjectProtocol, PyObject, PyResult, Python};
+
+use marketplace;
+
+impl<'source> FromPyObject<'source> for marketplace::Offer {
+    fn extract(py: Python, obj: &'source PyObject) -> PyResult<Self> {
+        let quality = obj
+            .getattr(py, "quality")?
+            .extract::<(f64, f64, f64, f64)>(py)?;
+        Ok(marketplace::Offer {
+            scaled_price: obj.getattr(py, "scaled_price")?.extract::<f64>(py)?,
+            reputation: obj.getattr(py, "reputation")?.extract::<f64>(py)?,
+            quality: marketplace::Quality {
+                s: quality.0,
+                t: quality.1,
+                f: quality.2,
+                r: quality.3,
+            },
+        })
+    }
+}

--- a/rust/golem/src/bindings/mod.rs
+++ b/rust/golem/src/bindings/mod.rs
@@ -1,0 +1,1 @@
+pub mod marketplace;

--- a/rust/golem/src/lib.rs
+++ b/rust/golem/src/lib.rs
@@ -1,27 +1,11 @@
 #[macro_use]
 extern crate cpython;
 
-use cpython::{FromPyObject, ObjectProtocol, PyObject, PyResult, Python};
+use cpython::PyResult;
+
+mod bindings;
 
 mod marketplace;
-
-impl<'source> FromPyObject<'source> for marketplace::Offer {
-    fn extract(py: Python, obj: &'source PyObject) -> PyResult<Self> {
-        let quality = obj
-            .getattr(py, "quality")?
-            .extract::<(f64, f64, f64, f64)>(py)?;
-        Ok(marketplace::Offer {
-            scaled_price: obj.getattr(py, "scaled_price")?.extract::<f64>(py)?,
-            reputation: obj.getattr(py, "reputation")?.extract::<f64>(py)?,
-            quality: marketplace::Quality {
-                s: quality.0,
-                t: quality.1,
-                f: quality.2,
-                r: quality.3,
-            },
-        })
-    }
-}
 
 py_module_initializer!(libgolem, initlibgolem, PyInit_golem, |_py, m| {
     try!(m.add(_py, "__doc__", "Parts of Golem core implemented in Rust"));


### PR DESCRIPTION
Small reorg to make things cleaner.
Main lib.rs will only contain the python bindings and any extra to/from python conversion will be under `bindings`