### PR TITLE
Updated stats RPC with accepted/rejected subtasks

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -872,32 +872,17 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             'provider_state': self.get_provider_status(),
             'in_network': self.get_task_count(),
             'supported': self.get_supported_task_count(),
-            'subtasks_computed': self.get_computed_task_count(),
-            'subtasks_accepted': self.get_accepted_task_count(),
-            'subtasks_rejected': self.get_rejected_task_count(),
-            'subtasks_with_errors': self.get_error_task_count(),
-            'subtasks_with_timeout': self.get_timeout_task_count(),
+            'subtasks_computed': self.get_comp_stat('computed_tasks'),
+            'subtasks_accepted': self.get_provider_stat('provider_sra_cnt'),
+            'subtasks_rejected': self.get_provider_stat('provider_srr_cnt'),
+            'subtasks_with_errors': self.get_comp_stat('tasks_with_errors'),
+            'subtasks_with_timeout': self.get_comp_stat('tasks_with_timeout'),
         }
-
-    def get_accepted_task_count(self):
-        return self.get_task_provider_stat('provider_sra_cnt')
-
-    def get_rejected_task_count(self):
-        return self.get_task_provider_stat('provider_srr_cnt')
 
     def get_supported_task_count(self) -> int:
         if self.task_server:
             return len(self.task_server.task_keeper.supported_tasks)
         return 0
-
-    def get_computed_task_count(self):
-        return self.get_task_computer_stat('computed_tasks')
-
-    def get_timeout_task_count(self):
-        return self.get_task_computer_stat('tasks_with_timeout')
-
-    def get_error_task_count(self):
-        return self.get_task_computer_stat('tasks_with_errors')
 
     @rpc_utils.expose('comp.tasks.unsupport')
     def get_unsupport_reasons(self, last_days):
@@ -913,12 +898,12 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         address = self.transaction_system.get_payment_address()
         return str(address) if address else None
 
-    def get_task_computer_stat(self, name):
+    def get_comp_stat(self, name):
         if self.task_server and self.task_server.task_computer:
             return self.task_server.task_computer.stats.get_stats(name)
         return None, None
 
-    def get_task_provider_stat(self, name):
+    def get_provider_stat(self, name):
         if self.task_server and self.task_manager:
             return self.task_manager.provider_stats_manager.get_stats(name)
         return None, None

--- a/golem/client.py
+++ b/golem/client.py
@@ -880,10 +880,10 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         }
 
     def get_accepted_task_count(self):
-        self.get_task_provider_stat('provider_sra_cnt')
+        return self.get_task_provider_stat('provider_sra_cnt')
 
     def get_rejected_task_count(self):
-        self.get_task_provider_stat('provider_srr_cnt')
+        return self.get_task_provider_stat('provider_srr_cnt')
 
     def get_supported_task_count(self) -> int:
         if self.task_server:
@@ -921,6 +921,7 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
     def get_task_provider_stat(self, name):
         if self.task_server and self.task_manager:
             return self.task_manager.provider_stats_manager.get_stats(name)
+        return None, None
 
     @rpc_utils.expose('pay.balance')
     def get_balance(self):

--- a/golem/client.py
+++ b/golem/client.py
@@ -873,9 +873,17 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             'in_network': self.get_task_count(),
             'supported': self.get_supported_task_count(),
             'subtasks_computed': self.get_computed_task_count(),
+            'subtasks_accepted': self.get_accepted_task_count(),
+            'subtasks_rejected': self.get_rejected_task_count(),
             'subtasks_with_errors': self.get_error_task_count(),
-            'subtasks_with_timeout': self.get_timeout_task_count()
+            'subtasks_with_timeout': self.get_timeout_task_count(),
         }
+
+    def get_accepted_task_count(self):
+        self.get_task_provider_stat('provider_sra_cnt')
+
+    def get_rejected_task_count(self):
+        self.get_task_provider_stat('provider_srr_cnt')
 
     def get_supported_task_count(self) -> int:
         if self.task_server:
@@ -909,6 +917,10 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         if self.task_server and self.task_server.task_computer:
             return self.task_server.task_computer.stats.get_stats(name)
         return None, None
