### PR TITLE
LoopingCallService sync by default

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -1630,10 +1630,6 @@ class NetworkConnectionPublisherService(LoopingCallService):
         self._client = client
         self._last_value = self.poll()
 
-    def _run_async(self):
-        # Skip the async_run call and publish events in the main thread
-        self._run()
-
     def _run(self):
         current_value = self.poll()
         if current_value == self._last_value:
@@ -1651,7 +1647,8 @@ class NetworkConnectionPublisherService(LoopingCallService):
 class TaskArchiverService(LoopingCallService):
     def __init__(self,
                  task_archiver: TaskArchiver) -> None:
-        super().__init__(interval_seconds=TASKARCHIVE_MAINTENANCE_INTERVAL)
+        super().__init__(interval_seconds=TASKARCHIVE_MAINTENANCE_INTERVAL,
+                         run_in_thread=True)
         self._task_archiver = task_archiver
 
     def _run(self):
@@ -1663,7 +1660,7 @@ class ResourceCleanerService(LoopingCallService):
                  client: Client,
                  interval_seconds: int,
                  older_than_seconds: int) -> None:
-        super().__init__(interval_seconds)
+        super().__init__(interval_seconds, run_in_thread=True)
         self._client = client
         self.older_than_seconds = older_than_seconds
 

--- a/golem/client.py
+++ b/golem/client.py
@@ -1548,8 +1548,6 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
 
 
 class DoWorkService(LoopingCallService):
-    _client = None  # type: Client
-
     def __init__(self, client: Client) -> None:
         super().__init__(interval_seconds=1)
         self._client = client
@@ -1583,8 +1581,6 @@ class DoWorkService(LoopingCallService):
 
 
 class MonitoringPublisherService(LoopingCallService):
-    _task_server = None  # type: TaskServer
-
     def __init__(self,
                  task_server: TaskServer,
                  interval_seconds: int) -> None:
@@ -1627,8 +1623,6 @@ class MonitoringPublisherService(LoopingCallService):
 
 
 class NetworkConnectionPublisherService(LoopingCallService):
-    _client = None  # type: Client
-
     def __init__(self,
                  client: Client,
                  interval_seconds: int) -> None:
@@ -1655,8 +1649,6 @@ class NetworkConnectionPublisherService(LoopingCallService):
 
 
 class TaskArchiverService(LoopingCallService):
-    _task_archiver = None  # type: TaskArchiver
-
     def __init__(self,
                  task_archiver: TaskArchiver) -> None:
         super().__init__(interval_seconds=TASKARCHIVE_MAINTENANCE_INTERVAL)
@@ -1667,9 +1659,6 @@ class TaskArchiverService(LoopingCallService):
 
 
 class ResourceCleanerService(LoopingCallService):
-    _client = None  # type: Client
-    older_than_seconds = 0  # type: int
-
     def __init__(self,
                  client: Client,
                  interval_seconds: int,
@@ -1686,8 +1675,6 @@ class ResourceCleanerService(LoopingCallService):
 
 
 class TaskCleanerService(LoopingCallService):
-    _client = None  # type: Client
-
     def __init__(self,
                  client: Client,
                  interval_seconds: int) -> None:
@@ -1699,7 +1686,6 @@ class TaskCleanerService(LoopingCallService):
 
 
 class MaskUpdateService(LoopingCallService):
-
     def __init__(
             self,
             requested_task_manager: 'RequestedTaskManager',

--- a/golem/client.py
+++ b/golem/client.py
@@ -1553,7 +1553,6 @@ class DoWorkService(LoopingCallService):
     def __init__(self, client: Client) -> None:
         super().__init__(interval_seconds=1)
         self._client = client
-        self._check_ts: Dict[Hashable, Any] = {}
 
     def start(self):
         super().start(now=False)
@@ -1581,13 +1580,6 @@ class DoWorkService(LoopingCallService):
             self._client.ranking.sync_network()
         except Exception:
             logger.exception("ranking.sync_network failed")
-
-    def _time_for(self, key: Hashable, interval_seconds: float):
-        now = time.time()
-        if now >= self._check_ts.get(key, 0):
-            self._check_ts[key] = now + interval_seconds
-            return True
-        return False
 
 
 class MonitoringPublisherService(LoopingCallService):

--- a/golem/core/service.py
+++ b/golem/core/service.py
@@ -36,10 +36,8 @@ class LoopingCallService(IService):
 
     This implementation uses LoopingCall from Twisted framework.
     """
-    __interval_seconds = 0  # type: int
-    _loopingCall = None  # type: LoopingCall
 
-    def __init__(self, interval_seconds: int = 1):
+    def __init__(self, interval_seconds: int = 1) -> None:
         self.__interval_seconds = interval_seconds
         self._loopingCall = LoopingCall(self._run_async)
 

--- a/golem/core/service.py
+++ b/golem/core/service.py
@@ -37,9 +37,11 @@ class LoopingCallService(IService):
     This implementation uses LoopingCall from Twisted framework.
     """
 
-    def __init__(self, interval_seconds: int = 1) -> None:
+    def __init__(self, interval_seconds: int = 1, run_in_thread: bool = False) \
+            -> None:
         self.__interval_seconds = interval_seconds
-        self._loopingCall = LoopingCall(self._run_async)
+        self._loopingCall = LoopingCall(
+            self._run_async if run_in_thread else self._run)
 
     @property
     def running(self) -> bool:

--- a/tests/golem/core/test_service.py
+++ b/tests/golem/core/test_service.py
@@ -42,7 +42,7 @@ def test_service_invalid_stop():
 
 class CountingService(LoopingCallService):
     def __init__(self):
-        super(CountingService, self).__init__()
+        super().__init__(run_in_thread=True)
         self.clock = Clock()
         self.count = 0
         # Mock the real clock.
@@ -54,7 +54,7 @@ class CountingService(LoopingCallService):
 
 class AsyncCountingService(LoopingCallService):
     def __init__(self):
-        super(AsyncCountingService, self).__init__()
+        super().__init__(run_in_thread=True)
         self.count = 0
 
     def _run(self):
@@ -63,7 +63,7 @@ class AsyncCountingService(LoopingCallService):
 
 class ExceptionalService(LoopingCallService):
     def __init__(self, delay):
-        super(ExceptionalService, self).__init__()
+        super().__init__(run_in_thread=True)
         self.initial_delay = delay
         self.delay = 0
         self.clock = Clock()

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -562,26 +562,6 @@ class TestDoWorkService(testwithreactor.TestWithReactor):
         assert logger.exception.call_count == 4
 
     @freeze_time("2018-01-01 00:00:00")
-    def test_time_for(self):
-        key = 'payments'
-        interval = 4.0
-
-        assert key not in self.do_work_service._check_ts
-        assert self.do_work_service._time_for(key, interval)
-        assert key in self.do_work_service._check_ts
-
-        next_check = self.do_work_service._check_ts[key]
-
-        with freeze_time("2018-01-01 00:00:01"):
-            assert not self.do_work_service._time_for(key, interval)
-            assert self.do_work_service._check_ts[key] == next_check
-
-        with freeze_time("2018-01-01 00:01:00"):
-            assert self.do_work_service._time_for(key, interval)
-            assert self.do_work_service._check_ts[
-                key] == time.time() + interval
-
-    @freeze_time("2018-01-01 00:00:00")
     def test_intervals(self):
         self.do_work_service._run()
 


### PR DESCRIPTION
For these services I think it's OK to let them run in threads:
- TaskArchiverService
- ResourceCleanerService

fixes #3660 
fixes #3245 
resolves #2851 
fixes #5083 