### PR TITLE
Remove persistance from FundsLocker

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -469,6 +469,7 @@ class Client(HardwarePresetsMixin):
                                          listening_failure=task.errback)
 
     def _restore_locks(self) -> None:
+        assert self.task_server is not None
         tm = self.task_server.task_manager
         for task_id, task_state in tm.tasks_states.items():
             if not task_state.status.is_completed():

--- a/golem/client.py
+++ b/golem/client.py
@@ -482,7 +482,7 @@ class Client(HardwarePresetsMixin):
                     self.funds_locker.lock_funds(
                         task_id,
                         task.subtask_price,
-                        task.get_total_tasks(),
+                        unfinished_subtasks,
                         task.header.deadline,
                     )
                 except NotEnoughFunds as e:

--- a/golem/client.py
+++ b/golem/client.py
@@ -42,6 +42,7 @@ from golem.diag.service import DiagnosticsService, DiagnosticsOutputFormat
 from golem.diag.vm import VMDiagnosticsProvider
 from golem.environments.environmentsmanager import EnvironmentsManager
 from golem.manager.nodestatesnapshot import ComputingSubtaskStateSnapshot
+from golem.ethereum.exceptions import NotEnoughFunds
 from golem.ethereum.fundslocker import FundsLocker
 from golem.ethereum.paymentskeeper import PaymentStatus
 from golem.ethereum.transactionsystem import TransactionSystem
@@ -184,8 +185,7 @@ class Client(HardwarePresetsMixin):
         self.transaction_system = transaction_system
         self.transaction_system.start()
 
-        self.funds_locker = FundsLocker(self.transaction_system,
-                                        Path(self.datadir))
+        self.funds_locker = FundsLocker(self.transaction_system)
         self._services.append(self.funds_locker)
 
         self.use_docker_manager = use_docker_manager
@@ -352,6 +352,25 @@ class Client(HardwarePresetsMixin):
             apps_manager=self.apps_manager,
             task_finished_cb=self._task_finished_cb,
         )
