### PR TITLE
Don't check created_time for overdue incomes

### DIFF
--- a/golem/ethereum/incomeskeeper.py
+++ b/golem/ethereum/incomeskeeper.py
@@ -147,15 +147,11 @@ class IncomesKeeper:
         :return: Updated incomes
         """
         accepted_ts_deadline = int(time.time()) - PAYMENT_DEADLINE
-        created_deadline = datetime.now() - timedelta(seconds=PAYMENT_DEADLINE)
 
         incomes = list(Income.select().where(
             Income.overdue == False,   # noqa pylint: disable=singleton-comparison
             Income.transaction.is_null(True),
-            (Income.accepted_ts < accepted_ts_deadline) | (
-                Income.accepted_ts.is_null(True) &
-                (Income.created_date < created_deadline)
-            )
+            Income.accepted_ts < accepted_ts_deadline,
         ))
 
         if not incomes:

--- a/tests/golem/ethereum/test_incomeskeeper.py
+++ b/tests/golem/ethereum/test_incomeskeeper.py
@@ -234,7 +234,6 @@ class TestIncomesKeeper(TestWithDatabase):
             accepted_ts=int(time.time()),
             transaction='transaction')
         income2 = self._create_income(
-            created_date=datetime.now() - timedelta(seconds=2*PAYMENT_DEADLINE),
             accepted_ts=int(time.time()) - 2*PAYMENT_DEADLINE,
             transaction='transaction')
         self.incomes_keeper.update_overdue_incomes()
@@ -244,23 +243,13 @@ class TestIncomesKeeper(TestWithDatabase):
     @freeze_time()
     def test_update_overdue_incomes_accepted_deadline_passed(self):
         overdue_income = self._create_income(
-            created_date=datetime.now() - timedelta(seconds=2*PAYMENT_DEADLINE),
             accepted_ts=int(time.time()) - 2*PAYMENT_DEADLINE)
         self.incomes_keeper.update_overdue_incomes()
         self.assertTrue(overdue_income.refresh().overdue)
 
     @freeze_time()
-    def test_update_overdue_incomes_old_but_recently_accepted(self):
-        income = self._create_income(
-            created_date=datetime.now() - timedelta(seconds=2*PAYMENT_DEADLINE),
-            accepted_ts=int(time.time()))
-        self.incomes_keeper.update_overdue_incomes()
-        self.assertFalse(income.refresh().overdue)
-
-    @freeze_time()
     def test_update_overdue_incomes_already_marked_as_overdue(self):
         income = self._create_income(
-            created_date=datetime.now() - timedelta(seconds=2*PAYMENT_DEADLINE),
             accepted_ts=int(time.time()) - 2*PAYMENT_DEADLINE,
             overdue=True)
         self.incomes_keeper.update_overdue_incomes()


### PR DESCRIPTION
`accepted_ts` is always not null now, so no need to check created_time.