### PR TITLE
Linux installer: install the correct version of Docker for nvidia-docker2

### DIFF
--- a/Installer/Installer_Linux/install.sh
+++ b/Installer/Installer_Linux/install.sh
@@ -122,8 +122,6 @@ function check_dependencies()
         info_msg "Already installed: nvidia-docker2"
     fi
 
-    INSTALL_NVIDIA_DOCKER=1
-
     # Check for nvidia-modprobe
     if [[ ${INSTALL_NVIDIA_DOCKER} -eq 1 ]]; then
         if [[ -z "$(which nvidia-modprobe)" ]]; then

--- a/Installer/Installer_Linux/install.sh
+++ b/Installer/Installer_Linux/install.sh
@@ -271,6 +271,10 @@ function install_dependencies()
     info_msg "Installing: ${packages[*]}"
     sudo apt-get install -q -y ${packages[*]} >/dev/null
 
+    if [[ ${INSTALL_NVIDIA_DOCKER} -eq 1 ]]; then
+        ! sudo apt-mark hold nvidia-docker2 docker-ce
+    fi
+
     declare -r hyperg=$(release_url "https://api.github.com/repos/golemfactory/golem-hyperdrive/releases")
     hyperg_release=$( echo ${hyperg} | cut -d '/' -f 8 | sed 's/v//' )
     # Older version of HyperG doesn't have `--version`, so need to kill

--- a/Installer/Installer_Linux/install.sh
+++ b/Installer/Installer_Linux/install.sh
@@ -4,26 +4,23 @@
 #author         :Golem Team
 #email          :contact@golem.network
 #date           :20170920
-#version        :0.4
+#version        :0.5
 #usage          :sh install.sh
 #notes          :Only for Ubuntu and Mint
 #==============================================================================
 
 # CONSTANTS
+declare -r PYTHON=python3
 declare -r HOME=$(readlink -f ~)
-declare -r CONFIG="$HOME/.local/.golem_version"
-declare -r docker_script='docker_install.sh'
-declare -r version_file='version'
-declare -r hyperg_pack=/tmp/hyperg.tar.gz
+declare -r GOLEM_DIR="$HOME/golem"
 declare -r PACKAGE="golem-linux.tar.gz"
+declare -r HYPERG_PACKAGE=/tmp/hyperg.tar.gz
 declare -r ELECTRON_PACKAGE="electron.tar.gz"
-declare -r GOLEM_DIR=$HOME'/golem'
 
 # Questions
 declare -i INSTALL_DOCKER=0
 declare -i INSTALL_NVIDIA_DOCKER=0
 declare -i INSTALL_NVIDIA_MODPROBE=0
-declare -i reinstall=0
 
 # PACKAGE VERSION
 CURRENT_VERSION="0.1.0"
@@ -39,21 +36,21 @@ declare -i DEVELOP=0
 # @param error message
 function error_msg()
 {
-    echo -e "\n\n\e[91m$@\e[39m\n" >&2
+    echo -e "\e[91m$@\e[39m" >&2
 }
 
 # @brief print warning message
 # @param warning message
 function warning_msg()
 {
-    echo -e "\n\n\e[93m$@\e[39m\n"
+    echo -e "\e[93m$@\e[39m"
 }
 
 # @brief print info message
 # @param info message
 function info_msg()
 {
-    echo -e "\n\n\e[92m$@\e[39m\n"
+    echo -e "\e[92m$@\e[39m"
 }
 
 
@@ -75,18 +72,24 @@ function ask_user()
     done
 }
 
+# @brief parse the JSON file and find the latest release binary URL
+# @param JSON URL
+# @return release binary URL
 function release_url()
 {
+    code=$(cat <<EOC
+import sys, json;
+j = json.load(sys.stdin);
+k = 'browser_download_url';
+print([asset[k] for entry in j
+           if 'assets' in entry
+       for asset in entry['assets']
+           if asset[k].find('linux') != -1
+      ][0])
+EOC
+)
     json=$(wget -qO- --header='Accept: application/json' $1)
-    echo ${json} | python3 -c '\
-        import sys, json;                          \
-        j = json.load(sys.stdin);                  \
-        k = "browser_download_url";                \
-        print([asset[k] for entry in j             \
-                   if "assets" in entry            \
-               for asset in entry["assets"]        \
-                   if asset[k].find("linux") != -1 \
-              ][0])'
+    echo ${json} | ${PYTHON} -c "${code}"
 }
 
 # @brief check if dependencies (Docker, nvidia-docker + nvidia-modprobe)
