### PR TITLE
Hyper-V memory fixes

### DIFF
--- a/golem/docker/hypervisor/hyperv.py
+++ b/golem/docker/hypervisor/hyperv.py
@@ -258,7 +258,7 @@ class HyperVHypervisor(DockerMachineHypervisor):
             logger.debug('raw hyperv info: summary=%r, memory=%r',
                          summary, mem_settings)
             result = dict()
-            result[CONSTRAINT_KEYS['mem']] = mem_settings['Limit']
+            result[CONSTRAINT_KEYS['mem']] = mem_settings['Reservation']
             result[CONSTRAINT_KEYS['cpu']] = summary['NumberOfProcessors']
             return result
         except (OSWinException, KeyError):

--- a/golem/hardware/presets.py
+++ b/golem/hardware/presets.py
@@ -65,12 +65,11 @@ class HardwarePresets:
 
     @classmethod
     def from_config(cls, config: ClientConfigDescriptor) -> HardwarePreset:
-        scale = hardware.MEM_MULTIPLE
         return HardwarePreset(
             name=config.hardware_preset_name,
             cpu_cores=hardware.cap_cpus(config.num_cores),
-            memory=hardware.cap_memory(config.max_memory_size * scale) // scale,
-            disk=hardware.cap_disk(config.max_resource_size * scale) // scale,
+            memory=hardware.cap_memory(config.max_memory_size),
+            disk=hardware.cap_disk(config.max_resource_size),
         )
 
     @classmethod

--- a/tests/golem/docker/test_hyperv.py
+++ b/tests/golem/docker/test_hyperv.py
@@ -151,7 +151,7 @@ class TestHyperVHypervisor(TestCase):
             'NumberOfProcessors': 1,
         }
         mem_settings = dict()
-        mem_settings['Limit'] = 2048
+        mem_settings['Reservation'] = 2048
         get_memory.return_value = mem_settings
 
         #  WHEN

--- a/tests/golem/hardware/test_presets.py
+++ b/tests/golem/hardware/test_presets.py
@@ -127,3 +127,17 @@ class TestHardwarePresets(testutils.DatabaseFixture):
         assert HardwarePresets.update_config(DEFAULT, self.config)
         assert self.config.max_resource_size == 7e9
         assert not HardwarePresets.update_config(DEFAULT, self.config)
+
+    def test_from_config(self, *_):
+        config = ClientConfigDescriptor()
+        config.hardware_preset_name = 'test'
+        config.num_cores = 4
+        config.max_memory_size = 4 * 1024 * 1024  # 4 GiB in kiB
+        config.max_resource_size = 10 * 1024 * 1024  # 10 GiB in kiB
+
+        preset = HardwarePresets.from_config(config)
+
+        self.assertEqual(preset.name, 'test')
+        self.assertEqual(preset.cpu_cores, 4)
+        self.assertEqual(preset.memory, 4 * 1024 * 1024)
+        self.assertEqual(preset.disk, 10 * 1024 * 1024)


### PR DESCRIPTION
### Fixed retrieving memory constraint for Hyper-V

The proper field for assigned memory is `'Reservation'` while `'Limit'` is the maximum memory available for the VM if dynamic memory is enabled.

###  Fixed memory units in `HardwarePresets.from_config()`

Both `HardwarePreset` and `ClientConfigDescriptor` use kilobytes as memory units so no scaling is necessary here. It caused memory and disk to be reduced (by order of 1024) every time when `Client.change_config()` was called.

Close #3800 