### PR TITLE
Remove end_task param

### DIFF
--- a/apps/blender/task/blenderrendertask.py
+++ b/apps/blender/task/blenderrendertask.py
@@ -195,7 +195,7 @@ class RenderingTaskTypeInfo(CoreTaskTypeInfo):
             method = cls.__get_border
 
         if not definition.options.use_frames:
-            return method(start_task, start_task, subtasks_count, res_x, res_y)
+            return method(start_task, subtasks_count, res_x, res_y)
         elif subtasks_count <= frames:
             if not as_path:
                 return []
@@ -208,16 +208,14 @@ class RenderingTaskTypeInfo(CoreTaskTypeInfo):
 
         parts = int(subtasks_count / frames)
         return method((start_task - 1) % parts + 1,
-                      (start_task - 1) % parts + 1,
                       parts, res_x, res_y)
 
     @classmethod
-    def __get_border(cls, start, end, parts, res_x, res_y):
+    def __get_border(cls, start, parts, res_x, res_y):
         """
         Return list of pixels that should be marked as a border of subtasks
         with numbers between start and end.
         :param int start: number of first subtask
-        :param int end: number of last subtask
         :param int parts: number of parts for single frame
         :param int res_x: image resolution width
         :param int res_y: image resolution height
@@ -231,7 +229,7 @@ class RenderingTaskTypeInfo(CoreTaskTypeInfo):
         x = int(math.floor(res_x * scale_factor))
 
         upper = offsets[start]
-        lower = offsets[end + 1]
+        lower = offsets[start + 1]
         for i in range(upper, lower):
             border.append((0, i))
             border.append((x, i))
@@ -241,12 +239,11 @@ class RenderingTaskTypeInfo(CoreTaskTypeInfo):
         return border
 
     @classmethod
-    def __get_border_path(cls, start, end, parts, res_x, res_y):
+    def __get_border_path(cls, start, parts, res_x, res_y):
         """
         Return list of points that make a border of subtasks with numbers
         between start and end.
         :param int start: number of first subtask
-        :param int end: number of last subtask
         :param int parts: number of parts for single frame
         :param int res_x: image resolution width
         :param int res_y: image resolution height
@@ -260,7 +257,7 @@ class RenderingTaskTypeInfo(CoreTaskTypeInfo):
 
         x = int(math.floor(res_x * scale_factor))
         upper = offsets[start]
-        lower = max(0, offsets[end + 1] - 1)
+        lower = max(0, offsets[start + 1] - 1)
 
         return [(0, upper), (x, upper),
                 (x, lower), (0, lower)]

