### PR TITLE
Just check for waiting in TaskServer

### DIFF
--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -722,10 +722,9 @@ class TaskServer(
             logger.info(f'network mask mismatch: {ids}')
             return False
 
-        if task.should_accept_client(node_id) != AcceptClientVerdict.ACCEPTED:
+        if task.should_accept_client(node_id) == AcceptClientVerdict.REJECTED:
             logger.info(f'provider {node_id} is not allowed'
-                        f' for this task at this moment '
-                        f'(either waiting for results or previously failed)')
+                        f' for this task (it has previously failed)')
             return False
 
         logger.debug('provider can be accepted %s', ids)

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -647,8 +647,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
             _assert_log_msg(
                 cm,
                 f'INFO:{logger.name}:provider {node_id}'
-                f' is not allowed for this task at this moment '
-                f'(either waiting for results or previously failed)'
+                f' is not allowed for this task (it has previously failed)'
             )
 
         # given


### PR DESCRIPTION
After #3467 requestor was sending `NoMoreSubtasks` to providers who were waiting for verification results making them not requests more subtasks for this particular task anymore.
This, in particular, made the DummyTask integration tests flaky.

Remove this condition from TaskServer check as it is checked later in the flow anyway.