@@ -94,47 +97,104 @@ function release_url()
 function check_dependencies()
 {
     # Check if docker daemon exists
-    if [[ -z "$( service --status-all 2>&1 | grep -F 'docker' )" ]]; then
-        ask_user "Docker not found. Do you want to install it? (y/n)"
-        INSTALL_DOCKER=$?
-    else
-        info_msg "Docker is already installed"
+    if [[ -z "$( service docker status 2>/dev/null )" ]]; then
+        info_msg "To be installed: docker-ce"
+        INSTALL_DOCKER=1
     fi
 
     # Check if nvidia-docker2 is installed
-    if [[ -z "$(dpkg -s nvidia-docker2 | grep -i 'status: install ok installed')" ]]; then
+    if [[ -z "$(dpkg -s nvidia-docker2 2>/dev/null | grep -i 'status: install ok installed')" ]]; then
         if [[ -z "$(lspci | grep -i nvidia)" ]]; then
-            warning_msg "nvidia-docker is not supported: incompatible device"
+            warning_msg "Not supported: nvidia-docker2: incompatible device"
         elif [[ ! -z "$(lsmod | grep -i nouveau)" ]]; then
-            warning_msg "nvidia-docker is not supported: please install the proprietary driver"
+            warning_msg "Not supported: nvidia-docker2: please install the proprietary driver"
         elif [[ -z "$(lsmod | grep -i nvidia)" ]]; then
-            warning_msg "nvidia-docker is not supported: no compatible driver found"
+            warning_msg "Not supported: nvidia-docker2: no compatible driver found"
         else
-            ask_user "nvidia-docker not found. Do you want to install it? (y/n)"
+            ask_user "nvidia-docker2 not found. Do you want to install it? (y/n)"
+            if [[ $? -eq 1 ]]; then
+                info_msg "To be installed: nvidia-docker2"
+            fi
+
             INSTALL_NVIDIA_DOCKER=$?
         fi
     else
-        info_msg "nvidia-docker is already installed"
+        info_msg "Already installed: nvidia-docker2"
     fi
+
+    INSTALL_NVIDIA_DOCKER=1
 
     # Check for nvidia-modprobe
     if [[ ${INSTALL_NVIDIA_DOCKER} -eq 1 ]]; then
         if [[ -z "$(which nvidia-modprobe)" ]]; then
             INSTALL_NVIDIA_MODPROBE=1
         else
-            info_msg "nvidia-modprobe is already installed"
+            info_msg "Already installed: nvidia-modprobe"
         fi
     fi
 }
 
+function nvidia_docker_dependency()
+{
+    code=$(cat <<EOC
+# =================================================================
+import sys
+import re
+from distutils.version import LooseVersion
+
+packages = sys.stdin.read().split('\n')
+candidate = None
+
+version_re = re.compile('docker-ce \\(= ([a-z0-9:\\~\\.\\-]+)\\)')
+inner_re = re.compile('(.*:)?([0-9\\.]+).*')
+
+
+def get_version(line):
+    version_match = version_re.search(line)
+    if not version_match:
+        return None
+
+    version_str = version_match.groups()[0]
+    inner_match = inner_re.search(version_str)
+    if not inner_match:
+        return None
+
+    inner = inner_match.groups()[1]
+    return version_str, LooseVersion(inner)
+
+def is_newer(version):
+    if not version:
+        return False
+    if not candidate:
+        return True
+    return version[1] > candidate[1]
+
+
+for line in packages:
+    if line.startswith('Depends'):
+        version = get_version(line)
+        try:
+            if is_newer(version):
+                candidate = version
+        except:
+            pass
+
+if candidate:
+    print(candidate[0])
+# =================================================================
+EOC
+)
+
+    PACKAGES=$(wget -qO- $1)
+    echo "${PACKAGES}" | ${PYTHON} -c "${code}"
+}
 
 # @brief Install/Upgrade required dependencies
 function install_dependencies()
 {
-    info_msg "INSTALLING GOLEM DEPENDENCIES"
     sudo id &> /dev/null
     if [[ $? -ne 0 ]]; then
-        error_msg "Dependency installation requires sudo privileges"
+        error_msg "This installer requires sudo privileges"
         exit 1
     fi
 
@@ -143,47 +203,75 @@ function install_dependencies()
                libgtk2.0-0 libxss1 libgconf-2-4 libnss3 libasound2 \
                libfreeimage3 )
 
