### PR TITLE
Fix GNT conversion when there's GNT top up in the meantime

### DIFF
--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -15,6 +15,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Tuple,
 )
 
 from ethereum.utils import denoms
@@ -108,7 +109,8 @@ class TransactionSystem(LoopingCallService):
         self._payment_processor: Optional[PaymentProcessor] = None
 
         self._gnt_faucet_requested = False
-        self._gnt_conversion_status = (ConversionStatus.NONE, None)
+        self._gnt_conversion_status: Tuple[ConversionStatus, Optional[str]] = \
+            (ConversionStatus.NONE, None)
         self._concent_withdraw_requested = False
 
         self._eth_balance: int = 0

--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -108,7 +108,7 @@ class TransactionSystem(LoopingCallService):
         self._payment_processor: Optional[PaymentProcessor] = None
 
         self._gnt_faucet_requested = False
-        self._gnt_conversion_status = ConversionStatus.NONE
+        self._gnt_conversion_status = (ConversionStatus.NONE, None)
         self._concent_withdraw_requested = False
 
         self._eth_balance: int = 0
@@ -206,7 +206,8 @@ class TransactionSystem(LoopingCallService):
         gate_address = self._sci.get_gate_address()
         if gate_address is not None:
             if self._sci.get_gnt_balance(gate_address):
-                self._gnt_conversion_status = ConversionStatus.UNFINISHED
+                self._gnt_conversion_status = \
+                    (ConversionStatus.UNFINISHED, None)
 
         self._payment_processor = PaymentProcessor(self._sci)
         self._eth_per_payment = self._current_eth_per_payment()
@@ -756,9 +757,9 @@ class TransactionSystem(LoopingCallService):
     @sci_required()
     def _try_convert_gnt(self) -> None:  # pylint: disable=too-many-branches
         self._sci: SmartContractsInterface
-        if self._gnt_conversion_status == ConversionStatus.UNFINISHED:
+        if self._gnt_conversion_status[0] == ConversionStatus.UNFINISHED:
             if self._gnt_balance > 0:
-                self._gnt_conversion_status = ConversionStatus.NONE
+                self._gnt_conversion_status = (ConversionStatus.NONE, None)
             else:
                 gas_cost = self.gas_price * \
                     self._sci.GAS_TRANSFER_FROM_GATE
@@ -768,7 +769,8 @@ class TransactionSystem(LoopingCallService):
                         "Finishing previously started GNT conversion %s",
                         tx_hash,
                     )
-                    self._gnt_conversion_status = ConversionStatus.TRANSFERRING
+                    self._gnt_conversion_status = \
+                        (ConversionStatus.TRANSFERRING, tx_hash)
                 else:
                     log.info(
                         "Not enough gas to finish GNT conversion, has %.6f,"
@@ -777,26 +779,35 @@ class TransactionSystem(LoopingCallService):
                         gas_cost / denoms.ether,
                     )
             return
+        if self._gnt_conversion_status[0] == ConversionStatus.TRANSFERRING:
+            receipt = self._sci.get_transaction_receipt(
+                self._gnt_conversion_status[1],
+            )
+            if receipt is None:
+                return
+            self._gnt_conversion_status = (ConversionStatus.NONE, None)
+
         if self._gnt_balance == 0:
-            self._gnt_conversion_status = ConversionStatus.NONE
             return
 
         gas_price = self.gas_price
         gate_address = self._sci.get_gate_address()
         if gate_address is None:
+            if self._gnt_conversion_status[0] == ConversionStatus.OPENING_GATE:
+                return
             gas_cost = gas_price * self._sci.GAS_OPEN_GATE
-            if self._gnt_conversion_status != ConversionStatus.OPENING_GATE:
-                if self._eth_balance >= gas_cost:
-                    tx_hash = self._sci.open_gate()
-                    log.info("Opening GNT-GNTB conversion gate %s", tx_hash)
-                    self._gnt_conversion_status = ConversionStatus.OPENING_GATE
-                else:
-                    log.info(
-                        "Not enough gas for opening conversion gate, has: %.6f,"
-                        " needed: %.6f",
-                        self._eth_balance / denoms.ether,
-                        gas_cost / denoms.ether,
-                    )
+            if self._eth_balance >= gas_cost:
+                tx_hash = self._sci.open_gate()
+                log.info("Opening GNT-GNTB conversion gate %s", tx_hash)
+                self._gnt_conversion_status = \
+                    (ConversionStatus.OPENING_GATE, None)
+            else:
+                log.info(
+                    "Not enough gas for opening conversion gate, has: %.6f,"
+                    " needed: %.6f",
+                    self._eth_balance / denoms.ether,
+                    gas_cost / denoms.ether,
+                )
             return
 
         # This is extra safety check, shouldn't ever happen
@@ -804,30 +815,30 @@ class TransactionSystem(LoopingCallService):
             log.critical('Gate address should not equal to %s', gate_address)
             return
 