--- a/apps/blender/task/blenderrendertask.py
+++ b/apps/blender/task/blenderrendertask.py
@@ -186,7 +186,6 @@ class RenderingTaskTypeInfo(CoreTaskTypeInfo):
         :return list: list of pixels that belong to a subtask border
         """
         start_task = subtask.extra_data['start_task']
-        end_task = subtask.extra_data['end_task']
         frames = len(definition.options.frames)
         res_x, res_y = definition.resolution
 
@@ -196,7 +195,7 @@ class RenderingTaskTypeInfo(CoreTaskTypeInfo):
             method = cls.__get_border
 
         if not definition.options.use_frames:
-            return method(start_task, end_task, subtasks_count, res_x, res_y)
+            return method(start_task, start_task, subtasks_count, res_x, res_y)
         elif subtasks_count <= frames:
             if not as_path:
                 return []
@@ -209,7 +208,7 @@ class RenderingTaskTypeInfo(CoreTaskTypeInfo):
 
         parts = int(subtasks_count / frames)
         return method((start_task - 1) % parts + 1,
-                      (end_task - 1) % parts + 1,
+                      (start_task - 1) % parts + 1,
                       parts, res_x, res_y)
 
     @classmethod
@@ -437,7 +436,7 @@ class BlenderRenderTask(FrameRenderingTask):
                          node_name: Optional[str] = None) \
             -> FrameRenderingTask.ExtraData:
 
-        start_task, end_task = self._get_next_task()
+        start_task = self._get_next_task()
         scene_file = self._get_scene_file_rel_path()
 
         if self.use_frames:
@@ -473,7 +472,6 @@ class BlenderRenderTask(FrameRenderingTask):
 
         extra_data = {"path_root": self.main_scene_dir,
                       "start_task": start_task,
-                      "end_task": end_task,
                       "total_tasks": self.total_tasks,
                       "outfilebasename": self.outfilebasename,
                       "scene_file": scene_file,
@@ -556,7 +554,6 @@ class BlenderRenderTask(FrameRenderingTask):
 
         extra_data = {"path_root": self.main_scene_dir,
                       "start_task": 1,
-                      "end_task": 1,
                       "total_tasks": 1,
                       "outfilebasename": "testresult",
                       "scene_file": scene_file,

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -295,8 +295,7 @@ class CoreTask(Task):
             self._mark_subtask_failed(subtask_id)
         elif subtask_info['status'] == SubtaskStatus.finished:
             self._mark_subtask_failed(subtask_id)
-            tasks = subtask_info['end_task'] - subtask_info['start_task'] + 1
-            self.num_tasks_received -= tasks
+            self.num_tasks_received -= 1
 
         if not was_failure_before:
             subtask_info['status'] = SubtaskStatus.restarted

--- a/apps/rendering/benchmark/renderingbenchmark.py
+++ b/apps/rendering/benchmark/renderingbenchmark.py
@@ -25,7 +25,6 @@ class RenderingBenchmark(CoreBenchmark):
         self._task_definition.total_tasks = 1
         self._task_definition.subtasks_count = 1
         self._task_definition.start_task = 1
-        self._task_definition.end_task = 1
         self._task_definition.task_id = str(uuid.uuid4())
 
         # magic constant obtained experimentally

--- a/apps/rendering/task/framerenderingtask.py
+++ b/apps/rendering/task/framerenderingtask.py
@@ -187,7 +187,6 @@ class FrameRenderingTask(RenderingTask):
         super().accept_results(subtask_id, result_files)
         num_start = self.subtasks_given[subtask_id]['start_task']
         parts = self.subtasks_given[subtask_id]['parts']
-        num_end = self.subtasks_given[subtask_id]['end_task']
         frames = self.subtasks_given[subtask_id]['frames']
 
         for result_file in result_files:
@@ -198,7 +197,7 @@ class FrameRenderingTask(RenderingTask):
             else:
                 self._collect_frame_part(num_start, result_file, parts)
 
-        self.num_tasks_received += num_end - num_start + 1
+        self.num_tasks_received += 1
 
         if self.num_tasks_received == self.total_tasks and not self.use_frames:
             self._put_image_together()

--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -165,7 +165,10 @@ class RenderingTask(CoreTask):
         x = int(round(self.res_x * self.scale_factor))
         y = int(round(self.res_y * self.scale_factor))
         upper = max(0, int(math.floor(y / self.total_tasks * (subtask['start_task'] - 1))))
-        lower = min(int(math.floor(y / self.total_tasks * (subtask['end_task']))), y)
+        lower = min(
+            int(math.floor(y / self.total_tasks * (subtask['start_task']))),
+            y,
+        )
         for i in range(0, x):
             for j in range(upper, lower):
                 img_task.putpixel((i, j), color)
@@ -184,17 +187,15 @@ class RenderingTask(CoreTask):
         if self.last_task != self.total_tasks:
             self.last_task += 1
             start_task = self.last_task
-            end_task = self.last_task
-            return start_task, end_task
+            return start_task
         else:
             for sub in self.subtasks_given.values():
                 if sub['status'] in [SubtaskStatus.failure, SubtaskStatus.restarted]:
                     sub['status'] = SubtaskStatus.resent
-                    end_task = sub['end_task']
                     start_task = sub['start_task']
                     self.num_failed_subtasks -= 1
-                    return start_task, end_task
-        return None, None
+                    return start_task
+        return None
 
     def _get_scene_file_rel_path(self):
         """Returns the path to the scene file relative to the directory where
@@ -214,7 +215,7 @@ class RenderingTask(CoreTask):
 
     def short_extra_data_repr(self, extra_data):
         l = extra_data
-        return "path_root: {path_root}, start_task: {start_task}, end_task: {end_task}, total_tasks: {total_tasks}, " \
+        return "path_root: {path_root}, start_task: {start_task}, total_tasks: {total_tasks}, " \
                "outfilebasename: {outfilebasename}, scene_file: {scene_file}".format(**l)
 
     def _open_preview(self, mode="RGB", ext=PREVIEW_EXT):

--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -214,9 +214,10 @@ class RenderingTask(CoreTask):
             return ''
 
     def short_extra_data_repr(self, extra_data):
