### PR TITLE
cherry pick of: Feature reuse keys and run faster node integration tests (#3930)

### DIFF
--- a/scripts/node_integration_tests/README.md
+++ b/scripts/node_integration_tests/README.md
@@ -171,6 +171,8 @@ environment variable, e.g.:
 GOLEM_INTEGRATION_TEST_DIR=/some/location pytest scripts/node_integration_tests
 ```
 
+#### Running tests selectively
+
 And finally, to run a single test using `pytest`, just use standard `pytest`
 syntax, e.g.:
 
@@ -181,7 +183,6 @@ pytest scripts/node_integration_tests/tests/test_golem.py::GolemNodeTest::test_r
 Suggestion: when you _don't_ provide the `GOLEM_INTEGRATION_TEST_DIR` variable
 to pytest, run `pytest -s -v [...]` so that you can see the paths generated
 automatically during the test run.
-
 
 #### Mac OS
 
@@ -195,4 +196,27 @@ as the default temporary directory, e.g.:
 
 ```
 TMPDIR=/tmp pytest scripts/node_integration_tests/
+```
+
+#### Node key reuse
+
+Normally, each test starts with empty provider and requestor datadirs. That
+also means that the nodes need to initialize their keystores, request GNT and
+ETH from the faucets and finally convert GNT into GNTB which adds several
+minutes to each run.
+
+To optimize that, we're now only initializing the keystores on the first test
+run by default and all subsequest tests reuse the same node key pairs.
+Thus, nodes don't need to wait for ETH, GNT and GNTB anymore.
+
+In some tests, we need to ensure there are no side effects on the blockchain.
+To achieve that, we can disable key reuse for this particular test by adding the
+`@disable_key_reuse` decorator to the test method
+(in test_golem.py and test_concent.py).
+
+To completely disable key reuse and run each test with a new key, specify a
+`--disable-key-reuse` option on the pytest's command line:
+
+```
+pytest --disable-key-reuse scripts/node_integration_tests
 ```

--- a/scripts/node_integration_tests/conftest.py
+++ b/scripts/node_integration_tests/conftest.py
@@ -1,0 +1,52 @@
+from typing import List
+import _pytest
+
+REUSE_KEYS = True
+
+
+class NodeKeyReuseException(Exception):
+    pass
+
+
+class NodeKeyReuse:
+    instance = None
+    _first_test = True
+
+    @classmethod
+    def get(cls):
+        if not cls.instance:
+            cls.instance = cls()
+        return cls.instance
+
+    @property
+    def keys_ready(self):
+        return not self._first_test
+
+    def mark_keys_ready(self):
+        if not self.enabled:
+            raise NodeKeyReuseException("Key reuse disabled.")
+        self._first_test = False
+
+    def disable(self):
+        global REUSE_KEYS
+        REUSE_KEYS = False
+
+    @property
+    def enabled(self):
+        return REUSE_KEYS
+
+
+def pytest_addoption(parser: _pytest.config.Parser) -> None:
+
+    parser.addoption(
+        "--disable-key-reuse", action="store_true",
+        help="Parameter disables reusing of provider's and "
+             "requestor's node keys. All node_integration_tests "
+             "run with new, fresh keys."
+    )
+
+
+def pytest_collection_modifyitems(config: _pytest.config.Config,
+                                  items: List[_pytest.main.Item]) -> None:
+    if config.getoption("--disable-key-reuse"):
+        NodeKeyReuse().disable()

--- a/scripts/node_integration_tests/playbooks/base.py
+++ b/scripts/node_integration_tests/playbooks/base.py
@@ -627,4 +627,3 @@ class NodeTestPlaybook:
 
         self.stop_nodes()
         self.exit_code = exit_code
-

--- a/scripts/node_integration_tests/tests/base.py
+++ b/scripts/node_integration_tests/tests/base.py
@@ -1,8 +1,23 @@
 import os
 import pathlib
+import shutil
 import subprocess
+from functools import wraps
+from typing import Callable
+
+from scripts.node_integration_tests.conftest import NodeKeyReuse
 
 from ..helpers import get_testdir
+
+KEYSTORE_DIR = 'rinkeby/keys'
+
+
+def disable_key_reuse(test_function: Callable)-> Callable:
+    @wraps(test_function)
+    def wrap(*args, **kwargs) -> None:
+        args[0].reuse_keys = False
+        test_function(*args, **kwargs)
+    return wrap
 
 
 class NodeTestBase:
@@ -12,10 +27,24 @@ class NodeTestBase:
         self.requestor_datadir = test_dir / 'requestor'
         os.makedirs(self.provider_datadir)
         os.makedirs(self.requestor_datadir)
+        self.reuse_keys = True
+
+        self.key_reuse_dir = test_dir.parent / 'key_reuse'
+        self.provider_reuse_dir = self.key_reuse_dir / 'provider'
+        self.requestor_reuse_dir = self.key_reuse_dir / 'requestor'
+
+    def tearDown(self):
+        key_reuse = NodeKeyReuse.get()
+        if key_reuse.enabled and not key_reuse.keys_ready:
+            self._copy_keystores()
+            key_reuse.mark_keys_ready()
 
     def _relative_id(self):
         from . import __name__ as parent_name
         return self.id().replace(parent_name + '.', '')
+
+    def _can_recycle_keys(self) -> bool:
+        return all([NodeKeyReuse.get().keys_ready, self.reuse_keys])
 
     def _run_test(self, playbook_class_path: str, *args, **kwargs):
         cwd = pathlib.Path(os.path.realpath(__file__)).parent.parent
@@ -30,4 +59,47 @@ class NodeTestBase:
             test_args.append('--' + k)
             test_args.append(v)
 
+        if self._can_recycle_keys():
+            self._recycle_keys()
+
         return subprocess.call(args=test_args)
+
+    @staticmethod
+    def _replace_keystore(src: pathlib.Path, dst: pathlib.Path) -> None:
+        src_file = src / 'keystore.json'
+        dst_file = dst / KEYSTORE_DIR / 'keystore.json'
+        os.makedirs(str(dst / KEYSTORE_DIR))
+        shutil.copyfile(str(src_file), str(dst_file))
+
+    def _recycle_keys(self):
+        self._replace_keystore(
+            self.provider_reuse_dir, self.provider_datadir
+        )
+        self._replace_keystore(
+            self.requestor_reuse_dir, self.requestor_datadir
+        )
+
+    def _copy_keystores(self):
+        self._prepare_keystore_reuse_folders()
+        self._copy_keystore(
+            self.provider_datadir, self.provider_reuse_dir
+        )
+        self._copy_keystore(
+            self.requestor_datadir, self.requestor_reuse_dir
+        )
+
+    def _prepare_keystore_reuse_folders(self) -> None:
+        shutil.rmtree(self.provider_reuse_dir, ignore_errors=True)
+        shutil.rmtree(self.requestor_reuse_dir, ignore_errors=True)
+        try:
+            os.makedirs(self.provider_reuse_dir)
+            os.makedirs(self.requestor_reuse_dir)
+        except OSError:
+            print('Unexpected problem with creating folders for keystore')
+            raise
+
+    @staticmethod
+    def _copy_keystore(datadir: pathlib.Path, reuse_dir: pathlib.Path) -> None:
+        src = str(datadir / KEYSTORE_DIR / 'keystore.json')
+        dst = str(reuse_dir / 'keystore.json')
+        shutil.copyfile(src, dst)

--- a/scripts/node_integration_tests/tests/test_concent.py
+++ b/scripts/node_integration_tests/tests/test_concent.py
@@ -1,6 +1,6 @@
 import unittest
 
-from .base import NodeTestBase
+from .base import NodeTestBase, disable_key_reuse
 
 
 class ConcentNodeTest(NodeTestBase, unittest.TestCase):
@@ -21,6 +21,7 @@ class ConcentNodeTest(NodeTestBase, unittest.TestCase):
         exit_code = self._run_test('concent.additional_verification.AdditionalVerification')
         self.assertEqual(exit_code, 0)
 
+    @disable_key_reuse
     def test_force_payment(self):
         exit_code = self._run_test('concent.force_payment.ForcePayment')
         self.assertEqual(exit_code, 0)


### PR DESCRIPTION
+ key reuse for `node_integration_tests`
+ decorator to disable key reuse for particular tests
+ command line switch to disable key reuse altogether
* Update description in README.md