### PR TITLE
Fix order of preferred geth nodes

### DIFF
--- a/golem/ethereum/node.py
+++ b/golem/ethereum/node.py
@@ -54,7 +54,7 @@ class NodeProcess(object):
             return False
 
     def _create_remote_rpc_provider(self):
-        addr = self.addr_list.pop()
+        addr = self.addr_list.pop(0)
         log.info('GETH: connecting to remote RPC interface at %s', addr)
         return ProviderProxy(HTTPProvider(addr))
 


### PR DESCRIPTION
We assume that the list of addresses is ordered by preference (i.e. last address is the least preferred), but the traversal order was reversed.