### PR TITLE
Fix locks in crossbar for binaries

### DIFF
--- a/golemapp.py
+++ b/golemapp.py
@@ -4,9 +4,7 @@ import os
 import platform
 import sys
 import logging
-from functools import wraps
 from multiprocessing import freeze_support
-from typing import Callable
 
 import click
 import humanize
@@ -118,12 +116,10 @@ slogging.SManager.getLogger = monkey_patched_getLogger
 @click.option('--realm', expose_value=False)
 @click.option('--loglevel', expose_value=False)  # Crossbar specific level
 @click.option('--title', expose_value=False)
-def start(monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
-          net, geth_address, password, accept_terms,
-          accept_concent_terms,
-          accept_all_terms,
-          version, log_level,
-          enable_talkback, m):
+def start(  # pylint: disable=too-many-arguments, too-many-locals
+        monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
+        net, geth_address, password, accept_terms, accept_concent_terms,
+        accept_all_terms, version, log_level, enable_talkback, m):
 
     freeze_support()
     delete_reactor()
@@ -131,7 +127,7 @@ def start(monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
     # Crossbar
     if m == 'crossbar.worker.process':
         start_crossbar_worker(m)
-        return
+        return 0
 
     if version:
         print("GOLEM version: {}".format(golem.__version__))
@@ -206,12 +202,14 @@ def start(monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
 
     try:
         with Lock(os.path.join(datadir, 'LOCK'), timeout=1):
-            _start(datadir)
+            _start()
 
     except LockException:
         logger.error(f'directory {datadir} is locked, possibly used by '
                      'another Golem instance')
         return 1
+    return 0
+
 
 def delete_reactor():
     if 'twisted.internet.reactor' in sys.modules:

--- a/golemapp.py
+++ b/golemapp.py
@@ -125,11 +125,6 @@ def start(monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
           version, log_level,
           enable_talkback, m):
 
-    # These are done locally since they rely on golem.config.active to be set
-    from golem.config.active import CONCENT_VARIANT
-    from golem.appconfig import AppConfig
-    from golem.node import Node
-
     freeze_support()
     delete_reactor()
 
@@ -142,7 +137,12 @@ def start(monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
         print("GOLEM version: {}".format(golem.__version__))
         return 0
 
-    from golem.core.simpleenv import get_local_datadir
+    set_environment('mainnet' if mainnet else net, concent)
+    # These are done locally since they rely on golem.config.active to be set
+    from golem.config.active import CONCENT_VARIANT
+    from golem.appconfig import AppConfig
+    from golem.node import Node
+
     # We should use different directories for different chains
     datadir = get_local_datadir('default', root_dir=datadir)
     os.makedirs(datadir, exist_ok=True)
@@ -170,7 +170,10 @@ def start(monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
         install_reactor()
 
         from golem.core.common import config_logging
-        config_logging(datadir=datadir, loglevel=log_level, config_desc=config_desc)
+        config_logging(
+            datadir=datadir,
+            loglevel=log_level,
+            config_desc=config_desc)
 
         log_golem_version()
         log_platform_info()

--- a/golemapp.py
+++ b/golemapp.py
@@ -145,6 +145,7 @@ def start(monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
     from golem.core.simpleenv import get_local_datadir
     # We should use different directories for different chains
     datadir = get_local_datadir('default', root_dir=datadir)
+    os.makedirs(datadir, exist_ok=True)
 
     def _start():
         generate_rpc_certificate(datadir)
@@ -175,7 +176,7 @@ def start(monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
         log_platform_info()
         log_ethereum_chain()
         log_concent_choice(CONCENT_VARIANT)
-        
+
         node = Node(
             datadir=datadir,
             app_config=app_config,


### PR DESCRIPTION
The binary version of golem was no longer working after: #3540

This was caused by the locking code called twice, `start()` is called twice when golem runs as binary.

This patch moves the locking to the ( non crossbar ) version of `start()` only.