### PR TITLE
Create Hyper-VM VM with minimum of memory

### DIFF
--- a/golem/docker/hypervisor/hyperv.py
+++ b/golem/docker/hypervisor/hyperv.py
@@ -218,16 +218,20 @@ class HyperVHypervisor(DockerMachineHypervisor):
         if cpu is not None:
             args += [self.OPTIONS['cpu'], str(cpu)]
         if mem is not None:
-            cap_mem = self._memory_cap(mem)
-            if cap_mem != mem:
-                self._log_and_publish_event(events.MEM, mem_mb=cap_mem)
+            # cap_mem = self._memory_cap(mem)
+            # if cap_mem != mem:
+            #     self._log_and_publish_event(events.MEM, mem_mb=cap_mem)
+            #
+            # if self._check_system_drive_space(cap_mem):
+            #     args += [self.OPTIONS['mem'], str(cap_mem)]
+            # else:
+            #     self._log_and_publish_event(events.DISK)
+            #     mem_key = CONSTRAINT_KEYS['mem']
+            #     args += [self.OPTIONS['mem'], str(MIN_CONSTRAINTS[mem_key])]
 
-            if self._check_system_drive_space(cap_mem):
-                args += [self.OPTIONS['mem'], str(cap_mem)]
-            else:
-                self._log_and_publish_event(events.DISK)
-                mem_key = CONSTRAINT_KEYS['mem']
-                args += [self.OPTIONS['mem'], str(MIN_CONSTRAINTS[mem_key])]
+            # TODO: Restore when we have a better estimation of available RAM
+            mem_key = CONSTRAINT_KEYS['mem']
+            args += [self.OPTIONS['mem'], str(MIN_CONSTRAINTS[mem_key])]
 
         return args
 

--- a/tests/golem/docker/test_hyperv.py
+++ b/tests/golem/docker/test_hyperv.py
@@ -47,7 +47,10 @@ class TestHyperVHypervisor(TestCase):
     def test_parse_create_params_constraints(self, *_):
         args = self.hyperv._parse_create_params(cpu=4, mem=4096)
         self._assert_param(args, '--hyperv-cpu-count', '4')
-        self._assert_param(args, '--hyperv-memory', '4096')
+        # self._assert_param(args, '--hyperv-memory', '4096')
+        # TODO: Restore when we have a better estimation of available RAM
+        self._assert_param(args, '--hyperv-memory',
+                           str(MIN_CONSTRAINTS[CONSTRAINT_KEYS['mem']]))
 
     @patch(PATCH_BASE + '.HyperVHypervisor._check_system_drive_space')
     @patch(PATCH_BASE + '.HyperVHypervisor._get_vswitch_name')
@@ -56,8 +59,11 @@ class TestHyperVHypervisor(TestCase):
     def test_parse_create_params_constraints_memory_cap(self, logger, *_):
         args = self.hyperv._parse_create_params(cpu=4, mem=4096)
         self._assert_param(args, '--hyperv-cpu-count', '4')
-        self._assert_param(args, '--hyperv-memory', '2048')
-        logger.warning.assert_called_once()
+        # self._assert_param(args, '--hyperv-memory', '2048')
+        # logger.warning.assert_called_once()
+        # TODO: Restore when we have a better estimation of available RAM
+        self._assert_param(args, '--hyperv-memory',
+                           str(MIN_CONSTRAINTS[CONSTRAINT_KEYS['mem']]))
 
     @patch(PATCH_BASE + '.HyperVHypervisor._get_vswitch_name')
     @patch(PATCH_BASE + '.HyperVHypervisor._memory_cap', lambda _, x: x)
@@ -69,7 +75,8 @@ class TestHyperVHypervisor(TestCase):
         self._assert_param(args, '--hyperv-cpu-count', '4')
         self._assert_param(args, '--hyperv-memory',
                            str(MIN_CONSTRAINTS[CONSTRAINT_KEYS['mem']]))
-        logger.warning.assert_called_once()
+        # logger.warning.assert_called_once()
+        # TODO: Restore when we have a better estimation of available RAM
 
     @patch(PATCH_BASE + '.HyperVHypervisor._check_system_drive_space')
     @patch(PATCH_BASE + '.subprocess.run',


### PR DESCRIPTION
The current method of computing available memory is faulty so that sometimes VMs get assigned too much RAM and fail to start. This breaks the whole VM creation process. As a workaround always create the VM with minimal amount of memory.