### PR TITLE
Fix displaying current tasks in golemcli.py

### DIFF
--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -60,11 +60,9 @@ class Tasks:
     )
 
     current_task = Argument(
-        'current',
+        '--current',
         help='Show only current tasks',
         optional=True,
-        boolean=True,
-        default=False,
     )
 
     last_days = Argument('last_days', optional=True, default="0",


### PR DESCRIPTION
resolves: #3629 

Changed `current` to `--current`, as the former was always treated as positional argument by argparse