### PR TITLE
Initialize hardware presets in Node.start

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -127,13 +127,8 @@ class Client(HardwarePresetsMixin):
                           keys_auth.key_id),
             datadir
         )
+
         self.db = database
-
-        # Hardware configuration
-        HardwarePresets.initialize(self.datadir)
-        HardwarePresets.update_config(self.config_desc.hardware_preset_name,
-                                      self.config_desc)
-
         self.keys_auth = keys_auth
 
         # NETWORK

--- a/golem/node.py
+++ b/golem/node.py
@@ -23,6 +23,7 @@ from golem.client import Client
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.config.active import IS_MAINNET, EthereumConfig
 from golem.core.deferred import chain_function
+from golem.core.hardware import HardwarePresets
 from golem.core.keysauth import KeysAuth, WrongPassword
 from golem.core import golem_async
 from golem.core.variables import PRIVATE_KEY
@@ -142,6 +143,10 @@ class Node(object):
                 raise Exception("Password incorrect")
 
     def start(self) -> None:
+
+        HardwarePresets.initialize(self._datadir)
+        HardwarePresets.update_config(self._config_desc.hardware_preset_name,
+                                      self._config_desc)
 
         try:
             rpc = self._start_rpc()

--- a/tests/golem/task/dummy/runner.py
+++ b/tests/golem/task/dummy/runner.py
@@ -86,6 +86,10 @@ def create_client(datadir):
     database = Database(
         db, fields=DB_FIELDS, models=DB_MODELS, db_dir=datadir)
 
+    from golem.core.hardware import HardwarePresets
+    HardwarePresets.initialize(datadir)
+    HardwarePresets.update_config('default', config_desc)
+
     ets = _make_mock_ets()
     return Client(datadir=datadir,
                   app_config=app_config,

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -26,6 +26,7 @@ from golem.client import Client, ClientTaskComputerEventListener, \
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.core.common import timeout_to_string
 from golem.core.deferred import sync_wait
+from golem.core.hardware import HardwarePresets
 from golem.core.variables import CONCENT_CHOICES
 from golem.manager.nodestatesnapshot import ComputingSubtaskStateSnapshot
 from golem.network.p2p.node import Node
@@ -200,10 +201,9 @@ class TestClient(TestClientBase):
 
     def test_activate_hw_preset(self, *_):
         config = self.client.config_desc
-        config.hardware_preset_name = 'non-existing'
-        config.num_cores = 0
-        config.max_memory_size = 0
-        config.max_resource_size = 0
+
+        HardwarePresets.initialize(self.client.datadir)
+        HardwarePresets.update_config('default', config)
 
         self.client.activate_hw_preset('custom')
 


### PR DESCRIPTION
Should significantly improve Docker VM startup times. The VM is no longer restarted after the first configuration change in `Client`