### PR TITLE
RPC for estimated Concent deposit payment and tx fee

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -1251,20 +1251,6 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
     def delete_task_preset(task_type, preset_name):
         taskpreset.delete_task_preset(task_type, preset_name)
 
-    @rpc_utils.expose('comp.tasks.estimated.cost')
-    def get_estimated_cost(self, task_type, options):
-        if self.task_server is None:
-            raise Exception('Cannot estimate costs')
-        options['price'] = float(options['price'])
-        options['subtask_time'] = float(options['subtask_time'])
-        options['num_subtasks'] = int(options['num_subtasks'])
-        return {
-            'GNT': self.task_server.task_manager.get_estimated_cost(task_type,
-                                                                    options),
-            'ETH': float(self.transaction_system.eth_for_batch_payment(
-                options['num_subtasks']) / denoms.ether),
-        }
-
     def _publish(self, event_name, *args, **kwargs):
         if self.rpc_publisher:
             self.rpc_publisher.publish(event_name, *args, **kwargs)

--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -150,7 +150,7 @@ def timeout_to_string(timeout):
     return TIMEOUT_FORMAT.format(hours, minutes, timeout)
 
 
-def string_to_timeout(string) -> int:
+def string_to_timeout(string: str) -> int:
     values = string.split(':')
     return int(values[0]) * 3600 + int(values[1]) * 60 + int(values[2])
 

--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -484,6 +484,11 @@ class TransactionSystem(LoopingCallService):
         return gas_price * self._sci.GAS_PER_PAYMENT
 
     @sci_required()
+    def eth_for_deposit(self) -> int:
+        self._sci: SmartContractsInterface
+        return self.gas_price * self._sci.GAS_TRANSFER_AND_CALL
+
+    @sci_required()
     def get_withdraw_gas_cost(
             self,
             amount: int,
@@ -492,8 +497,6 @@ class TransactionSystem(LoopingCallService):
 
         self._sci: SmartContractsInterface
         assert self._sci is not None
-
-        gas_price = self.gas_price
 
         if currency == 'ETH':
             return self._sci.estimate_transfer_eth_gas(destination, amount)

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -30,7 +30,7 @@ from golem.task.taskproviderstats import ProviderStatsManager
 logger = logging.getLogger('golem.task.taskkeeper')
 
 
-def compute_subtask_value(price: int, computation_time: int):
+def compute_subtask_value(price: int, computation_time: int) -> int:
     """
     Don't use math.ceil (this is general advice, not specific to the case here)
     >>> math.ceil(10 ** 18 / 6)

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -1038,14 +1038,6 @@ class TaskManager(TaskEventListener):
         """ Add a header of a task which this node may try to compute """
         self.comp_task_keeper.add_request(theader, price)
 
-    def get_estimated_cost(self, task_type, options):
-        try:
-            subtask_value = options['price'] * options['subtask_time']
-            return options['num_subtasks'] * subtask_value
-        except (KeyError, ValueError):
-            logger.exception("Cannot estimate price, wrong params")
-            return None
-
     def __add_subtask_to_tasks_states(self, node_name, node_id,
                                       ctd, address, price: int):
 

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -554,28 +554,28 @@ class TestGetEstimatedCost(ProviderBase):
         ts.eth_for_deposit.return_value = 20000
 
     def test_basic(self, *_):
-        num_subtasks = 5
+        subtasks = 5
         result = self.provider.get_estimated_cost(
             "task type",
             {
-                "price": '150.0',
-                "subtask_time": '2.5',
-                "num_subtasks": str(num_subtasks),
+                "price": '150',
+                "subtask_timeout": '00:00:02',
+                "subtasks": str(subtasks),
             },
         )
         self.assertEqual(
             result,
             {
-                "GNT": '1875.000000000000000000',
-                'ETH': '0.000000000000010000',
+                "GNT": '5',
+                'ETH': '10000',
                 'deposit': {
-                    'GNT_required': '3750.000000000000000000',
-                    'GNT_suggested': '7500.000000000000000000',
-                    'ETH': '0.000000000000020000',
+                    'GNT_required': '10',
+                    'GNT_suggested': '20',
+                    'ETH': '20000',
                 },
             },
         )
         self.transaction_system.eth_for_batch_payment.assert_called_once_with(
-            num_subtasks,
+            subtasks,
         )
         self.transaction_system.eth_for_deposit.assert_called_once_with()

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -936,16 +936,6 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.update_task_signatures()
         assert task.header.signature != sig
 
-    def test_get_estimated_cost(self):
-        tm = TaskManager(dt_p2p_factory.Node(), Mock(), root_path=self.path)
-        options = {'price': 100,
-                   'subtask_time': 1.5,
-                   'num_subtasks': 7
-                   }
-        assert tm.get_estimated_cost("Blender", options) == 1050
-        with self.assertLogs(logger, level="WARNING"):
-            assert tm.get_estimated_cost("Blender", {}) is None
-
     def test_errors(self):
         task_id = 'qaz123WSX'
         subtask_id = "qweasdzxc"

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -673,23 +673,6 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
             self.assertIsInstance(value, str)
             self.assertTrue(key in res_dirs)
 
-    def test_get_estimated_cost(self, *_):
-        self.client.transaction_system = make_mock_ets()
-        self.assertEqual(
-            self.client.get_estimated_cost(
-                "task type",
-                {
-                    "price": 150,
-                    "subtask_time": 2.5,
-                    "num_subtasks": 5,
-                },
-            ),
-            {
-                "GNT": 1875.0,
-                "ETH": 0.0001,
-            },
-        )
-
     def test_get_balance(self, *_):
         c = self.client
 


### PR DESCRIPTION
 * Moved get_estimed_cost() from Client to tasks.rpc.ClientProvider
 * Refactored out TaskManager.get_estimated_cost()
 * All output numerical values are casted to strings
 * Renamed subtask_time to subtask_timeout
 * Renamed num_subtasks to subtasks
 * subtask_timeout is string timedelta as in task creation
 * Added deposit subdictionary
Example input:
```python
{
    'price': '150',  # str(int)
    'subtask_timeout': '00:00:02',  # str(timedelta)
    'subtasks': '5',  # str(int)
}
```
Example output:
```python
            {                                                                          
                "GNT": '5',                                      
                'ETH': '10000',                                         
                'deposit': {                                                           
                    'GNT_required': '10',                         
                    'GNT_suggested': '20',                        
                    'ETH': '20000',                                     
                },                                                                     
            }
```
Actual GNT deposit amount will be inside `<GNT_required, GNT_suggested>`.

fixes: #3791 