+
+    def get_task_provider_stat(self, name):
+        if self.task_server and self.task_manager:
+            return self.task_manager.provider_stats_manager.get_stats(name)
 
     @rpc_utils.expose('pay.balance')
     def get_balance(self):

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -127,6 +127,8 @@ class TaskManager(TaskEventListener):
         )
 
         self.requestor_stats_manager = RequestorTaskStatsManager()
+        self.provider_stats_manager = \
+            self.comp_task_keeper.provider_stats_manager
 
         self.finished_cb = finished_cb
 

--- a/golem/task/taskproviderstats.py
+++ b/golem/task/taskproviderstats.py
@@ -56,9 +56,9 @@ class ProviderStatsManager:
             if isinstance(message, TaskToCompute):
                 self._on_ttc_message(message)
             elif isinstance(message, SubtaskResultsAccepted):
-                self._on_sra_message(message)
+                self._on_sra_message()
             elif isinstance(message, SubtaskResultsRejected):
-                self._on_srr_message(message)
+                self._on_srr_message()
 
     def _on_wtct_message(self, message: WantToComputeTask) -> None:
         ProviderTTCDelayTimers.start(message.task_id)
@@ -77,10 +77,10 @@ class ProviderStatsManager:
         self.keeper.increase_stat('provider_wtct_to_ttc_cnt')
         self.keeper.increase_stat('provider_wtct_to_ttc_delay_sum', dt)
 
-    def _on_sra_message(self, message: SubtaskResultsAccepted):
+    def _on_sra_message(self):
         self.keeper.increase_stat('provider_sra_cnt')
 
-    def _on_srr_message(self, message: SubtaskResultsRejected):
+    def _on_srr_message(self):
         self.keeper.increase_stat('provider_srr_cnt')
 
     # --- Subtask ---

--- a/golem/task/taskproviderstats.py
+++ b/golem/task/taskproviderstats.py
@@ -1,6 +1,8 @@
 from typing import Any
 
 from golem_messages.message import WantToComputeTask, TaskToCompute
+from golem_messages.message.tasks import SubtaskResultsAccepted, \
+    SubtaskResultsRejected
 from pydispatch import dispatcher
 
 from golem.core.statskeeper import IntStatsKeeper
@@ -17,6 +19,9 @@ class ProviderStats:
         # WantToComputeTask [tx] to TaskToCompute [rx] delta time
         self.provider_wtct_to_ttc_delay_sum: int = 0
         self.provider_wtct_to_ttc_cnt: int = 0
+        # Verification messages count
+        self.provider_sra_cnt: int = 0
+        self.provider_srr_cnt: int = 0
         # Incomes
         self.provider_income_assigned_sum: int = 0
         self.provider_income_completed_sum: int = 0
@@ -47,8 +52,13 @@ class ProviderStatsManager:
 
         if event == 'sent' and isinstance(message, WantToComputeTask):
             self._on_wtct_message(message)
-        elif event == 'received' and isinstance(message, TaskToCompute):
-            self._on_ttc_message(message)
+        elif event == 'received':
+            if isinstance(message, TaskToCompute):
+                self._on_ttc_message(message)
+            elif isinstance(message, SubtaskResultsAccepted):
+                self._on_sra_message(message)
+            elif isinstance(message, SubtaskResultsRejected):
+                self._on_srr_message(message)
 
     def _on_wtct_message(self, message: WantToComputeTask) -> None:
         ProviderTTCDelayTimers.start(message.task_id)
@@ -67,6 +77,12 @@ class ProviderStatsManager:
         self.keeper.increase_stat('provider_wtct_to_ttc_cnt')
         self.keeper.increase_stat('provider_wtct_to_ttc_delay_sum', dt)
 
+    def _on_sra_message(self, message: SubtaskResultsAccepted):
+        self.keeper.increase_stat('provider_sra_cnt')
+
+    def _on_srr_message(self, message: SubtaskResultsRejected):
+        self.keeper.increase_stat('provider_srr_cnt')
+
     # --- Subtask ---
 
     def _on_subtask_started(self, event='default', **kwargs) -> None:
