### PR TITLE
Added -PasswordNeverExpires flag to New-LocalUser

### DIFF
--- a/scripts/docker/prepare-docker-for-windows.ps1
+++ b/scripts/docker/prepare-docker-for-windows.ps1
@@ -23,7 +23,7 @@ if( ! $currentGolemUser )
 {
     "Creating local user"
     $securePassword = ConvertTo-SecureString $golemUserName -AsPlainText -Force
-    New-LocalUser -Name $golemUserName -Password $securePassword -Description "Account to use docker with golem." -AccountNeverExpires
+    New-LocalUser -Name $golemUserName -Password $securePassword -Description "Account to use docker with golem." -AccountNeverExpires -PasswordNeverExpires
     "Local user created"
 }
 # TODO: set execution policy here?


### PR DESCRIPTION
Password for `golem-docker` user would expire after some time thus making SMB authentication to fail. This bug was supposed to be fixed by `-AccountNeverExpires` flag but apparently it was the wrong flag.