### PR TITLE
fix retry_until_timeout() for batch transfers

### DIFF
--- a/scripts/concent_acceptance_tests/force_payment/test_payment.py
+++ b/scripts/concent_acceptance_tests/force_payment/test_payment.py
@@ -317,7 +317,7 @@ class RequestorPaysTest(ForcePaymentBase):
         self.requestor_sci.on_transaction_confirmed(tx_hash, _on_batch)
         sys.stderr.write('Waiting for confirmation %s' % (tx_hash,))
         self.retry_until_timeout(
-            lambda: confirmed,
+            lambda: not confirmed,
             'Batch transfer timeout',
         )
         sys.stderr.write('\n')


### PR DESCRIPTION
No issue for that, just simple acceptance tests fix