### PR TITLE
 Enabled frame restarts on finished tasks

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -648,21 +648,6 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         logger.debug('Aborting task "%r" ...', task_id)
         self.task_server.task_manager.abort_task(task_id)
 
-    @rpc_utils.expose('comp.task.subtasks.frame.restart')
-    def restart_frame_subtasks(self, task_id, frame):
-        logger.debug("restarting frame subtasks: task_id = %s, frame = %r",
-                     task_id, frame)
-        task_manager = self.task_server.task_manager
-
-        subtasks: Dict = task_manager.get_frame_subtasks(task_id, frame)
-        if subtasks is None:
-            logger.error("frame has no subtasks (task_id = %s, frame = %r",
-                         task_id, frame)
-            return
-
-        self.funds_locker.add_subtask(task_id, len(subtasks))
-        task_manager.restart_frame_subtasks(task_id, frame)
-
     @rpc_utils.expose('comp.task.subtask.restart')
     def restart_subtask(self, subtask_id):
         logger.debug("restarting subtask %s", subtask_id)

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -556,12 +556,7 @@ class ClientProvider:
                          'task_id=%r, frame=%r', task_id, frame)
             return
 
-        try:
-            task_state = self.client.task_manager.tasks_states[task_id]
-        except KeyError:
-            logger.error('Frame restart failed, unknown task.'
-                         'task_id=%r, frame=%r', task_id, frame)
-            return
+        task_state = self.client.task_manager.tasks_states[task_id]
 
         if task_state.status.is_active():
             for subtask_id in frame_subtasks:

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -889,28 +889,6 @@ class TaskManager(TaskEventListener):
                                  op=SubtaskOp.RESTARTED)
 
     @handle_task_key_error
-    def restart_frame_subtasks(self, task_id, frame):
-        task = self.tasks[task_id]
-        task_state = self.tasks_states[task_id]
-        subtasks = task.get_subtasks(frame)
-
-        if not subtasks:
-            return
-
-        for subtask_id in list(subtasks.keys()):
-            task.restart_subtask(subtask_id)
-            subtask_state = task_state.subtask_states[subtask_id]
-            subtask_state.subtask_status = SubtaskStatus.restarted
-            subtask_state.stderr = "[GOLEM] Restarted"
-            self.notice_task_updated(task_id,
-                                     subtask_id=subtask_id,
-                                     op=SubtaskOp.RESTARTED,
-                                     persist=False)
-
-        task_state.status = TaskStatus.computing
-        self.notice_task_updated(task_id, op=OtherOp.FRAME_RESTARTED)
-
-    @handle_task_key_error
     def abort_task(self, task_id):
         self.tasks[task_id].abort()
         self.tasks_states[task_id].status = TaskStatus.aborted

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -405,26 +405,6 @@ class TestClientRestartSubtasks(TestClientBase):
 
         self.client.task_server = Mock()
 
-    def test_restart_by_frame(self):
-        # given
-        frame_subtasks = {
-            'subtask_id1': Mock(),
-            'subtask_id2': Mock(),
-        }
-        self.client.task_server.task_manager.get_frame_subtasks.return_value = \
-            frame_subtasks
-
-        frame = 10
-
-        # when
-        self.client.restart_frame_subtasks(self.task_id, frame)
-
-        # then
-        self.client.task_server.task_manager.restart_frame_subtasks.\
-            assert_called_with(self.task_id, frame)
-        self.ts.lock_funds_for_payments.assert_called_with(
-            self.subtask_price, len(frame_subtasks))
-
     def test_restart_subtask(self):
         # given
         self.client.task_server.task_manager.get_task_id.return_value = \


### PR DESCRIPTION
Fixes: #3871

This changes the RPC call `comp.task.subtasks.frame.restart` to also work on tasks which are finished. Internally, this method uses the already existing logic for subtask restarts.