### PR TITLE
store proper type in msg_date in network history

### DIFF
--- a/golem/network/history.py
+++ b/golem/network/history.py
@@ -4,7 +4,6 @@ import operator
 import pickle
 import queue
 import threading
-import time
 from functools import reduce, wraps
 from typing import List
 from typing import Optional
@@ -270,7 +269,7 @@ def message_to_model(msg: message.base.Message,
         'task': getattr(msg, 'task_id', None),
         'subtask': getattr(msg, 'subtask_id', None),
         'node': node_id,
-        'msg_date': time.time(),
+        'msg_date': datetime.datetime.now(),
         'msg_cls': msg.__class__.__name__,
         'msg_data': pickle.dumps(msg),
         'local_role': local_role,

--- a/tests/golem/network/test_history.py
+++ b/tests/golem/network/test_history.py
@@ -6,6 +6,7 @@ import unittest
 import unittest.mock as mock
 
 from faker import Faker
+from freezegun import freeze_time
 from peewee import DataError, PeeweeException, IntegrityError
 
 from golem_messages import factories as msg_factories
@@ -336,6 +337,7 @@ class TestMessageToModel(unittest.TestCase):
     def setUp(self):
         self.msg = msg_factories.tasks.TaskToComputeFactory()
 
+    @freeze_time()
     def test_basic(self):
         node_id = fake.binary(length=64)
         local_role = fake.random_element(Actor)
@@ -350,7 +352,7 @@ class TestMessageToModel(unittest.TestCase):
             'task': self.msg.task_id,
             'subtask': self.msg.subtask_id,
             'node': node_id,
-            'msg_date': mock.ANY,
+            'msg_date': datetime.datetime.now(),
             'msg_cls': 'TaskToCompute',
             'msg_data': mock.ANY,
             'local_role': local_role,


### PR DESCRIPTION
This causes swipe to remove all records, no matter how old they are.

Fixes #3730