### PR TITLE
Try explicit exit 0 at the end of the script

### DIFF
--- a/scripts/docker/prepare-docker-for-windows.ps1
+++ b/scripts/docker/prepare-docker-for-windows.ps1
@@ -100,3 +100,5 @@ if( ! $firewallRule )
         exit 1
     }
 }
+
+exit 0


### PR DESCRIPTION
When it reaches the end of this script without errors it is a success.

This is to suppress some warning that generates exit code 3 instead