-        if self._gnt_conversion_status == ConversionStatus.OPENING_GATE:
-            self._gnt_conversion_status = ConversionStatus.NONE
+        if self._gnt_conversion_status[0] == ConversionStatus.OPENING_GATE:
+            self._gnt_conversion_status = (ConversionStatus.NONE, None)
 
         gas_cost = gas_price * \
             (self._sci.GAS_GNT_TRANSFER + self._sci.GAS_TRANSFER_FROM_GATE)
-        if self._gnt_conversion_status != ConversionStatus.TRANSFERRING:
-            if self._eth_balance >= gas_cost:
-                tx_hash1 = \
-                    self._sci.transfer_gnt(gate_address, self._gnt_balance)
-                tx_hash2 = self._sci.transfer_from_gate()
-                log.info(
-                    "Converting %.6f GNT to GNTB %s %s",
-                    self._gnt_balance / denoms.ether,
-                    tx_hash1,
-                    tx_hash2,
-                )
-                self._gnt_conversion_status = ConversionStatus.TRANSFERRING
-            else:
-                log.info(
-                    "Not enough gas for GNT conversion, has: %.6f,"
-                    " needed: %.6f",
-                    self._eth_balance / denoms.ether,
-                    gas_cost / denoms.ether,
-                )
+        if self._eth_balance >= gas_cost:
+            tx_hash1 = \
+                self._sci.transfer_gnt(gate_address, self._gnt_balance)
+            tx_hash2 = self._sci.transfer_from_gate()
+            log.info(
+                "Converting %.6f GNT to GNTB %s %s",
+                self._gnt_balance / denoms.ether,
+                tx_hash1,
+                tx_hash2,
+            )
+            self._gnt_conversion_status = \
+                (ConversionStatus.TRANSFERRING, tx_hash2)
+        else:
+            log.info(
+                "Not enough gas for GNT conversion, has: %.6f,"
+                " needed: %.6f",
+                self._eth_balance / denoms.ether,
+                gas_cost / denoms.ether,
+            )
 
     def _run(self) -> None:
         if not self._payment_processor:

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,7 +33,7 @@ eth-tester==0.1.0-beta.24
 eth-utils==1.0.3
 ethereum==1.6.1
 Golem-Messages==2.24.3
-Golem-Smart-Contracts-Interface==1.6.1
+Golem-Smart-Contracts-Interface==1.7.0
 Golem-Verificator==1.6.3.2
 greenlet==0.4.15
 h2==3.0.1

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -15,7 +15,7 @@ enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
 Golem-Messages==2.24.3
-Golem-Smart-Contracts-Interface==1.6.1
+Golem-Smart-Contracts-Interface==1.7.0
 Golem-Verificator==1.6.3.2
 html2text==2018.1.9
 humanize==0.5.1

--- a/tests/golem/ethereum/test_transactionsystem.py
+++ b/tests/golem/ethereum/test_transactionsystem.py
@@ -216,9 +216,37 @@ class TestTransactionSystem(TransactionSystemBase):
         self.sci.transfer_from_gate.assert_called_once_with()
         self.sci.transfer_gnt.reset_mock()
         self.sci.transfer_from_gate.reset_mock()
+        self.sci.get_gnt_balance.return_value = 0
+        self.ets._refresh_balances()
         self.ets._try_convert_gnt()
         self.sci.transfer_gnt.assert_not_called()
         self.sci.transfer_from_gate.assert_not_called()
+
+    def test_topup_while_convert(self):
+        amount1 = 1000 * denoms.ether
+        amount2 = 2000 * denoms.ether
+        gate_addr = '0x' + 40 * '2'
+        self.sci.get_gate_address.return_value = gate_addr
+        self.sci.get_gnt_balance.return_value = amount1
+        self.sci.get_eth_balance.return_value = denoms.ether
+        self.sci.get_current_gas_price.return_value = 0
+        self.sci.GAS_GNT_TRANSFER = 2
+        self.sci.GAS_TRANSFER_FROM_GATE = 5
+        self.ets._refresh_balances()
+
+        self.ets._try_convert_gnt()
+        self.sci.open_gate.assert_not_called()
+        self.sci.transfer_gnt.assert_called_once_with(gate_addr, amount1)
+        self.sci.transfer_from_gate.assert_called_once_with()
+        self.sci.transfer_gnt.reset_mock()
+        self.sci.transfer_from_gate.reset_mock()
+
+        # Top up with more GNT
+        self.sci.get_gnt_balance.return_value = amount2
+        self.ets._refresh_balances()
+        self.ets._try_convert_gnt()
+        self.sci.transfer_gnt.assert_called_once_with(gate_addr, amount2)
+        self.sci.transfer_from_gate.assert_called_once_with()
 
     def test_unfinished_gnt_conversion(self):
         amount = 1000 * denoms.ether


### PR DESCRIPTION
Previously when one topped up the account twice in quick succession the second amount of GNT would not convert.
That is fixed now.