### PR TITLE
Fix docker scripts [b0.19]

### DIFF
--- a/golem/core/windows.py
+++ b/golem/core/windows.py
@@ -1,7 +1,7 @@
 import subprocess
 from typing import List, Optional
 
-DEFAULT_SCRIPT_TIMEOUT = 5  # seconds
+DEFAULT_SCRIPT_TIMEOUT = 60  # seconds
 
 
 def run_powershell(
@@ -58,4 +58,4 @@ def run_powershell(
         stdout = f"{exc.stdout.decode('utf8')}\n" if exc.stdout else ''
         stderr = exc.stderr.decode('utf8') if exc.stderr else ''
 
-        raise RuntimeError(stdout + stderr)
+        raise RuntimeError(f'{exc}\nstdout: {stdout}\nstderr: {stderr}')

--- a/golem/docker/hypervisor/hyperv.py
+++ b/golem/docker/hypervisor/hyperv.py
@@ -94,7 +94,6 @@ class HyperVHypervisor(DockerMachineHypervisor):
     SCRIPTS_PATH = os.path.join(get_golem_path(), 'scripts', 'docker')
     GET_VSWITCH_SCRIPT_PATH = \
         os.path.join(SCRIPTS_PATH, 'get-default-vswitch.ps1')
-    SCRIPT_TIMEOUT = 5  # seconds
     START_VM_RETRIES = 2  # retries, not start attempts
 
     def __init__(self, *args, **kwargs):
@@ -297,7 +296,8 @@ class HyperVHypervisor(DockerMachineHypervisor):
 
     @classmethod
     def _get_vswitch_name(cls) -> str:
-        return run_powershell(script=cls.GET_VSWITCH_SCRIPT_PATH)
+        return run_powershell(
+            script=cls.GET_VSWITCH_SCRIPT_PATH)
 
     @classmethod
     def _get_hostname_for_sharing(cls) -> str:

--- a/scripts/docker/create-share.ps1
+++ b/scripts/docker/create-share.ps1
@@ -56,11 +56,11 @@ if (Get-SmbShare | Where-Object -Property Name -EQ $SmbShareName) {
 
 "Sharing directory..."
 
-$Command = "New-SmbShare -Name $SmbShareName -Path $SharedDirPath -FullAccess '$env:COMPUTERNAME\$UserName'"
+$Command = "New-SmbShare -Name $SmbShareName -Path '$SharedDirPath' -FullAccess '$env:COMPUTERNAME\$UserName'"
 $Output = (New-TemporaryFile).FullName
 
 $Process = Start-Process -FilePath "powershell.exe" `
-    -ArgumentList "-Command $Command 2>&1 | Out-File -FilePath $Output -Encoding UTF8" `
+    -ArgumentList "-Command $Command 2>&1 | Out-File -FilePath '$Output' -Encoding UTF8" `
     -Wait -PassThru -Verb RunAs
 
 Get-Content -Encoding "UTF8" $Output | Write-Output

--- a/scripts/docker/prepare-docker-for-windows.ps1
+++ b/scripts/docker/prepare-docker-for-windows.ps1
@@ -34,7 +34,7 @@ if( ! $currentGolemUser )
 $createShareScript = $createShareFolder + "create-share.ps1"
 "createShareScript: " + $createShareScript
 
-$golemDataDir = $appDataDir + "golem\golem\default"
+$golemDataDir = $appDataDir + "\golem\golem\default"
 $mainnetDir = $golemDataDir + "\mainnet\ComputerRes"
 "mainnetDir: " + $mainnetDir
 $testnetDir = $golemDataDir + "\rinkeby\ComputerRes"


### PR DESCRIPTION
### Fixed missing backslash in `prepare-docker-for-windows.ps1`

Added missing backslash to `$golemDataDir` path (without the script only worked if `$appDataDir` was provided with a trailing backslash)

 ---

### Fixed missing quotes in `create-share.ps1`

Added missing quotation marks around paths. Without them the script would fail if the username contained whitespace.

---

### Increased timeout for all powershell commands to ~10~ 60 seconds