-    if [[ ${INSTALL_DOCKER} -eq 1 ]]; then
-        info_msg "INSTALLING DOCKER"
+    docker_version="$(dpkg -l 2>/dev/null | grep "docker-ce\s" | grep ii | head -1 | awk '{print $3}')"
 
-        # Ubuntu 14.04 needs some additional dependencies
-        if [[ $( lsb_release -r | awk '{print $2}' ) == '14.04' ]]; then
-            packages+=("linux-image-extra-$(uname -r)" linux-image-extra-virtual)
+    if [[ ${INSTALL_NVIDIA_DOCKER} -eq 1 ]]; then
+
+        INSTALL_DOCKER=1
+        remove_docker=0
+
+        distribution=$(. /etc/os-release;echo ${ID}${VERSION_ID})
+        nv_docker_version=$(nvidia_docker_dependency https://nvidia.github.io/nvidia-docker/${distribution}/amd64/Packages)
+
+        wget -qO- https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
+
+        wget -qO- https://nvidia.github.io/nvidia-docker/${distribution}/nvidia-docker.list | \
+            sudo tee /etc/apt/sources.list.d/nvidia-docker.list
+
+        if [[ -z "${nv_docker_version}" ]]; then
+            warning_msg "Cannot read nvidia-docker2 docker dependency version"
+        elif [[ -z "${docker_version}" ]]; then
+            warning_msg "Forcing installation: docker-ce=${nv_docker_version}"
+            warning_msg "\t required by: nvidia-docker2"
+        elif [[ "${docker_version}" == "${nv_docker_version}" ]]; then
+            info_msg "Already installed: docker-ce=${nv_docker_version}"
+
+            INSTALL_DOCKER=0
+        else
+            warning_msg "Dependency version mismatch:"
+            warning_msg "\t required by: nvidia-docker2"
+            warning_msg "\t dependency:  docker-ce=${nv_docker_version}"
+            warning_msg "\t installed:   docker-ce=${docker_version}"
+
+            remove_docker=1
         fi
 
+        docker_version="${nv_docker_version}"
+        packages+=(nvidia-docker2)
+    fi
+
+    if [[ ${INSTALL_NVIDIA_MODPROBE} -eq 1 ]]; then
+        sudo apt-add-repository multiverse >/dev/null 2>&1
+        packages+=(nvidia-modprobe)
+    fi
+
+    if [[ ${remove_docker} -eq 1 ]]; then
+        info_msg "Removing: docker-engine docker.io docker-ce"
+        ! sudo service docker stop > /dev/null 2>&1
+        ! sudo apt-get purge -y docker-engine docker.io docker-ce nvidia-docker2 > /dev/null 2>&1
+    fi
+
+    if [[ ${INSTALL_DOCKER} -eq 1 ]]; then
         packages+=( apt-transport-https \
                     ca-certificates \
-                    software-properties-common)
+                    software-properties-common )
         wget -qO- https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
         sudo add-apt-repository \
             "deb [arch=amd64] https://download.docker.com/linux/ubuntu \
             $(lsb_release -cs) \
             stable"
+
+        if [[ -z "${docker_version}" ]]; then
+            packages+=(docker-ce)
+        else
+            packages+=("docker-ce=${docker_version}")
+        fi
     fi
 
