### PR TITLE
Remvoe unnecessary set/get_value methods

### DIFF
--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -252,11 +252,6 @@ class CompTaskKeeper:
     def get_node_for_task_id(self, task_id) -> typing.Optional[str]:
         return self.active_tasks[task_id].header.task_owner.key
 
-    @handle_key_error
-    def get_value(self, task_id: str) -> int:
-        comp_task_info: CompTaskInfo = self.active_tasks[task_id]
-        return comp_task_info.subtask_price
-
     def check_task_owner_by_subtask(self, task_owner_key_id, subtask_id):
         task_id = self.subtask_to_task.get(subtask_id)
         task = self.active_tasks.get(task_id)

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -681,24 +681,6 @@ class TaskManager(TaskEventListener):
         return subtask_state.node_id
 
     @handle_subtask_key_error
-    def set_subtask_value(self, subtask_id: str, price: int) -> None:
-        """Set price for a subtask"""
-        task_id = self.subtask2task_mapping[subtask_id]
-
-        ss = self.tasks_states[task_id].subtask_states[subtask_id]
-        ss.value = price
-
-    @handle_subtask_key_error
-    def get_value(self, subtask_id):
-        """ Return value of a given subtask
-        :param subtask_id:  id of a computed subtask
-        :return long: price that should be paid for given subtask
-        """
-        task_id = self.subtask2task_mapping[subtask_id]
-        value = self.tasks_states[task_id].subtask_states[subtask_id].value
-        return value
-
-    @handle_subtask_key_error
     def computed_task_received(self, subtask_id, result,
                                verification_finished):
         task_id = self.subtask2task_mapping[subtask_id]

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -1053,14 +1053,6 @@ class TaskManager(TaskEventListener):
         """ Add a header of a task which this node may try to compute """
         self.comp_task_keeper.add_request(theader, price)
 
-    @handle_task_key_error
-    def get_payment_for_task_id(self, task_id):
-        val = 0.0
-        t = self.tasks_states[task_id]
-        for ss in list(t.subtask_states.values()):
-            val += ss.value
-        return val
-
     def get_estimated_cost(self, task_type, options):
         try:
             subtask_value = options['price'] * options['subtask_time']
@@ -1084,7 +1076,6 @@ class TaskManager(TaskEventListener):
         ss.subtask_id = ctd['subtask_id']
         ss.extra_data = ctd['extra_data']
         ss.subtask_status = SubtaskStatus.starting
