### PR TITLE
Substract gas cost from ETH withdrawal

### DIFF
--- a/tests/golem/ethereum/test_transactionsystem.py
+++ b/tests/golem/ethereum/test_transactionsystem.py
@@ -141,134 +141,6 @@ class TestTransactionSystem(TransactionSystemBase):
 
         self.assertEqual(ets.gas_price_limit, self.sci.GAS_PRICE)
 
-    def test_withdraw_unknown_currency(self):
-        dest = '0x' + 40 * 'd'
-        with self.assertRaises(ValueError, msg="Unknown currency asd"):
-            self.ets.withdraw(1, dest, 'asd')
-
-    def test_withdraw(self):
-        eth_balance = 40 * denoms.ether
-        gnt_balance = 10 * denoms.ether
-        gntb_balance = 20 * denoms.ether
-        self.sci.get_eth_balance.return_value = eth_balance
-        self.sci.get_gnt_balance.return_value = gnt_balance
-        self.sci.get_gntb_balance.return_value = gntb_balance
-        eth_tx = '0xee'
-        gntb_tx = '0xfad'
-        self.sci.transfer_eth.return_value = eth_tx
-        self.sci.convert_gntb_to_gnt.return_value = gntb_tx
-        dest = '0x' + 40 * 'd'
-
-        self.ets._refresh_balances()
-
-        # Invalid address
-        with self.assertRaisesRegex(ValueError, 'is not valid ETH address'):
-            self.ets.withdraw(1, 'asd', 'ETH')
-
-        # Not enough GNT
-        with self.assertRaises(NotEnoughFunds):
-            self.ets.withdraw(gnt_balance + gntb_balance + 1, dest, 'GNT')
-
-        # Not enough ETH
-        with self.assertRaises(NotEnoughFunds):
-            self.ets.withdraw(eth_balance + 1, dest, 'ETH')
-
-        # Enough GNTB
-        withdraw_gntb = 2 * denoms.ether
-        res = self.ets.withdraw(withdraw_gntb, dest, 'GNT')
-        assert res == gntb_tx
-        self.sci.convert_gntb_to_gnt.assert_called_once_with(
-            dest,
-            withdraw_gntb,
-            None,
-        )
-        self.sci.reset_mock()
-        gntb_balance -= withdraw_gntb
-
-        # Custom gas price
-        gas_price = 111
-        withdraw_gntb_custom_gas = 3 * denoms.ether
-        res = self.ets.withdraw(
-            withdraw_gntb_custom_gas,
-            dest,
-            'GNT',
-            gas_price,
-        )
-        assert res == gntb_tx
-        self.sci.convert_gntb_to_gnt.assert_called_once_with(
-            dest,
-            withdraw_gntb_custom_gas,
-            gas_price,
-        )
-        self.sci.on_transaction_confirmed.call_args[0][1](Mock(status=True))
-        self.sci.reset_mock()
-        gntb_balance -= withdraw_gntb_custom_gas
-
-        # Not enough GNTB
-        with self.assertRaises(NotEnoughFunds):
-            self.ets.withdraw(gnt_balance + gntb_balance - 1, dest, 'GNT')
-        self.sci.reset_mock()
-
-        # Enough ETH
-        res = self.ets.withdraw(eth_balance - 1, dest, 'ETH')
-        assert res == eth_tx
-        self.sci.transfer_eth.assert_called_once_with(
-            dest,
-            eth_balance - 1,
-            None,
-        )
-        self.sci.reset_mock()
-
-        # Custom gas price
-        gas_price = 1111
-        res = self.ets.withdraw(eth_balance - 1, dest, 'ETH', gas_price)
-        assert res == eth_tx
-        self.sci.transfer_eth.assert_called_once_with(
-            dest,
-            eth_balance - 1,
-            gas_price,
-        )
-        self.sci.reset_mock()
-
-        # Enough ETH with lock
-        self.ets.lock_funds_for_payments(1, 1)
-        locked_eth = self.ets.get_locked_eth()
-        locked_gnt = self.ets.get_locked_gnt()
-        assert 0 < locked_eth < eth_balance
-        assert 0 < locked_gnt < gnt_balance
-        res = self.ets.withdraw(eth_balance - locked_eth, dest, 'ETH')
-        assert res == eth_tx
-        self.sci.transfer_eth.assert_called_once_with(
-            dest,
-            eth_balance - locked_eth,
-            None,
-        )
-        self.sci.reset_mock()
-
-        # Not enough ETH with lock
-        with self.assertRaises(NotEnoughFunds):
-            self.ets.withdraw(eth_balance - locked_eth + 1, dest, 'ETH')
-        self.sci.reset_mock()
-
-        # Enough GNTB with lock
-        res = self.ets.withdraw(gntb_balance - locked_gnt, dest, 'GNT')
-        self.sci.convert_gntb_to_gnt.assert_called_once_with(
-            dest,
-            gntb_balance - locked_gnt,
-            None,
-        )
-        self.sci.reset_mock()
-
-        # Not enough GNT with lock
-        with self.assertRaises(NotEnoughFunds):
-            self.ets.withdraw(gntb_balance + locked_gnt + 1, dest, 'GNT')
-        self.sci.reset_mock()
-
-    def test_withdraw_disabled(self):
-        ets = self._make_ets(withdrawals=False)
-        with self.assertRaisesRegex(Exception, 'Withdrawals are disabled'):
-            ets.withdraw(1, '0x' + 40 * '0', 'GNT')
-
     def test_locking_funds(self):
         eth_balance = 10 * denoms.ether
         gnt_balance = 1000 * denoms.ether