-    docker_version="$(apt-cache madison docker-ce 2>/dev/null | head -1 | awk '{print $3}')"
-    if [[ -z "${docker_version}" ]]; then
-        packages+=(docker-ce)
-    else
-        packages+=(docker-ce=${docker_version})
-    fi
-
-    if [[ ${INSTALL_NVIDIA_DOCKER} -eq 1 ]]; then
-        info_msg "INSTALLING NVIDIA-DOCKER"
-
-        wget -qO- https://nvidia.github.io/nvidia-docker/gpgkey | sudo apt-key add -
-        distribution=$(. /etc/os-release;echo ${ID}${VERSION_ID})
-
-        wget -qO- https://nvidia.github.io/nvidia-docker/${distribution}/nvidia-docker.list | \
-            sudo tee /etc/apt/sources.list.d/nvidia-docker.list
-
-        packages+=(nvidia-docker2)
-    fi
-
-    if [[ ${INSTALL_NVIDIA_MODPROBE} -eq 1 ]]; then
-        sudo apt-add-repository multiverse
-        packages+=(nvidia-modprobe)
-    fi
+    sudo apt-get update >/dev/null 2>&1
+    echo -e "\e[91m"
+    info_msg "Installing: ${packages[*]}"
+    sudo apt-get install -q -y ${packages[*]} >/dev/null
 
     declare -r hyperg=$(release_url "https://api.github.com/repos/golemfactory/golem-hyperdrive/releases")
     hyperg_release=$( echo ${hyperg} | cut -d '/' -f 8 | sed 's/v//' )
@@ -197,20 +285,17 @@ function install_dependencies()
         hyperg_version=0.0.0
     fi
     if [[ ! -f $HOME/hyperg/hyperg ]] || [[ "$hyperg_release" > "$hyperg_version" ]]; then
-        info_msg "Installing HyperG"
-        wget --show-progress -qO- ${hyperg} > ${hyperg_pack}
+        info_msg "Downloading: HyperG=${hyperg_release}"
+        wget --show-progress -qO- ${hyperg} > ${HYPERG_PACKAGE}
+        info_msg "Installing HyperG into $HOME/hyperg"
         [[ -d $HOME/hyperg ]] && rm -rf $HOME/hyperg
-        tar -xvf ${hyperg_pack} >/dev/null
+        tar -xvf ${HYPERG_PACKAGE} >/dev/null
         [[ "$PWD" != "$HOME" ]] && mv hyperg $HOME/
         [[ ! -f /usr/local/bin/hyperg ]] && sudo ln -s $HOME/hyperg/hyperg /usr/local/bin/hyperg
         [[ ! -f /usr/local/bin/hyperg-worker ]] && sudo ln -s $HOME/hyperg/hyperg-worker /usr/local/bin/hyperg-worker
-        rm -f ${hyperg_pack} &>/dev/null
+        rm -f ${HYPERG_PACKAGE} &>/dev/null
     fi
-    sudo apt-get update >/dev/null
-    echo -e "\e[91m"
-    for package in ${packages[*]}; do
-        sudo apt-get install -q -y ${package} >/dev/null
-    done
+
     echo -e "\e[39m"
     if [[ ${INSTALL_DOCKER} -eq 1 ]]; then
         if [[ -z "${SUDO_USER}" ]]; then
@@ -230,7 +315,6 @@ function install_dependencies()
     if [[ ${INSTALL_NVIDIA_DOCKER} -eq 1 ]]; then
         sudo pkill -SIGHUP dockerd
     fi
-    info_msg "Done installing Golem dependencies"
 }
 
 # @brief Download latest Golem package (if package wasn't passed)
