### PR TITLE
Fixed mounting error on Windows with Docker Toolbox

### DIFF
--- a/golem/docker/manager.py
+++ b/golem/docker/manager.py
@@ -145,7 +145,7 @@ class DockerManager(DockerConfigManager):
             host_config['binds'] = self.hypervisor.create_volumes(binds)
         else:
             host_config['binds'] = {
-                str(bind.source): {
+                bind.source_as_posix: {
                     'bind': bind.target,
                     'mode': bind.mode
                 }

--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -6,7 +6,7 @@ from typing import ClassVar, Optional, TYPE_CHECKING, Tuple, Dict, Union, \
 
 import requests
 
-from golem.core.common import is_windows, is_osx
+from golem.core.common import is_windows, is_osx, posix_path
 from golem.docker.image import DockerImage
 from golem.docker.job import DockerJob
 from golem.environments.environmentsmanager import EnvironmentsManager
@@ -58,10 +58,14 @@ class DockerDirMapping:
         self.logs.mkdir(exist_ok=exist_ok)
 
 
-class DockerBind(NamedTuple): # pylint: disable=too-few-public-methods
+class DockerBind(NamedTuple):  # pylint: disable=too-few-public-methods
     source: Path
     target: str
     mode: str = 'rw'
+
+    @property
+    def source_as_posix(self) -> str:
+        return posix_path(str(self.source))
 
 
 class DockerTaskThread(TaskThread):


### PR DESCRIPTION
Windows paths were not handled correctly as mount sources by the docker client. They need to be converted to POSIX. Not using `Path.as_posix()` because this method does not change 'C:/' into '/C/'.