-        l = extra_data
-        return "path_root: {path_root}, start_task: {start_task}, total_tasks: {total_tasks}, " \
-               "outfilebasename: {outfilebasename}, scene_file: {scene_file}".format(**l)
+        return "path_root: {path_root}, start_task: {start_task}, "\
+               "total_tasks: {total_tasks}, " \
+               "outfilebasename: {outfilebasename}, "\
+               "scene_file: {scene_file}".format(**extra_data)
 
     def _open_preview(self, mode="RGB", ext=PREVIEW_EXT):
         """ If preview file doesn't exist create a new empty one with given mode and extension.

--- a/golem/manager/nodestatesnapshot.py
+++ b/golem/manager/nodestatesnapshot.py
@@ -17,7 +17,6 @@ class ComputingSubtaskStateSnapshot:
             scene_file: str,
             frames: List[int],
             start_task: int,
-            end_task: int,
             total_tasks: int,
             # if there's something more in extra_data, just ignore it
             **_kwargs
@@ -31,7 +30,6 @@ class ComputingSubtaskStateSnapshot:
         self.scene_file = Path(scene_file).name
         self.frames = copy(frames)
         self.start_task = start_task
-        self.end_task = end_task
         self.total_tasks = total_tasks
 
 

--- a/scripts/concent_acceptance_tests/additional_verification/base.py
+++ b/scripts/concent_acceptance_tests/additional_verification/base.py
@@ -59,7 +59,6 @@ class SubtaskResultsVerifyBaseTest(SCIBaseTest):
         return {
             "path_root": '',
             "start_task": 1,
-            "end_task": 1,
             "total_tasks": 1,
             "outfilebasename": 'test task',
             "scene_file": '/golem/resources/wlochaty3.blend',

--- a/tests/apps/blender/task/test_blenderrendertask.py
+++ b/tests/apps/blender/task/test_blenderrendertask.py
@@ -353,7 +353,6 @@ class TestBlenderTask(TempDirFixture, LogTestCase):
         self.bt.accept_client("ABC")
         ctd = extra_data.ctd
         assert ctd['extra_data']['start_task'] == 1
-        assert ctd['extra_data']['end_task'] == 1
         self.bt.last_task = self.bt.total_tasks
         self.bt.subtasks_given[1] = {'status': SubtaskStatus.finished}
         assert self.bt.should_accept_client("ABC") != \
@@ -547,7 +546,7 @@ class TestBlenderTask(TempDirFixture, LogTestCase):
         # test the case with frames divided into multiple subtasks
 
         bt = self.build_bt(600, 200, 4, frames=[2, 3])
-        subtask = {"start_task": 2, "end_task": 2}
+        subtask = {"start_task": 2}
         file2 = self.temp_file_name('preview2.bmp')
         img_task2 = Image.new("RGB", (bt.res_x, bt.res_y))
         img_task2.save(file2, "BMP")
@@ -697,7 +696,7 @@ class TestHelpers(unittest.TestCase):
         definition.resolution = [800, 600]
 
         for k in range(1, 31):
-            subtask.extra_data = {'start_task': k, 'end_task': k}
+            subtask.extra_data = {'start_task': k}
             border = BlenderTaskTypeInfo.get_task_border(subtask, definition,
                                                          30, as_path=as_path)
             assert min(border) == (0, offsets[k])
@@ -708,14 +707,14 @@ class TestHelpers(unittest.TestCase):
         offsets = generate_expected_offsets(15, 800, 600)
 
         for k in range(1, 31):
-            subtask.extra_data = {'start_task': k, 'end_task': k}
+            subtask.extra_data = {'start_task': k}
             border = BlenderTaskTypeInfo.get_task_border(subtask, definition,
                                                          30, as_path=as_path)
             i = (k - 1) % 15 + 1
             assert min(border) == (0, offsets[i])
             assert max(border) == (798, offsets[i + 1] - 1)
 
-        subtask.extra_data = {'start_task': 2, 'end_task': 2}
+        subtask.extra_data = {'start_task': 2}
         definition.options.use_frames = True
         definition.options.frames = list(range(30))
         if as_path:

--- a/tests/apps/blender/verification/test_verificator_integration.py
+++ b/tests/apps/blender/verification/test_verificator_integration.py
@@ -34,7 +34,6 @@ class TestVerificatorModuleIntegration(TempDirFixture):
         self.subtask_info['res_y'] = 150
         self.subtask_info['samples'] = 35
         self.subtask_info['use_frames'] = False
-        self.subtask_info['end_task'] = 1
         self.subtask_info['total_tasks'] = 1
         self.subtask_info['node_id'] = 'deadbeef'
         self.subtask_info['frames'] = [1]
@@ -56,8 +55,6 @@ class TestVerificatorModuleIntegration(TempDirFixture):
         self.subtask_info['ctd']['docker_images'] = [DockerImage(
             'golemfactory/blender', tag='1.4').to_dict()]
         self.subtask_info['ctd']['extra_data'] = dict()
-        self.subtask_info['ctd']['extra_data']['end_task'] = \
-            self.subtask_info['end_task']
         self.subtask_info['ctd']['extra_data']['frames'] = \
             self.subtask_info['frames']
         self.subtask_info['ctd']['extra_data']['outfilebasename'] = \

--- a/tests/apps/core/task/test_coretask.py
+++ b/tests/apps/core/task/test_coretask.py
@@ -319,23 +319,18 @@ class TestCoreTask(LogTestCase, TestDirFixture):
 
         task.subtasks_given["deadbeef"] = {'status': SubtaskStatus.finished,
                                       'start_task': 1,
-                                      'end_task': 1,
                                       'node_id': 'ABC'}
         task.subtasks_given["abc"] = {'status': SubtaskStatus.failure,
                                       'start_task': 4,
-                                      'end_task': 4,
                                       'node_id': 'abc'}
         task.subtasks_given["def"] = {'status': SubtaskStatus.starting,
                                       'start_task': 8,
-                                      'end_task': 8,
                                       'node_id': 'DEF'}
         task.subtasks_given["ghi"] = {'status': SubtaskStatus.resent,
                                       'start_task': 2,
-                                      'end_task': 2,
                                       'node_id': 'aha'}
         task.subtasks_given["jkl"] = {'status': SubtaskStatus.downloading,
                                       'start_task': 8,
-                                      'end_task': 8,
                                       'node_id': 'DEF'}
         task.restart()
         assert task.num_tasks_received == 0

--- a/tests/apps/rendering/task/test_framerenderingtask.py
+++ b/tests/apps/rendering/task/test_framerenderingtask.py
@@ -77,7 +77,7 @@ class TestFrameRenderingTask(TestDirFixture, LogTestCase):
         task.accept_client("NODE 1")
         task.tmp_dir = self.path
         task.subtasks_given["SUBTASK1"] = {"start_task": 3, "node_id": "NODE 1", "parts": 1,
-                                           "end_task": 3, "frames": [1],
+                                           "frames": [1],
                                            "status": SubtaskStatus.starting}
         img_file = os.path.join(self.path, "img1.png")
         img = Image.new("RGB", (800, 600), "#0000ff")
@@ -93,10 +93,10 @@ class TestFrameRenderingTask(TestDirFixture, LogTestCase):
         preview_img.close()
 
         task.subtasks_given["SUBTASK2"] = {"start_task": 2, "node_id": "NODE 1", "parts": 1,
-                                           "end_task": 2, "frames": [1],
+                                           "frames": [1],
                                            "status": SubtaskStatus.starting}
         task.subtasks_given["SUBTASK3"] = {"start_task": 1, "node_id": "NODE 1", "parts": 1,
-                                           "end_task": 1, "frames": [1],
+                                           "frames": [1],
                                            "status": SubtaskStatus.starting}
         task.accept_results("SUBTASK2", [img_file])
         task.accept_results("SUBTASK3", [img_file])
@@ -111,7 +111,6 @@ class TestFrameRenderingTask(TestDirFixture, LogTestCase):
         task.subtasks_given["SUBTASK1"] = {"start_task": 3,
                                            "node_id": "NODE 1",
                                            "parts": 1,
-                                           "end_task": 3,
                                            "frames": [4, 5],
                                            "status": SubtaskStatus.downloading}
         img_file2 = os.path.join(self.path, "img2.png")

--- a/tests/apps/rendering/task/test_renderingtask.py
+++ b/tests/apps/rendering/task/test_renderingtask.py
@@ -101,7 +101,7 @@ class TestRenderingTask(TestDirFixture, LogTestCase):
 
     def test_remove_from_preview(self):
         rt = self.task
-        rt.subtasks_given["xxyyzz"] = {"start_task": 2, "end_task": 2}
+        rt.subtasks_given["xxyyzz"] = {"start_task": 2}
         tmp_dir = DirManager(rt.root_path).get_task_temporary_dir(rt.header.task_id)
        # tmp_dir = get_tmp_path(rt.header.task_id, rt.root_path)
        # makedirs(tmp_dir)
@@ -172,13 +172,13 @@ class TestRenderingTask(TestDirFixture, LogTestCase):
             task.restart_subtask("Not existing")
 
         task.accept_client("node_ABC")
-        task.subtasks_given["ABC"] = {'status': SubtaskStatus.starting, 'end_task':3,
+        task.subtasks_given["ABC"] = {'status': SubtaskStatus.starting,
                                       'start_task': 3, "node_id": "node_ABC"}
         task.restart_subtask("ABC")
         assert task.subtasks_given["ABC"]["status"] == SubtaskStatus.restarted
 
         task.accept_client("node_DEF")
-        task.subtasks_given["DEF"] = {'status': SubtaskStatus.finished, 'end_task': 3,
+        task.subtasks_given["DEF"] = {'status': SubtaskStatus.finished,
                                       'start_task': 3, "node_id": "node_DEF"}
         task.restart_subtask("DEF")
         assert task.subtasks_given["DEF"]["status"] == SubtaskStatus.restarted
@@ -187,19 +187,19 @@ class TestRenderingTask(TestDirFixture, LogTestCase):
         assert task.num_tasks_received == -1
 
         task.accept_client("node_GHI")
-        task.subtasks_given["GHI"] = {'status': SubtaskStatus.failure, 'end_task': 3,
+        task.subtasks_given["GHI"] = {'status': SubtaskStatus.failure,
                                       'start_task': 3, "node_id": "node_GHI"}
         task.restart_subtask("GHI")
         assert task.subtasks_given["GHI"]["status"] == SubtaskStatus.failure
 
         task.accept_client("node_JKL")
-        task.subtasks_given["JKL"] = {'status': SubtaskStatus.resent, 'end_task': 3,
+        task.subtasks_given["JKL"] = {'status': SubtaskStatus.resent,
                                       'start_task': 3, "node_id": "node_JKL"}
         task.restart_subtask("JKL")
         assert task.subtasks_given["JKL"]["status"] == SubtaskStatus.resent
 
         task.accept_client("node_MNO")
-        task.subtasks_given["MNO"] = {'status': SubtaskStatus.restarted, 'end_task': 3,
+        task.subtasks_given["MNO"] = {'status': SubtaskStatus.restarted,
                                       'start_task': 3, "node_id": "node_MNO"}
         task.restart_subtask("MNO")
         assert task.subtasks_given["MNO"]["status"] == SubtaskStatus.restarted
@@ -286,7 +286,7 @@ class TestRenderingTask(TestDirFixture, LogTestCase):
         task = self.task
         task.total_tasks = 10
         task.last_task = 10
-        assert task._get_next_task() == (None, None)
+        assert task._get_next_task() == None
 
     def test_put_collected_files_together(self):
         output_name = self.temp_file_name("output.exr")

--- a/tests/apps/rendering/task/test_renderingtask.py
+++ b/tests/apps/rendering/task/test_renderingtask.py
@@ -286,7 +286,7 @@ class TestRenderingTask(TestDirFixture, LogTestCase):
         task = self.task
         task.total_tasks = 10
         task.last_task = 10
-        assert task._get_next_task() == None
+        assert task._get_next_task() is None
 
     def test_put_collected_files_together(self):
         output_name = self.temp_file_name("output.exr")

--- a/tests/golem/docker/test_blender_job.py
+++ b/tests/golem/docker/test_blender_job.py
@@ -45,7 +45,6 @@ class TestBlenderDockerJob(TestDockerJob):
             "scene_file": str(dest_scene_file),
             "script_src": crop_script_contents,
             "start_task": 42,
-            "end_task": 42,
             "output_format": "EXR",
             "frames": [1],
         }

--- a/tests/golem/manager/test_nodestatesnapshot.py
+++ b/tests/golem/manager/test_nodestatesnapshot.py
@@ -17,7 +17,6 @@ class TestComputingSubtaskStateSnapshot(TestCase):
             'scene_file': "/golem/resources/cube.blend",
             'frames': [1],
             'start_task': 1,
-            'end_task': 1,
             'total_tasks': 1,
             'some_unused_field': 1234,
         }

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -1044,7 +1044,7 @@ class TestTaskManager(LogTestCase, TestDirFixtureWithReactor,
             subtask.results = []
             subtask.stderr = 'error_{}'.format(i)
             subtask.stdout = 'output_{}'.format(i)
-            subtask.extra_data = {'start_task': i, 'end_task': i}
+            subtask.extra_data = {'start_task': i}
             subtask_id = subtask.subtask_id
 
             subtasks[subtask.subtask_id] = subtask

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1037,7 +1037,6 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
             'scene_file': "/golem/resources/cube.blend",
             'frames': [1],
             'start_task': 1,
-            'end_task': 1,
             'total_tasks': 1,
         }
         task_computer.get_progress.return_value = \


### PR DESCRIPTION
This is some artifact from the ancient times and now is always equal to `start_task`