### PR TITLE
Move hardware mixin to node

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -104,7 +104,8 @@ class Client:
             concent_variant: dict = variables.CONCENT_CHOICES['disabled'],
             geth_address: Optional[str] = None,
             apps_manager: AppsManager = AppsManager(),
-            task_finished_cb=None) -> None:
+            task_finished_cb=None,
+            update_hw_preset=None) -> None:
 
         self.apps_manager = apps_manager
         self.datadir = datadir
@@ -192,6 +193,7 @@ class Client:
         self.monitor = None
         self.session_id = str(uuid.uuid4())
         self._task_finished_cb = task_finished_cb
+        self._update_hw_preset = update_hw_preset
 
         dispatcher.connect(
             self.p2p_listener,
@@ -1034,7 +1036,9 @@ class Client:
 
     def change_config(self, new_config_desc, run_benchmarks=False):
         self.config_desc = self.config_approver.change_config(new_config_desc)
-        self.upsert_hw_preset(HardwarePresets.from_config(self.config_desc))
+        if self._update_hw_preset:
+            self._update_hw_preset(
+                HardwarePresets.from_config(self.config_desc))
 
         if self.p2pservice:
             self.p2pservice.change_config(self.config_desc)

--- a/golem/client.py
+++ b/golem/client.py
@@ -192,6 +192,8 @@ class Client:  # pylint: disable=too-many-instance-attributes
         self.use_monitor = use_monitor
         self.monitor = None
         self.session_id = str(uuid.uuid4())
+
+        # TODO: Move to message queue #3160
         self._task_finished_cb = task_finished_cb
         self._update_hw_preset = update_hw_preset
 

--- a/golem/client.py
+++ b/golem/client.py
@@ -30,7 +30,7 @@ from golem.core.common import (
     to_unicode,
 )
 from golem.core.fileshelper import du
-from golem.hardware.presets import HardwarePresets, HardwarePresetsMixin
+from golem.hardware.presets import HardwarePresets
 from golem.core.keysauth import KeysAuth
 from golem.core.service import LoopingCallService
 from golem.core.simpleserializer import DictSerializer
@@ -86,7 +86,7 @@ class ClientTaskComputerEventListener(object):
         self.client.config_changed()
 
 
-class Client(HardwarePresetsMixin):
+class Client:
     _services = []  # type: List[IService]
 
     def __init__(  # noqa pylint: disable=too-many-arguments

--- a/golem/client.py
+++ b/golem/client.py
@@ -17,8 +17,8 @@ from twisted.internet.defer import (
     gatherResults,
     Deferred)
 
-import golem
 from apps.appsmanager import AppsManager
+import golem
 from golem.appconfig import TASKARCHIVE_MAINTENANCE_INTERVAL, AppConfig
 from golem.clientconfigdescriptor import ConfigApprover, ClientConfigDescriptor
 from golem.core import variables
@@ -86,10 +86,10 @@ class ClientTaskComputerEventListener(object):
         self.client.config_changed()
 
 
-class Client:
+class Client:  # pylint: disable=too-many-instance-attributes
     _services = []  # type: List[IService]
 
-    def __init__(  # noqa pylint: disable=too-many-arguments
+    def __init__(  # noqa pylint: disable=too-many-arguments,too-many-locals
             self,
             datadir: str,
             app_config: AppConfig,

--- a/golem/hardware/presets.py
+++ b/golem/hardware/presets.py
@@ -195,9 +195,6 @@ class HardwarePresetsMixin:
 
         return bool(deleted)
 
-    def activate_hw_preset(self, name, run_benchmarks=False):
-        raise NotImplementedError
-
     @staticmethod
     def __preset_to_dict(preset):
         return preset if isinstance(preset, dict) else preset.to_dict()

--- a/golem/node.py
+++ b/golem/node.py
@@ -135,7 +135,8 @@ class Node(HardwarePresetsMixin):
             concent_variant=concent_variant,
             geth_address=geth_address,
             apps_manager=self.apps_manager,
-            task_finished_cb=self._try_shutdown
+            task_finished_cb=self._try_shutdown,
+            update_hw_preset=self.upsert_hw_preset
         )
 
         if password is not None:

--- a/golem/node.py
+++ b/golem/node.py
@@ -23,7 +23,7 @@ from golem.client import Client
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.config.active import IS_MAINNET, EthereumConfig
 from golem.core.deferred import chain_function
-from golem.hardware.presets import HardwarePresets
+from golem.hardware.presets import HardwarePresets, HardwarePresetsMixin
 from golem.core.keysauth import KeysAuth, WrongPassword
 from golem.core import golem_async
 from golem.core.variables import PRIVATE_KEY
@@ -65,7 +65,7 @@ class ShutdownResponse(IntEnum):
 
 
 # pylint: disable=too-many-instance-attributes
-class Node(object):
+class Node(HardwarePresetsMixin):
     """ Simple Golem Node connecting console user interface with Client
     :type client golem.client.Client:
     """

--- a/tests/golem/config/test_presets.py
+++ b/tests/golem/config/test_presets.py
@@ -129,8 +129,3 @@ class TestHardwarePresetsMixin(TestWithDatabase):
         assert sanitize(
             CUSTOM_HARDWARE_PRESET_NAME) == CUSTOM_HARDWARE_PRESET_NAME
         assert sanitize('test') == 'test'
-
-    def test_activate_hw_preset(self):
-        mixin = HardwarePresetsMixin()
-        with self.assertRaises(NotImplementedError):
-            mixin.activate_hw_preset('any')

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -608,6 +608,7 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
                 apps_manager=self.client.apps_manager,
             )
         self.client.monitor = Mock()
+        self.client._update_hw_preset = Mock()
 
     def test_node(self, *_):
         c = self.client
@@ -757,6 +758,7 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
         c.update_setting('node_name', new_node_name)
         self.assertEqual(c.get_setting('node_name'), new_node_name)
         self.assertEqual(c.get_settings()['node_name'], new_node_name)
+        c._update_hw_preset.assert_called_once()
 
         newer_node_name = str(uuid.uuid4())
         self.assertNotEqual(c.get_setting('node_name'), newer_node_name)

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -1,4 +1,4 @@
-# pylint: disable=protected-access
+    # pylint: disable=protected-access
 from os import path
 import unittest
 from unittest.mock import patch, Mock, ANY, MagicMock
@@ -98,7 +98,8 @@ class TestNode(TestWithDatabase):
                                        concent_variant=concent_disabled,
                                        use_monitor=False,
                                        apps_manager=ANY,
-                                       task_finished_cb=node._try_shutdown)
+                                       task_finished_cb=node._try_shutdown,
+                                       update_hw_preset=node.upsert_hw_preset)
         self.assertEqual(
             self.node_kwargs['config_desc'].node_address,
             mock_client.mock_calls[0][2]['config_desc'].node_address,
@@ -160,7 +161,8 @@ class TestNode(TestWithDatabase):
                                        concent_variant=concent_disabled,
                                        use_monitor=False,
                                        apps_manager=ANY,
-                                       task_finished_cb=node._try_shutdown)
+                                       task_finished_cb=node._try_shutdown,
+                                       update_hw_preset=node.upsert_hw_preset)
 
     def test_geth_address_wo_http_should_fail(self, *_):
         runner = CliRunner()
@@ -241,7 +243,8 @@ class TestNode(TestWithDatabase):
                                        concent_variant=concent_disabled,
                                        use_monitor=False,
                                        apps_manager=ANY,
-                                       task_finished_cb=node._try_shutdown)
+                                       task_finished_cb=node._try_shutdown,
+                                       update_hw_preset=node.upsert_hw_preset)
 
     @patch('golem.node.Node')
     def test_net_testnet_should_be_passed_to_node(self, mock_node, *_):


### PR DESCRIPTION
So the RPC functions are available before the client is started

This way when docker crashes the GUI can change the preset