### PR TITLE
CPU affinity patch

### DIFF
--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -6,7 +6,6 @@ import sys
 from calendar import timegm
 from datetime import datetime
 from functools import wraps
-from multiprocessing import cpu_count
 from typing import Any, Callable, cast, List, TypeVar
 
 import pytz
@@ -17,8 +16,6 @@ F = TypeVar('F', bound=Callable[..., Any])
 
 TIMEOUT_FORMAT = '{}:{:0=2d}:{:0=2d}'
 DEVNULL = open(os.devnull, 'wb')
-MAX_CPU_WINDOWS = 32
-MAX_CPU_MACOS = 16
 
 
 def is_frozen():
@@ -284,20 +281,6 @@ def config_logging(suffix='', datadir=None, loglevel=None, config_desc=None):
         crossbar_log_lvl = 'warn'
 
     txaio.set_global_log_level(crossbar_log_lvl)  # pylint: disable=no-member
-
-
-def get_cpu_count():
-    """
-    Get number of cores with system limitations:
-    - max 32 on Windows due to VBox limitation
-    - max 16 on MacOS dut to xhyve limitation
-    :return: number of cores
-    """
-    if is_windows():
-        return min(cpu_count(), MAX_CPU_WINDOWS)  # VBox limitation
-    if is_osx():
-        return min(cpu_count(), MAX_CPU_MACOS)    # xhyve limitation
-    return cpu_count()  # No limitatons on Linux
 
 
 def install_reactor():

--- a/golem/core/hardware.py
+++ b/golem/core/hardware.py
@@ -43,13 +43,12 @@ def cpu_cores_available() -> List[int]:
     if is_linux():
         if len(affinity) == core_count and 0 in affinity:
             affinity.remove(0)
-    elif is_osx():
-        if len(affinity) > MAX_CPU_MACOS:
+    else:
+        if is_osx() and len(affinity) > MAX_CPU_MACOS:
             affinity = affinity[:MAX_CPU_MACOS]
-    elif is_windows():
-        if len(affinity) > MAX_CPU_WINDOWS:
+        elif is_windows() and len(affinity) > MAX_CPU_WINDOWS:
             affinity = affinity[:MAX_CPU_WINDOWS]
-
+        affinity = list(range(0, len(affinity)))
     return affinity or [0]
 
 

--- a/golem/core/hardware.py
+++ b/golem/core/hardware.py
@@ -1,4 +1,5 @@
 import logging
+from multiprocessing import cpu_count
 from typing import Union, List, Tuple, Optional, Dict
 import humanize
 import psutil
@@ -11,30 +12,45 @@ from golem.appconfig import \
     DEFAULT_HARDWARE_PRESET_NAME as DEFAULT, \
     CUSTOM_HARDWARE_PRESET_NAME as CUSTOM
 from golem.clientconfigdescriptor import ClientConfigDescriptor
-from golem.core.common import get_cpu_count, is_osx, is_windows, \
-    MAX_CPU_MACOS, MAX_CPU_WINDOWS
+from golem.core.common import is_osx, is_windows, is_linux
 from golem.core.fileshelper import free_partition_space
 from golem.model import HardwarePreset
 
 logger = logging.getLogger(__name__)
 
 
+MAX_CPU_WINDOWS = 32
+MAX_CPU_MACOS = 16
+
+
 def cpu_cores_available() -> List[int]:
-    """Retrieves available CPU cores except for the first one. Tries to read
-       process' CPU affinity first.
-    :return list: Available cpu cores except the first one.
     """
+    Lists CPU cores affined to the process (Linux, Windows) or the available
+    core count (macOS). On Linux, tries to remove the first core from the list
+    if no custom affinity has been set.
+    :return list: A list of CPU cores available for computation.
+    """
+    core_count = cpu_count()
+
     try:
         affinity = psutil.Process().cpu_affinity()
-        if is_osx() and len(affinity) > MAX_CPU_MACOS:
-            return list(range(0, MAX_CPU_MACOS))
-        if is_windows() and len(affinity) > MAX_CPU_WINDOWS:
-            return list(range(0, MAX_CPU_WINDOWS))
-        return affinity[:-1] or affinity
     except Exception as e:
         logger.debug("Couldn't read CPU affinity: %r", e)
-        num_cores = get_cpu_count()
-        return list(range(0, num_cores - 1)) or [0]
+        affinity = list(range(0, core_count - 1))
+
+    # FIXME: The Linux case will no longer be valid when VM computations are
+    #        introduced.
+    if is_linux():
+        if len(affinity) == core_count and 0 in affinity:
+            affinity.remove(0)
+    elif is_osx():
+        if len(affinity) > MAX_CPU_MACOS:
+            affinity = affinity[:MAX_CPU_MACOS]
+    elif is_windows():
+        if len(affinity) > MAX_CPU_WINDOWS:
+            affinity = affinity[:MAX_CPU_WINDOWS]
+
+    return affinity or [0]
 
 
 def memory_available() -> int:


### PR DESCRIPTION
Applies to https://github.com/golemfactory/golem/issues/3037 

- skips the 0 core on Linux if custom affinity has not been set
- respects process' affinity on Linux and Windows
- respects the maximum hypervisor CPU count on macOS and Windows

Does not address:
- enforcing CPU affinity for the VMs, which could be practically implemented only for VirtualBox on Windows (not considering the upcoming VM-direct computations)
- excluding container's 0 core affinity from the task process executed inside the VM (due to undefined number of the executed processes)