### PR TITLE
Disabled virtualization check on Linux platforms

### DIFF
--- a/golem/core/virtualization.py
+++ b/golem/core/virtualization.py
@@ -15,14 +15,15 @@ WIN_SCRIPT_PATH = os.path.join(
 
 
 @rpc_utils.expose('env.hw.virtualization')
-def is_virtualization_enabled() -> bool:
+def is_virtualization_satisfied() -> bool:
     """ Checks if hardware virtualization is available on this machine.
-    Currently, this check is limited to Intel CPUs (VT and VT-x support).
-    :return bool: True if virtualization is available or the OS is Linux.
+    If hardware virtualization is not required to run Golem (e.g. on Linux),
+    the actual check is skipped. Currently, this function is limited to Intel
+    CPUs (VT and VT-x support).
+    :return bool: True if virtualization is available or is not required.
     On Windows, we additionally check if the feature is enabled in firmware.
     """
     if is_linux():
-        # Virtualization support is not required to run Golem on Linux.
         return True
     elif is_windows():
         return _check_vt_windows()

--- a/golem/core/virtualization.py
+++ b/golem/core/virtualization.py
@@ -2,7 +2,7 @@ import os
 
 from cpuinfo import get_cpu_info
 
-from golem.core.common import get_golem_path, is_windows
+from golem.core.common import get_golem_path, is_linux, is_windows
 from golem.core.windows import run_powershell
 from golem.rpc import utils as rpc_utils
 
@@ -18,10 +18,13 @@ WIN_SCRIPT_PATH = os.path.join(
 def is_virtualization_enabled() -> bool:
     """ Checks if hardware virtualization is available on this machine.
     Currently, this check is limited to Intel CPUs (VT and VT-x support).
-    :return bool: True if virtualization is available. On Windows, we also check
-    if the feature is enabled in firmware.
+    :return bool: True if virtualization is available or the OS is Linux.
+    On Windows, we additionally check if the feature is enabled in firmware.
     """
-    if is_windows():
+    if is_linux():
+        # Virtualization support is not required to run Golem on Linux.
+        return True
+    elif is_windows():
         return _check_vt_windows()
 
     return _check_vt_unix()
@@ -35,3 +38,4 @@ def _check_vt_unix() -> bool:
 def _check_vt_windows() -> bool:
     virtualization_state = run_powershell(script=WIN_SCRIPT_PATH)
     return virtualization_state == 'True'
+

--- a/golem/core/virtualization.py
+++ b/golem/core/virtualization.py
@@ -38,4 +38,3 @@ def _check_vt_unix() -> bool:
 def _check_vt_windows() -> bool:
     virtualization_state = run_powershell(script=WIN_SCRIPT_PATH)
     return virtualization_state == 'True'
-

--- a/tests/golem/core/test_virtualization.py
+++ b/tests/golem/core/test_virtualization.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
-from golem.core.virtualization import is_virtualization_enabled, WIN_SCRIPT_PATH
+from golem.core.virtualization import is_virtualization_satisfied, WIN_SCRIPT_PATH
 
 
 def get_mock_cpuinfo_output(vt_supported=True) -> dict:
@@ -21,7 +21,7 @@ def get_mock_cpuinfo_output(vt_supported=True) -> dict:
 class VirtualizationTestLinux(TestCase):
 
     def test_vt_enabled(self, *_):
-        self.assertTrue(is_virtualization_enabled())
+        self.assertTrue(is_virtualization_satisfied())
 
 
 @patch('golem.core.virtualization.is_linux', side_effect=lambda: False)
@@ -31,12 +31,12 @@ class VirtualizationTestOsx(TestCase):
     @patch('golem.core.virtualization.get_cpu_info',
            return_value=get_mock_cpuinfo_output())
     def test_vt_enabled(self, *_):
-        self.assertTrue(is_virtualization_enabled())
+        self.assertTrue(is_virtualization_satisfied())
 
     @patch('golem.core.virtualization.get_cpu_info',
            return_value=get_mock_cpuinfo_output(vt_supported=False))
     def test_vt_unsupported(self, *_):
-        self.assertFalse(is_virtualization_enabled())
+        self.assertFalse(is_virtualization_satisfied())
 
 
 @patch('golem.core.virtualization.is_linux', side_effect=lambda: False)
@@ -46,12 +46,12 @@ class VirtualizationTestWindows(TestCase):
     @patch('golem.core.virtualization.run_powershell',
            return_value='True')
     def test_vt_enabled(self, *_):
-        self.assertTrue(is_virtualization_enabled())
+        self.assertTrue(is_virtualization_satisfied())
 
     @patch('golem.core.virtualization.run_powershell',
            return_value='False')
     def test_vt_disabled(self, *_):
-        self.assertFalse(is_virtualization_enabled())
+        self.assertFalse(is_virtualization_satisfied())
 
     def test_script_path(self, *_):
         self.assertTrue(Path(WIN_SCRIPT_PATH).exists())

--- a/tests/golem/core/test_virtualization.py
+++ b/tests/golem/core/test_virtualization.py
@@ -2,7 +2,8 @@ from pathlib import Path
 from unittest import TestCase
 from unittest.mock import patch
 
-from golem.core.virtualization import is_virtualization_satisfied, WIN_SCRIPT_PATH
+from golem.core.virtualization import is_virtualization_satisfied,\
+    WIN_SCRIPT_PATH
 
 
 def get_mock_cpuinfo_output(vt_supported=True) -> dict:

--- a/tests/golem/core/test_virtualization.py
+++ b/tests/golem/core/test_virtualization.py
@@ -17,8 +17,16 @@ def get_mock_cpuinfo_output(vt_supported=True) -> dict:
     }
 
 
+@patch('golem.core.virtualization.is_linux', side_effect=lambda: True)
+class VirtualizationTestLinux(TestCase):
+
+    def test_vt_enabled(self, *_):
+        self.assertTrue(is_virtualization_enabled())
+
+
+@patch('golem.core.virtualization.is_linux', side_effect=lambda: False)
 @patch('golem.core.virtualization.is_windows', side_effect=lambda: False)
-class VirtualizationTestUnix(TestCase):
+class VirtualizationTestOsx(TestCase):
 
     @patch('golem.core.virtualization.get_cpu_info',
            return_value=get_mock_cpuinfo_output())
@@ -31,6 +39,7 @@ class VirtualizationTestUnix(TestCase):
         self.assertFalse(is_virtualization_enabled())
 
 
+@patch('golem.core.virtualization.is_linux', side_effect=lambda: False)
 @patch('golem.core.virtualization.is_windows', side_effect=lambda: True)
 class VirtualizationTestWindows(TestCase):
 
@@ -46,3 +55,4 @@ class VirtualizationTestWindows(TestCase):
 
     def test_script_path(self, *_):
         self.assertTrue(Path(WIN_SCRIPT_PATH).exists())
+

--- a/tests/golem/core/test_virtualization.py
+++ b/tests/golem/core/test_virtualization.py
@@ -55,4 +55,3 @@ class VirtualizationTestWindows(TestCase):
 
     def test_script_path(self, *_):
         self.assertTrue(Path(WIN_SCRIPT_PATH).exists())
-


### PR DESCRIPTION
Resolves: #3937

This change skips the virtualization check on Linux systems, always returning positive support status.