### PR TITLE
Sign every message that is manually remembered

### DIFF
--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -248,7 +248,10 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             )
             self.send(response_msg)
             history.add(
-                response_msg,
+                copy_and_sign(
+                    msg=response_msg,
+                    private_key=self.my_private_key,
+                ),
                 node_id=task_to_compute.provider_id,
                 local_role=Actor.Requestor,
                 remote_role=Actor.Provider,
@@ -596,7 +599,10 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
         )
         self.send(ttc)
         history.add(
-            msg=ttc,
+            msg=copy_and_sign(
+                msg=ttc,
+                private_key=self.my_private_key,
+            ),
             node_id=self.key_id,
             local_role=Actor.Requestor,
             remote_role=Actor.Provider,

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -1201,6 +1201,7 @@ class SubtaskResultsAcceptedTest(TestCase):
             self.requestor_keys.raw_privkey
         self.task_server.keys_auth.public_key = \
             self.requestor_keys.raw_pubkey
+        self.task_server.accept_result.return_value = 11111
 
         def computed_task_received(*args):
             args[3]()


### PR DESCRIPTION
Just sign everything that's manually put into history.

fixes: #3516 