### PR TITLE
fix math of calculating scaled price for marketplace

### DIFF
--- a/golem/marketplace/__init__.py
+++ b/golem/marketplace/__init__.py
@@ -1,1 +1,1 @@
-from .offerpool import Offer, OfferPool  # noqa pylint: disable=unused-import
+from .offerpool import scale_price, Offer, OfferPool  # noqa pylint: disable=unused-import

--- a/golem/marketplace/offerpool.py
+++ b/golem/marketplace/offerpool.py
@@ -1,3 +1,4 @@
+import sys
 import logging
 from typing import List, Dict, ClassVar, Tuple
 
@@ -11,7 +12,8 @@ logger = logging.getLogger(__name__)
 
 def scale_price(task_price: float, offered_price: float) -> float:
     if offered_price == 0:
-        return float('inf')
+        # using float('inf') breaks math in order_providers, when alpha < 1
+        return sys.float_info.max
     return task_price / offered_price
 
 

--- a/golem/marketplace/offerpool.py
+++ b/golem/marketplace/offerpool.py
@@ -9,6 +9,12 @@ from .rust import order_providers
 logger = logging.getLogger(__name__)
 
 
+def scale_price(task_price: float, offered_price: float) -> float:
+    if offered_price == 0:
+        return float('inf')
+    return task_price / offered_price
+
+
 class Offer:
     def __init__(
             self,

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -20,7 +20,7 @@ from golem.core.keysauth import KeysAuth
 from golem.core import variables
 from golem.docker.environment import DockerEnvironment
 from golem.docker.image import DockerImage
-from golem.marketplace import Offer, OfferPool
+from golem.marketplace import scale_price, Offer, OfferPool
 from golem.model import Actor
 from golem.network import history
 from golem.network.concent import helpers as concent_helpers
@@ -623,11 +623,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
 
         task = self.task_manager.tasks[msg.task_id]
         offer = Offer(
-            scaled_price=(
-                msg.price / task.header.max_price
-                if task.header.max_price > 0
-                else float('inf')
-            ),
+            scaled_price=scale_price(task.header.max_price, msg.price),
             reputation=get_provider_efficiency(self.key_id),
             quality=get_provider_efficacy(self.key_id).vector,
         )

--- a/rust/golem/src/marketplace.rs
+++ b/rust/golem/src/marketplace.rs
@@ -1,3 +1,5 @@
+use std::f64;
+
 // Price sensitivity factor. 0 <= ALPHA <= 1
 const ALPHA: f64 = 0.67;
 // Distrust factor. 1 <= D
@@ -82,16 +84,26 @@ mod tests {
                     r: 0.0,
                 },
             },
+            Offer {
+                scaled_price: f64::MAX,
+                reputation: 15.0,
+                quality: Quality {
+                    s: 0.0,
+                    t: 0.0,
+                    f: 0.0,
+                    r: 0.0,
+                },
+            },
         ];
     }
     #[test]
     fn order_providers_price_preference() {
         let offers = gen_offers();
-        assert_eq!(order_providers_impl(offers, 1.0, PSI, D), vec![3, 1, 0, 2]);
+        assert_eq!(order_providers_impl(offers, 1.0, PSI, D), vec![4, 3, 1, 0, 2]);
     }
     #[test]
     fn order_providers_reputation_preference() {
         let offers = gen_offers();
-        assert_eq!(order_providers_impl(offers, 0.0, PSI, D), vec![1, 2, 3, 0]);
+        assert_eq!(order_providers_impl(offers, 0.0, PSI, D), vec![1, 2, 4, 3, 0]);
     }
 }

--- a/tests/golem/marketplace/test_offerpool.py
+++ b/tests/golem/marketplace/test_offerpool.py
@@ -1,7 +1,15 @@
 from unittest import TestCase
 from unittest.mock import Mock, patch, ANY
 
-from golem.marketplace import Offer, OfferPool
+from golem.marketplace import scale_price, Offer, OfferPool
+
+
+class TestScalePrice(TestCase):
+    def test_basic(self):
+        assert scale_price(5, 2) == 2.5
+
+    def test_zero(self):
+        assert scale_price(5, 0) == float('inf')
 
 
 @patch('golem.marketplace.offerpool.task.deferLater')

--- a/tests/golem/marketplace/test_offerpool.py
+++ b/tests/golem/marketplace/test_offerpool.py
@@ -1,3 +1,4 @@
+import sys
 from unittest import TestCase
 from unittest.mock import Mock, patch, ANY
 
@@ -9,7 +10,7 @@ class TestScalePrice(TestCase):
         assert scale_price(5, 2) == 2.5
 
     def test_zero(self):
-        assert scale_price(5, 0) == float('inf')
+        assert scale_price(5, 0) == sys.float_info.max
 
 
 @patch('golem.marketplace.offerpool.task.deferLater')

--- a/tests/golem/marketplace/test_rust.py
+++ b/tests/golem/marketplace/test_rust.py
@@ -1,4 +1,4 @@
-from golem.marketplace import Offer
+from golem.marketplace import scale_price, Offer
 from golem.marketplace.rust import order_providers
 
 
@@ -6,6 +6,8 @@ def test_order_providers():
     offer0 = Offer(scaled_price=2., reputation=1., quality=(1., 1., 6., 1.))
     offer1 = Offer(scaled_price=3., reputation=5., quality=(1., 3., 1., 4.))
     offer2 = Offer(scaled_price=4., reputation=2., quality=(2., 1., 1., 3.))
-    res = order_providers([offer0, offer1, offer2])
+    offer3 = Offer(scaled_price=scale_price(5, 0), reputation=3.,
+                   quality=(1., 2., 3., 4.))
+    res = order_providers([offer0, offer1, offer2, offer3])
     # Actual order is not important, just that it is a permutation
-    assert sorted(res) == list(range(3))
+    assert sorted(res) == list(range(4))


### PR DESCRIPTION
1. revert from `msg.price / task.header.max_price` back to `task.header.max_price / msg.price`
2. put this calculation, with handling of 0, into a function in marketplace module.

Related issues: #3453, #3479, #3964 

