### PR TITLE
Do not ban providers on CannotComputeTask (OfferCancelled)

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -199,8 +199,8 @@ class CoreTask(Task):
     def finished_computation(self):
         return self.num_tasks_received == self.total_tasks
 
-    def computation_failed(self, subtask_id):
-        self._mark_subtask_failed(subtask_id)
+    def computation_failed(self, subtask_id, ban_node=True):
+        self._mark_subtask_failed(subtask_id, ban_node)
 
     def computation_finished(self, subtask_id, task_result,
                              verification_finished=None):
@@ -297,7 +297,7 @@ class CoreTask(Task):
         if subtask_info['status'].is_active():
             # TODO Restarted tasks that were waiting for verification should
             # cancel it. Issue #2423
-            self._mark_subtask_restarted(subtask_id)
+            self._mark_subtask_failed(subtask_id)
         elif subtask_info['status'] == SubtaskStatus.finished:
             self._mark_subtask_failed(subtask_id)
             self.num_tasks_received -= 1
@@ -444,22 +444,16 @@ class CoreTask(Task):
             return ""
 
     @handle_key_error
-    def _mark_subtask_restarted(self, subtask_id):
-        logger.debug('_mark_subtask_restarted. subtask_id=%r', subtask_id)
-        self.subtasks_given[subtask_id]['status'] = SubtaskStatus.failure
-        node_id = self.subtasks_given[subtask_id]['node_id']
-        if node_id in self.counting_nodes:
-            self.counting_nodes[node_id].cancel()
-        self.num_failed_subtasks += 1
-
-    @handle_key_error
-    def _mark_subtask_failed(self, subtask_id):
+    def _mark_subtask_failed(self, subtask_id, ban_node: bool = True):
         logger.debug('_mark_subtask_failed. subtask_id=%r', subtask_id)
 
         self.subtasks_given[subtask_id]['status'] = SubtaskStatus.failure
         node_id = self.subtasks_given[subtask_id]['node_id']
         if node_id in self.counting_nodes:
-            self.counting_nodes[node_id].reject()
+            if ban_node:
+                self.counting_nodes[node_id].reject()
+            else:
+                self.counting_nodes[node_id].cancel()
         self.num_failed_subtasks += 1
 
     def get_resources(self):

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -199,7 +199,7 @@ class CoreTask(Task):
     def finished_computation(self):
         return self.num_tasks_received == self.total_tasks
 
