### PR TITLE
Prevent loading default clean interval from old config

### DIFF
--- a/golem/appconfig.py
+++ b/golem/appconfig.py
@@ -65,8 +65,9 @@ RESOURCE_SESSION_TIMEOUT = 600
 WAITING_FOR_TASK_SESSION_TIMEOUT = 20
 FORWARDED_SESSION_REQUEST_TIMEOUT = 30
 CLEAN_RESOURES_OLDER_THAN_SECS = 3*24*60*60     # 3 days
+CLEAN_TASKS_OLDER_THAN_SECONDS = 3*24*60*60     # 3 days
 # FIXME Issue #3862
-CLEAN_TASKS_OLDER_THAN_SECONDS = 0              # Do not remove old tasks
+CLEANING_ENABLED = 0
 
 # Default max price per hour
 MAX_PRICE = int(1.0 * denoms.ether)
@@ -169,6 +170,7 @@ class AppConfig:
             forwarded_session_request_timeout=FORWARDED_SESSION_REQUEST_TIMEOUT,
             clean_resources_older_than_seconds=CLEAN_RESOURES_OLDER_THAN_SECS,
             clean_tasks_older_than_seconds=CLEAN_TASKS_OLDER_THAN_SECONDS,
+            cleaning_enabled=CLEANING_ENABLED,
             debug_third_party=DEBUG_THIRD_PARTY,
             # network masking
             net_masking_enabled=NET_MASKING_ENABLED,

--- a/golem/client.py
+++ b/golem/client.py
@@ -170,7 +170,9 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
 
         clean_resources_older_than = \
             self.config_desc.clean_resources_older_than_seconds
-        if clean_resources_older_than > 0:
+        cleaning_enabled = self.config_desc.cleaning_enabled
+        if cleaning_enabled and clean_resources_older_than > 0:
+            logger.debug('Starting resource cleaner service ...')
             self._services.append(
                 ResourceCleanerService(
                     self,
@@ -398,7 +400,8 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
 
         clean_tasks_older_than = \
             self.config_desc.clean_tasks_older_than_seconds
-        if clean_tasks_older_than > 0:
+        cleaning_enabled = self.config_desc.cleaning_enabled
+        if cleaning_enabled and clean_tasks_older_than > 0:
             self.clean_old_tasks()
 
         resource_manager = HyperdriveResourceManager(
@@ -416,7 +419,8 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         self.task_server.restore_resources()
 
         # Start service after restore_resources() to avoid race conditions
-        if clean_tasks_older_than:
+        if cleaning_enabled and clean_tasks_older_than > 0:
+            logger.debug('Starting task cleaner service ...')
             task_cleaner_service = TaskCleanerService(
                 client=self,
                 interval_seconds=max(1, clean_tasks_older_than // 10)

--- a/golem/clientconfigdescriptor.py
+++ b/golem/clientconfigdescriptor.py
@@ -40,6 +40,7 @@ class ClientConfigDescriptor(object):
         self.resource_session_timeout = 0
         self.clean_resources_older_than_seconds = 0
         self.clean_tasks_older_than_seconds = 0
+        self.cleaning_enabled = 0
         self.offer_pooling_interval = 0.0
 
         self.node_snapshot_interval = 0.0

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -210,6 +210,24 @@ class TestClient(TestClientBase):
         self.client.db = None
         self.client.quit()
 
+    @patch('golem.client.TaskCleanerService.start')
+    def test_task_cleaning_disabled(self, task_cleaner, *_):
+        self.client.config_desc.cleaning_enabled = 0
+        self.client.config_desc.clean_tasks_older_than_seconds = 0
+
+        self.client.start_network()
+
+        task_cleaner.assert_not_called()
+
+    @patch('golem.client.TaskCleanerService.start')
+    def test_task_cleaning_enabled(self, task_cleaner, *_):
+        self.client.config_desc.cleaning_enabled = 1
+        self.client.config_desc.clean_tasks_older_than_seconds = 1
+
+        self.client.start_network()
+
+        task_cleaner.assert_called()
+
     def test_collect_gossip(self, *_):
         self.client.start_network()
         self.client.collect_gossip()


### PR DESCRIPTION
Related to: #3862

Adds a client config field which controls whether tasks and resources
should be cleaned periodically based on their age. This ensures that
deleting outdated tasks is disabled by default, regardless of the client
config from previous versions.