### PR TITLE
Use res_id instead task_id in ResourceManager

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -611,14 +611,11 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         if self.db:
             self.db.close()
 
-    def task_resource_send(self, task_id):
-        self.task_server.task_manager.resources_send(task_id)
+    def resource_collected(self, res_id):
+        self.task_server.task_computer.resource_collected(res_id)
 
-    def task_resource_collected(self, task_id):
-        self.task_server.task_computer.task_resource_collected(task_id)
-
-    def task_resource_failure(self, task_id, reason):
-        self.task_server.task_computer.task_resource_failure(task_id, reason)
+    def resource_failure(self, res_id, reason):
+        self.task_server.task_computer.resource_failure(res_id, reason)
 
     @rpc_utils.expose('comp.tasks.check.abort')
     def abort_test_task(self) -> bool:

--- a/golem/resource/base/resourceserver.py
+++ b/golem/resource/base/resourceserver.py
@@ -100,7 +100,7 @@ class BaseResourceServer(object):
             collected = not self.pending_resources.get(res_id)
 
         if collected:
-            self.client.task_resource_collected(res_id)
+            self.client.resource_collected(res_id)
 
     def _add_pending_resource(self, resource, res_id, client_options):
         if res_id not in self.pending_resources:
@@ -156,7 +156,7 @@ class BaseResourceServer(object):
 
     def _download_error(self, error, resource, res_id):
         self._remove_pending_resource(resource, res_id)
-        self.client.task_resource_failure(res_id, error)
+        self.client.resource_failure(res_id, error)
 
     def _extract_resources(self, resource, res_id):
         resource_dir = self.resource_manager.storage.get_dir(res_id)
@@ -174,7 +174,7 @@ class BaseResourceServer(object):
 
         async_req = golem_async.AsyncRequest(extract_packages, resource[1])
         golem_async.async_run(async_req).addCallbacks(
-            lambda _: self.client.task_resource_collected(res_id),
+            lambda _: self.client.resource_collected(res_id),
             lambda e: self._download_error(e, resource, res_id)
         )
 

--- a/golem/resource/base/resourceserver.py
+++ b/golem/resource/base/resourceserver.py
@@ -21,9 +21,9 @@ class TransferStatus(Enum):
 
 class PendingResource(object):
 
-    def __init__(self, resource, task_id, client_options, status):
+    def __init__(self, resource, res_id, client_options, status):
         self.resource = resource
-        self.task_id = task_id
+        self.res_id = res_id
         self.client_options = client_options
         self.status = status
 
@@ -59,25 +59,25 @@ class BaseResourceServer(object):
     def sync_network(self):
         self._download_resources()
 
-    def add_task(self, pkg_path, pkg_sha1, task_id, pkg_size,  # noqa pylint:disable=too-many-arguments
+    def add_resources(self, pkg_path, pkg_sha1, res_id, pkg_size,  # noqa pylint:disable=too-many-arguments
                  client_options=None) -> Deferred:
         _result = Deferred()
-        _result.addErrback(self._add_task_error)
+        _result.addErrback(self._add_res_error)
 
         def callback(r):
             value = r, pkg_path, pkg_sha1, pkg_size
             _result.callback(value)
 
         _deferred = self.resource_manager.add_resources(
-            [pkg_path], task_id, client_options=client_options)
+            [pkg_path], res_id, client_options=client_options)
         _deferred.addCallback(callback)
         _deferred.addErrback(_result.errback)
 
         return _result
 