@@ -83,3 +99,6 @@ class ProviderStatsManager:
         elif event == 'confirmed':
             self.keeper.increase_stat('provider_income_paid_sum',
                                       int(kwargs['amount']))
+
+    def get_stats(self, name):
+        return self.keeper.get_stats(name)

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -814,7 +814,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
         ))
 
     @history.provider_history
-    def _react_to_subtask_result_accepted(
+    def _react_to_subtask_results_accepted(
             self, msg: message.tasks.SubtaskResultsAccepted):
         # The message must be verified, and verification requires self.key_id.
         # This assert is for mypy, which only knows that it's Optional[str].
@@ -830,10 +830,17 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             self.disconnect(message.base.Disconnect.REASON.BadProtocol)
             return
 
+        dispatcher.send(
+            signal='golem.message',
+            event='received',
+            message=msg
+        )
+
         self.concent_service.cancel_task_message(
             msg.subtask_id,
             'ForceSubtaskResults',
         )
+
         self.task_server.subtask_accepted(
             self.key_id,
             msg.subtask_id,
@@ -886,6 +893,12 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             )
 
         else:
+            dispatcher.send(
+                signal='golem.message',
+                event='received',
+                message=msg
+            )
+            
             self.task_server.subtask_rejected(
                 sender_node_id=self.key_id,
                 subtask_id=subtask_id,
@@ -1130,7 +1143,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             message.resources.ResourceList:
                 self._react_to_resource_list,
             message.tasks.SubtaskResultsAccepted:
-                self._react_to_subtask_result_accepted,
+                self._react_to_subtask_results_accepted,
             message.tasks.SubtaskResultsRejected:
                 self._react_to_subtask_results_rejected,
             message.tasks.TaskFailure:

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -898,7 +898,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 event='received',
                 message=msg
             )
-            
+
             self.task_server.subtask_rejected(
                 sender_node_id=self.key_id,
                 subtask_id=subtask_id,

--- a/tests/golem/task/test_taskproviderstats.py
+++ b/tests/golem/task/test_taskproviderstats.py
@@ -3,7 +3,7 @@ from unittest.mock import Mock, patch, call
 
 from golem_messages.message import WantToComputeTask, TaskToCompute, \
     ComputeTaskDef
-
+from golem_messages import factories as msg_factories
 from golem.task.taskproviderstats import ProviderStats, ProviderStatsManager
 
 
@@ -15,22 +15,26 @@ class TestProviderStats(TestCase):
             provider_ttc_cnt=2,
             provider_wtct_to_ttc_delay_sum=3,
             provider_wtct_to_ttc_cnt=4,
-            provider_income_assigned_sum=5,
-            provider_income_completed_sum=6,
-            provider_income_paid_sum=7,
+            provider_sra_cnt=5,
+            provider_srr_cnt=6,
+            provider_income_assigned_sum=7,
+            provider_income_completed_sum=8,
+            provider_income_paid_sum=9,
         )
 
         # The number of properties didn't change
-        assert len(vars(stats)) == 7
+        assert len(vars(stats)) == 9
 
         # The names of properties didn't change
         assert stats.provider_wtct_cnt == 1
         assert stats.provider_ttc_cnt == 2
         assert stats.provider_wtct_to_ttc_delay_sum == 3
         assert stats.provider_wtct_to_ttc_cnt == 4
-        assert stats.provider_income_assigned_sum == 5
-        assert stats.provider_income_completed_sum == 6
-        assert stats.provider_income_paid_sum == 7
+        assert stats.provider_sra_cnt == 5
+        assert stats.provider_srr_cnt == 6
+        assert stats.provider_income_assigned_sum == 7
+        assert stats.provider_income_completed_sum == 8
+        assert stats.provider_income_paid_sum == 9
 
 
 @patch('golem.task.taskproviderstats.ProviderTTCDelayTimers')
@@ -85,6 +89,22 @@ class TestProviderStatsManager(TestCase):
 
         manager._on_message(event="received", message=message)
         manager.keeper.increase_stat.assert_has_calls(calls)
+
+    def test_on_sra_message(self, _):
+        manager = self.manager
+        sra = msg_factories.tasks.SubtaskResultsAcceptedFactory()
+
+        manager._on_message(event='received', message=sra)
+        manager.keeper.increase_stat.assert_called_once_with(
+            'provider_sra_cnt')
+
+    def test_on_srr_message(self, _):
+        manager = self.manager
+        srr = msg_factories.tasks.SubtaskResultsRejectedFactory()
+
+        manager._on_message(event='received', message=srr)
+        manager.keeper.increase_stat.assert_called_once_with(
+            'provider_srr_cnt')
 
     def test_on_subtask_started_invalid_arguments(self, _):
         manager = self.manager

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -556,7 +556,11 @@ class TestTaskSession(ConcentMessageMixin, LogTestCase,
             subtask_id=srr.report_computed_task.subtask_id,  # noqa pylint:disable=no-member
         )
 
+        kwargs = dispatch_listener.call_args_list[0][1]
         dispatch_listener.assert_called_once()
+        self.assertEqual(kwargs['event'], 'received')
+        self.assertEqual(kwargs['signal'], 'golem.message')
+        self.assertEqual(kwargs['message'], srr)
 
     def test_result_rejected_with_wrong_key(self):
         srr = self._get_srr(key2='notmine')
@@ -1171,7 +1175,11 @@ class SubtaskResultsAcceptedTest(TestCase):
             'ForceSubtaskResults',
         )
 
