### PR TITLE
Interfaces for environments refactoring

### DIFF
--- a/golem/envs/__init__.py
+++ b/golem/envs/__init__.py
@@ -1,0 +1,130 @@
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any, Callable, Dict, List, Optional
+
+from twisted.internet.defer import Deferred
+
+CounterId = str
+CounterUsage = Any
+
+EnvId = str
+EnvSupportStatus = bool
+EnvConfig = Dict[str, Any]
+
+EnvEventId = str
+EnvEvent = Any  # TODO: Define environment events
+
+RuntimeEventId = str
+RuntimeEvent = Any  # TODO: Define runtime events
+
+
+class Payload:
+    pass
+
+
+class RuntimeStatus(Enum):
+    CREATED = 0
+    PREPARING = 1
+    PREPARED = 2
+    STARTING = 3
+    STARTED = 4
+    RUNNING = 5
+    STOPPED = 6
+    CLEANING_UP = 7
+    TORN_DOWN = 8
+    FAILURE = 9
+
+
+class Runtime(ABC):
+
+    @abstractmethod
+    def start(self) -> Deferred:
+        raise NotImplementedError
+
+    @abstractmethod
+    def stop(self) -> Deferred:
+        raise NotImplementedError
+
+    @abstractmethod
+    def status(self) -> RuntimeStatus:
+        raise NotImplementedError
+
+    @abstractmethod
+    def usage_counters(self) -> Dict[CounterId, CounterUsage]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def listen(self, event_id: RuntimeEventId,
+               callback: Callable[[RuntimeEvent], Any]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def call(self, alias: str, *args, **kwargs) -> Deferred:
+        raise NotImplementedError
+
+
+class EnvMetadata:
+    id: EnvId
+    description: str
+    supported_counters: List[CounterId]
+    custom_metadata: Dict[str, Any]
+
+
+class Environment(ABC):
+
+    @classmethod
+    @abstractmethod
+    def supported(cls) -> EnvSupportStatus:
+        raise NotImplementedError
+
+    @abstractmethod
+    def prepare(self) -> Deferred:
+        raise NotImplementedError
+
+    @abstractmethod
+    def cleanup(self) -> Deferred:
+        raise NotImplementedError
+
+    @abstractmethod
+    def metadata(self) -> EnvMetadata:
+        raise NotImplementedError
+
+    @abstractmethod
+    def config(self) -> EnvConfig:
+        raise NotImplementedError
+
+    @abstractmethod
+    def update_config(self, config: EnvConfig) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def listen(self, event_id: EnvEventId,
+               callback: Callable[[EnvEvent], Any]) -> None:
+        raise NotImplementedError
+
+    @abstractmethod
+    def runtime(self, payload: Payload, config: Optional[EnvConfig]) \
+            -> Runtime:
+        raise NotImplementedError
+
+
+class EnvironmentManager:
+
+    def state(self) -> Dict[EnvId, bool]:
+        raise NotImplementedError
+
+    def set_state(self, state: Dict[EnvId, bool]) -> None:
+        raise NotImplementedError
+
+    def enabled(self, env_id: EnvId) -> bool:
+        raise NotImplementedError
+
+    def set_enabled(self, env_id: EnvId, enabled: bool) -> None:
+        raise NotImplementedError
+
+    def environments(self) -> List[Environment]:
+        raise NotImplementedError
+
+    def environment(self, env_id: EnvId) -> Environment:
+        raise NotImplementedError
+

--- a/golem/envs/__init__.py
+++ b/golem/envs/__init__.py
@@ -70,11 +70,22 @@ class EnvMetadata:
     custom_metadata: Dict[str, Any]
 
 
+class EnvStatus(Enum):
+    DISABLED = 0
+    PREPARING = 1
+    ENABLED = 2
+    CLEANING_UP = 3
+
+
 class Environment(ABC):
 
     @classmethod
     @abstractmethod
     def supported(cls) -> EnvSupportStatus:
+        raise NotImplementedError
+
+    @abstractmethod
+    def status(self) -> EnvStatus:
         raise NotImplementedError
 
     @abstractmethod

--- a/golem/envs/__init__.py
+++ b/golem/envs/__init__.py
@@ -127,8 +127,9 @@ class EnvironmentManager:
 
     def register_env(self, env: Environment) -> None:
         env_id = env.metadata().id
-        self._envs[env_id] = env
-        self._state[env_id] = False
+        if env_id not in self._envs:
+            self._envs[env_id] = env
+            self._state[env_id] = False
 
     def state(self) -> Dict[EnvId, bool]:
         return dict(self._state)

--- a/golem/envs/__init__.py
+++ b/golem/envs/__init__.py
@@ -121,21 +121,31 @@ class Environment(ABC):
 
 class EnvironmentManager:
 
+    def __init__(self):
+        self._envs: Dict[EnvId, Environment] = {}
+        self._state: Dict[EnvId, bool] = {}
+
+    def register_env(self, env: Environment) -> None:
+        env_id = env.metadata().id
+        self._envs[env_id] = env
+        self._state[env_id] = False
+
     def state(self) -> Dict[EnvId, bool]:
-        raise NotImplementedError
+        return dict(self._state)
 
     def set_state(self, state: Dict[EnvId, bool]) -> None:
-        raise NotImplementedError
+        for env_id, enabled in state.items():
+            self.set_enabled(env_id, enabled)
 
     def enabled(self, env_id: EnvId) -> bool:
-        raise NotImplementedError
+        return self._state[env_id]
 
     def set_enabled(self, env_id: EnvId, enabled: bool) -> None:
-        raise NotImplementedError
+        if env_id in self._state:
+            self._state[env_id] = enabled
 
     def environments(self) -> List[Environment]:
-        raise NotImplementedError
+        return list(self._envs.values())
 
     def environment(self, env_id: EnvId) -> Environment:
-        raise NotImplementedError
-
+        return self._envs[env_id]

--- a/tests/golem/envs/test_environment_manager.py
+++ b/tests/golem/envs/test_environment_manager.py
@@ -1,0 +1,80 @@
+from unittest import TestCase
+from unittest.mock import MagicMock
+
+from golem.envs import Environment, EnvironmentManager
+
+
+class TestEnvironmentManager(TestCase):
+
+    def setUp(self):
+        self.manager = EnvironmentManager()
+
+    @staticmethod
+    def new_env(env_id):
+        env = MagicMock(spec=Environment)
+        env.metadata().id = env_id
+        return env
+
+    def test_register_env(self):
+        # Given
+        self.assertEqual(self.manager.environments(), [])
+        self.assertEqual(self.manager.state(), {})
+
+        # When
+        env = self.new_env("env1")
+        self.manager.register_env(env)
+
+        # Then
+        self.assertEqual(self.manager.environments(), [env])
+        self.assertEqual(self.manager.state(), {"env1": False})
+
+    def test_re_register_env(self):
+        # Given
+        env = self.new_env("env1")
+        self.manager.register_env(env)
+        self.manager.set_enabled("env1", True)
+        self.assertEqual(self.manager.environments(), [env])
+        self.assertTrue(self.manager.enabled("env1"))
+
+        # When
+        self.manager.register_env(env)
+
+        # Then
+        self.assertEqual(self.manager.environments(), [env])
+        self.assertTrue(self.manager.enabled("env1"))
+
+    def test_set_enabled(self):
+        # Given
+        env = self.new_env("env1")
+        self.manager.register_env(env)
+        self.assertFalse(self.manager.enabled("env1"))
+
+        # When
+        self.manager.set_enabled("env1", True)
+        # Then / Given
+        self.assertTrue(self.manager.enabled("env1"))
+
+        # When
+        self.manager.set_enabled("env1", False)
+        # Then
+        self.assertFalse(self.manager.enabled("env1"))
+
+    def test_set_state(self):
+        # Given
+        env1 = self.new_env("env1")
+        env2 = self.new_env("env2")
+        self.manager.register_env(env1)
+        self.manager.register_env(env2)
+        self.assertFalse(self.manager.enabled("env1"))
+        self.assertFalse(self.manager.enabled("env2"))
+
+        # When
+        self.manager.set_state({
+            "env2": True,
+            "bogus_env": True
+        })
+
+        # Then
+        self.assertFalse(self.manager.enabled("env1"))
+        self.assertTrue(self.manager.enabled("env2"))
+        self.assertRaises(KeyError, self.manager.enabled, "bogus_env")


### PR DESCRIPTION
Used `golem.envs` instead of `golem.environments` because we don't want to replace the old environments *yet*. The old package will be removed when we are done.

Environment events should probably be somehow defined.

We can think of using `NewType` for all ID types so that one would have to use the type explicitly.

---

Added `EvironmentManager` implemetation + unit tests