-    def create_resource_package(self, files, task_id) -> Deferred:
-        resource_dir = self.resource_manager.storage.get_dir(task_id)
-        package_path = os.path.join(resource_dir, task_id)
+    def create_resource_package(self, files, res_id) -> Deferred:
+        resource_dir = self.resource_manager.storage.get_dir(res_id)
+        package_path = os.path.join(resource_dir, res_id)
         request = golem_async.AsyncRequest(
             self.packager.create,
             package_path, files,
@@ -85,34 +85,34 @@ class BaseResourceServer(object):
         return golem_async.async_run(request)
 
     @staticmethod
-    def _add_task_error(error):
-        logger.error("Resource server: add_task error: %r", error)
+    def _add_res_error(error):
+        logger.error("Resource server: add_resources error: %r", error)
         return error  # continue with the errback chain
 
-    def remove_task(self, task_id):
-        self.resource_manager.remove_resources(task_id)
+    def remove_resources(self, res_id):
+        self.resource_manager.remove_resources(res_id)
 
-    def download_resources(self, resources, task_id, client_options=None):
+    def download_resources(self, resources, res_id, client_options=None):
         with self._lock:
             for resource in resources:
-                self._add_pending_resource(resource, task_id, client_options)
+                self._add_pending_resource(resource, res_id, client_options)
 
-            collected = not self.pending_resources.get(task_id)
+            collected = not self.pending_resources.get(res_id)
 
         if collected:
-            self.client.task_resource_collected(task_id)
+            self.client.task_resource_collected(res_id)
 
-    def _add_pending_resource(self, resource, task_id, client_options):
-        if task_id not in self.pending_resources:
-            self.pending_resources[task_id] = []
+    def _add_pending_resource(self, resource, res_id, client_options):
+        if res_id not in self.pending_resources:
+            self.pending_resources[res_id] = []
 
-        self.pending_resources[task_id].append(PendingResource(
-            resource, task_id, client_options, TransferStatus.idle
+        self.pending_resources[res_id].append(PendingResource(
+            resource, res_id, client_options, TransferStatus.idle
         ))
 
-    def _remove_pending_resource(self, resource, task_id):
+    def _remove_pending_resource(self, resource, res_id):
         with self._lock:
-            pending_resources = self.pending_resources.get(task_id, [])
+            pending_resources = self.pending_resources.get(res_id, [])
 
             for i, pending_resource in enumerate(pending_resources):
                 if pending_resource.resource == resource:
@@ -120,8 +120,8 @@ class BaseResourceServer(object):
                     break
 
         if not pending_resources:
-            self.pending_resources.pop(task_id, None)
-            return task_id
+            self.pending_resources.pop(res_id, None)
+            return res_id
 
     def _download_resources(self, async_=True):
         download_statuses = [TransferStatus.idle, TransferStatus.failed]
@@ -135,31 +135,31 @@ class BaseResourceServer(object):
                 entry.status = TransferStatus.transferring
 
                 self.resource_manager.pull_resource(
-                    entry.resource, entry.task_id,
+                    entry.resource, entry.res_id,
                     client_options=entry.client_options,
                     success=self._download_success,
                     error=self._download_error,
                     async_=async_
                 )
 
-    def _download_success(self, resource, _, task_id):
+    def _download_success(self, resource, _, res_id):
         if not resource:
             self._download_error("Downloaded an empty resource package",
-                                 resource, task_id)
+                                 resource, res_id)
             return
 
-        if not self._remove_pending_resource(resource, task_id):
-            logger.warning("Resources for task %r were re-downloaded", task_id)
+        if not self._remove_pending_resource(resource, res_id):
+            logger.warning("Resources for id %r were re-downloaded", res_id)
             return
 
-        self._extract_task_resources(resource, task_id)
+        self._extract_resources(resource, res_id)
 
-    def _download_error(self, error, resource, task_id):
-        self._remove_pending_resource(resource, task_id)
-        self.client.task_resource_failure(task_id, error)
+    def _download_error(self, error, resource, res_id):
+        self._remove_pending_resource(resource, res_id)
+        self.client.task_resource_failure(res_id, error)
 
-    def _extract_task_resources(self, resource, task_id):
-        resource_dir = self.resource_manager.storage.get_dir(task_id)
+    def _extract_resources(self, resource, res_id):
+        resource_dir = self.resource_manager.storage.get_dir(res_id)
         ctk = self.client.task_server.task_manager.comp_task_keeper
 
         def extract_packages(package_files):
@@ -170,12 +170,12 @@ class BaseResourceServer(object):
                 logger.info('Extracting task resource: %r', package_path)
                 self.packager.extract(package_path, resource_dir)
 
-            ctk.add_package_paths(task_id, package_paths)
+            ctk.add_package_paths(res_id, package_paths)
 
         async_req = golem_async.AsyncRequest(extract_packages, resource[1])
         golem_async.async_run(async_req).addCallbacks(
-            lambda _: self.client.task_resource_collected(task_id),
-            lambda e: self._download_error(e, resource, task_id)
+            lambda _: self.client.task_resource_collected(res_id),
+            lambda e: self._download_error(e, resource, res_id)
         )
 
     def start_accepting(self):

--- a/golem/resource/base/resourceserver.py
+++ b/golem/resource/base/resourceserver.py
@@ -68,7 +68,7 @@ class BaseResourceServer(object):
             value = r, pkg_path, pkg_sha1, pkg_size
             _result.callback(value)
 
-        _deferred = self.resource_manager.add_task(
+        _deferred = self.resource_manager.add_resources(
             [pkg_path], task_id, client_options=client_options)
         _deferred.addCallback(callback)
         _deferred.addErrback(_result.errback)
@@ -90,7 +90,7 @@ class BaseResourceServer(object):
         return error  # continue with the errback chain
 
     def remove_task(self, task_id):
-        self.resource_manager.remove_task(task_id)
+        self.resource_manager.remove_resources(task_id)
 
     def download_resources(self, resources, task_id, client_options=None):
         with self._lock:

--- a/golem/resource/hyperdrive/resource.py
+++ b/golem/resource/hyperdrive/resource.py
@@ -134,25 +134,25 @@ class ResourceStorage(object):
         self.resource_dir_method = resource_dir_method
         self.cache = ResourceCache()
 
-    def get_dir(self, task_id):
-        return norm_path(self.resource_dir_method(task_id))
+    def get_dir(self, res_id):
+        return norm_path(self.resource_dir_method(res_id))
 
-    def get_path(self, relative_file_path, task_id):
-        resource_dir = self.get_dir(task_id)
+    def get_path(self, relative_file_path, res_id):
+        resource_dir = self.get_dir(res_id)
         return os.path.join(resource_dir, norm_path(relative_file_path))
 
     def get_root(self):
         return self.dir_manager.get_node_dir()
 
-    def get_resources(self, task_id) -> List[Resource]:
-        return self.cache.get_resources(task_id)
+    def get_resources(self, res_id) -> List[Resource]:
+        return self.cache.get_resources(res_id)
 
     def exists(self, resource):
         return self.cache.has_resource(resource) and resource.exists
 
-    def relative_path(self, path, task_id):
+    def relative_path(self, path, res_id):
         path = norm_path(path)
-        common_prefix = self.cache.get_prefix(task_id)
+        common_prefix = self.cache.get_prefix(res_id)
         return relative_path(path, common_prefix)
 
     def copy_dir(self, src_dir):
@@ -164,10 +164,10 @@ class ResourceStorage(object):
             copy_file_tree(src_dir, root_dir)
             return True
 
-    def copy(self, src_path, dst_relative_path, task_id):
+    def copy(self, src_path, dst_relative_path, res_id):
 
         dst_relative_path = norm_path(dst_relative_path)
-        dst_path = self.get_path(dst_relative_path, task_id)
+        dst_path = self.get_path(dst_relative_path, res_id)
         src_path = norm_path(src_path)
 
         if os.path.isfile(dst_path):

--- a/golem/resource/hyperdrive/resource.py
+++ b/golem/resource/hyperdrive/resource.py
@@ -25,23 +25,23 @@ class ResourceError(RuntimeError):
 
 class Resource:
 
-    __slots__ = ('hash', 'files', 'path', 'task_id')
+    __slots__ = ('hash', 'files', 'path', 'res_id')
 
-    def __init__(self, resource_hash, task_id=None, files=None, path=None):
+    def __init__(self, resource_hash, res_id=None, files=None, path=None):
         self.hash = resource_hash
-        self.task_id = task_id
+        self.res_id = res_id
         self.files = files
         self.path = path
 
     def __eq__(self, other):
         return other and \
-            self.task_id == other.task_id and \
+            self.res_id == other.res_id and \
             self.hash == other.hash and \
             self.path == other.path and \
             self.files == other.files
 
     def __str__(self):
-        return 'Resource(hash: {}, task: {})'.format(self.hash, self.task_id)
+        return 'Resource(hash: {}, id: {})'.format(self.hash, self.res_id)
 
     def __repr__(self):
         return str(self)
@@ -79,7 +79,7 @@ class ResourceCache(object):
         self._task_to_prefix = dict()
 
     def add_resource(self, resource):
-        task_id = resource.task_id
+        task_id = resource.res_id
 
         with self._lock:
             resource_list = self._task_to_res.get(task_id)
@@ -97,7 +97,7 @@ class ResourceCache(object):
         return self._path_to_res.get(resource_path, default)
 
     def has_resource(self, resource):
-        if resource.task_id and resource.task_id not in self._task_to_res:
+        if resource.res_id and resource.res_id not in self._task_to_res:
             return False
         if resource.hash and resource.hash not in self._hash_to_res:
             return False

--- a/golem/resource/hyperdrive/resource.py
+++ b/golem/resource/hyperdrive/resource.py
@@ -73,18 +73,18 @@ class ResourceCache(object):
         self._hash_to_res = dict()
         # path to resource
         self._path_to_res = dict()
-        # task to resources
-        self._task_to_res = dict()
-        # task to resource common prefix
-        self._task_to_prefix = dict()
+        # id to resources
+        self._id_to_res = dict()
+        # id to resource common prefix
+        self._id_to_prefix = dict()
 
     def add_resource(self, resource):
-        task_id = resource.res_id
+        res_id = resource.res_id
 
         with self._lock:
-            resource_list = self._task_to_res.get(task_id)
+            resource_list = self._id_to_res.get(res_id)
             if not resource_list:
-                self._task_to_res[task_id] = resource_list = list()
+                self._id_to_res[res_id] = resource_list = list()
             resource_list.append(resource)
 
             self._hash_to_res[resource.hash] = resource
@@ -97,34 +97,34 @@ class ResourceCache(object):
         return self._path_to_res.get(resource_path, default)
 
     def has_resource(self, resource):
-        if resource.res_id and resource.res_id not in self._task_to_res:
+        if resource.res_id and resource.res_id not in self._id_to_res:
             return False
         if resource.hash and resource.hash not in self._hash_to_res:
             return False
         return resource.path in self._path_to_res
 
-    def get_resources(self, task_id, default=None):
-        return self._task_to_res.get(task_id, default or [])
+    def get_resources(self, res_id, default=None):
+        return self._id_to_res.get(res_id, default or [])
 
-    def set_prefix(self, task_id, prefix):
-        self._task_to_prefix[task_id] = norm_path(prefix)
+    def set_prefix(self, res_id, prefix):
+        self._id_to_prefix[res_id] = norm_path(prefix)
 
-    def get_prefix(self, task_id, default=''):
-        return self._task_to_prefix.get(task_id, default)
+    def get_prefix(self, res_id, default=''):
+        return self._id_to_prefix.get(res_id, default)
 
-    def remove(self, task_id):
-        resources = self._task_to_res.pop(task_id, [])
+    def remove(self, res_id):
+        resources = self._id_to_res.pop(res_id, [])
         for r in resources:
             self._hash_to_res.pop(r.hash, None)
             self._path_to_res.pop(r.path, None)
-        self._task_to_prefix.pop(task_id, None)
+        self._id_to_prefix.pop(res_id, None)
         return resources
 
     def clear(self):
         self._hash_to_res = dict()
         self._path_to_res = dict()
-        self._task_to_res = dict()
-        self._task_to_prefix = dict()
+        self._id_to_res = dict()
+        self._id_to_prefix = dict()
 
 
 class ResourceStorage(object):

--- a/golem/resource/hyperdrive/resourcesmanager.py
+++ b/golem/resource/hyperdrive/resourcesmanager.py
@@ -251,7 +251,7 @@ class HyperdriveResourceManager(ClientHandler):
         :param task_id: Task id that files are associated with
         """
         resource_path = self.storage.get_path('', task_id)
-        resource = Resource(resource_hash, task_id=task_id,
+        resource = Resource(resource_hash, res_id=task_id,
                             files=list(files), path=resource_path)
         self._cache_resource(resource)
 
@@ -274,7 +274,7 @@ class HyperdriveResourceManager(ClientHandler):
                       client=None, client_options=None, async_=True):
 
         resource_path = self.storage.get_path('', task_id)
-        resource = Resource(resource_hash=entry[0], task_id=task_id,
+        resource = Resource(resource_hash=entry[0], res_id=task_id,
                             files=entry[1], path=resource_path)
 
         if resource.files and self.storage.exists(resource):

--- a/golem/resource/hyperdrive/resourcesmanager.py
+++ b/golem/resource/hyperdrive/resourcesmanager.py
@@ -104,63 +104,66 @@ class HyperdriveResourceManager(ClientHandler):
 
         return results
 
-    def get_resources(self, task_id):
-        return self.storage.get_resources(task_id)
+    def get_resources(self, res_id):
+        return self.storage.get_resources(res_id)
 
-    def remove_task(self, task_id):
-        resources = self.storage.cache.remove(task_id)
+    def remove_resources(self, res_id):
+        resources = self.storage.cache.remove(res_id)
         if not resources:
-            raise ResourceError("Resource manager: no resources to remove in "
-                                "task '{}'".format(task_id))
+            raise ResourceError("Resource manager: no resources to remove with "
+                                "id '{}'".format(res_id))
 
-        on_error = partial(log_error, "Error removing task: %r")
+        on_error = partial(log_error, "Error removing resources for id: %r")
         for resource in resources:
             self.client.cancel_async(resource.hash) \
                 .addErrback(on_error)
 
-    @handle_async(on_error=partial(log_error, "Error adding task: %r"))
-    def add_task(self, files, task_id,  # pylint: disable=too-many-arguments
+    @handle_async(on_error=partial(log_error,
+                                   "Error adding resources for id: %r"))
+    def add_resources(self, files, res_id,  # pylint: disable=too-many-arguments
                  resource_hash=None, async_=True, client_options=None):
 
-        prefix = self.storage.cache.get_prefix(task_id)
-        resources = self.storage.get_resources(task_id)
+        prefix = self.storage.cache.get_prefix(res_id)
+        resources = self.storage.get_resources(res_id)
 
         if prefix and resources:
-            logger.warning("Resource manager: Task '%s' exists", task_id)
+            logger.warning("Resource manager: Resources for id '%s' exist",
+                           res_id)
             return resources[0].hash, resources[0].files
 
         if not files:
-            raise ResourceError("Empty files for task {}".format(task_id))
+            raise ResourceError("Empty files for resources for id {}".format(
+                res_id))
         if len(files) == 1:
             prefix = os.path.dirname(next(iter(files)))
         else:
             prefix = common_dir(files)
 
-        self.storage.cache.set_prefix(task_id, prefix)
-        return self._add_files(files, task_id,
+        self.storage.cache.set_prefix(res_id, prefix)
+        return self._add_files(files, res_id,
                                resource_hash=resource_hash,
                                client_options=client_options,
                                async_=async_)
 
     @handle_async(on_error=partial(log_error, "Error adding file: %r"))
-    def add_file(self, path, task_id, async_=False, client_options=None):
-        return self._add_files([path], task_id, async_=async_,
+    def add_file(self, path, res_id, async_=False, client_options=None):
+        return self._add_files([path], res_id, async_=async_,
                                client_options=client_options)
 
     @handle_async(on_error=partial(log_error, "Error adding files: %r"))
-    def add_files(self, files, task_id,  # pylint: disable=too-many-arguments
+    def add_files(self, files, res_id,  # pylint: disable=too-many-arguments
                   resource_hash=None, async_=False, client_options=None):
-        return self._add_files(files, task_id,
+        return self._add_files(files, res_id,
                                resource_hash=resource_hash,
                                async_=async_,
                                client_options=client_options)
 
-    def _add_files(self, files, task_id,  # pylint: disable=too-many-arguments
+    def _add_files(self, files, res_id,  # pylint: disable=too-many-arguments
                    resource_hash=None, async_=False, client_options=None):
         """
         Adds files to hyperdrive.
         :param files: File collection
-        :param task_id: Task's id
+        :param res_id: Resources id
         :param resource_hash: If set, a 'restore' method is called; 'add'
         otherwise
         :param async_: Use asynchronous methods of HyperdriveAsyncClient
@@ -168,28 +171,29 @@ class HyperdriveResourceManager(ClientHandler):
         """
         if not all(os.path.isabs(f) for f in files):
             raise ResourceError("Resource manager: trying to add relative file "
-                                "paths for task '{}':\n{}".format(task_id,
-                                                                  files))
+                                "paths for resources with id '{}'"
+                                ":\n{}".format(res_id, files))
 
         if len(files) == 1:
             files = {path: os.path.basename(path)
                      for path in files}
         else:
-            files = {path: self.storage.relative_path(path, task_id)
+            files = {path: self.storage.relative_path(path, res_id)
                      for path in files}
 
         missing = [f for f in files if not os.path.exists(f)]
         if missing:
-            raise ResourceError("Resource manager: missing files (task: '{}'):"
-                                "\n{}".format(task_id, missing))
+            raise ResourceError("Resource manager: missing files "
+                                "(resources id: '{}'):\n{}".format(
+                                    res_id, missing))
 
         if async_:
-            return self._add_files_async(resource_hash, files, task_id,
+            return self._add_files_async(resource_hash, files, res_id,
                                          client_options=client_options)
-        return self._add_files_sync(resource_hash, files, task_id,
+        return self._add_files_sync(resource_hash, files, res_id,
                                     client_options=client_options)
 
-    def _add_files_async(self, resource_hash: str, files: dict, task_id: str,
+    def _add_files_async(self, resource_hash: str, files: dict, res_id: str,
                          client_options=None):
         """
         Adds files to hyperdrive using the asynchronous HyperdriveAsyncClient
@@ -197,14 +201,14 @@ class HyperdriveResourceManager(ClientHandler):
         :param resource_hash: If set, the 'restore_async' method is called;
         'add_async' otherwise
         :param files: Dictionary of {full_path: relative_path} of files
-        :param task_id: Task's id
+        :param res_id: Resources id
         :return: Deferred object
         """
         resource_files = list(files.values())
         result = Deferred()
 
         def success(hyperdrive_hash):
-            self._cache_files(hyperdrive_hash, resource_files, task_id)
+            self._cache_files(hyperdrive_hash, resource_files, res_id)
             result.callback((hyperdrive_hash, resource_files))
 
         if resource_hash:
@@ -217,14 +221,14 @@ class HyperdriveResourceManager(ClientHandler):
         client_result.addCallbacks(success, result.errback)
         return result
 
-    def _add_files_sync(self, resource_hash: str, files: dict, task_id: str,
+    def _add_files_sync(self, resource_hash: str, files: dict, res_id: str,
                         client_options=None):
         """
         Adds files to hyperdrive using the synchronous HyperdriveClient method.
         :param resource_hash: If set, the 'restore' method is called; 'add'
         otherwise
         :param files: Dictionary of {full_path: relative_path} of files
-        :param task_id: Task's id
+        :param res_id: Resources id
         :return: hash, file list
         """
         resource_files = list(files.values())
@@ -240,18 +244,18 @@ class HyperdriveResourceManager(ClientHandler):
             raise ResourceError("Resource manager: error adding files: {}"
                                 .format(exc))
 
-        self._cache_files(resource_hash, resource_files, task_id)
+        self._cache_files(resource_hash, resource_files, res_id)
         return resource_hash, resource_files
 
-    def _cache_files(self, resource_hash: str, files: Iterable, task_id: str):
+    def _cache_files(self, resource_hash: str, files: Iterable, res_id: str):
         """
         Put the files in storage cache.
         :param resource_hash: Hash that files are identified by
         :param files: Collection of files
-        :param task_id: Task id that files are associated with
+        :param res_id: Task id that files are associated with
         """
-        resource_path = self.storage.get_path('', task_id)
-        resource = Resource(resource_hash, res_id=task_id,
+        resource_path = self.storage.get_path('', res_id)
+        resource = Resource(resource_hash, res_id=res_id,
                             files=list(files), path=resource_path)
         self._cache_resource(resource)
 
@@ -269,16 +273,18 @@ class HyperdriveResourceManager(ClientHandler):
                                     .format(resource.path, resource.hash))
             logger.warning("Resource does not exist: %r", resource.path)
 
-    def pull_resource(self, entry, task_id,
+    # pylint: disable=too-many-arguments
+    # pylint: disable=too-many-locals
+    def pull_resource(self, entry, res_id,
                       success, error,
                       client=None, client_options=None, async_=True):
 
-        resource_path = self.storage.get_path('', task_id)
-        resource = Resource(resource_hash=entry[0], res_id=task_id,
+        resource_path = self.storage.get_path('', res_id)
+        resource = Resource(resource_hash=entry[0], res_id=res_id,
                             files=entry[1], path=resource_path)
 
         if resource.files and self.storage.exists(resource):
-            success(entry, resource.files, task_id)
+            success(entry, resource.files, res_id)
             return
 
 
@@ -287,18 +293,18 @@ class HyperdriveResourceManager(ClientHandler):
                          resource.path, resource.hash)
 
             self._cache_resource(resource)
-            files = self._parse_pull_response(response, task_id)
-            success(entry, files, task_id)
+            files = self._parse_pull_response(response, res_id)
+            success(entry, files, res_id)
 
         def error_wrapper(exception, **_):
             logger.warning("Error downloading resource."
                            "path=%s, hash=%s, error=%s",
                            resource.path, resource.hash, exception)
-            error(exception, entry, task_id)
+            error(exception, entry, res_id)
 
         logger.debug("Preparing to download resource. path=%s, hash=%s",
                      resource.path, resource.hash)
-        path = self.storage.get_path(resource.path, task_id)
+        path = self.storage.get_path(resource.path, res_id)
         local = self.storage.cache.get_by_hash(resource.hash)
         os.makedirs(path, exist_ok=True)
 
@@ -307,27 +313,28 @@ class HyperdriveResourceManager(ClientHandler):
 
         if local:
             try:
-                self.storage.copy(local.path, resource.path, task_id)
+                self.storage.copy(local.path, resource.path, res_id)
                 success_wrapper(entry)
             except Exception as exc:
                 error_wrapper(exc)
         else:
-            self._pull(resource, task_id,
+            self._pull(resource, res_id,
                        success=success_wrapper,
                        error=error_wrapper,
                        client=client,
                        client_options=client_options,
                        async_=async_)
 
-    def _pull(self, resource: Resource, task_id: str,
+    # pylint: disable=too-many-arguments
+    def _pull(self, resource: Resource, res_id: str,
               success, error,
               client=None, client_options=None, async_=True):
 
         client = client or self.client
         kwargs = dict(
             content_hash=resource.hash,
-            filename=self.storage.relative_path(resource.path, task_id),
-            filepath=self.storage.get_dir(task_id),
+            filename=self.storage.relative_path(resource.path, res_id),
+            filepath=self.storage.get_dir(res_id),
             client_options=client_options
         )
 
@@ -343,11 +350,11 @@ class HyperdriveResourceManager(ClientHandler):
             except Exception as e:
                 error(e)
 
-    def _parse_pull_response(self, response: list, task_id: str) -> list:
+    def _parse_pull_response(self, response: list, res_id: str) -> list:
         # response -> [(path, hash, [file_1, file_2, ...])]
         relative = self.storage.relative_path
         if response and len(response[0]) >= 3:
-            return [relative(f, task_id) for f in response[0][2]]
+            return [relative(f, res_id) for f in response[0][2]]
         return []
 
 

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -302,7 +302,7 @@ def _inform_subsystems(client, task, packager_result):
         task.header.deadline,
     )
 
-    resource_server_result = yield client.resource_server.add_task(
+    resource_server_result = yield client.resource_server.add_resources(
         package_path,
         package_sha1,
         task_id,

--- a/golem/task/server/resources.py
+++ b/golem/task/server/resources.py
@@ -58,7 +58,7 @@ class TaskResourcesMixin:
         options.timeout = timeout
 
         try:
-            resource_hash, _ = resource_manager.add_task(
+            resource_hash, _ = resource_manager.add_resources(
                 files, task_id, resource_hash=resource_hash,
                 client_options=options, async_=False
             )

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -109,10 +109,10 @@ class TaskComputer(object):
     def has_assigned_task(self) -> bool:
         return bool(self.assigned_subtask)
 
-    def task_resource_collected(self, task_id):
+    def resource_collected(self, res_id):
         subtask = self.assigned_subtask
-        if not subtask or subtask['task_id'] != task_id:
-            logger.error("Resource collected for a wrong task, %s", task_id)
+        if not subtask or subtask['task_id'] != res_id:
+            logger.error("Resource collected for a wrong task, %s", res_id)
             return False
         self.last_task_timeout_checking = time.time()
         self.__compute_task(
@@ -122,10 +122,10 @@ class TaskComputer(object):
             subtask['deadline'])
         return True
 
-    def task_resource_failure(self, task_id, reason):
+    def resource_failure(self, res_id, reason):
         subtask = self.assigned_subtask
-        if not subtask or subtask['task_id'] != task_id:
-            logger.error("Resource failure for a wrong task, %s", task_id)
+        if not subtask or subtask['task_id'] != res_id:
+            logger.error("Resource failure for a wrong task, %s", res_id)
             return
         self.task_server.send_task_failed(
             subtask['subtask_id'],

--- a/tests/golem/docker/test_docker_task.py
+++ b/tests/golem/docker/test_docker_task.py
@@ -168,7 +168,7 @@ class DockerTaskTestCase(
 
         # Start task computation
         task_computer.task_given(ctd)
-        result = task_computer.task_resource_collected(ctd['task_id'])
+        result = task_computer.resource_collected(ctd['task_id'])
         self.assertTrue(result)
 
         task_thread = None

--- a/tests/golem/resource/base/common.py
+++ b/tests/golem/resource/base/common.py
@@ -42,7 +42,7 @@ class AddGetResources(TempDirFixture, LogTestCase):
 
         self.resources_relative, resources = self._create_resources(
             self.resource_dir_1)
-        client_1.resource_server.resource_manager.add_task(
+        client_1.resource_server.resource_manager.add_resources(
             resources, self.task_id, async_=False)
 
     def tearDown(self):

--- a/tests/golem/resource/base/test_base_resourceserver.py
+++ b/tests/golem/resource/base/test_base_resourceserver.py
@@ -23,10 +23,10 @@ class MockClient:
         self.failed = None
         self.task_server = mock.Mock()
 
-    def task_resource_collected(self, *args, **kwargs):
+    def resource_collected(self, *args, **kwargs):
         self.downloaded = True
 
-    def task_resource_failure(self, *args, **kwrags):
+    def resource_failure(self, *args, **kwrags):
         self.failed = True
 
 

--- a/tests/golem/resource/base/test_base_resourceserver.py
+++ b/tests/golem/resource/base/test_base_resourceserver.py
@@ -104,9 +104,10 @@ class TestResourceServer(testwithreactor.TestDirFixtureWithReactor):
         _deferred = rs.create_resource_package(existing_paths, self.task_id)
         pkg_path, pkg_sha1 = sync_wait(_deferred)
         resource_size = os.path.getsize(pkg_path)
-        return rm, rs.add_task(pkg_path, pkg_sha1, self.task_id, resource_size)
+        return rm, rs.add_resources(pkg_path, pkg_sha1, self.task_id,
+                                    resource_size)
 
-    def testAddTask(self):
+    def testAddResources(self):
         rm, deferred = self._add_task()
 
         def test(*_):
@@ -152,10 +153,10 @@ class TestResourceServer(testwithreactor.TestDirFixtureWithReactor):
         if os.path.exists(new_path):
             shutil.rmtree(new_path)
 
-    def testRemoveTask(self):
+    def testRemoveResources(self):
         self.resource_manager.add_files(self._resources(), self.task_id)
         assert self.resource_manager.storage.get_resources(self.task_id)
-        self.resource_server.remove_task(self.task_id)
+        self.resource_server.remove_resources(self.task_id)
         assert not self.resource_manager.storage.get_resources(self.task_id)
 
     def testPendingResources(self):

--- a/tests/golem/resource/base/test_base_resourceserver.py
+++ b/tests/golem/resource/base/test_base_resourceserver.py
@@ -159,7 +159,7 @@ class TestResourceServer(testwithreactor.TestDirFixtureWithReactor):
         assert not self.resource_manager.storage.get_resources(self.task_id)
 
     def testPendingResources(self):
-        self.resource_manager.add_task(self.target_resources, self.task_id,
+        self.resource_manager.add_resources(self.target_resources, self.task_id,
                                        async_=False)
 
         resources = self.resource_manager.storage.get_resources(self.task_id)
@@ -170,7 +170,7 @@ class TestResourceServer(testwithreactor.TestDirFixtureWithReactor):
         assert len(pending) == len(resources)
 
     def testGetResources(self):
-        self.resource_manager.add_task(self.target_resources, self.task_id,
+        self.resource_manager.add_resources(self.target_resources, self.task_id,
                                        async_=False)
 
         resources = self.resource_manager.storage.get_resources(self.task_id)

--- a/tests/golem/resource/hyperdrive/test_hyperdrive_resource.py
+++ b/tests/golem/resource/hyperdrive/test_hyperdrive_resource.py
@@ -26,24 +26,24 @@ class TestResourceCache(TempDirFixture):
         self.cache.set_prefix(self.task_id, self.prefix)
         resource = Resource(
             self.resource_hash,
-            task_id=self.task_id,
+            res_id=self.task_id,
             files=self.resource_files,
             path=self.resource_path
         )
 
-        assert self.cache.get_prefix(resource.task_id) == self.prefix
+        assert self.cache.get_prefix(resource.res_id) == self.prefix
         assert self.cache.get_prefix(str(uuid.uuid4())) == ''
         assert self.cache.get_prefix(str(uuid.uuid4()), 'default_value') == \
             'default_value'
 
         self.cache.add_resource(resource)
-        self.cache.remove(resource.task_id)
-        assert self.cache.get_prefix(resource.task_id) == ''
+        self.cache.remove(resource.res_id)
+        assert self.cache.get_prefix(resource.res_id) == ''
 
     def test_resources(self):
         resource = Resource(
             self.resource_hash,
-            task_id=self.task_id,
+            res_id=self.task_id,
             files=self.resource_files,
             path=self.resource_path
         )
@@ -51,7 +51,7 @@ class TestResourceCache(TempDirFixture):
         new_task_file = 'new_name'
         new_resource = Resource(
             str(uuid.uuid4()),
-            task_id=str(uuid.uuid4()),
+            res_id=str(uuid.uuid4()),
             files=[new_task_file],
             path=self.resource_path
         )
@@ -64,7 +64,7 @@ class TestResourceCache(TempDirFixture):
         self.cache.add_resource(resource)
 
         assert self.cache.get_resources(self.task_id) == [resource]
-        assert self.cache.get_resources(new_resource.task_id) == []
+        assert self.cache.get_resources(new_resource.res_id) == []
         assert self.cache.get_resources('unknown') == []
         assert self.cache.has_resource(resource)
         assert not self.cache.has_resource(new_resource)
@@ -75,14 +75,14 @@ class TestResourceCache(TempDirFixture):
         assert new_resource.exists
 
         assert self.cache.get_resources(self.task_id) == [resource]
-        assert self.cache.get_resources(new_resource.task_id) == [new_resource]
+        assert self.cache.get_resources(new_resource.res_id) == [new_resource]
         assert self.cache.get_resources('unknown') == []
         assert self.cache.has_resource(resource)
         assert self.cache.has_resource(new_resource)
 
         assert self.cache.remove(self.task_id)
         assert self.cache.remove('unknown') == []
-        assert self.cache.get_resources(new_resource.task_id) == [new_resource]
+        assert self.cache.get_resources(new_resource.res_id) == [new_resource]
 
     def test_remove(self):
         self._add_all()
@@ -92,7 +92,7 @@ class TestResourceCache(TempDirFixture):
         new_path = '/other/path'
         new_resource = Resource(
             str(uuid.uuid4()),
-            task_id=str(uuid.uuid4()),
+            res_id=str(uuid.uuid4()),
             path=new_path,
             files=[new_path]
         )
@@ -114,7 +114,7 @@ class TestResourceCache(TempDirFixture):
     def _add_all(self):
         resource = Resource(
             self.resource_hash,
-            task_id=self.task_id,
+            res_id=self.task_id,
             path=self.resource_path,
             files=['file']
         )

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -81,15 +81,15 @@ class ProviderBase(test_client.TestClientBase):
             result = 'package_path', 'package_sha1'
             return test_client.done_deferred(result)
 
-        def add_task(*_args, **_kwargs):
+        def add_resources(*_args, **_kwargs):
             resource_manager_result = 'res_hash', ['res_file_1']
             result = resource_manager_result, 'res_file_1', 'package_hash', 42
             return test_client.done_deferred(result)
 
         self.client.resource_server.create_resource_package = mock.Mock(
             side_effect=create_resource_package)
-        self.client.resource_server.add_task = mock.Mock(
-            side_effect=add_task)
+        self.client.resource_server.add_resources = mock.Mock(
+            side_effect=add_resources)
 
         def add_new_task(task, *_args, **_kwargs):
             instance = self.client.task_manager
@@ -198,7 +198,7 @@ class TestRestartTask(ProviderBase):
             result = 'package_path', 'package_sha1'
             return test_client.done_deferred(result)
 
-        def add_task(*_args, **_kwargs):
+        def add_resources(*_args, **_kwargs):
             resource_manager_result = 'res_hash', ['res_file_1']
             result = resource_manager_result, 'res_file_1', 'package_hash', 0
             return test_client.done_deferred(result)
@@ -207,7 +207,7 @@ class TestRestartTask(ProviderBase):
             create_resource_package=mock.Mock(
                 side_effect=create_resource_package,
             ),
-            add_task=mock.Mock(side_effect=add_task)
+            add_resources=mock.Mock(side_effect=add_resources)
         )
 
         task_manager = self.client.task_server.task_manager
@@ -340,7 +340,7 @@ class TestEnqueueNewTask(ProviderBase):
         task_id = task.header.task_id
         assert isinstance(task, taskbase.Task)
         assert task.header.task_id
-        assert c.resource_server.add_task.called
+        assert c.resource_server.add_resources.called
 
         c.task_server.task_manager.tasks[task_id] = task
         c.task_server.task_manager.tasks_states[task_id] = taskstate.TaskState()

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -80,7 +80,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         task_id = 'xyz'
         subtask_id = 'xxyyzz'
 
-        tc.task_resource_failure(task_id, 'reason')
+        tc.resource_failure(task_id, 'reason')
         assert not task_server.send_task_failed.called
 
         tc.assigned_subtask = ComputeTaskDef(
@@ -88,7 +88,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
             subtask_id=subtask_id,
         )
 
-        tc.task_resource_failure(task_id, 'reason')
+        tc.resource_failure(task_id, 'reason')
         assert task_server.send_task_failed.called
 
     def test_computation(self):  # pylint: disable=too-many-statements
@@ -129,7 +129,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         tc.task_server.request_resource.assert_called_with(
             "xyz", "xxyyzz", ["abcd", "efgh"])
 
-        assert tc.task_resource_collected("xyz")
+        assert tc.resource_collected("xyz")
         assert tc.counting_thread is None
         assert tc.assigned_subtask is None
         task_server.send_task_failed.assert_called_with(
@@ -137,7 +137,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
 
         tc.support_direct_computation = True
         tc.task_given(ctd)
-        assert tc.task_resource_collected("xyz")
+        assert tc.resource_collected("xyz")
         assert tc.counting_thread is not None
         self.assertGreater(tc.counting_thread.time_to_compute, 8)
         self.assertLessEqual(tc.counting_thread.time_to_compute, 10)
@@ -166,7 +166,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
                              timeout_to_deadline(5))
         tc.task_server.request_resource.assert_called_with(
             "xyz", "aabbcc", ["abcd", "efgh"])
-        self.assertTrue(tc.task_resource_collected("xyz"))
+        self.assertTrue(tc.resource_collected("xyz"))
         self.__wait_for_tasks(tc)
 
         self.assertIsNone(tc.counting_thread)
@@ -180,7 +180,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         ctd['extra_data']['src_code'] = "print('Hello world')"
         ctd['deadline'] = timeout_to_deadline(5)
         tc.task_given(ctd)
-        self.assertTrue(tc.task_resource_collected("xyz"))
+        self.assertTrue(tc.resource_collected("xyz"))
         self.__wait_for_tasks(tc)
 
         task_server.send_task_failed.assert_called_with(
@@ -194,7 +194,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         ctd['extra_data']['src_code'] = "output={'data': 0, 'result_type': 0}"
         ctd['deadline'] = timeout_to_deadline(40)
         tc.task_given(ctd)
-        self.assertTrue(tc.task_resource_collected("xyz"))
+        self.assertTrue(tc.resource_collected("xyz"))
         self.assertIsNotNone(tc.counting_thread)
         self.assertGreater(tc.counting_thread.time_to_compute, 10)
         self.assertLessEqual(tc.counting_thread.time_to_compute, 20)
@@ -203,7 +203,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         ctd['subtask_id'] = "xxyyzz2"
         ctd['deadline'] = timeout_to_deadline(1)
         tc.task_given(ctd)
-        self.assertTrue(tc.task_resource_collected("xyz"))
+        self.assertTrue(tc.resource_collected("xyz"))
         mock_finished.assert_called_once_with()
         mock_finished.reset_mock()
         tt = tc.counting_thread

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -918,7 +918,7 @@ class TestRestoreResources(LogTestCase, testutils.DatabaseFixture,
                          prv_addresses=['10.0.0.2'],)
 
         self.resource_manager = Mock(
-            add_task=Mock(side_effect=lambda *a, **b: ([], "a1b2c3"))
+            add_resources=Mock(side_effect=lambda *a, **b: ([], "a1b2c3"))
         )
         with patch('golem.network.concent.handlers_library.HandlersLibrary'
                    '.register_handler',):
@@ -951,20 +951,21 @@ class TestRestoreResources(LogTestCase, testutils.DatabaseFixture,
             task_server.task_manager.tasks_states[task_id] = TaskState()
 
     def test_without_tasks(self, *_):
-        with patch.object(self.resource_manager, 'add_task',
+        with patch.object(self.resource_manager, 'add_resources',
                           side_effect=ConnectionError):
             self.ts.restore_resources()
-            assert not self.resource_manager.add_task.called
+            assert not self.resource_manager.add_resources.called
             assert not self.ts.task_manager.delete_task.called
             assert not self.ts.task_manager.notify_update_task.called
 
     def test_with_connection_error(self, *_):
         self._create_tasks(self.ts, self.task_count)
 
-        with patch.object(self.resource_manager, 'add_task',
+        with patch.object(self.resource_manager, 'add_resources',
                           side_effect=ConnectionError):
             self.ts.restore_resources()
-            assert self.resource_manager.add_task.call_count == self.task_count
+            assert self.resource_manager.add_resources.call_count == \
+                self.task_count
             assert self.ts.task_manager.delete_task.call_count == \
                 self.task_count
             assert not self.ts.task_manager.notify_update_task.called
@@ -972,10 +973,11 @@ class TestRestoreResources(LogTestCase, testutils.DatabaseFixture,
     def test_with_http_error(self, *_):
         self._create_tasks(self.ts, self.task_count)
 
-        with patch.object(self.resource_manager, 'add_task',
+        with patch.object(self.resource_manager, 'add_resources',
                           side_effect=HTTPError):
             self.ts.restore_resources()
-            assert self.resource_manager.add_task.call_count == self.task_count
+            assert self.resource_manager.add_resources.call_count == \
+                self.task_count
             assert self.ts.task_manager.delete_task.call_count == \
                 self.task_count
             assert not self.ts.task_manager.notify_update_task.called
@@ -991,10 +993,10 @@ class TestRestoreResources(LogTestCase, testutils.DatabaseFixture,
         for state in self.ts.task_manager.tasks_states.values():
             state.resource_hash = str(uuid.uuid4())
 
-        with patch.object(self.resource_manager, 'add_task',
+        with patch.object(self.resource_manager, 'add_resources',
                           side_effect=error_class):
             self.ts.restore_resources()
-            assert self.resource_manager.add_task.call_count ==\
+            assert self.resource_manager.add_resources.call_count ==\
                 self.task_count * 2
             assert self.ts.task_manager.delete_task.call_count == \
                 self.task_count
@@ -1004,7 +1006,7 @@ class TestRestoreResources(LogTestCase, testutils.DatabaseFixture,
         self._create_tasks(self.ts, self.task_count)
 
         self.ts.restore_resources()
-        assert self.resource_manager.add_task.call_count == self.task_count
+        assert self.resource_manager.add_resources.call_count == self.task_count
         assert not self.ts.task_manager.delete_task.called
         assert self.ts.task_manager.notify_update_task.call_count == \
             self.task_count


### PR DESCRIPTION
This one will be needed if we want to introduce resources per subtask and not just per task.
res_id is used instead of task_id in Resource, ResourceStorage, ResourceManager and ResourceServer.
That way function names and arguments are more universal and we will be able to use them for subtasks resources, additional resources etc. 