-    def computation_failed(self, subtask_id, ban_node=True):
+    def computation_failed(self, subtask_id: str, ban_node: bool = True):
         self._mark_subtask_failed(subtask_id, ban_node)
 
     def computation_finished(self, subtask_id, task_result,

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -297,7 +297,7 @@ class CoreTask(Task):
         if subtask_info['status'].is_active():
             # TODO Restarted tasks that were waiting for verification should
             # cancel it. Issue #2423
-            self._mark_subtask_failed(subtask_id)
+            self._mark_subtask_restarted(subtask_id)
         elif subtask_info['status'] == SubtaskStatus.finished:
             self._mark_subtask_failed(subtask_id)
             self.num_tasks_received -= 1
@@ -442,6 +442,12 @@ class CoreTask(Task):
         except IOError as err:
             logger.error("Can't read file %s: %s", log, err)
             return ""
+
+    @handle_key_error
+    def _mark_subtask_restarted(self, subtask_id):
+        logger.debug('_mark_subtask_restarted. subtask_id=%r', subtask_id)
+        self.subtasks_given[subtask_id]['status'] = SubtaskStatus.restarted
+        self.num_failed_subtasks += 1
 
     @handle_key_error
     def _mark_subtask_failed(self, subtask_id):

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -446,7 +446,7 @@ class CoreTask(Task):
     @handle_key_error
     def _mark_subtask_restarted(self, subtask_id):
         logger.debug('_mark_subtask_restarted. subtask_id=%r', subtask_id)
-        self.subtasks_given[subtask_id]['status'] = SubtaskStatus.restarted
+        self.subtasks_given[subtask_id]['status'] = SubtaskStatus.failure
         node_id = self.subtasks_given[subtask_id]['node_id']
         if node_id in self.counting_nodes:
             self.counting_nodes[node_id].cancel()

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -447,6 +447,9 @@ class CoreTask(Task):
     def _mark_subtask_restarted(self, subtask_id):
         logger.debug('_mark_subtask_restarted. subtask_id=%r', subtask_id)
         self.subtasks_given[subtask_id]['status'] = SubtaskStatus.restarted
+        node_id = self.subtasks_given[subtask_id]['node_id']
+        if node_id in self.counting_nodes:
+            self.counting_nodes[node_id].cancel()
         self.num_failed_subtasks += 1
 
     @handle_key_error

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -444,7 +444,7 @@ class CoreTask(Task):
             return ""
 
     @handle_key_error
-    def _mark_subtask_failed(self, subtask_id, ban_node: bool = True):
+    def _mark_subtask_failed(self, subtask_id: str, ban_node: bool = True):
         logger.debug('_mark_subtask_failed. subtask_id=%r', subtask_id)
 
         self.subtasks_given[subtask_id]['status'] = SubtaskStatus.failure

--- a/apps/rendering/task/framerenderingtask.py
+++ b/apps/rendering/task/framerenderingtask.py
@@ -125,8 +125,8 @@ class FrameRenderingTask(RenderingTask):
         self.last_preview_path = None
 
     @CoreTask.handle_key_error
-    def computation_failed(self, subtask_id):
-        CoreTask.computation_failed(self, subtask_id)
+    def computation_failed(self, subtask_id, ban_node=True):
+        CoreTask.computation_failed(self, subtask_id, ban_node)
         if self.use_frames:
             self._update_frame_task_preview()
             self._update_subtask_frame_status(subtask_id)

--- a/apps/rendering/task/framerenderingtask.py
+++ b/apps/rendering/task/framerenderingtask.py
@@ -125,7 +125,7 @@ class FrameRenderingTask(RenderingTask):
         self.last_preview_path = None
 
     @CoreTask.handle_key_error
-    def computation_failed(self, subtask_id, ban_node=True):
+    def computation_failed(self, subtask_id: str, ban_node: bool = True):
         CoreTask.computation_failed(self, subtask_id, ban_node)
         if self.use_frames:
             self._update_frame_task_preview()

--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -84,7 +84,7 @@ class RenderingTask(CoreTask):
         self.test_task_res_path = None
 
     @CoreTask.handle_key_error
-    def computation_failed(self, subtask_id, ban_node=True):
+    def computation_failed(self, subtask_id: str, ban_node: bool = True):
         super().computation_failed(subtask_id, ban_node)
         self._update_task_preview()
 

--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -84,8 +84,8 @@ class RenderingTask(CoreTask):
         self.test_task_res_path = None
 
     @CoreTask.handle_key_error
-    def computation_failed(self, subtask_id):
-        super().computation_failed(subtask_id)
+    def computation_failed(self, subtask_id, ban_node=True):
+        super().computation_failed(subtask_id, ban_node)
         self._update_task_preview()
 
     def restart(self):

--- a/golem/appconfig.py
+++ b/golem/appconfig.py
@@ -64,6 +64,7 @@ TASK_SESSION_TIMEOUT = 900
 RESOURCE_SESSION_TIMEOUT = 600
 WAITING_FOR_TASK_SESSION_TIMEOUT = 20
 FORWARDED_SESSION_REQUEST_TIMEOUT = 30
+COMPUTATION_CANCELLATION_TIMEOUT = 10.0
 CLEAN_RESOURES_OLDER_THAN_SECS = 3*24*60*60     # 3 days
 CLEAN_TASKS_OLDER_THAN_SECONDS = 3*24*60*60     # 3 days
 # FIXME Issue #3862
@@ -168,6 +169,7 @@ class AppConfig:
             resource_session_timeout=RESOURCE_SESSION_TIMEOUT,
             waiting_for_task_session_timeout=WAITING_FOR_TASK_SESSION_TIMEOUT,
             forwarded_session_request_timeout=FORWARDED_SESSION_REQUEST_TIMEOUT,
+            computation_cancellation_timeout=COMPUTATION_CANCELLATION_TIMEOUT,
             clean_resources_older_than_seconds=CLEAN_RESOURES_OLDER_THAN_SECS,
             clean_tasks_older_than_seconds=CLEAN_TASKS_OLDER_THAN_SECONDS,
             cleaning_enabled=CLEANING_ENABLED,

--- a/golem/clientconfigdescriptor.py
+++ b/golem/clientconfigdescriptor.py
@@ -35,6 +35,7 @@ class ClientConfigDescriptor(object):
         self.task_request_interval = 0.0
         self.waiting_for_task_session_timeout = 0.0
         self.forwarded_session_request_timeout = 0.0
+        self.computation_cancellation_timeout = 0.0
         self.p2p_session_timeout = 0
         self.task_session_timeout = 0
         self.resource_session_timeout = 0

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -199,9 +199,10 @@ class Task(abc.ABC):
         return  # Implement in derived class
 
     @abc.abstractmethod
-    def computation_failed(self, subtask_id):
+    def computation_failed(self, subtask_id: str, ban_node: bool = True):
         """ Inform that computation of a task with given id has failed
         :param subtask_id:
+        :param ban_node: Whether to ban this node from this task
         """
         return  # Implement in derived class
 

--- a/golem/task/taskclient.py
+++ b/golem/task/taskclient.py
@@ -42,6 +42,12 @@ class TaskClient(object):
         with self._lock:
             self._started += 1
 
+    def cancel(self):
+        with self._lock:
+            if self._finishing == self._started:
+                self._finishing = max(self._finishing - 1, 0)
+            self._started = max(self._started - 1, 0)
+
     def finish(self):
         with self._lock:
             self._finishing += 1

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -1,4 +1,3 @@
-import copy
 import logging
 import os
 import pickle
@@ -10,7 +9,6 @@ from pathlib import Path
 from typing import Optional, Dict, List, Iterable
 from zipfile import ZipFile
 
-from golem_messages.datastructures import tasks as dt_tasks
 from golem_messages.message import ComputeTaskDef
 from pydispatch import dispatcher
 from twisted.internet.defer import Deferred
@@ -21,7 +19,6 @@ from apps.core.task.coretask import CoreTask
 from golem.core.common import get_timestamp_utc, HandleForwardedError, \
     HandleKeyError, node_info_str, short_node_id, to_unicode, update_dict
 from golem.manager.nodestatesnapshot import LocalTaskStateSnapshot
-from golem.network.transport.tcpnetwork import SocketAddress
 from golem.ranking.manager.database_manager import update_provider_efficiency, \
     update_provider_efficacy
 from golem.resource.dirmanager import DirManager
@@ -746,33 +743,58 @@ class TaskManager(TaskEventListener):
         return ss
 
     @handle_subtask_key_error
-    def task_computation_failure(self, subtask_id, err):
+    def task_computation_failure(self, subtask_id: str, err: object) -> bool:
         task_id = self.subtask2task_mapping[subtask_id]
-
-        subtask_state = self.tasks_states[task_id].subtask_states[subtask_id]
+        task = self.tasks[task_id]
+        task_state = self.tasks_states[task_id]
+        subtask_state = task_state.subtask_states[subtask_id]
         subtask_status = subtask_state.subtask_status
 
         if not subtask_status.is_computed():
             logger.warning(
-                "TaskFailure for subtask %s when subtask state is %s",
-                subtask_id, subtask_status.value
+                "Subtask %s status cannot be changed from '%s' to '%s'",
+                subtask_id, subtask_status.value, SubtaskStatus.failure,
             )
             self.notice_task_updated(task_id,
                                      subtask_id=subtask_id,
                                      op=OtherOp.UNEXPECTED)
             return False
 
-        self.tasks[task_id].computation_failed(subtask_id)
-        ss = self.tasks_states[task_id].subtask_states[subtask_id]
-        ss.subtask_progress = 1.0
-        ss.subtask_rem_time = 0.0
-        ss.subtask_status = SubtaskStatus.failure
-        ss.stderr = str(err)
+        task.computation_failed(subtask_id)
+
+        subtask_state.subtask_progress = 1.0
+        subtask_state.subtask_rem_time = 0.0
+        subtask_state.subtask_status = SubtaskStatus.failure
+        subtask_state.stderr = str(err)
 
         self.notice_task_updated(task_id,
                                  subtask_id=subtask_id,
                                  op=SubtaskOp.FAILED)
         return True
+
+    @handle_subtask_key_error
+    def task_computation_cancelled(self, subtask_id: str, err: object,
+                                   timeout: float) -> bool:
+        task_id = self.subtask2task_mapping[subtask_id]
+        task_state = self.tasks_states[task_id]
+        subtask_state = task_state.subtask_states[subtask_id]
+        subtask_status = subtask_state.subtask_status
+
+        if subtask_state.time_started + timeout < time.time():
+            return self.task_computation_failure(subtask_id, err)
+
+        if subtask_status.is_computed():
+            self.restart_subtask(subtask_id)
+            return True
+
+        logger.warning(
+            "Subtask %s cannot be cancelled (restarted) with a '%s' status",
+            subtask_id, subtask_status.value
+        )
+        self.notice_task_updated(task_id,
+                                 subtask_id=subtask_id,
+                                 op=OtherOp.UNEXPECTED)
+        return False
 
     def task_result_incoming(self, subtask_id):
         node_id = self.get_node_id_for_subtask(subtask_id)

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -751,10 +751,16 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 msg.subtask_id,
                 msg.reason,
             )
