### PR TITLE
Created RPC call for checking VT/VT-x status

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -222,9 +222,11 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             MinPerformanceMultiplier
         from golem.network.concent import soft_switch as concent_soft_switch
         from golem.task import rpc as task_rpc
+        from golem.core import virtualization
         task_rpc_provider = task_rpc.ClientProvider(self)
         providers = (
             self,
+            virtualization,
             concent_soft_switch,
             framerenderingtask,
             MinPerformanceMultiplier,

--- a/golem/client.py
+++ b/golem/client.py
@@ -1374,11 +1374,6 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             logger.info('change hw config result: %r', result)
             return self.environments_manager.get_performance_values()
 
-    @rpc_utils.expose('env.hw.virtualization')
-    @staticmethod
-    def get_virtualization_support():
-        return is_virtualization_enabled()
-
     @staticmethod
     def enable_talkback(value):
         enable_sentry_logger(value)

--- a/golem/client.py
+++ b/golem/client.py
@@ -222,11 +222,9 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             MinPerformanceMultiplier
         from golem.network.concent import soft_switch as concent_soft_switch
         from golem.task import rpc as task_rpc
-        from golem.core import virtualization
         task_rpc_provider = task_rpc.ClientProvider(self)
         providers = (
             self,
-            virtualization,
             concent_soft_switch,
             framerenderingtask,
             MinPerformanceMultiplier,

--- a/golem/client.py
+++ b/golem/client.py
@@ -34,6 +34,7 @@ from golem.config.active import EthereumConfig
 from golem.core.keysauth import KeysAuth
 from golem.core.service import LoopingCallService
 from golem.core.simpleserializer import DictSerializer
+from golem.core.virtualization import is_virtualization_enabled
 from golem.database import Database
 from golem.diag.service import DiagnosticsService, DiagnosticsOutputFormat
 from golem.diag.vm import VMDiagnosticsProvider
@@ -1372,6 +1373,10 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             result = yield deferred
             logger.info('change hw config result: %r', result)
             return self.environments_manager.get_performance_values()
+
+    @rpc_utils.expose('env.hw.virtualization')
+    def get_virtualization_support(self):
+        return is_virtualization_enabled()
 
     @staticmethod
     def enable_talkback(value):

--- a/golem/client.py
+++ b/golem/client.py
@@ -34,7 +34,6 @@ from golem.config.active import EthereumConfig
 from golem.core.keysauth import KeysAuth
 from golem.core.service import LoopingCallService
 from golem.core.simpleserializer import DictSerializer
-from golem.core.virtualization import is_virtualization_enabled
 from golem.database import Database
 from golem.diag.service import DiagnosticsService, DiagnosticsOutputFormat
 from golem.diag.vm import VMDiagnosticsProvider

--- a/golem/client.py
+++ b/golem/client.py
@@ -1375,7 +1375,8 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             return self.environments_manager.get_performance_values()
 
     @rpc_utils.expose('env.hw.virtualization')
-    def get_virtualization_support(self):
+    @staticmethod
+    def get_virtualization_support():
         return is_virtualization_enabled()
 
     @staticmethod

--- a/golem/core/virtualization.py
+++ b/golem/core/virtualization.py
@@ -15,8 +15,8 @@ def is_virtualization_enabled() -> bool:
     """
     if is_windows():
         return __check_vt_windows()
-    else:
-        return __check_vt_unix()
+
+    return __check_vt_unix()
 
 
 def __check_vt_unix() -> bool:
@@ -27,7 +27,6 @@ def __check_vt_unix() -> bool:
 def __check_vt_windows() -> bool:
     sys_info: subprocess.CompletedProcess = \
         subprocess.run('systeminfo', check=True, stdout=subprocess.PIPE)
-    output: str = None
 
     # https://stackoverflow.com/a/9228117
     try:

--- a/golem/core/virtualization.py
+++ b/golem/core/virtualization.py
@@ -5,8 +5,10 @@ import subprocess
 from cpuinfo import get_cpu_info
 
 from golem.core.common import is_windows
+from golem.rpc import utils as rpc_utils
 
 
+@rpc_utils.expose('env.hw.virtualization')
 def is_virtualization_enabled() -> bool:
     """ Checks if hardware virtualization is available on this machine.
     Currently, this check is limited to Intel CPUs (VT and VT-x support).

--- a/golem/core/virtualization.py
+++ b/golem/core/virtualization.py
@@ -6,7 +6,12 @@ from golem.core.common import get_golem_path, is_windows
 from golem.core.windows import run_powershell
 from golem.rpc import utils as rpc_utils
 
-WIN_SCRIPT_PATH = os.path.join(get_golem_path(), 'scripts', 'virtualization', 'get-virtualization-state.ps1')
+WIN_SCRIPT_PATH = os.path.join(
+    get_golem_path(),
+    'scripts',
+    'virtualization',
+    'get-virtualization-state.ps1'
+)
 
 
 @rpc_utils.expose('env.hw.virtualization')

--- a/golem/core/virtualization.py
+++ b/golem/core/virtualization.py
@@ -1,0 +1,31 @@
+import locale
+import re
+import subprocess
+
+from golem.core.common import is_windows, is_osx
+
+win_key_vt_supported = 'VM Monitor Mode Extensions'
+win_key_vt_enabled = 'Virtualization Enabled In Firmware'
+
+
+def is_vt_enabled() -> bool:
+    if is_windows():
+        sys_info: subprocess.CompletedProcess = \
+            subprocess.run('systeminfo', check=True, stdout=subprocess.PIPE)
+        output: str = None
+
+        # https://stackoverflow.com/a/9228117
+        try:
+            output = sys_info.stdout.decode(locale.getpreferredencoding())
+        except ValueError:
+            output = sys_info.stdout.decode()
+
+        return __check_systeminfo_field(win_key_vt_supported, output) and \
+            __check_systeminfo_field(win_key_vt_enabled, output)
+
+
+def __check_systeminfo_field(key: str, command_output: str) -> bool:
+    pattern = re.compile(f'(.*){key}:(\\s+)(\\w*)')
+    match = pattern.search(command_output)
+
+    return match and match.group(match.lastindex) == 'Yes'

--- a/golem/core/windows.py
+++ b/golem/core/windows.py
@@ -23,7 +23,7 @@ def run_powershell(
     cmd = ['powershell.exe']
 
     if not use_profile:
-        cmd += '-NoProfile'
+        cmd += ['-NoProfile']
 
     if script and not command:
         cmd += [

--- a/golem/core/windows.py
+++ b/golem/core/windows.py
@@ -16,8 +16,9 @@ def run_powershell(
     :param script: path of PowerShell script to execute
     :param command: PowerShell command to execute
     :param args: optional extra arguments
-    :param use_profile: when set to True, PowerShell will first load all profile scripts present on the machine before
-    running the actual command or script.
+    :param use_profile: when set to True, PowerShell will first load all
+    profile scripts present on the machine before running the actual command
+    or script.
     :param timeout: timeout for the script or command, in seconds
     """
     cmd = ['powershell.exe']
@@ -43,15 +44,15 @@ def run_powershell(
     try:
         return subprocess \
             .run(
-            cmd,
-            timeout=timeout,  # seconds
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        ) \
+                cmd,
+                timeout=timeout,  # seconds
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+            ) \
             .stdout \
             .decode('utf8') \
             .strip()
-    except (subprocess.CalledProcessError, \
+    except (subprocess.CalledProcessError,
             subprocess.TimeoutExpired) as exc:
         raise RuntimeError(exc.stderr.decode('utf8') if exc.stderr else '')

--- a/golem/core/windows.py
+++ b/golem/core/windows.py
@@ -8,7 +8,7 @@ def run_powershell(
         script: Optional[str] = None,
         command: Optional[str] = None,
         args: Optional[List[str]] = None,
-        use_profile: Optional[bool] = False,
+        use_profile: bool = False,
         timeout: int = DEFAULT_SCRIPT_TIMEOUT
 ) -> str:
     """

--- a/golem/core/windows.py
+++ b/golem/core/windows.py
@@ -1,0 +1,57 @@
+import subprocess
+from typing import List, Optional
+
+DEFAULT_SCRIPT_TIMEOUT = 5  # seconds
+
+
+def run_powershell(
+        script: Optional[str] = None,
+        command: Optional[str] = None,
+        args: Optional[List[str]] = None,
+        use_profile: Optional[bool] = False,
+        timeout: int = DEFAULT_SCRIPT_TIMEOUT
+) -> str:
+    """
+    Runs a PowerShell script or command and returns its output in UTF8.
+    :param script: path of PowerShell script to execute
+    :param command: PowerShell command to execute
+    :param args: optional extra arguments
+    :param use_profile: when set to True, PowerShell will first load all profile scripts present on the machine before
+    running the actual command or script.
+    :param timeout: timeout for the script or command, in seconds
+    """
+    cmd = ['powershell.exe']
+
+    if not use_profile:
+        cmd += '-NoProfile'
+
+    if script and not command:
+        cmd += [
+            '-ExecutionPolicy', 'RemoteSigned',
+            '-File', script
+        ]
+    elif command and not script:
+        cmd += [
+            '-Command', command
+        ]
+    else:
+        raise ValueError("Exactly one of (script, command) is required")
+
+    if args:
+        cmd += args
+
+    try:
+        return subprocess \
+            .run(
+            cmd,
+            timeout=timeout,  # seconds
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        ) \
+            .stdout \
+            .decode('utf8') \
+            .strip()
+    except (subprocess.CalledProcessError, \
+            subprocess.TimeoutExpired) as exc:
+        raise RuntimeError(exc.stderr.decode('utf8') if exc.stderr else '')

--- a/golem/docker/hypervisor/hyperv.py
+++ b/golem/docker/hypervisor/hyperv.py
@@ -14,6 +14,7 @@ from os_win.utils.compute.vmutils import VMUtils
 
 from golem import hardware
 from golem.core.common import get_golem_path
+from golem.core.windows import run_powershell
 from golem.docker import smbshare
 from golem.docker.client import local_client
 from golem.docker.config import CONSTRAINT_KEYS, MIN_CONSTRAINTS
@@ -128,7 +129,7 @@ class HyperVHypervisor(DockerMachineHypervisor):
         try:
             # The windows VM fails to start when too much memory is assigned
             logger.info("Hyper-V: Starting VM %s ...", name)
-            self._run_ps(
+            run_powershell(
                 script=self.START_VM_SCRIPT_PATH,
                 args=[
                     '-VMName', name,
@@ -147,7 +148,7 @@ class HyperVHypervisor(DockerMachineHypervisor):
     def is_available(cls) -> bool:
         command = "@(Get-Module -ListAvailable hyper-v).Name | Get-Unique"
         try:
-            output = cls._run_ps(command=command)
+            output = run_powershell(command=command)
             return output == "Hyper-V"
         except (RuntimeError, OSError) as e:
             logger.warning(f"Error checking Hyper-V availability: {e}")
@@ -254,7 +255,7 @@ class HyperVHypervisor(DockerMachineHypervisor):
 
     @classmethod
     def _get_vswitch_name(cls) -> str:
-        return cls._run_ps(script=cls.GET_VSWITCH_SCRIPT_PATH)
+        return run_powershell(script=cls.GET_VSWITCH_SCRIPT_PATH)
 
     @classmethod
     def _get_hostname_for_sharing(cls) -> str:
@@ -266,51 +267,6 @@ class HyperVHypervisor(DockerMachineHypervisor):
         if not hostname:
             raise RuntimeError('COMPUTERNAME environment variable not set')
         return hostname
-
-    @classmethod
-    def _run_ps(
-            cls,
-            script: Optional[str] = None,
-            command: Optional[str] = None,
-            args: Optional[List[str]] = None,
-            timeout: int = SCRIPT_TIMEOUT
-    ) -> str:
-        """
-        Run a powershell script or command and return its output in UTF8
-        """
-        cmd = [
-            'powershell.exe', '-NoProfile'
-        ]
-        if script and not command:
-            cmd += [
-                '-ExecutionPolicy', 'RemoteSigned',
-                '-File', script
-            ]
-        elif command and not script:
-            cmd += [
-                '-Command', command
-            ]
-        else:
-            raise ValueError("Exactly one of (script, command) is required")
-
-        if args:
-            cmd += args
-
-        try:
-            return subprocess\
-                .run(
-                    cmd,
-                    timeout=timeout,  # seconds
-                    check=True,
-                    stdout=subprocess.PIPE,
-                    stderr=subprocess.PIPE,
-                )\
-                .stdout\
-                .decode('utf8')\
-                .strip()
-        except (subprocess.CalledProcessError, \
-                subprocess.TimeoutExpired) as exc:
-            raise RuntimeError(exc.stderr.decode('utf8') if exc.stderr else '')
 
     @staticmethod
     def uses_volumes() -> bool:

--- a/golem/docker/smbshare.py
+++ b/golem/docker/smbshare.py
@@ -7,6 +7,7 @@ from subprocess import CalledProcessError, TimeoutExpired
 import sys
 
 from golem.core.common import get_golem_path, is_windows
+from golem.core.windows import run_powershell
 
 SCRIPT_PATH = path.join(
     get_golem_path(), 'scripts', 'docker', 'create-share.ps1')
@@ -19,22 +20,12 @@ def create_share(user_name: str, shared_dir_path: Path) -> None:
 
     if not shared_dir_path.is_dir():
         makedirs(shared_dir_path, exist_ok=True)
-    try:
-        subprocess.run(
-            [
-                'powershell.exe',
-                '-ExecutionPolicy', 'RemoteSigned',
-                '-File', SCRIPT_PATH,
-                '-UserName', user_name,
-                '-SharedDirPath', str(shared_dir_path)
-            ],
-            timeout=SCRIPT_TIMEOUT,
-            check=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT
-        )
-    except (CalledProcessError, TimeoutExpired) as exc:
-        raise RuntimeError(exc.stdout.decode('utf8'))
+
+    run_powershell(
+        script=SCRIPT_PATH,
+        timeout=SCRIPT_TIMEOUT,
+        args=['-UserName', user_name, '-SharedDirPath', str(shared_dir_path)],
+    )
 
 
 def get_share_name(shared_dir_path: Path) -> str:

--- a/golem/node.py
+++ b/golem/node.py
@@ -27,6 +27,7 @@ from golem.hardware.presets import HardwarePresets, HardwarePresetsMixin
 from golem.core.keysauth import KeysAuth, WrongPassword
 from golem.core import golem_async
 from golem.core.variables import PRIVATE_KEY
+from golem.core import virtualization
 from golem.database import Database
 from golem.docker.manager import DockerManager
 from golem.ethereum.transactionsystem import TransactionSystem
@@ -246,9 +247,7 @@ class Node(HardwarePresetsMixin):
         deferred = self.rpc_session.connect()
 
         def on_connect(*_):
-            methods = rpc_utils.object_method_map(self)
-            methods['sys.exposed_procedures'] = \
-                self.rpc_session.exposed_procedures
+            methods = self.get_rpc_mapping()
             self.rpc_session.add_procedures(methods)
             self._rpc_publisher = Publisher(self.rpc_session)
             StatusPublisher.set_publisher(self._rpc_publisher)
@@ -326,6 +325,19 @@ class Node(HardwarePresetsMixin):
         # subscribe to events
 
         return ShutdownResponse.on
+
+    def get_rpc_mapping(self) -> dict:
+        mapping = {}
+        rpc_providers = (
+            self,
+            virtualization,
+            self.rpc_session
+        )
+
+        for provider in rpc_providers:
+            mapping.update(rpc_utils.object_method_map(provider))
+
+        return mapping
 
     def _try_shutdown(self) -> None:
         # is not in shutdown?

--- a/golem/node.py
+++ b/golem/node.py
@@ -6,6 +6,7 @@ from typing import (
     Any,
     Callable,
     cast,
+    Dict,
     List,
     Optional,
     TypeVar,
@@ -326,8 +327,8 @@ class Node(HardwarePresetsMixin):
 
         return ShutdownResponse.on
 
-    def get_rpc_mapping(self) -> dict:
-        mapping = {}
+    def get_rpc_mapping(self) -> Dict[str, Callable]:
+        mapping: Dict[str, Callable] = {}
         rpc_providers = (
             self,
             virtualization,

--- a/golem/rpc/session.py
+++ b/golem/rpc/session.py
@@ -16,6 +16,7 @@ from twisted.internet.endpoints import (
 )
 
 from golem.rpc.common import X509_COMMON_NAME
+from golem.rpc import utils as rpc_utils
 
 logger = logging.getLogger('golem.rpc')
 
@@ -202,6 +203,7 @@ class Session(ApplicationSession):
             deferred.addErrback(self._on_error)
             yield deferred
 
+    @rpc_utils.expose('sys.exposed_procedures')
     def exposed_procedures(self):
         exposed: typing.Dict[str, str] = {}
         for registration in self._registrations.values():

--- a/requirements.txt
+++ b/requirements.txt
@@ -79,7 +79,7 @@ pluggy==0.6.0
 portalocker==1.2.1
 priority==1.3.0
 psutil==5.2.2
-py-cpuinfo==3.3.0
+py-cpuinfo==4.0.0
 py-ubjson==0.11.0
 pyasn1-modules==0.2.1
 pyasn1==0.4.1

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -33,7 +33,7 @@ Pillow==4.2.1
 pluggy==0.6.0
 portalocker==1.2.1
 psutil==5.2.2
-py-cpuinfo==3.3.0
+py-cpuinfo==4.0.0
 pyasn1==0.4.1
 pycparser==2.17
 pydispatcher

--- a/scripts/virtualization/get-virtualization-state.ps1
+++ b/scripts/virtualization/get-virtualization-state.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
+
+$SystemInfo = (GWMI Win32_Processor)
+return $SystemInfo.VMMonitorModeExtensions -and $SystemInfo.VirtualizationFirmwareEnabled

--- a/tests/golem/core/test_virtualization.py
+++ b/tests/golem/core/test_virtualization.py
@@ -1,0 +1,87 @@
+import unittest
+from unittest.mock import patch, Mock
+
+from golem.core.virtualization import is_virtualization_enabled
+
+
+@patch('golem.core.virtualization.is_windows', side_effect=lambda: False)
+class VirtualizationTestUnix(unittest.TestCase):
+
+    @patch('golem.core.virtualization.get_cpu_info')
+    def test_vt_enabled(self, cpu_info_mock, *_):
+        cpu_info_mock.return_value = get_cpuinfo_output_mock()
+
+        self.assertTrue(is_virtualization_enabled())
+
+    @patch('golem.core.virtualization.get_cpu_info')
+    def test_vt_unsupported(self, cpu_info_mock, *_):
+        cpu_info_mock.return_value = get_cpuinfo_output_mock(vt_supported=False)
+
+        self.assertFalse(is_virtualization_enabled())
+
+
+@patch('golem.core.virtualization.is_windows', side_effect=lambda: True)
+@patch('locale.getpreferredencoding', side_effect=lambda: 'cp1250')
+class VirtualizationTestWindows(unittest.TestCase):
+
+    @patch('subprocess.run')
+    def test_vt_enabled(self, run_mock, *_):
+        run_mock.return_value = get_sysinfo_output_mock()
+
+        self.assertTrue(is_virtualization_enabled())
+
+    @patch('subprocess.run')
+    def test_vt_disabled(self, run_mock, *_):
+        run_mock.return_value = get_sysinfo_output_mock(vt_enabled=False)
+
+        self.assertFalse(is_virtualization_enabled())
+
+    @patch('subprocess.run')
+    def test_vt_unsupported(self, run_mock, *_):
+        run_mock.return_value = get_sysinfo_output_mock(vt_supported=False)
+
+        self.assertFalse(is_virtualization_enabled())
+
+    @patch('subprocess.run')
+    def test_vt_fields_missing(self, run_mock, *_):
+        run_mock.return_value = get_sysinfo_output_mock(include_vt_fields=False)
+
+        self.assertFalse(is_virtualization_enabled())
+
+
+def get_cpuinfo_output_mock(vt_supported=True) -> dict:
+    cmd_output = {
+        'arch': 'X86_64',
+        'vendor_id': 'GenuineIntel',
+        'flags': [
+            'fpe', 'pae', 'msr'
+        ]
+    }
+
+    if vt_supported:
+        cmd_output['flags'].append('vmx')
+
+    return cmd_output
+
+
+def get_sysinfo_output_mock(
+        include_vt_fields=True,
+        vt_supported=True,
+        vt_enabled=True
+) -> Mock:
+    vt_fields = f"""
+    VM Monitor Mode Extensions: {'Yes' if vt_supported else 'No'}
+    Virtualization Enabled In Firmware: {'Yes' if vt_enabled else 'No'}
+    Second Level Address Translation: Yes
+    Data Execution Prevention Available: Yes
+    """
+
+    cmd_output = Mock()
+    cmd_output.stdout = f"""
+    Host Name: golem-test
+    OS Name: Microsoft Windows 10 
+    Total Physical Memory: 66˙666 MB
+    Hyper-V Requirements: {vt_fields if include_vt_fields else ''}
+    """.encode(encoding='cp1250')
+
+    return cmd_output

--- a/tests/golem/core/test_virtualization.py
+++ b/tests/golem/core/test_virtualization.py
@@ -9,13 +9,13 @@ class VirtualizationTestUnix(unittest.TestCase):
 
     @patch('golem.core.virtualization.get_cpu_info')
     def test_vt_enabled(self, cpu_info_mock, *_):
-        cpu_info_mock.return_value = get_cpuinfo_output_mock()
+        cpu_info_mock.return_value = get_mock_cpuinfo_output()
 
         self.assertTrue(is_virtualization_enabled())
 
     @patch('golem.core.virtualization.get_cpu_info')
     def test_vt_unsupported(self, cpu_info_mock, *_):
-        cpu_info_mock.return_value = get_cpuinfo_output_mock(vt_supported=False)
+        cpu_info_mock.return_value = get_mock_cpuinfo_output(vt_supported=False)
 
         self.assertFalse(is_virtualization_enabled())
 
@@ -26,45 +26,42 @@ class VirtualizationTestWindows(unittest.TestCase):
 
     @patch('subprocess.run')
     def test_vt_enabled(self, run_mock, *_):
-        run_mock.return_value = get_sysinfo_output_mock()
+        run_mock.return_value = get_mock_sysinfo_output()
 
         self.assertTrue(is_virtualization_enabled())
 
     @patch('subprocess.run')
     def test_vt_disabled(self, run_mock, *_):
-        run_mock.return_value = get_sysinfo_output_mock(vt_enabled=False)
+        run_mock.return_value = get_mock_sysinfo_output(vt_enabled=False)
 
         self.assertFalse(is_virtualization_enabled())
 
     @patch('subprocess.run')
     def test_vt_unsupported(self, run_mock, *_):
-        run_mock.return_value = get_sysinfo_output_mock(vt_supported=False)
+        run_mock.return_value = get_mock_sysinfo_output(vt_supported=False)
 
         self.assertFalse(is_virtualization_enabled())
 
     @patch('subprocess.run')
     def test_vt_fields_missing(self, run_mock, *_):
-        run_mock.return_value = get_sysinfo_output_mock(include_vt_fields=False)
+        run_mock.return_value = get_mock_sysinfo_output(include_vt_fields=False)
 
         self.assertFalse(is_virtualization_enabled())
 
 
-def get_cpuinfo_output_mock(vt_supported=True) -> dict:
-    cmd_output = {
+def get_mock_cpuinfo_output(vt_supported=True) -> dict:
+    flags = ['fpe', 'pae', 'msr']
+    if vt_supported:
+        flags.append('vmx')
+
+    return {
         'arch': 'X86_64',
         'vendor_id': 'GenuineIntel',
-        'flags': [
-            'fpe', 'pae', 'msr'
-        ]
+        'flags': flags
     }
 
-    if vt_supported:
-        cmd_output['flags'].append('vmx')
 
-    return cmd_output
-
-
-def get_sysinfo_output_mock(
+def get_mock_sysinfo_output(
         include_vt_fields=True,
         vt_supported=True,
         vt_enabled=True

--- a/tests/golem/core/test_virtualization.py
+++ b/tests/golem/core/test_virtualization.py
@@ -1,7 +1,8 @@
+from pathlib import Path
 import unittest
 from unittest.mock import patch
 
-from golem.core.virtualization import is_virtualization_enabled
+from golem.core.virtualization import is_virtualization_enabled, WIN_SCRIPT_PATH
 
 
 def get_mock_cpuinfo_output(vt_supported=True) -> dict:
@@ -28,3 +29,20 @@ class VirtualizationTestUnix(unittest.TestCase):
            return_value=get_mock_cpuinfo_output(vt_supported=False))
     def test_vt_unsupported(self, *_):
         self.assertFalse(is_virtualization_enabled())
+
+
+@patch('golem.core.virtualization.is_windows', side_effect=lambda: True)
+class VirtualizationTestWindows(unittest.TestCase):
+
+    @patch('golem.core.virtualization.run_powershell',
+           return_value='True')
+    def test_vt_enabled(self, *_):
+        self.assertTrue(is_virtualization_enabled())
+
+    @patch('golem.core.virtualization.run_powershell',
+           return_value='False')
+    def test_vt_disabled(self, *_):
+        self.assertFalse(is_virtualization_enabled())
+
+    def test_script_path(self, *_):
+        self.assertTrue(Path(WIN_SCRIPT_PATH).exists())

--- a/tests/golem/core/test_virtualization.py
+++ b/tests/golem/core/test_virtualization.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch, Mock
+from unittest.mock import patch
 
 from golem.core.virtualization import is_virtualization_enabled
 
@@ -16,29 +16,6 @@ def get_mock_cpuinfo_output(vt_supported=True) -> dict:
     }
 
 
-def get_mock_sysinfo_output(
-        include_vt_fields=True,
-        vt_supported=True,
-        vt_enabled=True
-) -> Mock:
-    vt_fields = f"""
-    VM Monitor Mode Extensions: {'Yes' if vt_supported else 'No'}
-    Virtualization Enabled In Firmware: {'Yes' if vt_enabled else 'No'}
-    Second Level Address Translation: Yes
-    Data Execution Prevention Available: Yes
-    """
-
-    cmd_output = Mock()
-    cmd_output.stdout = f"""
-    Host Name: golem-test
-    OS Name: Microsoft Windows 10 
-    Total Physical Memory: 66˙666 MB
-    Hyper-V Requirements: {vt_fields if include_vt_fields else ''}
-    """.encode(encoding='cp1250')
-
-    return cmd_output
-
-
 @patch('golem.core.virtualization.is_windows', side_effect=lambda: False)
 class VirtualizationTestUnix(unittest.TestCase):
 
@@ -50,28 +27,4 @@ class VirtualizationTestUnix(unittest.TestCase):
     @patch('golem.core.virtualization.get_cpu_info',
            return_value=get_mock_cpuinfo_output(vt_supported=False))
     def test_vt_unsupported(self, *_):
-        self.assertFalse(is_virtualization_enabled())
-
-
-@patch('golem.core.virtualization.is_windows', side_effect=lambda: True)
-@patch('locale.getpreferredencoding', side_effect=lambda: 'cp1250')
-class VirtualizationTestWindows(unittest.TestCase):
-
-    @patch('subprocess.run', return_value=get_mock_sysinfo_output())
-    def test_vt_enabled(self, *_):
-        self.assertTrue(is_virtualization_enabled())
-
-    @patch('subprocess.run',
-           return_value=get_mock_sysinfo_output(vt_enabled=False))
-    def test_vt_disabled(self, *_):
-        self.assertFalse(is_virtualization_enabled())
-
-    @patch('subprocess.run',
-           return_value=get_mock_sysinfo_output(vt_supported=False))
-    def test_vt_unsupported(self, *_):
-        self.assertFalse(is_virtualization_enabled())
-
-    @patch('subprocess.run',
-           return_value=get_mock_sysinfo_output(include_vt_fields=False))
-    def test_vt_fields_missing(self, *_):
         self.assertFalse(is_virtualization_enabled())


### PR DESCRIPTION
Resolves: #3268

This adds logic for checking whether the machine's CPU supports hardware virtualization (currently only checks for Intel VT/VT-x). On Windows, the result is based on the output of systeminfo command. On all other platforms, the py-cpuinfo library is used.