### PR TITLE
Add `sleep` in `RequestorPaysTest` tests

### DIFF
--- a/scripts/concent_acceptance_tests/base.py
+++ b/scripts/concent_acceptance_tests/base.py
@@ -367,8 +367,7 @@ class SCIBaseTest(ConcentBaseTest):
 
         if sci.get_deposit_value(sci.get_eth_address()) < amount:
             raise RuntimeError("Deposit failed")
-        sys.stderr.write('Long sleep. hrrrr\n')
-        time.sleep(120)
+        self._blockchain_sleep(120)
         dump_balance(sci)
 
     def requestor_put_deposit(self, price: int):
@@ -381,3 +380,8 @@ class SCIBaseTest(ConcentBaseTest):
     def provider_put_deposit(self, price: int):
         amount, _ = helpers.provider_deposit_amount(price)
         return self.put_deposit(self.provider_sci, amount)
+
+    @staticmethod
+    def _blockchain_sleep(sleep_time=60):
+        sys.stderr.write(f'Going to sleep for: {sleep_time} seconds...\n')
+        time.sleep(sleep_time)

--- a/scripts/concent_acceptance_tests/base.py
+++ b/scripts/concent_acceptance_tests/base.py
@@ -382,6 +382,6 @@ class SCIBaseTest(ConcentBaseTest):
         return self.put_deposit(self.provider_sci, amount)
 
     @staticmethod
-    def _blockchain_sleep(sleep_time=60):
+    def blockchain_sleep(sleep_time=60):
         sys.stderr.write(f'Going to sleep for: {sleep_time} seconds...\n')
         time.sleep(sleep_time)

--- a/scripts/concent_acceptance_tests/force_payment/test_payment.py
+++ b/scripts/concent_acceptance_tests/force_payment/test_payment.py
@@ -321,9 +321,7 @@ class RequestorPaysTest(ForcePaymentBase):
             'Batch transfer timeout',
         )
         sys.stderr.write('\n')
-        sleep_time = 60
-        sys.stderr.write(f'Going to sleep for: {sleep_time}\n')
-        time.sleep(sleep_time)
+        self._blockchain_sleep()
         return LOA, V
 
     def test_requestor_already_paid(self):

--- a/scripts/concent_acceptance_tests/force_payment/test_payment.py
+++ b/scripts/concent_acceptance_tests/force_payment/test_payment.py
@@ -321,6 +321,9 @@ class RequestorPaysTest(ForcePaymentBase):
             'Batch transfer timeout',
         )
         sys.stderr.write('\n')
+        sleep_time = 60
+        sys.stderr.write(f'Going to sleep for: {sleep_time}\n')
+        time.sleep(sleep_time)
         return LOA, V
 
     def test_requestor_already_paid(self):


### PR DESCRIPTION
`RequestorPaysTest` were ocasionally failing, probably due to the fact, that there might be not enough time to synchronize blockchains state after payment transactions