-            self.task_manager.task_computation_failure(
+
+            config = self.task_server.config_desc
+            timeout = config.computation_cancellation_timeout
+
+            self.task_manager.task_computation_cancelled(
                 msg.subtask_id,
-                'Task computation rejected: {}'.format(msg.reason)
+                'Task computation rejected: {}'.format(msg.reason),
+                timeout,
             )
+
         self.dropped()
 
     @history.provider_history

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -59,7 +59,7 @@ class SubtaskState(object):
         self.extra_data = {}
         # FIXME: subtask_rem_time is always equal 0 (#2562)
         self.subtask_rem_time = 0
-        self.subtask_status: Optional[SubtaskStatus] = None
+        self.subtask_status: SubtaskStatus = SubtaskStatus.starting
         self.stdout = ""
         self.stderr = ""
         self.results = []

--- a/tests/apps/core/benchmark/test_benchmarkrunner.py
+++ b/tests/apps/core/benchmark/test_benchmarkrunner.py
@@ -23,7 +23,7 @@ class DummyTask(Task):
                              verification_finished):
         pass
 
-    def computation_failed(self, subtask_id, ban_node=True):
+    def computation_failed(self, subtask_id: str, ban_node: bool = True):
         pass
 
     def verify_subtask(self, subtask_id):