+
+        tm = self.task_server.task_manager
+        for task_id, task_state in tm.tasks_states.items():
+            if not task_state.status.is_completed():
+                unfinished_subtasks = 0
+                for subtask_state in task_state.subtask_states.values():
+                    if not subtask_state.status.is_finished():
+                        unfinished_subtasks += 1
+                task = tm.tasks[task_id]
+                try:
+                    self.funds_locker.lock_funds(
+                        task_id,
+                        task.subtask_price,
+                        task.get_total_tasks(),
+                        task.header.deadline,
+                    )
+                except NotEnoughFunds as e:
+                    # May happen when gas prices increase, not much we can do
+                    logger.info("Not enough funds to restore old locks: %r", e)
 
         monitoring_publisher_service = MonitoringPublisherService(
             self.task_server,

--- a/golem/ethereum/fundslocker.py
+++ b/golem/ethereum/fundslocker.py
@@ -1,24 +1,21 @@
 import logging
-import pickle
 import time
-from pathlib import Path
 
 from ethereum.utils import denoms
 
 from golem.core.service import LoopingCallService
 from golem.core.variables import PAYMENT_DEADLINE
 
-from .exceptions import NotEnoughFunds
 from .transactionsystem import TransactionSystem
 
 logger = logging.getLogger(__name__)
 
 
 class TaskFundsLock:
-    def __init__(self, task):
-        self.price = task.subtask_price
-        self.num_tasks = task.get_total_tasks()
-        self.task_deadline = task.header.deadline
+    def __init__(self, subtask_price: int, num_tasks: int, deadline):
+        self.price = subtask_price
+        self.num_tasks = num_tasks
+        self.task_deadline = deadline
 
     @property
     def gnt_lock(self):
@@ -26,23 +23,26 @@ class TaskFundsLock:
 
 
 class FundsLocker(LoopingCallService):
-    def __init__(self, transaction_system: TransactionSystem, datadir: Path,
-                 persist: bool = True, interval_seconds: int = 60) -> None:
+    def __init__(
+            self,
+            transaction_system: TransactionSystem,
+            interval_seconds: int = 60) -> None:
         super().__init__(interval_seconds)
         self.task_lock = {}
         self.transaction_system = transaction_system
-        self.dump_path = datadir / "fundslockv2.pickle"
-        self.persist = persist
-        self.restore()
 
-    def lock_funds(self, task):
-        task_id = task.header.task_id
+    def lock_funds(
+            self,
+            task_id: str,
+            subtask_price: int,
+            num_tasks: int,
+            deadline) -> None:
         if self.task_lock.get(task_id) is not None:
             logger.error("Tried to duplicate lock_fund with same "
                          "task_id %r", task_id)
             return
 
-        tfl = TaskFundsLock(task)
+        tfl = TaskFundsLock(subtask_price, num_tasks, deadline)
         logger.info(
             'Locking funds for task: %r price: %f num: %d',
             task_id,
@@ -54,46 +54,15 @@ class FundsLocker(LoopingCallService):
             tfl.num_tasks,
         )
         self.task_lock[task_id] = tfl
-        self.dump_locks()
 
     def remove_old(self):
         time_ = time.time()
         for task_id, task in list(self.task_lock.items()):
             if task.task_deadline + PAYMENT_DEADLINE < time_:
                 del self.task_lock[task_id]
-        self.dump_locks()
 
     def _run(self):
         self.remove_old()
-
-    def restore(self):
-        if not self.persist:
-            return
-        if not self.dump_path.exists():
-            return
-        with self.dump_path.open('rb') as f:
-            try:
-                self.task_lock = pickle.load(f)
-            except (pickle.UnpicklingError, EOFError, AttributeError, KeyError):
-                logger.exception("Problem restoring dumpfile: %s",
-                                 self.dump_path)
-                return
-        for task_id, task in self.task_lock.items():
-            logger.info('Restoring old tasks locks: %r', task_id)
-            # Bandait solution for increasing gas price
-            try:
-                self.transaction_system.lock_funds_for_payments(
-                    task.price,
-                    task.num_tasks,
-                )
-            except NotEnoughFunds:
-                pass
-
-    def dump_locks(self):
-        if not self.persist:
-            return
-        with self.dump_path.open('wb') as f:
-            pickle.dump(self.task_lock, f)
 
     def remove_subtask(self, task_id):
         task_lock = self.task_lock.get(task_id)
@@ -103,7 +72,6 @@ class FundsLocker(LoopingCallService):
             return
         logger.info('Removing subtask lock for task %r', task_id)
         task_lock.num_tasks -= 1
-        self.dump_locks()
         self.transaction_system.unlock_funds_for_payments(task_lock.price, 1)
 
     def remove_task(self, task_id):
@@ -114,7 +82,6 @@ class FundsLocker(LoopingCallService):
             return
         logger.info('Removing task lock %r', task_id)
         del self.task_lock[task_id]
-        self.dump_locks()
         self.transaction_system.unlock_funds_for_payments(
             task_lock.price,
             task_lock.num_tasks,
@@ -128,5 +95,4 @@ class FundsLocker(LoopingCallService):
             return
         logger.info('Adding subtask lock for task %r', task_id)
         task_lock.num_tasks += num
-        self.dump_locks()
         self.transaction_system.lock_funds_for_payments(task_lock.price, num)

--- a/golem/ethereum/fundslocker.py
+++ b/golem/ethereum/fundslocker.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 
 class TaskFundsLock:
-    def __init__(self, subtask_price: int, num_tasks: int, deadline):
+    def __init__(self, subtask_price: int, num_tasks: int, deadline) -> None:
         self.price = subtask_price
         self.num_tasks = num_tasks
         self.task_deadline = deadline

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -324,7 +324,12 @@ def enqueue_new_task(client, task, force=False) \
         raise CreateTaskError("Golem is not ready")
 
     task_id = task.header.task_id
-    client.funds_locker.lock_funds(task)
+    client.funds_locker.lock_funds(
+        task_id,
+        task.subtask_price,
+        task.get_total_tasks(),
+        task.header.deadline,
+    )
     logger.info('Enqueue new task %r', task)
 
     yield _ensure_task_deposit(

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -126,6 +126,9 @@ class SubtaskStatus(Enum):
     def is_active(self) -> bool:
         return self in [self.starting, self.downloading, self.verifying]
 
+    def is_finished(self) -> bool:
+        return self == self.finished
+
 
 class TaskTestStatus(Enum):
     started = 'Started'

--- a/tests/golem/ethereum/test_fundslocker.py
+++ b/tests/golem/ethereum/test_fundslocker.py
@@ -1,5 +1,5 @@
 import time
-from unittest import mock
+from unittest import mock, TestCase
 
 from golem.core.common import timeout_to_deadline
 from golem.core.variables import PAYMENT_DEADLINE
@@ -8,7 +8,6 @@ from golem.ethereum.fundslocker import (
     FundsLocker,
     TaskFundsLock,
 )
-from golem.testutils import TempDirFixture
 
 
 def make_mock_task(*_, task_id: str = 'tid', subtask_price: int = 100,
@@ -21,42 +20,41 @@ def make_mock_task(*_, task_id: str = 'tid', subtask_price: int = 100,
     return task
 
 
-class TestFundsLocker(TempDirFixture):
+class TestFundsLocker(TestCase):
     def setUp(self):
-        super().setUp()
         self.ts = mock.Mock()
 
     def test_init(self):
-        fl = FundsLocker(self.ts, self.new_path)
-        assert isinstance(fl, FundsLocker)
+        fl = FundsLocker(self.ts)
         assert isinstance(fl.task_lock, dict)
 
     def test_lock_funds(self):
-        fl = FundsLocker(self.ts, self.new_path)
-        task = make_mock_task(task_id="abc", subtask_price=320, total_tasks=10)
-        fl.lock_funds(task)
+        fl = FundsLocker(self.ts)
+        task_id = "abc"
+        subtask_price = 320
+        num_tasks = 10
+        deadline = time.time() + 3600
+        fl.lock_funds(task_id, subtask_price, num_tasks, deadline)
         self.ts.lock_funds_for_payments.assert_called_once_with(
-            task.subtask_price, task.get_total_tasks())
-        tfl = fl.task_lock[task.header.task_id]
+            subtask_price, num_tasks)
+        tfl = fl.task_lock[task_id]
 
         def test_params(tfl):
             assert isinstance(tfl, TaskFundsLock)
-            assert tfl.gnt_lock == task.subtask_price * task.get_total_tasks()
-            assert tfl.num_tasks == task.get_total_tasks()
-            assert tfl.task_deadline == task.header.deadline
+            assert tfl.gnt_lock == subtask_price * num_tasks
+            assert tfl.num_tasks == num_tasks
+            assert tfl.task_deadline == deadline
 
         test_params(tfl)
 
-        task2 = make_mock_task(task_id="abc", subtask_price=111, total_tasks=5)
-        with self.assertLogs(logger, "ERROR"):
-            fl.lock_funds(task2)
-        tfl = fl.task_lock['abc']
+        fl.lock_funds(task_id, subtask_price + 1, num_tasks + 1, deadline + 1)
+        tfl = fl.task_lock[task_id]
         test_params(tfl)
 
     @mock.patch("golem.ethereum.fundslocker.time")
     def test_remove_old(self, time_mock):
         time_mock.time.return_value = time.time()
-        fl = FundsLocker(self.ts, self.new_path)
+        fl = FundsLocker(self.ts)
         self._add_tasks(fl)
         time_mock.time.return_value += PAYMENT_DEADLINE + 1
         fl.remove_old()
@@ -65,54 +63,27 @@ class TestFundsLocker(TempDirFixture):
         assert fl.task_lock.get("ghi") is None
         assert fl.task_lock.get("jkl") is not None
 
-    def test_dump_and_restore(self):
-        fl = FundsLocker(self.ts, self.new_path)
-
-        # we should dump tasks after every lock
-        self._add_tasks(fl)
-
-        # new fund locker should restore tasks
-        self.ts.reset_mock()
-        fl2 = FundsLocker(self.ts, self.new_path)
-        assert len(fl2.task_lock) == 4
-        assert fl2.task_lock['abc'].gnt_lock == 320 * 10
-        assert self.ts.lock_funds_for_payments.call_count == 4
-        assert self.ts.lock_funds_for_payments.call_args_list[0][0] == (320, 10)
-        assert self.ts.lock_funds_for_payments.call_args_list[1][0] == (140, 7)
-        assert self.ts.lock_funds_for_payments.call_args_list[2][0] == (10, 4)
-        assert self.ts.lock_funds_for_payments.call_args_list[3][0] == (13, 1)
-
     @staticmethod
     def _add_tasks(fl):
-        task = make_mock_task(task_id="abc", subtask_price=320, total_tasks=10,
-                              timeout=0.5)
-        fl.lock_funds(task)
-
-        task = make_mock_task(task_id="def", subtask_price=140, total_tasks=7,
-                              timeout=2)
-        fl.lock_funds(task)
-
-        task = make_mock_task(task_id="ghi", subtask_price=10, total_tasks=4,
-                              timeout=0.2)
-        fl.lock_funds(task)
-
-        task = make_mock_task(task_id="jkl", subtask_price=13, total_tasks=1,
-                              timeout=3.5)
-        fl.lock_funds(task)
+        now = time.time()
+        fl.lock_funds("abc", 320, 10, now + 0.5)
+        fl.lock_funds("def", 140, 7, now + 2)
+        fl.lock_funds("ghi", 10, 4, now + 0.2)
+        fl.lock_funds("jkl", 13, 1, now + 3.5)
 
     def test_exception(self):
         self.ts.lock_funds_for_payments.side_effect = Exception
-        fl = FundsLocker(self.ts, self.new_path)
+        fl = FundsLocker(self.ts)
         task = make_mock_task()
         with self.assertRaises(Exception):
             fl.lock_funds(task)
         self.ts.lock_funds_for_payments.reset_mock()
         # that restores locks from the storage
-        fl = FundsLocker(self.ts, self.new_path)
+        fl = FundsLocker(self.ts)
         self.ts.lock_funds_for_payments.assert_not_called()
 
     def test_remove_task(self):
-        fl = FundsLocker(self.ts, self.new_path, persist=False)
+        fl = FundsLocker(self.ts)
         self._add_tasks(fl)
         assert fl.task_lock['ghi']
         fl.remove_task('ghi')
@@ -131,7 +102,7 @@ class TestFundsLocker(TempDirFixture):
         assert fl.task_lock.get('ghi') is None
 
     def test_remove_subtask(self):
-        fl = FundsLocker(self.ts, self.new_path, persist=False)
+        fl = FundsLocker(self.ts)
         self._add_tasks(fl)
         assert fl.task_lock.get("ghi")
         assert fl.task_lock["ghi"].num_tasks == 4
@@ -147,20 +118,21 @@ class TestFundsLocker(TempDirFixture):
             self.ts.unlock_funds_for_payments.assert_not_called()
 
     def test_add_subtask(self):
-        fl = FundsLocker(self.ts, self.new_path, persist=False)
+        fl = FundsLocker(self.ts)
 
-        task = make_mock_task()
-        fl.lock_funds(task)
+        task_id = "abc"
+        subtask_price = 320
+        num_tasks = 10
+        deadline = time.time() + 3600
+        fl.lock_funds(task_id, subtask_price, num_tasks, deadline)
 
         self.ts.reset_mock()
 
-        with self.assertLogs(logger, level="WARNING"):
-            fl.add_subtask("NONEXISTING")
-            self.ts.lock_funds_for_payments.assert_not_called()
+        fl.add_subtask("NONEXISTING")
+        self.ts.lock_funds_for_payments.assert_not_called()
 
         num = 3
-        fl.add_subtask(task.header.task_id, num)
-        self.ts.lock_funds_for_payments.assert_called_with(task.subtask_price,
+        fl.add_subtask(task_id, num)
+        self.ts.lock_funds_for_payments.assert_called_with(subtask_price,
                                                            num)
-        assert fl.task_lock[task.header.task_id].num_tasks == \
-            task.get_total_tasks() + num
+        assert fl.task_lock[task_id].num_tasks == num_tasks + num


### PR DESCRIPTION
The state of locks is trivially retrievable from tasks state so no need for a separate storage.
![adam_pickles](https://user-images.githubusercontent.com/3904252/47439604-f46e0d80-d7ac-11e8-90bc-4efada5f4451.jpg)