@@ -301,24 +173,6 @@ class TestTransactionSystem(TransactionSystemBase):
 
         with self.assertRaisesRegex(Exception, "Can't unlock .* GNT"):
             self.ets.unlock_funds_for_payments(1, 1)
-
-    def test_withdraw_lock_gntb(self):
-        eth_balance = 10 * denoms.ether
-        gntb_balance = 1000 * denoms.ether
-        self.sci.get_eth_balance.return_value = eth_balance
-        self.sci.get_gntb_balance.return_value = gntb_balance
-        self.ets._refresh_balances()
-
-        assert self.ets.get_available_gnt() == gntb_balance
-
-        self.ets.withdraw(gntb_balance, '0x' + 40 * '0', 'GNT')
-        assert self.ets.get_available_gnt() == 0
-        self.sci.on_transaction_confirmed.assert_called_once()
-
-        self.sci.get_gntb_balance.return_value = 0
-        self.ets._refresh_balances()
-        self.sci.on_transaction_confirmed.call_args[0][1](Mock(status=True))
-        assert self.ets.get_available_gnt() == 0
 
     def test_locking_funds_changing_gas_price(self):
         eth_balance = 10 * denoms.ether
@@ -437,6 +291,144 @@ class TestTransactionSystem(TransactionSystemBase):
 
         # Shouldn't throw
         self._make_ets(datadir=self.new_path / 'other', password=password)
