### PR TITLE
Don't keep subtask price locally

### DIFF
--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -599,7 +599,6 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 provider_id=self.key_id,
                 package_hash='sha1:' + task_state.package_hash,
                 concent_enabled=msg.concent_enabled,
-                price=price,
                 size=task_state.package_size
             )
             ttc.generate_ethsig(self.my_private_key)

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -528,15 +528,12 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
             ctk.add_request(header, -2)
         ctk.add_request(header, 5 * 10 ** 18)
         self.assertEqual(ctk.active_tasks["xyz"].requests, 1)
-        self.assertEqual(ctk.active_task_offers["xyz"], 1388888888888889)
         self.assertEqual(ctk.active_tasks["xyz"].header, header)
         ctk.add_request(header, 1 * 10 ** 17)
         self.assertEqual(ctk.active_tasks["xyz"].requests, 2)
-        self.assertEqual(ctk.active_task_offers["xyz"], 27777777777778)
         self.assertEqual(ctk.active_tasks["xyz"].header, header)
         header.task_id = "xyz2"
         ctk.add_request(header, 314 * 10 ** 15)
-        self.assertEqual(ctk.active_task_offers["xyz2"], 87222222222223)
         header.task_id = "xyz"
         thread = get_task_header()
         thread.task_id = "qaz123WSX"


### PR DESCRIPTION
Now that TaskHeader is included in WantToComputeTask, the price is clearly determined in the TaskToCompute message, so no need for a local check here.