### PR TITLE
Added -NoProfile flag to powershell.exe

### DIFF
--- a/golem/docker/hypervisor/hyperv.py
+++ b/golem/docker/hypervisor/hyperv.py
@@ -278,15 +278,16 @@ class HyperVHypervisor(DockerMachineHypervisor):
         """
         Run a powershell script or command and return its output in UTF8
         """
+        cmd = [
+            'powershell.exe', '-NoProfile'
+        ]
         if script and not command:
-            cmd = [
-                'powershell.exe',
+            cmd += [
                 '-ExecutionPolicy', 'RemoteSigned',
                 '-File', script
             ]
         elif command and not script:
-            cmd = [
-                'powershell.exe',
+            cmd += [
                 '-Command', command
             ]
         else:


### PR DESCRIPTION
Custom commands in users' powershell profiles could cause some unwanted data to be printed out in the output. This would break `HyperVHypervisor.is_available()` method because it uses strict comparison with `'Hyper-V'` pattern.