### PR TITLE
Skip updating HW presets when no preset name is provided

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -1070,7 +1070,13 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
 
     def change_config(self, new_config_desc, run_benchmarks=False):
         self.config_desc = self.config_approver.change_config(new_config_desc)
-        if self._update_hw_preset:
+
+        hw_preset_present = bool(getattr(
+            new_config_desc,
+            'hardware_preset_name',
+            None,
+        ))
+        if self._update_hw_preset and hw_preset_present:
             self._update_hw_preset(
                 HardwarePresets.from_config(self.config_desc))
 

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -762,6 +762,9 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
         c.update_setting('node_name', new_node_name)
         self.assertEqual(c.get_setting('node_name'), new_node_name)
         self.assertEqual(c.get_settings()['node_name'], new_node_name)
+        c._update_hw_preset.assert_not_called()
+
+        c.update_setting('hardware_preset_name', 'custom')
         c._update_hw_preset.assert_called_once()
 
         newer_node_name = str(uuid.uuid4())


### PR DESCRIPTION
Prevents unintended hardware preset updates during startup that may cause VM to restart.

Observed on Windows 10 Pro (1803) + Hyper-V.