### PR TITLE
Properly break task selection algorithm to ask for subtasks

### DIFF
--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -211,8 +211,8 @@ class TaskServer(
         return self.task_keeper.environments_manager.get_environment_by_id(
             env_id)
 
-    # This method chooses random task from the network to compute on our machine
     def request_task(self) -> Optional[str]:
+        """Chooses random task from network to compute on our machine"""
         theader = self.task_keeper.get_task(self.requested_tasks)
         if theader is None:
             return None
@@ -281,7 +281,7 @@ class TaskServer(
                                                       supported)
         except Exception as err:
             logger.warning("Cannot send request for task: {}".format(err))
-            self.task_keeper.remove_task_header(theader.task_id)
+            self.remove_task_header(theader.task_id)
 
         return None
 
@@ -289,7 +289,7 @@ class TaskServer(
                    price: int) -> bool:
         if not self.task_computer.task_given(ctd):
             return False
-        self.requested_tasks.remove(ctd['task_id'])
+        self.requested_tasks.clear()
         update_requestor_assigned_sum(node_id, price)
         dispatcher.send(
             signal='golem.subtask',
@@ -418,6 +418,7 @@ class TaskServer(
         return True
 
     def remove_task_header(self, task_id) -> bool:
+        self.requested_tasks.discard(task_id)
         return self.task_keeper.remove_task_header(task_id)
 
     def add_task_session(self, subtask_id, session: TaskSession):
@@ -512,6 +513,18 @@ class TaskServer(
         self.task_result_sent(subtask_id)
         self.client.transaction_system.settle_income(
             sender_node_id, subtask_id, settled_ts)
+
+    def subtask_waiting(self, task_id, subtask_id=None):
+        logger.debug(
+            "Requestor waits for subtask results."
+            " task_id=%(task_id)s subtask_id=%(subtask_id)s",
+            {
+                'task_id': task_id,
+                'subtask_id': subtask_id,
+            },
+        )
+        # We can still try to request a subtask for this task next time.
+        self.requested_tasks.discard(task_id)
 
     def subtask_failure(self, subtask_id, err):
         logger.info("Computation for task %r failed: %r.", subtask_id, err)
@@ -1000,22 +1013,6 @@ class TaskServer(
             if sessions[subtask_id].task_computer is not None:
                 sessions[subtask_id].task_computer.session_timeout()
             sessions[subtask_id].dropped()
-
-    def _find_sessions(self, subtask):
-        if subtask in self.task_sessions:
-            return [self.task_sessions[subtask]]
-        for s in set(self.task_sessions_incoming):
-            logger.debug('Checking session: %r', s)
-            if s.subtask_id == subtask:
-                return [s]
-            try:
-                task_id = self.task_manager.subtask2task_mapping[subtask]
-            except KeyError:
-                pass
-            else:
-                if s.task_id == task_id:
-                    return [s]
-        return []
 
     def __send_waiting_results(self):
         for subtask_id in list(self.results_to_send.keys()):

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -131,7 +131,9 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         task_id = task_header.task_id
         ts.add_task_header(task_header)
         self.assertEqual(ts.request_task(), task_id)
+        self.assertIn(task_id, ts.requested_tasks)
         assert ts.remove_task_header(task_id)
+        self.assertNotIn(task_id, ts.requested_tasks)
 
         task_header = get_example_task_header(keys_auth.public_key)
         task_header.task_owner.pub_port = 0
@@ -828,10 +830,9 @@ class TaskServerTaskHeaderTest(TaskServerTestBase):
         self.assertFalse(ts.add_task_header(task_header))
 
 
-
-class TestTaskServer2(TestDatabaseWithReactor, testutils.TestWithClient):
+class TaskServerBase(TestDatabaseWithReactor, testutils.TestWithClient):
     def setUp(self):
-        for parent in self.__class__.__bases__:
+        for parent in TaskServerBase.__bases__:
             parent.setUp(self)
         random.seed()
         self.ccd = self._get_config_desc()
@@ -846,27 +847,17 @@ class TestTaskServer2(TestDatabaseWithReactor, testutils.TestWithClient):
         self.ts.task_computer = MagicMock()
 
     def tearDown(self):
-        for parent in self.__class__.__bases__:
+        for parent in TaskServerBase.__bases__:
             parent.tearDown(self)
 
-    def test_find_sessions(self, *_):
-        subtask_id = str(uuid.uuid4())
+    def _get_config_desc(self):
+        ccd = ClientConfigDescriptor()
+        ccd.root_path = self.path
+        return ccd
 
-        # Empty
-        self.assertEqual([], self.ts._find_sessions(subtask_id))
 
-        # Found task_id
-        task_id = str(uuid.uuid4())
-        session = MagicMock()
-        session.task_id = task_id
-        self.ts.task_manager.subtask2task_mapping[subtask_id] = task_id
-        self.ts.task_sessions_incoming.add(session)
-        self.assertEqual([session], self.ts._find_sessions(subtask_id))
-
-        # Found in task_sessions
-        subtask_session = MagicMock()
-        self.ts.task_sessions[subtask_id] = subtask_session
-        self.assertEqual([subtask_session], self.ts._find_sessions(subtask_id))
+# pylint: disable=too-many-ancestors
+class TestTaskServer2(TaskServerBase):
 
     @patch("golem.task.taskmanager.TaskManager.dump_task")
     @patch("golem.task.taskserver.Trust")
@@ -911,10 +902,15 @@ class TestTaskServer2(TestDatabaseWithReactor, testutils.TestWithClient):
         self.ts.disconnect()
         assert self.ts.task_sessions['task_id'].dropped.called
 
-    def _get_config_desc(self):
-        ccd = ClientConfigDescriptor()
-        ccd.root_path = self.path
-        return ccd
+
+# pylint: disable=too-many-ancestors
+class TestSubtaskWaiting(TaskServerBase):
+    def test_requested_tasks(self, *_):
+        task_id = str(uuid.uuid4())
+        subtask_id = str(uuid.uuid4())
+        self.ts.requested_tasks.add(task_id)
+        self.ts.subtask_waiting(task_id, subtask_id)
+        self.assertNotIn(task_id, self.ts.requested_tasks)
 
 
 class TestRestoreResources(LogTestCase, testutils.DatabaseFixture,


### PR DESCRIPTION
fixes: #3858 

Providers' `TaskServer.requested_tasks` set used to grow potentially infinitely. It wasn't cleared on `CannotAssignTask`.