### PR TITLE
Fix docker scripts

### DIFF
--- a/scripts/docker/create-share.ps1
+++ b/scripts/docker/create-share.ps1
@@ -56,11 +56,11 @@ if (Get-SmbShare | Where-Object -Property Name -EQ $SmbShareName) {
 
 "Sharing directory..."
 
-$Command = "New-SmbShare -Name $SmbShareName -Path $SharedDirPath -FullAccess '$env:COMPUTERNAME\$UserName'"
+$Command = "New-SmbShare -Name $SmbShareName -Path '$SharedDirPath' -FullAccess '$env:COMPUTERNAME\$UserName'"
 $Output = (New-TemporaryFile).FullName
 
 $Process = Start-Process -FilePath "powershell.exe" `
-    -ArgumentList "-Command $Command 2>&1 | Out-File -FilePath $Output -Encoding UTF8" `
+    -ArgumentList "-Command $Command 2>&1 | Out-File -FilePath '$Output' -Encoding UTF8" `
     -Wait -PassThru -Verb RunAs
 
 Get-Content -Encoding "UTF8" $Output | Write-Output

--- a/scripts/docker/prepare-docker-for-windows.ps1
+++ b/scripts/docker/prepare-docker-for-windows.ps1
@@ -45,7 +45,7 @@ function EnsureShare {
     "Ensure Shared folder"
     md $folder -Force
     "Folder created, create share"
-    PowerShell.exe -WindowStyle hidden -File "$createShareScript" "$golemUserName" "$folder"
+    &"$createShareScript" "$golemUserName" "$folder"
     "Share created"
 }
 

--- a/scripts/docker/prepare-docker-for-windows.ps1
+++ b/scripts/docker/prepare-docker-for-windows.ps1
@@ -34,7 +34,7 @@ if( ! $currentGolemUser )
 $createShareScript = $createShareFolder + "create-share.ps1"
 "createShareScript: " + $createShareScript
 
-$golemDataDir = $appDataDir + "golem\golem\default"
+$golemDataDir = $appDataDir + "\golem\golem\default"
 $mainnetDir = $golemDataDir + "\mainnet\ComputerRes"
 "mainnetDir: " + $mainnetDir
 $testnetDir = $golemDataDir + "\rinkeby\ComputerRes"


### PR DESCRIPTION
### Revert 3870850

Changed PowerShell.exe invocation back to simple `&` because it was not needed after all and it made the terminal close after running the script, which was quite inconvenient.

---

### Fixed missing backslash in `prepare-docker-for-windows.ps1`

Added missing backslash to `$golemDataDir` path (without the script only worked if `$appDataDir` was provided with a trailing backslash)

---

###  Fixed missing quotes in `create-share.ps1`

Added missing quotation marks around paths. Without them the script would fail if the username contained whitespace.