### PR TITLE
Removed raising KeyError in ActionTimers

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -1171,8 +1171,9 @@ class TaskManager(TaskEventListener):
         computation_time = ProviderComputeTimers.time(subtask_id)
 
         if not computation_time:
-            raise ValueError("Invalid value for computation_time: "
-                             f"{computation_time}")
+            logger.warning("Could not obtain computation time for subtask: %r",
+                           subtask_id)
+            return
 
         computation_time = int(round(computation_time))
 
@@ -1202,7 +1203,8 @@ class TaskManager(TaskEventListener):
         computation_time = ProviderComputeTimers.time(subtask_id)
 
         if not computation_time:
-            raise ValueError("computation_time cannot be equal to "
-                             f"{computation_time}")
+            logger.warning("Could not obtain computation time for subtask: %r",
+                           subtask_id)
+            return
 
         update_provider_efficiency(node_id, timeout, computation_time)

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -547,9 +547,9 @@ class TaskManager(TaskEventListener):
             self.subtask2task_mapping[new_subtask_id] = \
                 new_task_id
             self.__add_subtask_to_tasks_states(
-                node_name=None,
-                node_id=None,
-                address=None,
+                node_name='',
+                node_id='',
+                address='',
                 price=0,
                 ctd=extra_data.ctd)
             new_subtasks_ids.append(new_subtask_id)

--- a/golem/task/timer.py
+++ b/golem/task/timer.py
@@ -1,7 +1,7 @@
 import logging
 import math
 import time
-from typing import ClassVar, Optional, Dict, Tuple
+from typing import ClassVar, Optional, Dict
 
 logger = logging.getLogger(__name__)
 
@@ -79,9 +79,12 @@ class ActionTimers:
 
     def time(self, identifier: str) -> Optional[float]:
         """ Returns time spent on an action; None if action hasn't
-            been finished yet. Throws a KeyError if identifier is not known.
+            been finished yet or if the identifier is not known.
         """
-        return self._history[identifier].time
+        try:
+            return self._history[identifier].time
+        except KeyError:
+            return None
 
     def start(self, identifier: str) -> None:
         """ Initializes the start and finished (= None) timestamps.
@@ -103,10 +106,13 @@ class ActionTimers:
             timer.finish()
 
     def remove(self, identifier: str) -> Optional[float]:
-        """ Removes the identifier from history. Throws a KeyError if identifier
+        """ Removes the identifier from history. Returns None if the identifier
             is not known.
         """
-        return self._history.pop(identifier).time
+        try:
+            return self._history.pop(identifier).time
+        except KeyError:
+            return None
 
 
 ProviderTimer = ThirstTimer()  # noqa

--- a/tests/golem/task/test_timer.py
+++ b/tests/golem/task/test_timer.py
@@ -93,8 +93,7 @@ class TestActionTimers(unittest.TestCase):
         timer = ActionTimers()
         identifier = str(uuid.uuid4())
 
-        with self.assertRaises(KeyError):
-            assert timer.time(identifier) is None
+        assert timer.time(identifier) is None
 
         timer.start(identifier)
         frozen_time.tick(timedelta(seconds=5))
@@ -110,15 +109,13 @@ class TestActionTimers(unittest.TestCase):
         timer = ActionTimers()
         identifier = str(uuid.uuid4())
 
-        with self.assertRaises(KeyError):
-            timer.remove(identifier)
+        timer.remove(identifier)
 
         timer.start(identifier)
         frozen_time.tick(timedelta(seconds=5))
         assert timer.remove(identifier) is None
 
-        with self.assertRaises(KeyError):
-            timer.remove(identifier)
+        timer.remove(identifier)
 
         timer.start(identifier)
         frozen_time.tick(timedelta(seconds=5))


### PR DESCRIPTION
Fixes: #3790

This changes the default behaviour of action timers to return None rather than raise a KeyError when retrieving and removing timers for a specific identifier (e.g. subtask ID).

In cases where a task with completed subtasks was restarted, the finished subtasks were erronously interpreted as failed. This was caused by the new subtask IDs not registered in action timers.