+        kwargs = dispatch_listener.call_args_list[0][1]
         dispatch_listener.assert_called_once()
+        self.assertEqual(kwargs['event'], 'received')
+        self.assertEqual(kwargs['signal'], 'golem.message')
+        self.assertEqual(kwargs['message'], sra)
 
     def test_react_with_wrong_key(self):
         # given

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -1176,11 +1176,12 @@ class SubtaskResultsAcceptedTest(TestCase):
             'ForceSubtaskResults',
         )
 
-        dispatch_listener.assert_called_once()
-        # FIXME Look at .test_results_rejected()
-        self.assertEqual(kwargs['event'], 'received')
-        self.assertEqual(kwargs['signal'], 'golem.message')
-        self.assertEqual(kwargs['message'], sra)
+        dispatch_listener.assert_called_once_with(
+            event='received',
+            signal='golem.message',
+            message=sra,
+            sender=ANY,
+        )
 
     def test_react_with_wrong_key(self):
         # given

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -556,11 +556,12 @@ class TestTaskSession(ConcentMessageMixin, LogTestCase,
             subtask_id=srr.report_computed_task.subtask_id,  # noqa pylint:disable=no-member
         )
 
-        kwargs = dispatch_listener.call_args_list[0][1]
-        dispatch_listener.assert_called_once()
-        self.assertEqual(kwargs['event'], 'received')
-        self.assertEqual(kwargs['signal'], 'golem.message')
-        self.assertEqual(kwargs['message'], srr)
+        dispatch_listener.assert_called_once_with(
+            event='received',
+            signal='golem.message',
+            message=srr,
+            sender=ANY,
+        )
 
     def test_result_rejected_with_wrong_key(self):
         srr = self._get_srr(key2='notmine')
@@ -1175,8 +1176,8 @@ class SubtaskResultsAcceptedTest(TestCase):
             'ForceSubtaskResults',
         )
 
-        kwargs = dispatch_listener.call_args_list[0][1]
         dispatch_listener.assert_called_once()
+        # FIXME Look at .test_results_rejected()
         self.assertEqual(kwargs['event'], 'received')
         self.assertEqual(kwargs['signal'], 'golem.message')
         self.assertEqual(kwargs['message'], sra)

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -911,6 +911,8 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
             'in_network': 0,
             'supported': 0,
             'subtasks_computed': (0, 0),
+            'subtasks_accepted': (0, 0),
+            'subtasks_rejected': (0, 0),
             'subtasks_with_errors': (0, 0),
             'subtasks_with_timeout': (0, 0)
         }


### PR DESCRIPTION
#3697

This adds two new fields to the RPC call 'comp.tasks.stats' These fields contain the total
count of SRA and SRR messages received by the provider (stored as stats
counters in local db).