-        ss.value = 0
 
         (self.tasks_states[ctd['task_id']].
             subtask_states[ctd['subtask_id']]) = ss

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -464,18 +464,13 @@ class TaskServer(
         Trust.COMPUTED.decrease(node_id)
         self.task_manager.task_computation_failure(subtask_id, err)
 
-    def accept_result(self, subtask_id, key_id, eth_address: str):
+    def accept_result(self, subtask_id, key_id, eth_address: str, value: int):
         mod = min(
             max(self.task_manager.get_trust_mod(subtask_id), self.min_trust),
             self.max_trust)
         Trust.COMPUTED.increase(key_id, mod)
 
         task_id = self.task_manager.get_task_id(subtask_id)
-        value = self.task_manager.get_value(subtask_id)
-
-        if not value:
-            logger.info("Invaluable subtask: %r value: %r", subtask_id, value)
-            return
 
         payment_processed_ts = self.client.transaction_system.add_payment_info(
             subtask_id,

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -226,6 +226,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 subtask_id,
                 self.key_id,
                 task_to_compute.provider_ethereum_address,
+                task_to_compute.price,
             )
 
             response_msg = message.tasks.SubtaskResultsAccepted(
@@ -572,10 +573,6 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             size=task_state.package_size
         )
         ttc.generate_ethsig(self.my_private_key)
-        self.task_manager.set_subtask_value(
-            subtask_id=ttc.subtask_id,
-            price=price,
-        )
         self.send(ttc)
         history.add(
             msg=copy_and_sign(

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -60,7 +60,6 @@ class SubtaskState(object):
         # FIXME: subtask_rem_time is always equal 0 (#2562)
         self.subtask_rem_time = 0
         self.subtask_status: Optional[SubtaskStatus] = None
-        self.value = 0
         self.stdout = ""
         self.stderr = ""
         self.results = []

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -595,16 +595,13 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         self.assertEqual(ctk.active_tasks["xyz"].requests, 1)
         self.assertEqual(ctk.active_tasks["xyz"].subtask_price, 240)
         self.assertEqual(ctk.active_tasks["xyz"].header, header)
-        self.assertEqual(ctk.get_value("xyz"), 240)
         ctk.add_request(header, 23)
         self.assertEqual(ctk.active_tasks["xyz"].requests, 2)
         self.assertEqual(ctk.active_tasks["xyz"].subtask_price, 240)
         self.assertEqual(ctk.active_tasks["xyz"].header, header)
-        self.assertEqual(ctk.get_value("xyz"), 240)
         header.task_id = "xyz2"
         ctk.add_request(header, 25000)
         self.assertEqual(ctk.active_tasks["xyz2"].subtask_price, 834)
-        self.assertEqual(ctk.get_value("xyz2"), 834)
         header.task_id = "xyz"
         thread = get_task_header()
         thread.task_id = "qaz123WSX"
@@ -613,7 +610,6 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         with self.assertRaises(TypeError):
             ctk.add_request(thread, '1')
         ctk.add_request(thread, 12)
-        self.assertEqual(ctk.get_value(thread.task_id), 1)
 
         ctd = ComputeTaskDef()
         ttc = msg_factories.tasks.TaskToComputeFactory(price=0)
@@ -622,8 +618,6 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
             self.assertFalse(ctk.receive_subtask(ttc))
         with self.assertLogs(logger, level="WARNING"):
             self.assertIsNone(ctk.get_node_for_task_id("abc"))
-        with self.assertLogs(logger, level="WARNING"):
-            self.assertIsNone(ctk.get_value("abc"))
 
         with self.assertLogs(logger, level="WARNING"):
             ctk.request_failure("abc")

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -396,37 +396,6 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             assert self.tm.tasks_states.get(task_id) is None
             assert not paf.is_file()
 
-    def test_get_and_set_value(self):
-        with self.assertLogs(logger, level="WARNING"):
-            self.tm.get_value("xxyyzz")
-
-        task_mock = self._get_task_mock()
-
-        self.tm.add_new_task(task_mock)
-
-        self.tm.tasks_states["xyz"].status = self.tm.activeStatus[0]
-        with patch('golem.task.taskbase.Task.needs_computation',
-                   return_value=True):
-            wrong_task = not self.tm.is_my_task("xyz")
-            subtask = self.tm.get_next_subtask(
-                node_id="DEF",
-                node_name="DEF",
-                task_id="xyz",
-                estimated_performance=1000,
-                price=10,
-                max_resource_size=5,
-                max_memory_size=10,
-                num_cores=2,
-                address="10.10.10.10",
-            )
-            self.assertIsInstance(subtask, ComputeTaskDef)
-            self.assertFalse(wrong_task)
-
-        self.tm.set_subtask_value("xxyyzz", 13)
-        self.assertEqual(
-            self.tm.tasks_states["xyz"].subtask_states["xxyyzz"].value, 13)
-        self.assertEqual(self.tm.get_value("xxyyzz"), 13)
-
     def test_change_config(self):
         self.assertTrue(self.tm.use_distributed_resources)
         self.tm.change_config(self.path, False)

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -913,46 +913,13 @@ class TestTaskServer2(TestDatabaseWithReactor, testutils.TestWithClient):
             "10.10.10.10")
         assert subtask is not None
         expected_value = ceil(1031 * 1010 / 3600)
-        ts.task_manager.set_subtask_value("xxyyzz", expected_value)
         prev_calls = trust.COMPUTED.increase.call_count
-        ts.accept_result("xxyyzz", "key", "eth_address")
+        ts.accept_result("xxyyzz", "key", "eth_address", expected_value)
         ts.client.transaction_system.add_payment_info.assert_called_with(
             "xxyyzz",
             expected_value,
             "eth_address")
         self.assertGreater(trust.COMPUTED.increase.call_count, prev_calls)
-
-    @patch("golem.task.taskmanager.TaskManager.dump_task")
-    @patch("golem.task.taskserver.Trust")
-    def test_results_no_payment_addr(self, *_):
-        # FIXME: This test is too heavy, it starts up whole Golem Client.
-        ts = self.ts
-        ts.task_manager.listen_address = "10.10.10.10"
-        ts.task_manager.listen_port = 1111
-
-        extra_data = Mock()
-        extra_data.ctd = ComputeTaskDef()
-        extra_data.ctd['subtask_id'] = "xxyyzz"
-
-        task_mock = get_mock_task("xyz", "xxyyzz")
-        task_id = task_mock.header.task_id
-        task_mock.get_trust_mod.return_value = ts.max_trust
-        extra_data.ctd['task_id'] = task_id
-        task_mock.query_extra_data.return_value = extra_data
-        task_mock.task_definition.subtask_timeout = 3600
-        task_mock.should_accept_client.return_value = \
-            AcceptClientVerdict.ACCEPTED
-
-        ts.task_manager.add_new_task(task_mock)
-        ts.task_manager.tasks_states[task_id].status = \
-            ts.task_manager.activeStatus[0]
-        subtask = ts.task_manager.get_next_subtask(
-            "DEF", "DEF", task_id, 1000, 10, 5, 10, 2, "10.10.10.10")
-
-        assert subtask is not None
-        ts.accept_result("xxyyzz", "key", "eth_address")
-        self.assertEqual(
-            ts.client.transaction_system.add_payment_info.call_count, 0)
 
     def test_disconnect(self, *_):
         self.ts.task_sessions = {'task_id': Mock()}


### PR DESCRIPTION
subtask value is taken from `report_computed_task` instead