### PR TITLE
0.18.0 port status always available

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -236,10 +236,15 @@ class Client(HardwarePresetsMixin):
     def p2p_listener(self, event='default', **kwargs):
         if event == 'unreachable':
             self.on_unreachable(**kwargs)
+        elif event == 'open':
+            self.on_open(**kwargs)
         elif event == 'unsynchronized':
             self.on_unsynchronized(**kwargs)
         elif event == 'new_version':
             self.on_new_version(**kwargs)
+
+    def on_open(self, port, description, **_):
+        self.node.port_statuses[port] = description
 
     def on_unreachable(self, port, description, **_):
         logger.warning('Port %d unreachable: %s', port, description)

--- a/golem/monitor/monitor.py
+++ b/golem/monitor/monitor.py
@@ -85,6 +85,7 @@ class SystemMonitor(object):
 
         if not result['success']:
             for port_status in result['port_statuses']:
+                log.debug("Port status: %s", port_status)
                 if not port_status['is_open']:
                     dispatcher.send(
                         signal='golem.p2p',

--- a/golem/monitor/monitor.py
+++ b/golem/monitor/monitor.py
@@ -83,13 +83,15 @@ class SystemMonitor(object):
         if not result:
             return
 
-        for port_status in result['port_statuses']:
-            dispatcher.send(
-                signal='golem.p2p',
-                event='open' if port_status['is_open'] else 'unreachable',
-                port=port_status['port'],
-                description=port_status['description']
-            )
+        port_statuses = result.get('port_statuses')
+        if port_statuses:
+            for port_status in port_statuses:
+                dispatcher.send(
+                    signal='golem.p2p',
+                    event='open' if port_status['is_open'] else 'unreachable',
+                    port=port_status['port'],
+                    description=port_status['description']
+                )
 
         if result['time_diff'] > variables.MAX_TIME_DIFF:
             dispatcher.send(

--- a/golem/monitor/monitor.py
+++ b/golem/monitor/monitor.py
@@ -83,16 +83,13 @@ class SystemMonitor(object):
         if not result:
             return
 
-        if not result['success']:
-            for port_status in result['port_statuses']:
-                log.debug("Port status: %s", port_status)
-                if not port_status['is_open']:
-                    dispatcher.send(
-                        signal='golem.p2p',
-                        event='unreachable',
-                        port=port_status['port'],
-                        description=port_status['description']
-                    )
+        for port_status in result['port_statuses']:
+            dispatcher.send(
+                signal='golem.p2p',
+                event='open' if port_status['is_open'] else 'unreachable',
+                port=port_status['port'],
+                description=port_status['description']
+            )
 
         if result['time_diff'] > variables.MAX_TIME_DIFF:
             dispatcher.send(

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1431,16 +1431,32 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
         StatusPublisher.publish(*status)
         assert self.client.get_golem_status() == status
 
-    def test_port_status(self, *_):
+    def test_port_status_open(self, *_):
         port = random.randint(1, 65535)
         self.assertIsNone(self.client.node.port_statuses.get(port))
 
         dispatcher.send(
             signal="golem.p2p",
-            event="no event at all",
+            event="open",
+            port=port,
+            description="open"
+        )
+        self.assertEqual(self.client.node.port_statuses.get(port), "open")
+
+    def test_port_status_unreachable(self, *_):
+        port = random.randint(1, 65535)
+        self.assertIsNone(self.client.node.port_statuses.get(port))
+
+        dispatcher.send(
+            signal="golem.p2p",
+            event="unreachable",
             port=port,
             description="timeout"
         )
+        self.assertEqual(self.client.node.port_statuses.get(port), "timeout")
+
+    def test_port_status_other(self, *_):
+        port = random.randint(1, 65535)
         self.assertIsNone(self.client.node.port_statuses.get(port))
 
         dispatcher.send(


### PR DESCRIPTION
Make port statuses always available in RPC/CLI output (for open and timed-out ports alike).

That way:
1) the users will have an easier way of telling which ports their golem instances are listening on
2) the integration tests and other automated tools will have an easy way to query the golem instance for that information (again, irrespective of whether those ports are actually reachable or not reachable from the outside world)

for some reason, previously, Golem only made that information available when the ports were _NOT_ reachable... 