--- a/tests/apps/core/benchmark/test_benchmarkrunner.py
+++ b/tests/apps/core/benchmark/test_benchmarkrunner.py
@@ -23,7 +23,7 @@ class DummyTask(Task):
                              verification_finished):
         pass
 
-    def computation_failed(self, subtask_id):
+    def computation_failed(self, subtask_id, ban_node=True):
         pass
 
     def verify_subtask(self, subtask_id):

--- a/tests/golem/task/dummy/task.py
+++ b/tests/golem/task/dummy/task.py
@@ -241,7 +241,7 @@ class DummyTask(Task):
         """
         self.resource_parts = resource_parts
 
-    def computation_failed(self, subtask_id):
+    def computation_failed(self, subtask_id, ban_node=True):
         print('DummyTask.computation_failed called')
         self.computation_finished(subtask_id, None)
 

--- a/tests/golem/task/dummy/task.py
+++ b/tests/golem/task/dummy/task.py
@@ -241,7 +241,7 @@ class DummyTask(Task):
         """
         self.resource_parts = resource_parts
 
-    def computation_failed(self, subtask_id, ban_node=True):
+    def computation_failed(self, subtask_id: str, ban_node: bool = True):
         print('DummyTask.computation_failed called')
         self.computation_finished(subtask_id, None)
 

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -677,11 +677,11 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
                                                   "computing another task",
                                                   timeout)
         ss = self.tm.tasks_states["xyz"].subtask_states["aabbcc"]
-        assert ss.subtask_status == SubtaskStatus.restarted
+        assert ss.subtask_status == SubtaskStatus.failure
         assert not self.tm.task_computation_cancelled("aabbcc",
                                                       "computing another task",
                                                       timeout)
-        checker([("xyz", "aabbcc", SubtaskOp.RESTARTED),
+        checker([("xyz", "aabbcc", SubtaskOp.FAILED),
                  ("xyz", "aabbcc", OtherOp.UNEXPECTED)])
         del handler
 

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -228,7 +228,7 @@ class TaskSessionTaskToComputeTest(TestCase):
             reason=message.tasks.CannotComputeTask.REASON.WrongCTD,
             task_to_compute=None,
         ))
-        assert ts2.task_manager.task_computation_failure.called
+        assert ts2.task_manager.task_computation_cancelled.called
 
     def test_cannot_compute_task_bad_subtask_id(self):
         ts2 = self._get_requestor_tasksession()


### PR DESCRIPTION
Computation can be cancelled in a 10 second window, counting from computation start timestamp on requestor's side.

Addresses https://github.com/golemfactory/golem/issues/3900