### PR TITLE
Fix passing `task_id` and `subtask_id` in test_already_processed

### DIFF
--- a/scripts/concent_acceptance_tests/force_accept/test_requestor_doesnt_send.py
+++ b/scripts/concent_acceptance_tests/force_accept/test_requestor_doesnt_send.py
@@ -9,6 +9,7 @@ from golem_messages import constants
 from golem_messages import factories as msg_factories
 from golem_messages import helpers
 from golem_messages import message
+from golem_messages.factories.helpers import fake_golem_uuid
 
 from golem.network.concent import exceptions as concent_exceptions
 
@@ -172,13 +173,13 @@ class RequestorDoesntSendTestCase(SCIBaseTest):
         )
 
     def test_already_processed(self):
-        task_id = str(uuid.uuid1())
-        subtask_id = str(uuid.uuid1())
-        ctd_prefix = 'task_to_compute__' \
-            'compute_task_def__'
+        requestor_id = "1234"
+        task_id = fake_golem_uuid(requestor_id)
+        subtask_id = fake_golem_uuid(requestor_id)
         kwargs = {
-            ctd_prefix+'task_id': task_id,
-            ctd_prefix+'subtask_id': subtask_id,
+            'task_to_compute__requestor_id': requestor_id,
+            'task_to_compute__task_id': task_id,
+            'task_to_compute__subtask_id': subtask_id,
         }
         self.assertIsNone(self.provider_send_force(rct_kwargs=kwargs))
         second_response = self.provider_send_force(rct_kwargs=kwargs)


### PR DESCRIPTION
resolves: https://github.com/golemfactory/golem/issues/3580