@@ -240,7 +324,7 @@ function download_package() {
         info_msg "Local package provided, skipping downloading..."
         cp "$LOCAL_PACKAGE" "/tmp/$PACKAGE"
     else
-        info_msg "Downloading Golem package"
+        info_msg "Downloading: Golem"
         if [[ ${DEVELOP} -eq 0 ]]; then
             golem_url=$(release_url "https://api.github.com/repos/golemfactory/golem/releases")
         else
@@ -250,7 +334,7 @@ function download_package() {
     fi
     if [[ ! -f /tmp/${PACKAGE} ]]; then
         error_msg "Cannot find Golem package"
-        error_msg "Contact golem team: https://chat.golem.network/ or contact@golem.network"
+        error_msg "Contact Golem team: https://chat.golem.network/ or contact@golem.network"
         exit 1
     fi
 
@@ -258,7 +342,7 @@ function download_package() {
         info_msg "UI package provided, skipping downloading..."
         cp ${UI_PACKAGE} /tmp/${ELECTRON_PACKAGE}
     else
-        info_msg "Downloading ui package (it may take awhile)"
+        info_msg "Downloading: Golem GUI"
         if [[ ${DEVELOP} -eq 0 ]]; then
             electron_url=$(release_url "https://api.github.com/repos/golemfactory/golem-electron/releases")
         else
@@ -298,7 +382,6 @@ function check_symlink()
 # @return 1 if error occurred, 0 otherwise
 function install_golem()
 {
-    info_msg "Installing Golem"
     download_package
     result=$?
     if [[ ${result} -eq 1 ]]; then
@@ -372,7 +455,10 @@ function main()
 {
     check_dependencies
     install_dependencies
-    [[ ${DEPS_ONLY} -eq 1 ]] && return
+    if [[ ${DEPS_ONLY} -eq 1 ]]; then
+        info_msg "Finished installing dependencies"
+        return
+    fi
     install_golem
     result=$?
     if [[ ${INSTALL_DOCKER} -eq 1 ]]; then

--- a/Installer/Installer_Linux/install.sh
+++ b/Installer/Installer_Linux/install.sh
@@ -59,10 +59,7 @@ function info_msg()
 # @return 1 if answer is 'yes', 0 if 'no'
 function ask_user()
 {
-    # if want to install only deps,
-    # we don't have to ask if want to install any dependency
-    [[ ${DEPS_ONLY} -eq 1 ]] && return 1
-    while [ 1 ]; do
+    while [[ 1 ]]; do
         read -p "$@ " yn
         case ${yn} in
             y|Y ) return 1;;
@@ -96,8 +93,8 @@ EOC
 # are installed and set proper 'global' variables
 function check_dependencies()
 {
-    # Check if docker daemon exists
-    if [[ -z "$( service docker status 2>/dev/null )" ]]; then
+    # Check if docker-ce is installed
+    if [[ -z "$(dpkg -s docker-ce 2>/dev/null | grep -i 'status: install ok installed')" ]]; then
         info_msg "To be installed: docker-ce"
         INSTALL_DOCKER=1
     fi
@@ -463,11 +460,10 @@ function main()
     fi
     install_golem
     result=$?
-    if [[ ${INSTALL_DOCKER} -eq 1 ]]; then
-        info_msg "You need to restart your PC to finish installation"
-    fi
     if [[ ${result} -ne 0 ]]; then
         error_msg "Installation failed"
+    else
+        info_msg "Installation complete"
     fi
     return ${result}
 }

--- a/Installer/Installer_Linux/install.sh
+++ b/Installer/Installer_Linux/install.sh
@@ -201,7 +201,7 @@ function install_dependencies()
                libgtk2.0-0 libxss1 libgconf-2-4 libnss3 libasound2 \
                libfreeimage3 )
 
-    docker_version="$(dpkg -l 2>/dev/null | grep "docker-ce\s" | grep ii | head -1 | awk '{print $3}')"
+    docker_version="$(dpkg -l 2>/dev/null | grep "docker-ce\s" | grep -E 'hi|ii' | head -1 | awk '{print $3}')"
 
     if [[ ${INSTALL_NVIDIA_DOCKER} -eq 1 ]]; then
 
@@ -244,7 +244,7 @@ function install_dependencies()
     fi
 
     if [[ ${remove_docker} -eq 1 ]]; then
-        info_msg "Removing: docker-engine docker.io docker-ce"
+        info_msg "Removing: docker-engine docker.io docker-ce nvidia-docker2"
         ! sudo service docker stop > /dev/null 2>&1
         ! sudo apt-get purge -y docker-engine docker.io docker-ce nvidia-docker2 > /dev/null 2>&1
     fi

--- a/Installer/Installer_Linux/install.sh
+++ b/Installer/Installer_Linux/install.sh
@@ -3,7 +3,7 @@
 #description    :This script will install Golem and required dependencies
 #author         :Golem Team
 #email          :contact@golem.network
-#date           :20170920
+#date           :20190111
 #version        :0.5
 #usage          :sh install.sh
 #notes          :Only for Ubuntu and Mint


### PR DESCRIPTION
Functional changes:
- `docker-ce` is now required
- `docker-ce` will be reinstalled on version mismatch
- `docker.io` and `docker-engine` will be removed

New / changed features:
- adds a function for parsing the latest `docker-ce` requirement version of `nvidia-docker2` 
- changes the dependency check order of `nvidia_docker2` and `docker-ce`
- `docker-ce` and `nvidia-docker2` packages are put on hold after the installation completes
- removes extra newlines from messages for readability
- unifies `info` messages for readability
- adds new `info` messages for better installation process tracking
