### PR TITLE
Add GLambda app 

### DIFF
--- a/apps/glambda/benchmark/benchmark.py
+++ b/apps/glambda/benchmark/benchmark.py
@@ -1,0 +1,63 @@
+import json
+import uuid
+
+from apps.core.benchmark.benchmarkrunner import CoreBenchmark
+from apps.glambda.task.glambdatask import (
+    GLambdaTask,
+    GLambdaTaskDefinition,
+)
+
+
+class GLambdaTaskBenchmark(CoreBenchmark):
+    EXPECTED_OUTPUT = 'test arg'
+    EXPECTED_FILE_OUTPUT = json.dumps({"data": "test arg"})
+
+    def __init__(self):
+        self._normalization_constant = 1000
+        self._task_definition = GLambdaTaskDefinition()
+        self._task_definition.name = 'GLambda'
+        self._task_definition.task_id = str(uuid.uuid4())
+        self._task_definition.subtasks_count = 1
+        self._task_definition.resources = []
+        self._task_definition.compute_on = 'cpu'
+
+        serializer = GLambdaTask.PythonObjectSerializer()
+
+        my_args = ' arg'
+
+        def test_task(args):
+            return 'test' + args
+
+        self._task_definition.options.method = serializer.serialize(test_task)
+        self._task_definition.options.args = serializer.serialize(my_args)
+        self._task_definition.options.verification = {
+            'type': GLambdaTask.VerificationMethod.NO_VERIFICATION
+        }
+        self._task_definition.options.outputs = ['result.json', 'stdout.log',
+                                                 'stderr.log']
+
+    @property
+    def normalization_constant(self):
+        return self._normalization_constant
+
+    @property
+    def task_definition(self):
+        return self._task_definition
+
+    def verify_result(self, result_data_path) -> bool:
+        result_json_file = None
+        for f in result_data_path:
+            if f.endswith('result.json'):
+                result_json_file = f
+
+        if not result_json_file:
+            return False
+
+        with open(result_json_file, 'r') as f:
+            try:
+                json_obj = json.loads(f.read())
+            except json.decoder.JSONDecodeError:
+                return False
+            if 'data' not in json_obj:
+                return False
+            return json_obj['data'] == self.EXPECTED_OUTPUT

--- a/apps/glambda/glambdaenvironment.py
+++ b/apps/glambda/glambdaenvironment.py
@@ -1,4 +1,9 @@
+import shutil
+from typing import Dict
+
+from golem.core.common import is_linux
 from golem.docker.environment import DockerEnvironment
+from golem.environments.environment import SupportStatus, UnsupportReason
 
 
 class GLambdaTaskEnvironment(DockerEnvironment):
@@ -6,3 +11,20 @@ class GLambdaTaskEnvironment(DockerEnvironment):
     DOCKER_TAG = "1.3"
     ENV_ID = "glambda"
     SHORT_DESCRIPTION = "GLambda PoC"
+
+    def check_support(self) -> SupportStatus:
+        GVISOR_SECURE_RUNTIME = 'runsc'
+        if is_linux() and not shutil.which(GVISOR_SECURE_RUNTIME):
+            return SupportStatus.err({
+                UnsupportReason.ENVIRONMENT_NOT_SECURE: self.ENV_ID
+            })
+        return super().check_support()
+
+    def get_container_config(self) -> Dict:
+        return dict(
+            runtime='runsc' if is_linux() else None,
+            volumes=[],
+            binds={},
+            devices=[],
+            environment={}
+        )

--- a/apps/glambda/glambdaenvironment.py
+++ b/apps/glambda/glambdaenvironment.py
@@ -1,0 +1,8 @@
+from golem.docker.environment import DockerEnvironment
+
+
+class GLambdaTaskEnvironment(DockerEnvironment):
+    DOCKER_IMAGE = "golemfactory/glambda"
+    DOCKER_TAG = "1.3"
+    ENV_ID = "glambda"
+    SHORT_DESCRIPTION = "GLambda PoC"

