### PR TITLE
Add check that only peers with valid address are returned

### DIFF
--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -662,7 +662,9 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
                 })
             return [_mapper_session(session) for session in neighbours]
 
-        neighbours = self.peer_keeper.neighbours(node_key_id, alpha)
+        node_neighbours: List[dt_p2p.Node] = self.peer_keeper.neighbours(
+            node_key_id, alpha
+        )
 
         def _mapper(peer: dt_p2p.Node) -> dt_p2p.Peer:
             return dt_p2p.Peer({
@@ -671,7 +673,8 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
                 "node": peer,
             })
 
-        return [_mapper(peer) for peer in neighbours]
+        return [_mapper(peer) for peer in node_neighbours if
+                self._is_address_valid(peer.prv_addr, peer.prv_port)]
 
     # Resource functions
     #############################

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -114,9 +114,17 @@ class TestP2PService(TestDatabaseWithReactor):
             prv_port=random.randint(1, 2 ** 16 - 1),
             pub_port=random.randint(1, 2 ** 16 - 1),
         )
+        neighbour_node_with_invalid_port = dt_p2p_factory.Node(
+            prv_addr=fake.ipv4(),
+            pub_addr=fake.ipv4(),
+            prv_port=None,
+        )
         self.service.peer_keeper.neighbours = mock.MagicMock(
             return_value=[
                 neighbour_node,
+                neighbour_node_with_invalid_port,
+
+
             ])
         expected = [{
             'address': neighbour_node.prv_addr,


### PR DESCRIPTION
(probably) resolves: https://github.com/golemfactory/golem/issues/3817

I was not able to reproduce the issue, but it seems that this check will prevent the issue from happening again