### PR TITLE
Docker argv: execute 'python3' instead of '/usr/bin/python3' in DockerJob

### DIFF
--- a/golem/docker/job.py
+++ b/golem/docker/job.py
@@ -130,7 +130,7 @@ class DockerJob:
             image=self.image.name,
             volumes=self.volumes,
             host_config=host_cfg,
-            command=[f'/usr/bin/python3 "{self.script_filepath}"'],
+            command=[f'python3 "{self.script_filepath}"'],
             working_dir=self.WORK_DIR,
             environment=self.environment,
         )


### PR DESCRIPTION
The `image_metrics` Docker image tests are missing (issue #3772) and thus the missing symlink to `/usr/bin/python3` hasn't been brought to attention