--- a/apps/glambda/resources/images/Dockerfile
+++ b/apps/glambda/resources/images/Dockerfile
@@ -1,0 +1,54 @@
+# Dockerfile for a base image for computing tasks in Golem.
+# Installs python and sets up directories for Golem tasks.
+
+FROM ubuntu:18.04 as builder
+
+ENV RASPA_DIR=/opt/RASPA
+
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates wget curl pkg-config libopenbabel-dev swig \
+    && apt-get install -y python3 python3-pip
+
+RUN apt-get update && \
+	apt-get install -y \
+        apt-utils \
+		curl \
+		bzip2 \
+        git \
+        libtool \
+        automake \
+        make \
+		libglu1-mesa \
+		libgomp1 && \
+    apt-get upgrade -y && \
+	apt-get -y autoremove && \
+	rm -rf /var/lib/apt/lists/* && \
+    git clone https://github.com/numat/RASPA2.git && \
+    cd RASPA2 && \
+    git checkout 256c44ea04fd79eefda67e394e4ea49346032bde && \
+    mkdir m4 && \
+    aclocal && \
+    autoreconf -i && \
+    automake --add-missing && \
+    autoconf && \
+    ./configure --prefix=${RASPA_DIR} && \
+    make  -j8 && \
+    make install && \
+    chmod -R 757 ${RASPA_DIR}/
+
+FROM golemfactory/base:1.4
+ENV RASPA_DIR=/opt/RASPA
+
+RUN set -x \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates wget curl pkg-config libopenbabel-dev swig \
+    && apt-get install -y python3 python3-pip
+
+ RUN set -x \
+    && pip3 install cloudpickle==0.6.1 RASPA2 openbabel
+
+WORKDIR /
+COPY --from=builder /opt/RASPA /opt
+RUN mkdir -p /golem/scripts
+COPY glambda/resources/scripts/job.py /golem/scripts/job.py

--- a/apps/glambda/resources/scripts/job.py
+++ b/apps/glambda/resources/scripts/job.py
@@ -1,0 +1,36 @@
+import base64
+import functools
+import json
+import os
+
+import cloudpickle
+
+
+def run_job():
+    with open('params.json', 'r') as params_file:
+        params = json.load(params_file)
+
+    result_obj = {}
+
+    result_path = os.path.join(os.environ['OUTPUT_DIR'],
+                               'result.json')
+
+    def write_path(path, content):
+        with open(path, 'w') as out:
+            out.write(content)
+
+    write_result = functools.partial(write_path, result_path)
+
+    try:
+        method_code = cloudpickle.loads(base64.b64decode(params['method']))
+        args = cloudpickle.loads(base64.b64decode(params['args']))
+        result = method_code(args)
+        result_obj['data'] = result
+        write_result(json.dumps(result_obj))
+    except Exception as e:  # pylint: disable=broad-except
+        result_obj['error'] = '{}:{}'.format(e.__class__, str(e))
+        write_result(json.dumps(result_obj))
+
+
+if __name__ == '__main__':
+    run_job()

--- a/apps/glambda/task/glambdatask.py
+++ b/apps/glambda/task/glambdatask.py
@@ -1,0 +1,269 @@
+import base64
+import logging
+import os
+import shutil
+from enum import IntEnum
+from typing import List, Optional, Dict, Any, Type
+
+import cloudpickle
+from golem_messages.datastructures import p2p as dt_p2p
+
+from apps.core.task.coretask import CoreTask, CoreTaskBuilder, \
+    CoreVerifier
+from apps.core.task.coretaskstate import TaskDefinition, Options
+from apps.glambda.glambdaenvironment import GLambdaTaskEnvironment
+from golem.resource.dirmanager import DirManager
+from golem.task.taskbase import Task, TaskTypeInfo
+from golem.task.taskstate import SubtaskStatus
+from golem.verificator.verifier import SubtaskVerificationState
+
+logger = logging.getLogger(__name__)
+
+
+class GLambdaTaskOptions(Options):
+    def __init__(self) -> None:
+        super().__init__()
+        self.method: str = ''
+        self.args: str = ''
+        self.verification: Dict[str, IntEnum] = {}
+        self.outputs: List[str] = []
+
+
+class GLambdaTaskDefinition(TaskDefinition):
+    def __init__(self) -> None:
+        super().__init__()
+        self.task_type: str = 'GLambda'
+        self.options: GLambdaTaskOptions = GLambdaTaskOptions()
+
+
+class GLambdaTaskTypeInfo(TaskTypeInfo):
+    def __init__(self) -> None:
+        super().__init__(
+            "GLambda",
+            GLambdaTaskDefinition,
+            GLambdaTaskOptions,
+            GLambdaTaskBuilder
+        )
+
+
+# pylint:disable=too-many-instance-attributes
+class GLambdaTask(CoreTask):
+    class PythonObjectSerializer:
+        @classmethod
+        def serialize(cls, obj) -> str:
+            return base64.b64encode(cloudpickle.dumps(obj)).decode('ascii')
+
+        @classmethod
+        def deserialize(cls, obj) -> Any:
+            return cloudpickle.loads(base64.b64decode(obj))
+
+    class VerificationMethod():
+        NO_VERIFICATION = "None"
+        EXTERNALLY_VERIFIED = "External"
+
+    ENVIRONMENT_CLASS = GLambdaTaskEnvironment
+    MAX_PENDING_CLIENT_RESULTS = 1
+
+    # pylint:disable=too-many-arguments
+    def __init__(self,
+                 task_definition: TaskDefinition,
+                 owner: dt_p2p.Node,
+                 dir_manager: DirManager,
+                 resource_size=None,
+                 root_path: Optional[str] = None,
+                 total_tasks=1) -> None:
+        super().__init__(task_definition,
+                         owner,
+                         self.MAX_PENDING_CLIENT_RESULTS,
+                         resource_size,
+                         root_path,
+                         total_tasks)
+        self.method = task_definition.options.method
+        self.args = task_definition.options.args
+        self.verification_metadata = task_definition.options.verification
+        self.verification_type = self.verification_metadata['type']
+        self.dir_manager = dir_manager
+        self.outputs = [
+            os.path.join(
+                dir_manager.get_task_output_dir(task_definition.task_id),
+                output)
+            for output in task_definition.options.outputs
+        ]
+
+    def _get_subtask_data(self) -> Dict[str, Any]:
+        return {
+            'method': self.method,
+            'args': self.args,
+            'content_type': None,
+            'entrypoint': 'python3 /golem/scripts/job.py'
+        }
+
+    def query_extra_data(self, perf_index: float,
+                         node_id: Optional[str] = None,
+                         node_name: Optional[str] = None) -> Task.ExtraData:
+
+        # last_task has to be incremented each time a new subtask is created
+        self.last_task += 1
+
+        # For each failed/restarted task we decrement num_failed_subtasks
+        # count because we want to recompute them
+        for sub in self.subtasks_given.values():
+            if sub['status'] \
+                    in [SubtaskStatus.failure, SubtaskStatus.restarted]:
+                sub['status'] = SubtaskStatus.resent
+                self.num_failed_subtasks -= 1
+
+        extra_data = self._get_subtask_data()
+
+        ctd = self._new_compute_task_def(
+            subtask_id=self.create_subtask_id(),
+            extra_data=extra_data,
+            perf_index=perf_index
+        )
+
+        subtask_id = ctd['subtask_id']
+
+        logger.debug(
+            'Created new subtask for task. '
+            'task_id=%s, subtask_id=%s, node_id=%s',
+            self.header.task_id,
+            subtask_id,
+            (node_id or '')
+        )
+
+        self.subtasks_given[subtask_id] = {
+            'subtask_id': subtask_id,
+            'subtask_data': extra_data,
+        }
+        self.subtasks_given[subtask_id]['subtask_id'] = subtask_id
+        self.subtasks_given[subtask_id]['status'] = SubtaskStatus.starting
+        self.subtasks_given[subtask_id]['node_id'] = node_id
+        self.subtasks_given[subtask_id]['subtask_timeout'] = \
+            self.header.subtask_timeout
+
+        return Task.ExtraData(ctd=ctd)
+
+    def query_extra_data_for_test_task(self) -> TaskDefinition:
+        return self._new_compute_task_def(
+            subtask_id=self.create_subtask_id(),
+            extra_data=self._get_subtask_data()
+        )
+
+    def _move_subtask_results_to_task_output_dir(self, subtask_id) -> None:
+        '''Required for external subtask results verification. Results
+        moved to task output directory are accessible to the user over RPC
+        even before the task has been completed.
+        '''
+        outdir_content = os.listdir(
+            os.path.join(
+                self.dir_manager.get_task_temporary_dir(
+                    self.task_definition.task_id),
+                subtask_id
+            )
+        )
+
+        for obj in outdir_content:
+            shutil.move(
+                os.path.join(
+                    self.dir_manager.get_task_temporary_dir(
+                        self.task_definition.task_id),
+                    subtask_id,
+                    obj),
+                self.dir_manager.get_task_output_dir(
+                    self.task_definition.task_id,
+                    os.path.basename(obj))
+            )
+
+    def _task_verified(self, subtask_id, verif_cb) -> None:
+        self.accept_results(subtask_id, None)
+        verif_cb()
+        self._move_subtask_results_to_task_output_dir(subtask_id)
+
+    def computation_finished(self, subtask_id, task_result,
+                             verification_finished=None) -> None:
+        if not self.should_accept(subtask_id):
+            logger.info("Not accepting results for %s", subtask_id)
+            return
+
+        self.subtasks_given[subtask_id]['status'] = SubtaskStatus.verifying
+
+        # NOTE: Only VerificationMethod.NO_VERIFICATION is supported at this
+        # moment. branch golem^glambda0.2 contains logic for EXTERNALLY_VERIFIED
+        # user tasks.
+        if self.verification_type == self.VerificationMethod.NO_VERIFICATION:
+            verdict = SubtaskVerificationState.VERIFIED
+        elif self.verification_type == \
+                self.VerificationMethod.EXTERNALLY_VERIFIED:
+            self.subtasks_given[subtask_id]['verif_cb'] = verification_finished
+            verdict = SubtaskVerificationState.IN_PROGRESS
+        try:
+            self._handle_verification_verdict(subtask_id, verdict,
+                                              verification_finished)
+        except Exception as e:  # pylint: disable=broad-except
+            logger.warning("Failed during accepting results %s", e)
+
+    def _handle_verification_verdict(self, subtask_id, verdict,
+                                     verif_cb) -> None:
+        if verdict == SubtaskVerificationState.VERIFIED:
+            self.num_tasks_received += 1
+            self._task_verified(subtask_id, verif_cb)
+        elif verdict in [SubtaskVerificationState.TIMEOUT,
+                         SubtaskVerificationState.WRONG_ANSWER,
+                         SubtaskVerificationState.NOT_SURE]:
+            self.computation_failed(subtask_id)
+            verif_cb()
+        else:
+            logger.warning("Unhandled verification verdict: %d", verdict)
+
+    def get_output_names(self) -> List[str]:
+        return self.outputs
+
+
+class GLambdaTaskVerifier(CoreVerifier):
+    def __init__(self,
+                 verification_data: Optional[Dict[str, Any]] = None) -> None:
+        super().__init__()
+        if verification_data:
+            self.subtask_info = verification_data['subtask_info']
+            self.results = verification_data['results']
+        else:
+            self.subtask_info = None
+            self.results = None
+
+    def _verify_result(self, results: Dict[str, Any]):
+        return True
+
+
+class GLambdaTaskBuilder(CoreTaskBuilder):
+    TASK_CLASS: Type[GLambdaTask] = GLambdaTask
+
+    def get_task_kwargs(self, **kwargs):
+        kwargs = super().get_task_kwargs(**kwargs)
+        kwargs["dir_manager"] = self.dir_manager
+        return kwargs
+
+    @classmethod
+    def build_minimal_definition(cls, task_type: TaskTypeInfo, dictionary):
+        definition = task_type.definition()
+        definition.task_type = task_type.name
+        definition.compute_on = dictionary.get('compute_on', 'cpu')
+        if 'resources' in dictionary:
+            definition.resources = set(dictionary['resources'])
+        options = dictionary['options']
+        definition.subtasks_count = int(dictionary['subtasks_count'])
+        definition.options.method = options['method']
+        definition.options.args = options['args']
+        definition.options.verification = options['verification']
+        definition.options.outputs = options['outputs']
+        return definition
+
+
+class GLambdaBenchmarkTask(GLambdaTask):
+    def query_extra_data(self, perf_index: float, node_id: Optional[str] = None,
+                         node_name: Optional[str] = None) -> Task.ExtraData:
+        ctd = self.query_extra_data_for_test_task()
+        return self.ExtraData(ctd)
+
+
+class GLambdaBenchmarkTaskBuilder(GLambdaTaskBuilder):
+    TASK_CLASS: Type[GLambdaTask] = GLambdaBenchmarkTask

--- a/apps/images.ini
+++ b/apps/images.ini
@@ -5,3 +5,4 @@ golemfactory/blender_verifier blender/resources/images/blender_verifier.Dockerfi
 golemfactory/blender_nvgpu blender/resources/images/blender_nvgpu.Dockerfile 1.3 . apps.core.nvgpu.is_supported
 golemfactory/dummy dummy/resources/images/Dockerfile 1.1 dummy/resources/images
 golemfactory/wasm wasm/resources/images/Dockerfile 0.2.1 .
+golemfactory/glambda glambda/resources/images/Dockerfile 1.3 .

--- a/apps/registered_test.ini
+++ b/apps/registered_test.ini
@@ -18,3 +18,9 @@ builder=apps.wasm.task.WasmTaskBuilder
 task_type_info=apps.wasm.task.WasmTaskTypeInfo
 benchmark=apps.wasm.benchmark.WasmTaskBenchmark
 benchmark_builder=apps.wasm.task.WasmBenchmarkTaskBuilder
+[GLambda]
+env=apps.glambda.glambdaenvironment.GLambdaTaskEnvironment
+builder=apps.glambda.task.glambdatask.GLambdaTaskBuilder
+task_type_info=apps.glambda.task.glambdatask.GLambdaTaskTypeInfo
+benchmark=apps.glambda.benchmark.benchmark.GLambdaTaskBenchmark
+benchmark_builder=apps.glambda.task.glambdatask.GLambdaBenchmarkTaskBuilder

--- a/golem/client.py
+++ b/golem/client.py
@@ -33,7 +33,7 @@ from golem.core.fileshelper import du
 from golem.hardware.presets import HardwarePresets
 from golem.config.active import EthereumConfig
 from golem.core.keysauth import KeysAuth
-from golem.core.service import LoopingCallService
+from golem.core.service import LoopingCallService, IService
 from golem.core.simpleserializer import DictSerializer
 from golem.database import Database
 from golem.diag.service import DiagnosticsService, DiagnosticsOutputFormat
@@ -877,6 +877,7 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             return subtasks
         except KeyError:
             logger.info("Task not found: '%s'", task_id)
+            return None
 
     @rpc_utils.expose('comp.task.subtask')
     def get_subtask(self, subtask_id: str) \
@@ -918,8 +919,7 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             raise ValueError("Incorrect number of days: {}".format(last_days))
         if last_days > 0:
             return self.task_archiver.get_unsupport_reasons(last_days)
-        else:
-            return self.task_server.task_keeper.get_unsupport_reasons()
+        return self.task_server.task_keeper.get_unsupport_reasons()
 
     @rpc_utils.expose('pay.ident')
     def get_payment_address(self):
@@ -1130,8 +1130,7 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
     @rpc_utils.expose('comp.task.state')
     def query_task_state(self, task_id):
         state = self.task_server.task_manager.query_task_state(task_id)
-        if state:
-            return DictSerializer.dump(state)
+        return DictSerializer.dump(state)
 
     def pull_resources(self, task_id, resources, client_options=None):
         self.resource_server.download_resources(
@@ -1201,7 +1200,8 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         if self.task_server is None:
             return {}
         headers = {}
-        for key, header in list(self.task_server.task_keeper.task_headers.items()):  # noqa
+        for key, header in\
+                list(self.task_server.task_keeper.task_headers.items()):  # noqa
             headers[str(key)] = DictSerializer.dump(header)
         return headers
 
@@ -1231,14 +1231,14 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
     @rpc_utils.expose('comp.environment.enable')
     def enable_environment(self, env_id):
         try:
-            self.environments_manager.change_accept_tasks(env_id, True)
+            return self.environments_manager.change_accept_tasks(env_id, True)
         except KeyError:
             return "No such environment"
 
     @rpc_utils.expose('comp.environment.disable')
     def disable_environment(self, env_id):
         try:
-            self.environments_manager.change_accept_tasks(env_id, False)
+            return self.environments_manager.change_accept_tasks(env_id, False)
         except KeyError:
             return "No such environment"
 
@@ -1389,6 +1389,7 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             result = yield deferred
             logger.info('change hw config result: %r', result)
             return self.environments_manager.get_performance_values()
+        return None
 
     @staticmethod
     def enable_talkback(value):
@@ -1415,10 +1416,10 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
 class DoWorkService(LoopingCallService):
     _client = None  # type: Client
 
-    def __init__(self, client: Client):
+    def __init__(self, client: Client) -> None:
         super().__init__(interval_seconds=1)
         self._client = client
-        self._check_ts = {}
+        self._check_ts: Dict[Hashable, Any] = {}
 
     def start(self):
         super().start(now=False)

--- a/golem/config/environments/testnet.py
+++ b/golem/config/environments/testnet.py
@@ -44,7 +44,7 @@ class EthereumConfig:
         contracts.Faucet: '0x77b6145E853dfA80E8755a4e824c4F510ac6692e',
     }
 
-    deposit_contract_address = CONCENT_CHOICES[  # type: ignore  #wth mypy?
+    deposit_contract_address = CONCENT_CHOICES[
         os.environ[CONCENT_ENVIRONMENT_VARIABLE]
     ].get('deposit_contract_address')
 

--- a/golem/environments/environment.py
+++ b/golem/environments/environment.py
@@ -46,6 +46,7 @@ class UnsupportReason(enum.Enum):
     ENVIRONMENT_MISSING = 'environment_missing'
     ENVIRONMENT_UNSUPPORTED = 'environment_unsupported'
     ENVIRONMENT_NOT_ACCEPTING_TASKS = 'environment_not_accepting_tasks'
+    ENVIRONMENT_NOT_SECURE = 'environment_not_secure'
     MAX_PRICE = 'max_price'
     APP_VERSION = 'app_version'
     DENY_LIST = 'deny_list'

--- a/golem/node.py
+++ b/golem/node.py
@@ -1,6 +1,7 @@
 from enum import IntEnum
 import functools
 import logging
+from pathlib import Path
 import time
 from typing import (
     Any,
@@ -12,7 +13,7 @@ from typing import (
     TypeVar,
 )
 
-from pathlib import Path
+from fs.tempfs import TempFS
 from twisted.internet import threads
 from twisted.internet.defer import gatherResults, Deferred, succeed, fail, \
     FirstError
@@ -44,6 +45,8 @@ from golem.rpc.session import (
     Session,
 )
 from golem import terms
+from golem.tools.uploadcontroller import UploadController
+from golem.tools.remotefs import RemoteFS
 
 F = TypeVar('F', bound=Callable[..., Any])
 logger = logging.getLogger(__name__)
@@ -80,8 +83,8 @@ class Node(HardwarePresetsMixin):
                  # SEE golem.core.variables.CONCENT_CHOICES
                  concent_variant: dict,
                  peers: Optional[List[SocketAddress]] = None,
-                 use_monitor: bool = None,
-                 use_talkback: bool = None,
+                 use_monitor: bool = False,
+                 use_talkback: bool = False,
                  use_docker_manager: bool = True,
                  geth_address: Optional[str] = None,
                  password: Optional[str] = None
@@ -142,6 +145,9 @@ class Node(HardwarePresetsMixin):
             task_finished_cb=self._try_shutdown,
             update_hw_preset=self.upsert_hw_preset
         )
+
+        self.tempfs = TempFS()
+        self.remotefs = RemoteFS(self.tempfs, UploadController(self.tempfs))
 
         if password is not None:
             if not self.set_password(password):
@@ -230,6 +236,33 @@ class Node(HardwarePresetsMixin):
     @rpc_utils.expose('golem.password.unlocked')
     def is_account_unlocked(self) -> bool:
         return self._keys_auth is not None
+
+    @rpc_utils.expose('comp.task.results_purge')
+    def purge_task_results(self, task_id):
+        path = self.get_temp_results_path_for_task(task_id)
+        self.tempfs.removetree(path)
+
+    @staticmethod
+    def get_temp_results_path_for_task(task_id):
+        return 'results-{task_id}'.format(task_id=task_id)
+
+    @rpc_utils.expose('comp.task.subtask_results')
+    def get_subtask_results(self, task_id, subtask_id):
+        task = self.client.task_server.task_manager.tasks[task_id]
+        results = task.get_results(subtask_id)
+        res_path = self.get_temp_results_path_for_task(subtask_id)
+        # Create a directory there results will be held temporarily
+        outs = self.remotefs.copy_files_to_tmp_location(results, res_path)
+        return outs
+
+    @rpc_utils.expose('comp.task.result')
+    def get_task_results(self, task_id):
+        # FIXME Obtain task state in less hacky way
+        state = self.client.task_server.task_manager.query_task_state(task_id)
+        res_path = self.get_temp_results_path_for_task(task_id)
+        outs = self.remotefs.copy_files_to_tmp_location(state.outputs,
+                                                        res_path)
+        return outs
 
     @rpc_utils.expose('golem.mainnet')
     @classmethod
@@ -348,7 +381,8 @@ class Node(HardwarePresetsMixin):
         rpc_providers = (
             self,
             virtualization,
-            self.rpc_session
+            self.rpc_session,
+            self.remotefs
         )
 
         for provider in rpc_providers:

--- a/golem/rpc/router.py
+++ b/golem/rpc/router.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from collections import namedtuple
-from typing import Iterable
+from typing import Iterable, Optional
 
 import enum
 from crossbar.common import checkconfig
@@ -34,8 +34,8 @@ class CrossbarRouter(object):
     # pylint: disable=too-many-arguments
     def __init__(self,
                  datadir: str,
-                 host: str = CROSSBAR_HOST,
-                 port: int = CROSSBAR_PORT,
+                 host: Optional[str] = CROSSBAR_HOST,
+                 port: Optional[int] = CROSSBAR_PORT,
                  realm: str = CROSSBAR_REALM,
                  crossbar_log_level: str = 'info',
                  ssl: bool = True,

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -347,3 +347,10 @@ class Task(abc.ABC):
     # pylint: disable=unused-argument, no-self-use
     def get_finishing_subtasks(self, node_id: str) -> List[dict]:
         return []
+
+    def external_verify_subtask(self, subtask_id, verdict):
+        """
+        Verify subtask results
+        """
+        return None
+

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -353,4 +353,3 @@ class Task(abc.ABC):
         Verify subtask results
         """
         return None
-

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -85,7 +85,7 @@ class TaskManager(TaskEventListener):
             tasks_dir="tasks", task_persistence=True,
             apps_manager=AppsManager(),
             finished_cb=None,
-    ):
+    ) -> None:
         super().__init__()
 
         self.apps_manager = apps_manager
@@ -571,7 +571,8 @@ class TaskManager(TaskEventListener):
         # Map new subtasks to old by 'start_task'
         subtasks_to_copy = {
             subtask['start_task']: subtask for subtask in
-            map(lambda id_: old_task.subtasks_given[id_], subtask_ids_to_copy)
+            map(lambda id_: old_task.subtasks_given[id_],  # type: ignore
+                subtask_ids_to_copy)
         }
 
         # Generate all subtasks for the new task
@@ -772,9 +773,8 @@ class TaskManager(TaskEventListener):
                                                  op=TaskOp.NOT_ACCEPTED)
 
         self.notice_task_updated(task_id,
-                                    subtask_id=subtask_id,
-                                    op=SubtaskOp.VERIFYING
-                                 )
+                                 subtask_id=subtask_id,
+                                 op=SubtaskOp.VERIFYING)
         self.tasks[task_id].computation_finished(
             subtask_id, result, verification_finished_
         )
@@ -1148,8 +1148,10 @@ class TaskManager(TaskEventListener):
         self.notice_task_updated(task_id)
 
     @handle_task_key_error
-    def notice_task_updated(self, task_id: str, subtask_id: str = None,
-                            op: Operation = None, persist: bool = True):
+    def notice_task_updated(self, task_id: str,
+                            subtask_id: Optional[str] = None,
+                            op: Optional[Operation] = None,
+                            persist: bool = True):
         """Called when a task is modified, saves the task and
         propagates information
 

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -771,6 +771,10 @@ class TaskManager(TaskEventListener):
                         self.notice_task_updated(task_id,
                                                  op=TaskOp.NOT_ACCEPTED)
 
+        self.notice_task_updated(task_id,
+                                    subtask_id=subtask_id,
+                                    op=SubtaskOp.VERIFYING
+                                 )
         self.tasks[task_id].computation_finished(
             subtask_id, result, verification_finished_
         )
@@ -1032,6 +1036,17 @@ class TaskManager(TaskEventListener):
 
         subtask_states = list(task_state.subtask_states.values())
         return [subtask_state.subtask_id for subtask_state in subtask_states]
+
+    @rpc_utils.expose('comp.task.verify_subtask')
+    def external_verify_subtask(self, subtask_id, verdict):
+        logger.info("external_verify_subtask. subtask_id=%r",
+                    subtask_id)
+        if subtask_id in self.subtask2task_mapping:
+            task_id = self.subtask2task_mapping[subtask_id]
+            return self.tasks[task_id].external_verify_subtask(subtask_id,
+                                                               verdict)
+        else:
+            raise ValueError('Not my subtask')
 
     def get_frame_subtasks(self, task_id: str, frame) \
             -> Optional[FrozenSet[str]]:

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -232,12 +232,14 @@ class SubtaskOp(Operation):
     FAILED = auto()
     TIMEOUT = auto()
     RESTARTED = auto()
+    VERIFYING = auto()
 
     def is_completed(self) -> bool:
         return self not in (
             SubtaskOp.ASSIGNED,
             SubtaskOp.RESULT_DOWNLOADING,
-            SubtaskOp.RESTARTED
+            SubtaskOp.RESTARTED,
+            SubtaskOp.VERIFYING
         )
 
 

--- a/golem/tools/remotefs.py
+++ b/golem/tools/remotefs.py
@@ -1,0 +1,97 @@
+import os
+from pathlib import PurePath
+import traceback
+from typing import List, Dict, Any
+
+import fs
+from fs.osfs import OSFS
+
+from golem.rpc import utils as rpc_utils
+
+
+class RemoteFS:
+    def __init__(self, filesystem, upload_ctrl):
+        self._fs = filesystem
+        self.upload_ctrl = upload_ctrl
+
+    @rpc_utils.expose('fs.isdir')
+    def fs_isdir(self, path) -> bool:
+        path = str(PurePath(path))
+        return self._fs.getinfo(path).is_dir
+
+    @rpc_utils.expose('fs.isfile')
+    def fs_isfile(self, path) -> bool:
+        path = str(PurePath(path))
+        return self._fs.getinfo(path).is_file
+
+    @rpc_utils.expose('fs.listdir')
+    def fs_listdir(self, path) -> List[str]:
+        try:
+            return [
+                str(PurePath(f)) for f in self._fs.listdir(path)
+            ]
+        except (fs.errors.DirectoryExpected, fs.errors.ResourceNotFound):
+            traceback.print_stack()
+            return []
+
+    @rpc_utils.expose('fs.mkdir')
+    def fs_mkdir(self, path) -> None:
+        path = str(PurePath(path))
+        try:
+            self._fs.makedir(path, recreate=True)
+        except (fs.errors.DirectoryExpected, fs.errors.ResourceNotFound):
+            traceback.print_stack()
+
+    @rpc_utils.expose('fs.remove')
+    def fs_remove(self, path) -> None:
+        path = str(PurePath(path))
+        return self._fs.remove(path)
+
+    @rpc_utils.expose('fs.removetree')
+    def fs_removetree(self, path) -> None:
+        path = str(PurePath(path))
+        try:
+            return self._fs.removetree(path)
+        except fs.errors.ResourceNotFound:
+            pass
+
+    @rpc_utils.expose('fs.meta')
+    def fs_meta(self) -> Dict[str, Any]:
+        return self.upload_ctrl.meta
+
+    @rpc_utils.expose('fs.upload_id')
+    def fs_upload_id(self, path) -> List[str]:
+        path = str(PurePath(path))
+        return self.upload_ctrl.open(path, 'wb')
+
+    @rpc_utils.expose('fs.upload')
+    def fs_upload(self, id_, data) -> List[str]:
+        return self.upload_ctrl.upload(id_, data)
+
+    @rpc_utils.expose('fs.download_id')
+    def fs_download_id(self, path) -> List[str]:
+        path = str(PurePath(path))
+        return self.upload_ctrl.open(path, 'rb')
+
+    @rpc_utils.expose('fs.download')
+    def fs_download(self, id_) -> List[str]:
+        return self.upload_ctrl.download(id_)
+
+    def copy_files_to_tmp_location(self,
+                                   files: List[str],
+                                   dest: str) -> List[str]:
+        outs = []
+        osfs = OSFS('/')
+        self._fs.makedir(dest)
+        for output in files:
+            out_path = os.path.join(
+                dest,
+                os.path.basename(os.path.normpath(output)))
+            if os.path.isfile(output):
+                fs.copy.copy_file(osfs, output, self._fs, out_path)
+            elif os.path.isdir(output):
+                fs.copy.copy_dir(osfs, output, self._fs, out_path)
+            else:
+                pass
+            outs.append(str(PurePath(out_path)))
+        return outs

--- a/golem/tools/uploadcontroller.py
+++ b/golem/tools/uploadcontroller.py
@@ -1,0 +1,35 @@
+import sys
+import uuid
+
+
+class UploadController(object):
+    # TODO https://github.com/golemfactory/golem/issues/4157
+    def __init__(self, fs):
+        self.fs = fs
+        self.meta = {
+            # This is empirically chosen big enough value (512kB)
+            # that works with autobahn
+            'chunk_size': 131072*4,
+            'platform': sys.platform,
+            'syspath': fs.getsyspath('')
+        }
+        self.fd_id_map = {}
+
+    def open(self, path, mode):
+        id_ = str(uuid.uuid4())
+        self.fd_id_map[id_] = self.fs.open(path, mode)
+        return id_
+
+    def upload(self, id_, data):
+        count = self.fd_id_map[id_].write(data)
+        if len(data) < self.meta['chunk_size']:
+            self.fd_id_map[id_].close()
+            del self.fd_id_map[id_]
+        return count
+
+    def download(self, id_):
+        data = self.fd_id_map[id_].read(self.meta['chunk_size'])
+        if len(data) < self.meta['chunk_size']:
+            self.fd_id_map[id_].close()
+            del self.fd_id_map[id_]
+        return data

--- a/golem/verificator/verifier.py
+++ b/golem/verificator/verifier.py
@@ -1,11 +1,11 @@
 import logging
 from datetime import datetime
-from enum import Enum
+from enum import IntEnum
 
 logger = logging.getLogger("verifier")
 
 
-class SubtaskVerificationState(Enum):
+class SubtaskVerificationState(IntEnum):
     UNKNOWN_SUBTASK = 0
     WAITING = 1
     IN_PROGRESS = 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ certifi==2018.1.18
 cffi==1.10.0
 chardet==3.0.4
 click==6.7
+cloudpickle==0.6.1
 coincurve==7.1.0
 constantly==15.1.0
 crossbar==17.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ eth-keys==0.2.0b3
 eth-tester==0.1.0-beta.24
 eth-utils==1.0.3
 ethereum==1.6.1
+fs==2.4.4
 Golem-Messages==3.4.0
 Golem-Smart-Contracts-Interface==1.7.0
 greenlet==0.4.15

--- a/tests/apps/glambda/test_glambda_benchmark.py
+++ b/tests/apps/glambda/test_glambda_benchmark.py
@@ -1,0 +1,38 @@
+from unittest import TestCase
+
+from mock import mock_open, patch
+
+from apps.glambda.benchmark.benchmark import GLambdaTaskBenchmark
+from apps.glambda.task.glambdatask import GLambdaTask
+
+
+class GLambdaBenchmarkTestCase(TestCase):
+    def setUp(self):
+        self.benchmark = GLambdaTaskBenchmark()
+
+    def test_definition(self):
+        task_def = self.benchmark.task_definition
+        self.assertEqual(task_def.subtasks_count, 1)
+        self.assertCountEqual(
+            task_def.resources,
+            []
+        )
+
+        self.assertEqual(task_def.options.outputs,
+                         ['result.json', 'stdout.log', 'stderr.log'])
+        self.assertEqual(task_def.options.verification, {
+            'type': GLambdaTask.VerificationMethod.NO_VERIFICATION})
+
+    def test_verification(self):
+        self.assertFalse(
+            self.benchmark.verify_result(['no', 'expected', 'output', 'file'])
+        )
+
+        with patch('builtins.open', mock_open(read_data='wrong_content')):
+            self.assertFalse(
+                self.benchmark.verify_result(['/path/result.json']))
+
+        good_content = GLambdaTaskBenchmark.EXPECTED_FILE_OUTPUT
+        with patch('builtins.open', mock_open(read_data=good_content)):
+            self.assertTrue(
+                self.benchmark.verify_result(['/path/to/result.json']))

--- a/tests/apps/glambda/test_job.py
+++ b/tests/apps/glambda/test_job.py
@@ -1,0 +1,166 @@
+from contextlib import ExitStack
+from json import dumps
+from unittest import TestCase
+from mock import mock_open, patch
+
+from apps.glambda.resources.scripts import job
+from apps.glambda.task.glambdatask import GLambdaTask
+
+
+class GLambdaJobTestCase(TestCase):
+    def test_job_success(self):
+
+        def test_task(args):
+            return 1 + args['b']
+
+        test_args = {
+            'b': 2
+        }
+
+        serializer = GLambdaTask.PythonObjectSerializer()
+
+        params = {
+            'method': serializer.serialize(test_task),
+            'args': serializer.serialize(test_args)
+        }
+
+        env = {
+            'OUTPUT_DIR': '',
+        }
+
+        with ExitStack() as stack:
+            mocked_file = stack.enter_context(
+                patch('builtins.open', mock_open(read_data=dumps(params))),
+            )
+            stack.enter_context(patch.dict('os.environ', env))
+            job.run_job()
+
+        expected_result = {
+            'data': 3
+        }
+
+        file_handle = mocked_file.return_value.__enter__.return_value
+        file_handle.write.assert_called_with(dumps(expected_result))
+
+
+    def test_job_invalid_input_task(self):
+
+        test_task = None
+
+        test_args = {
+            'b': 2
+        }
+
+        serializer = GLambdaTask.PythonObjectSerializer()
+
+        params = {
+            'method': serializer.serialize(test_task),
+            'args': serializer.serialize(test_args)
+        }
+
+        env = {
+            'OUTPUT_DIR': '',
+        }
+
+        with ExitStack() as stack:
+            mocked_file = stack.enter_context(
+                patch('builtins.open', mock_open(read_data=dumps(params))),
+            )
+            stack.enter_context(patch.dict('os.environ', env))
+            job.run_job()
+
+        expected_result = {"error": "<class \'TypeError\'>:\'NoneType\' "
+                                    "object is not callable"}
+
+        file_handle = mocked_file.return_value.__enter__.return_value
+        file_handle.write.assert_called_with(dumps(expected_result))
+
+
+    def test_job_non_existent_input_arguments(self):
+        def test_task(args):
+            return 1 + args['b']
+
+        test_args = {}
+
+        serializer = GLambdaTask.PythonObjectSerializer()
+
+        params = {
+            'method': serializer.serialize(test_task),
+            'args': serializer.serialize(test_args)
+        }
+
+        env = {
+            'OUTPUT_DIR': '',
+        }
+
+        with ExitStack() as stack:
+            mocked_file = stack.enter_context(
+                patch('builtins.open', mock_open(read_data=dumps(params))),
+            )
+            stack.enter_context(patch.dict('os.environ', env))
+            job.run_job()
+
+        expected_result = {"error": "<class \'KeyError\'>:\'b\'"}
+
+        file_handle = mocked_file.return_value.__enter__.return_value
+        file_handle.write.assert_called_with(dumps(expected_result))
+
+
+    def test_job_raises_exception(self):
+        def test_task(args): # pylint: disable=unused-argument
+            raise ValueError('my error!')
+
+        test_args = {}
+
+        serializer = GLambdaTask.PythonObjectSerializer()
+
+        params = {
+            'method': serializer.serialize(test_task),
+            'args': serializer.serialize(test_args)
+        }
+
+        env = {
+            'OUTPUT_DIR': '',
+        }
+
+        with ExitStack() as stack:
+            mocked_file = stack.enter_context(
+                patch('builtins.open', mock_open(read_data=dumps(params))),
+            )
+            stack.enter_context(patch.dict('os.environ', env))
+            job.run_job()
+
+        expected_result = {"error": "<class \'ValueError\'>:my error!"}
+
+        file_handle = mocked_file.return_value.__enter__.return_value
+        file_handle.write.assert_called_with(dumps(expected_result))
+
+
+    def test_job_empty_task(self):
+        def test_task(args): # pylint: disable=unused-argument
+            pass
+
+        test_args = {}
+
+        serializer = GLambdaTask.PythonObjectSerializer()
+
+        params = {
+            'method': serializer.serialize(test_task),
+            'args': serializer.serialize(test_args)
+        }
+
+        env = {
+            'OUTPUT_DIR': '',
+        }
+
+        with ExitStack() as stack:
+            mocked_file = stack.enter_context(
+                patch('builtins.open', mock_open(read_data=dumps(params))),
+            )
+            stack.enter_context(patch.dict('os.environ', env))
+            job.run_job()
+
+        expected_result = {"data": None}
+
+        file_handle = mocked_file.return_value.__enter__.return_value
+        file_handle.write.assert_called_with(dumps(expected_result))

--- a/tests/apps/glambda/test_task.py
+++ b/tests/apps/glambda/test_task.py
@@ -155,3 +155,62 @@ class GLambdaTaskTestCase(TempDirFixture):
                          SubtaskStatus.finished)
         verif_cb.assert_called_once()
 
+    def test_external_verification_finish(self):
+        self.task.verification_type = \
+            GLambdaTask.VerificationMethod.EXTERNALLY_VERIFIED
+
+        results = ['result']
+        verif_cb = MagicMock()
+
+        self.task.counting_nodes = MagicMock()
+        self.task.should_accept = MagicMock()
+        self.task.should_accept.return_value = True
+        self.task._copy_results = MagicMock()
+
+        # Subtask results are not filled by Hyperg therefore it makes
+        # no sense to move subtask results between directories.
+        self.task._move_subtask_results_to_task_output_dir = MagicMock()
+
+        self.task.subtasks_given['some_id'] = {'node_id': 'some_node'}
+        self.task.computation_finished('some_id', results, verif_cb)
+
+        self.assertEqual(self.task.SUBTASK_CALLBACKS['some_id'],
+                         verif_cb)
+        self.assertEqual(self.task.results['some_id'],
+                         results)
+        verif_cb.assert_not_called()
+
+        self.task.external_verify_subtask('some_id',
+                                          SubtaskVerificationState.VERIFIED)
+
+        self.assertTrue('verif_cb' not in self.task.subtasks_given['some_id'])
+        self.assertEqual(self.task.num_tasks_received, 1)
+        verif_cb.assert_called_once()
+
+    def test_external_verification_failed(self):
+        self.task.verification_type = \
+            GLambdaTask.VerificationMethod.EXTERNALLY_VERIFIED
+
+        results = ['result']
+        verif_cb = MagicMock()
+
+        self.task.counting_nodes = MagicMock()
+        self.task.should_accept = MagicMock()
+        self.task.should_accept.return_value = True
+        self.task._copy_results = MagicMock()
+        self.task.computation_failed = MagicMock()
+
+        self.task.subtasks_given['some_id'] = {'node_id': 'some_node'}
+        self.task.computation_finished('some_id', results, verif_cb)
+
+        self.assertEqual(self.task.SUBTASK_CALLBACKS['some_id'], verif_cb)
+        self.assertEqual(self.task.results['some_id'],
+                         results)
+        verif_cb.assert_not_called()
+        self.task.external_verify_subtask('some_id',
+                                          SubtaskVerificationState.WRONG_ANSWER)
+
+        self.assertTrue('verif_cb' not in self.task.subtasks_given['some_id'])
+        self.assertEqual(self.task.num_tasks_received, 0)
+        verif_cb.assert_called()
+        self.task.computation_failed.assert_called_once()

--- a/tests/apps/glambda/test_task.py
+++ b/tests/apps/glambda/test_task.py
@@ -1,0 +1,157 @@
+from unittest import TestCase
+from uuid import uuid4
+
+from golem_messages.factories.datastructures import p2p
+from mock import MagicMock, patch
+
+from apps.glambda.task.glambdatask import GLambdaTask
+from apps.glambda.task.glambdatask import (
+    GLambdaTaskVerifier,
+    GLambdaTaskBuilder,
+    GLambdaTaskTypeInfo,
+    GLambdaTaskOptions,
+    GLambdaBenchmarkTaskBuilder,
+    GLambdaBenchmarkTask
+)
+from golem.resource.dirmanager import DirManager
+from golem.task.taskstate import SubtaskStatus
+from golem.testutils import TempDirFixture
+from golem.verificator.verifier import SubtaskVerificationState
+
+
+def my_test_task(args):
+    return 1 + args['b']
+
+
+test_args = {'b': 2}
+
+TEST_TASK_DEF_DICT = {
+    'type': 'GLambda',
+    'name': 'my_task',
+    'bid': 1,
+    'timeout': '00:10:00',
+    'subtask_timeout': '00:10:00',
+    'subtasks_count': 1,
+    'options': {
+        'method': GLambdaTask.PythonObjectSerializer.serialize(my_test_task),
+        'args': GLambdaTask.PythonObjectSerializer.serialize(test_args),
+        'verification': {
+            'type': GLambdaTask.VerificationMethod.NO_VERIFICATION},
+        'outputs': ['result.json', 'stdout.log', 'stderr.log'],
+        'output_path': ''
+    }
+}
+
+
+class GLambdaTaskVerifierTestCase(TestCase):
+    def test_verifier(self):
+        verifier = GLambdaTaskVerifier()
+        self.assertTrue(
+            verifier._verify_result({'abitrary': 'result accepted'}))
+
+
+class GLambdaTaskBuilderTestCase(TestCase):
+    def test_build_full_definition(self):
+        task_def = GLambdaTaskBuilder.build_full_definition(
+            GLambdaTaskTypeInfo(), TEST_TASK_DEF_DICT,
+        )
+        self.assertEqual(task_def.subtasks_count, 1)
+
+        opts: GLambdaTaskOptions = task_def.options
+        self.assertEqual(opts.method, TEST_TASK_DEF_DICT['options']['method'])
+        self.assertEqual(opts.args, TEST_TASK_DEF_DICT['options']['args'])
+        self.assertEqual(opts.verification, {
+            'type': GLambdaTask.VerificationMethod.NO_VERIFICATION})
+        self.assertEqual(set(opts.outputs),
+                         set(['result.json', 'stdout.log', 'stderr.log']))
+
+
+class GLambdaBenchmarkTaskTestCase(TestCase):
+    def test_query_extra_data(self):
+        task_def = GLambdaBenchmarkTaskBuilder.build_full_definition(
+            GLambdaTaskTypeInfo(), TEST_TASK_DEF_DICT,
+        )
+        task_def.task_id = str(uuid4())
+        dir_manager = DirManager(root_path='/')
+        dir_manager.get_task_output_dir = MagicMock()
+        dir_manager.get_task_output_dir.return_value = ''
+
+        task = GLambdaBenchmarkTask(
+            total_tasks=1, task_definition=task_def,
+            root_path='/', owner=p2p.Node(), dir_manager=dir_manager
+        )
+
+        data = task.query_extra_data(0.1337, 'test_id', 'test_name')
+
+        self.assertEqual(
+            data.ctd['extra_data']['method'],
+            TEST_TASK_DEF_DICT['options']['method']
+        )
+
+        self.assertEqual(
+            data.ctd['extra_data']['args'],
+            TEST_TASK_DEF_DICT['options']['args']
+        )
+
+
+class GLambdaTaskTestCase(TempDirFixture):
+    def setUp(self):
+        super(GLambdaTaskTestCase, self).setUp()
+        task_def = GLambdaTaskBuilder.build_full_definition(
+            GLambdaTaskTypeInfo(), TEST_TASK_DEF_DICT,
+        )
+        task_def.task_id = str(uuid4())
+        self.task = GLambdaTask(
+            total_tasks=1, task_definition=task_def,
+            root_path='/', owner=p2p.Node(),
+            dir_manager=DirManager(root_path=self.tempdir)
+        )
+
+    def test_query_extra_data(self):
+        next_subtask_data = {'extra': 'data'}
+        with patch(
+            'apps.glambda.task.glambdatask.GLambdaTask._get_subtask_data',
+            return_value=next_subtask_data,
+        ):
+            data = self.task.query_extra_data(0.1337, 'test_id', 'test_name')
+
+        self.assertEqual(data.ctd['extra_data'], next_subtask_data)
+
+        self.assertEqual(self.task.subtasks_given[data.ctd['subtask_id']], {
+            'subtask_data': {'extra': 'data'},
+            'status': SubtaskStatus.starting,
+            'subtask_timeout': 600,
+            'subtask_id': data.ctd['subtask_id'],
+            'node_id': 'test_id'
+        })
+
+    def test_query_extra_data_for_test_task(self):
+        next_subtask_data = {'extra': 'data'}
+        with patch(
+            'apps.glambda.task.glambdatask.GLambdaTask._get_subtask_data',
+            return_value=next_subtask_data,
+        ):
+            data = self.task.query_extra_data(0.1337, 'test_id', 'test_name')
+        self.assertEqual(data.ctd['extra_data'], {'extra': 'data'})
+
+    def test_computation_finished_for_arbitrary_result(self):
+        """
+        Test if VerificatonMethod.NO_VERIFICATION accepts every result
+        and sets subtask state to finished.
+        """
+        results = ['result']
+        verif_cb = MagicMock()
+
+        self.task.counting_nodes = MagicMock()
+        self.task.should_accept = MagicMock()
+        self.task.should_accept.return_value = True
+        self.task._copy_results = MagicMock()
+
+        self.task.subtasks_given['some_id'] = {'node_id': 'some_node'}
+        self.task.computation_finished('some_id', results, verif_cb)
+
+        self.assertEqual(self.task.num_tasks_received, 1)
+        self.assertEqual(self.task.subtasks_given['some_id']['status'],
+                         SubtaskStatus.finished)
+        verif_cb.assert_called_once()
+

--- a/tests/golem/docker/test_docker_manager.py
+++ b/tests/golem/docker/test_docker_manager.py
@@ -303,9 +303,9 @@ class TestDockerManager(TestCase):  # pylint: disable=too-many-public-methods
 
         from apps.core import nvgpu
         if nvgpu.is_supported():
-            expected = 7
+            expected = 8
         else:
-            expected = 5
+            expected = 6
 
         assert pulls[0] == expected
 
@@ -332,9 +332,9 @@ class TestDockerManager(TestCase):  # pylint: disable=too-many-public-methods
 
         from apps.core import nvgpu
         if nvgpu.is_supported():
-            expected = 7
+            expected = 8
         else:
-            expected = 5
+            expected = 6
 
         assert builds[0] == expected
         assert tags[0] == expected

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -566,6 +566,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         checker([("task4", "ttt4", SubtaskOp.NOT_ACCEPTED),
                  ("task4", "ttt4", OtherOp.UNEXPECTED),
                  ("task4", "sss4", SubtaskOp.ASSIGNED),
+                 ("task4", "sss4", SubtaskOp.VERIFYING),
                  ("task4", "sss4", SubtaskOp.FINISHED),
                  ("task4", None, TaskOp.FINISHED)])
         del handler
@@ -600,7 +601,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         expected_warn = f"Task finished but was not accepted. " \
                         f"task_id='{task_id}'"
         assert any(expected_warn in s for s in log.output)
-        assert self.tm.notice_task_updated.call_count == 2
+        assert self.tm.notice_task_updated.call_count == 3
         self.tm.notice_task_updated.assert_called_with(
             task_id, op=TaskOp.NOT_ACCEPTED)
         mock_finished.assert_called_once()


### PR DESCRIPTION
RASPA2 use-case related app. Allows user to submit arbitrary python code for provider side execution. It's called RASPA2 because docker environment that executes the script has RASPA2. Therefore it's possible to compute molecular dynamics using python3 + RASPA2 (inspired by [RASPA2 workflow](https://github.com/numat/RASPA2/wiki/Workflow).

Complementary client library: [golemrpc](https://github.com/golemfactory/golemrpc). Required because user defined methods are sent to Golem in app specific serialization format (cloudpickle + base64 encoding). One can not submit a task in traditional way, e.g. by using `golemcli` and providing `task.json`. 

This app has 4 changes that are subject to discussion and (if required) can easily be reverted without affecting base GLambda app:
- "Add file upload" - Adds RemoteFS class that allows clients to upload artifacts over RPC, useful when RPC client is not colocated with Golem client.
- "Add empty resource handling" - Changes to `resultpackage.py` allowing empty resources to be exchanged over hyperdrive
- "Add external verification support to GLambda App" - introduces RPC call `comp.task.verify_subtask` and  `external_verify_subtask` abstract method to TaskBase, allowing clients to provide verification verdict. Useful when RPC client wants to perform organic verification e.g. asking user if this result is OK - YES/NO. 
- "Add gVisor secure container runtime to GLambda App" - introduces new runtime for docker environment - gVisor

EDIT:
During tests/QA make sure that `gvisor` runtime installation does not override existing runtime installations for docker e.g. `nvidia-runtime`.