+
+
+class WithdrawTest(TransactionSystemBase):
+    def setUp(self):
+        super().setUp()
+        self.eth_balance = 10 * denoms.ether
+        self.gnt_balance = 1000 * denoms.ether
+        self.gas_price = 10 ** 9
+        self.gas_cost = 21000
+        self.sci.get_eth_balance.return_value = self.eth_balance
+        self.sci.get_gntb_balance.return_value = self.gnt_balance
+        self.sci.get_current_gas_price.return_value = self.gas_price
+        self.sci.estimate_transfer_eth_gas.return_value = self.gas_cost
+        self.dest = '0x' + 40 * 'd'
+
+        self.eth_tx = '0xee'
+        self.gntb_tx = '0xfad'
+        self.sci.transfer_eth.return_value = self.eth_tx
+        self.sci.convert_gntb_to_gnt.return_value = self.gntb_tx
+
+        self.ets._refresh_balances()
+
+    def test_unknown_currency(self):
+        with self.assertRaises(ValueError, msg="Unknown currency asd"):
+            self.ets.withdraw(1, self.dest, 'asd')
+
+    def test_invalid_address(self):
+        with self.assertRaisesRegex(ValueError, 'is not valid ETH address'):
+            self.ets.withdraw(1, 'asd', 'ETH')
+
+    def test_not_enough_gnt(self):
+        with self.assertRaises(NotEnoughFunds):
+            self.ets.withdraw(self.gnt_balance + 1, self.dest, 'GNT')
+
+    def test_not_enough_eth(self):
+        with self.assertRaises(NotEnoughFunds):
+            self.ets.withdraw(self.eth_balance + 1, self.dest, 'ETH')
+
+    def test_enough_gnt(self):
+        amount = 3 * denoms.ether
+        res = self.ets.withdraw(amount, self.dest, 'GNT')
+        assert res == self.gntb_tx
+        self.sci.convert_gntb_to_gnt.assert_called_once_with(
+            self.dest,
+            amount,
+            None,
+        )
+
+    def test_custom_gas_price_gnt(self):
+        gas_price = 111
+        amount = 3 * denoms.ether
+        self.ets.withdraw(amount, self.dest, 'GNT', gas_price)
+        self.sci.convert_gntb_to_gnt.assert_called_once_with(
+            self.dest,
+            amount,
+            gas_price,
+        )
+
+    def test_enough_eth(self):
+        amount = denoms.ether
+        res = self.ets.withdraw(amount, self.dest, 'ETH')
+        assert res == self.eth_tx
+        self.sci.transfer_eth.assert_called_once_with(
+            self.dest,
+            amount - self.gas_price * self.gas_cost,
+            self.gas_price,
+        )
+
+    def test_custom_gas_price_eth(self):
+        gas_price = 1111
+        amount = denoms.ether
+        self.ets.withdraw(amount, self.dest, 'ETH', gas_price)
+        self.sci.transfer_eth.assert_called_once_with(
+            self.dest,
+            amount - gas_price * self.gas_cost,
+            gas_price,
+        )
+
+    def test_eth_with_lock(self):
+        self.ets.lock_funds_for_payments(1, 1)
+        locked_eth = self.ets.get_locked_eth()
+        assert 0 < locked_eth < self.eth_balance
+        self.ets.withdraw(self.eth_balance - locked_eth, self.dest, 'ETH')
+        self.sci.transfer_eth.assert_called_once_with(
+            self.dest,
+            self.eth_balance - locked_eth - self.gas_price * self.gas_cost,
+            self.gas_price,
+        )
+
+    def test_not_enough_eth_with_lock(self):
+        self.ets.lock_funds_for_payments(1, 1)
+        locked_eth = self.ets.get_locked_eth()
+        assert 0 < locked_eth < self.eth_balance
+        with self.assertRaisesRegex(NotEnoughFunds, 'ETH'):
+            self.ets.withdraw(
+                self.eth_balance - locked_eth + 1,
+                self.dest,
+                'ETH',
+            )
+
+    def test_gnt_with_lock(self):
+        self.ets.lock_funds_for_payments(1, 1)
+        locked_gnt = self.ets.get_locked_gnt()
+        assert 0 < locked_gnt < self.gnt_balance
+        self.ets.withdraw(self.gnt_balance - locked_gnt, self.dest, 'GNT')
+        self.sci.convert_gntb_to_gnt.assert_called_once_with(
+            self.dest,
+            self.gnt_balance - locked_gnt,
+            None,
+        )
+
+    def test_not_enough_gnt_with_lock(self):
+        self.ets.lock_funds_for_payments(1, 1)
+        locked_gnt = self.ets.get_locked_gnt()
+        assert 0 < locked_gnt < self.gnt_balance
+        with self.assertRaisesRegex(NotEnoughFunds, 'GNT'):
+            self.ets.withdraw(
+                self.gnt_balance + locked_gnt + 1,
+                self.dest,
+                'GNT',
+            )
+
+    def test_disabled(self):
+        ets = self._make_ets(withdrawals=False)
+        with self.assertRaisesRegex(Exception, 'Withdrawals are disabled'):
+            ets.withdraw(1, self.dest, 'GNT')
+
+    def test_lock_gntb(self):
+        assert self.ets.get_available_gnt() == self.gnt_balance
+
+        self.ets.withdraw(self.gnt_balance, self.dest, 'GNT')
+        assert self.ets.get_available_gnt() == 0
+        self.sci.on_transaction_confirmed.assert_called_once()
+
+        self.sci.get_gntb_balance.return_value = 0
+        self.ets._refresh_balances()
+        self.sci.on_transaction_confirmed.call_args[0][1](Mock(status=True))
+        assert self.ets.get_available_gnt() == 0
 
 
 class ConcentDepositTest(TransactionSystemBase):


### PR DESCRIPTION
Cover the gas cost withdrawal from the amount withdrawn.
Also refactor corresponding tests.