### PR TITLE
Use TTC instead of CTD in taskcomputer

### DIFF
--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -284,17 +284,16 @@ class TaskServer(
 
         return None
 
-    def task_given(self, node_id: str, ctd: message.ComputeTaskDef,
-                   price: int) -> bool:
-        if not self.task_computer.task_given(ctd):
+    def task_given(self, msg: message.TaskToCompute) -> bool:
+        if not self.task_computer.task_given(msg):
             return False
-        self.requested_tasks.remove(ctd['task_id'])
-        update_requestor_assigned_sum(node_id, price)
+        self.requested_tasks.remove(msg.task_id)
+        update_requestor_assigned_sum(msg.requestor_id, msg.price)
         dispatcher.send(
             signal='golem.subtask',
             event='started',
-            subtask_id=ctd['subtask_id'],
-            price=price,
+            subtask_id=msg.subtask_id,
+            price=msg.price,
         )
         return True
 

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -722,7 +722,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             self.task_server.add_task_session(
                 ctd['subtask_id'], self
             )
-            if self.task_server.task_given(self.key_id, ctd, msg.price):
+            if self.task_server.task_given(msg):
                 return
         _cannot_compute(self.err_msg)
 

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -665,11 +665,7 @@ class TestTaskSession(ConcentMessageMixin, LogTestCase,
         ts.task_manager.comp_task_keeper.receive_subtask.assert_called_with(msg)
         ts.task_computer.session_closed.assert_not_called()
         ts.task_server.add_task_session.assert_called_with(msg.subtask_id, ts)
-        ts.task_server.task_given.assert_called_with(
-            header.task_owner.key,
-            ctd,
-            msg.price,
-        )
+        ts.task_server.task_given.assert_called_with(msg)
         conn.close.assert_not_called()
 
         # Wrong key id -> failure
@@ -713,11 +709,7 @@ class TestTaskSession(ConcentMessageMixin, LogTestCase,
         msg = _prepare_and_react(ctd)
         ts.task_computer.session_closed.assert_not_called()
         ts.task_server.add_task_session.assert_called_with(msg.subtask_id, ts)
-        ts.task_server.task_given.assert_called_with(
-            header.task_owner.key,
-            ctd,
-            msg.price,
-        )
+        ts.task_server.task_given.assert_called_with(msg)
         conn.close.assert_not_called()
 
         # No environment available -> failure


### PR DESCRIPTION
Now that TTC includes TaskHeader it is more self-contained and doesn't require checking local state (taskkeeper) for headers.