### PR TITLE
Keep Golem running after Docker issues at startup

### DIFF
--- a/golem/docker/manager.py
+++ b/golem/docker/manager.py
@@ -43,6 +43,7 @@ class DockerManager(DockerConfigManager):
         self._env_checked = True
 
         try:
+            raise EnvironmentError("No VM hypervisor found.")
             if not is_linux():
                 self.hypervisor = self._select_hypervisor()
                 self.hypervisor.setup()
@@ -52,13 +53,14 @@ class DockerManager(DockerConfigManager):
                 ***************************************************************
                 No supported VM hypervisor was found.
                 Golem will not be able to compute anything.
-                hypervisor.setup() returned {}
+                hypervisor.setup() returned {!r}
                 ***************************************************************
                 """.format(e)
             )
-            raise EnvironmentError
+            raise EnvironmentError("No VM hypervisor found.")
 
         try:
+            raise EnvironmentError("Docker unavailable.")
             # We're checking the availability of "docker" command line utility
             # (other commands may result in an error if docker env variables
             # are set incorrectly)
@@ -69,11 +71,11 @@ class DockerManager(DockerConfigManager):
                 ***************************************************************
                 Docker is not available, not building images.
                 Golem will not be able to compute anything.
-                Command 'docker info' returned {}
+                Command 'docker info' returned {!r}
                 ***************************************************************
                 """.format(err)
             )
-            raise EnvironmentError
+            raise EnvironmentError("Docker unavailable.")
 
         try:
             self.pull_images()

--- a/golem/docker/manager.py
+++ b/golem/docker/manager.py
@@ -43,7 +43,6 @@ class DockerManager(DockerConfigManager):
         self._env_checked = True
 
         try:
-            raise EnvironmentError("No VM hypervisor found.")
             if not is_linux():
                 self.hypervisor = self._select_hypervisor()
                 self.hypervisor.setup()
@@ -60,7 +59,6 @@ class DockerManager(DockerConfigManager):
             raise EnvironmentError("No VM hypervisor found.")
 
         try:
-            raise EnvironmentError("Docker unavailable.")
             # We're checking the availability of "docker" command line utility
             # (other commands may result in an error if docker env variables
             # are set incorrectly)

--- a/golem/node.py
+++ b/golem/node.py
@@ -164,7 +164,7 @@ class Node(HardwarePresetsMixin):
 
             def on_start_error(failure: FirstError):
                 failure.value.subFailure.trap(EnvironmentError)
-                logger.warning(
+                logger.error(
                     """
                     There was a problem setting up the environment. Golem will
                     run with limited functionality to support communication with

--- a/golem/node.py
+++ b/golem/node.py
@@ -14,7 +14,8 @@ from typing import (
 
 from pathlib import Path
 from twisted.internet import threads
-from twisted.internet.defer import gatherResults, Deferred, succeed, fail, FirstError
+from twisted.internet.defer import gatherResults, Deferred, succeed, fail, \
+    FirstError
 from twisted.python.failure import Failure
 
 from apps.appsmanager import AppsManager

--- a/golem/node.py
+++ b/golem/node.py
@@ -163,13 +163,15 @@ class Node(HardwarePresetsMixin):
                 return gatherResults([terms_, keys, docker], consumeErrors=True)
 
             def on_start_error(failure: FirstError):
-                failure.value.subFailure.trap(EnvironmentError)
+                sub_failure: Failure = failure.value.subFailure
+                sub_failure.trap(EnvironmentError)
+
                 logger.error(
                     """
-                    There was a problem setting up the environment. Golem will
-                    run with limited functionality to support communication with
-                    local clients.
-                    """
+                    There was a problem setting up the environment: {}
+                    Golem will run with limited functionality to support
+                    communication with local clients.
+                    """.format(sub_failure.getErrorMessage())
                 )
 
             chain_function(rpc, on_rpc_ready).addCallbacks(

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -99,7 +99,7 @@ def validate_client(client: Client):
     if client.config_desc.in_shutdown:
         raise CreateTaskError(
             'Can not enqueue task: shutdown is in progress, '
-            'toggle shutdown mode off to create a new tasks.')
+            'toggle shutdown mode off to create new tasks.')
     if client.task_server is None:
         raise CreateTaskError("Golem is not ready")
 

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -591,8 +591,8 @@ class TestOptNode(TempDirFixture):
             self.node.start()
 
         setup_client_mock.assert_not_called()
-        self.node._docker_manager.apply_config.assert_not_called()
-        self.node._docker_manager.check_environment.assert_called()
+        self.node._docker_manager.apply_config.assert_not_called() # noqa # pylint: disable=no-member
+        self.node._docker_manager.check_environment.assert_called() # noqa # pylint: disable=no-member
 
     @patch('golem.node.DockerManager')
     def test_start_docker_other_error(self, mock_dm, *_):


### PR DESCRIPTION
Fixes #3966

This change adds handling of Docker issues during client startup, preventing Golem from exiting.
Golem will continue running without connecting to the network and with basic RPCs registered to support communication with its frontend.