### PR TITLE
Removed default of concent_variant from client init params

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -22,7 +22,6 @@ from apps.appsmanager import AppsManager
 from golem.appconfig import TASKARCHIVE_MAINTENANCE_INTERVAL, AppConfig
 from golem.clientconfigdescriptor import ConfigApprover, ClientConfigDescriptor
 from golem.config.presets import HardwarePresetsMixin
-from golem.core import variables
 from golem.core.common import (
     datetime_to_timestamp_utc,
     get_timestamp_utc,
@@ -98,11 +97,11 @@ class Client(HardwarePresetsMixin):
             keys_auth: KeysAuth,
             database: Database,
             transaction_system: TransactionSystem,
+            # SEE: golem.core.variables.CONCENT_CHOICES
+            concent_variant: dict,
             connect_to_known_hosts: bool = True,
             use_docker_manager: bool = True,
             use_monitor: bool = True,
-            # SEE: golem.core.variables.CONCENT_CHOICES
-            concent_variant: dict = variables.CONCENT_CHOICES['disabled'],
             geth_address: Optional[str] = None,
             apps_manager: AppsManager = AppsManager(),
             task_finished_cb=None) -> None:

--- a/tests/golem/resource/base/common.py
+++ b/tests/golem/resource/base/common.py
@@ -7,6 +7,7 @@ from golem_messages import message
 from golem.client import Client
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.core.simplehash import SimpleHash
+from golem.core.variables import CONCENT_CHOICES
 from golem.database import Database
 from golem.model import db, DB_FIELDS, DB_MODELS
 from golem.network.p2p.node import Node
@@ -94,7 +95,8 @@ class AddGetResources(TempDirFixture, LogTestCase):
                             transaction_system=mock.Mock(),
                             connect_to_known_hosts=False,
                             use_docker_manager=False,
-                            use_monitor=False)
+                            use_monitor=False,
+                            concent_variant=CONCENT_CHOICES['disabled'])
 
         client.resource_server = BaseResourceServer(resource_manager,
                                                     dir_manager,

--- a/tests/golem/task/dummy/runner.py
+++ b/tests/golem/task/dummy/runner.py
@@ -23,6 +23,7 @@ from twisted.internet import reactor
 
 from golem.appconfig import AppConfig
 from golem.clientconfigdescriptor import ClientConfigDescriptor
+from golem.core.variables import CONCENT_CHOICES
 from golem.database import Database
 from golem.environments.environment import Environment
 from golem.resource.dirmanager import DirManager
@@ -99,7 +100,8 @@ def create_client(datadir):
                   transaction_system=ets,
                   use_monitor=False,
                   connect_to_known_hosts=False,
-                  use_docker_manager=False)
+                  use_docker_manager=False,
+                  concent_variant=CONCENT_CHOICES['disabled'])
 
 
 def _make_mock_ets():

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -106,6 +106,7 @@ def make_client(*_, **kwargs):
         'connect_to_known_hosts': False,
         'use_docker_manager': False,
         'use_monitor': False,
+        'concent_variant': CONCENT_CHOICES['disabled'],
     }
     default_kwargs.update(kwargs)
     client = Client(**default_kwargs)


### PR DESCRIPTION
This default value was only used in unit tests and it broke the linter.