### PR TITLE
Add copying entrypoints to blender_nvgpu image

### DIFF
--- a/apps/blender/resources/images/blender_nvgpu.Dockerfile
+++ b/apps/blender/resources/images/blender_nvgpu.Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get update && \
 		libgl1-mesa-dev \
 		libglu1-mesa \
 		libxi6 \
-		libxrender1 && \
+		libxrender1 \
+		python3 && \
 	apt-get -y autoremove && \
 	rm -rf /var/lib/apt/lists/*
 

--- a/apps/blender/resources/images/blender_nvgpu.Dockerfile
+++ b/apps/blender/resources/images/blender_nvgpu.Dockerfile
@@ -29,3 +29,5 @@ RUN curl -Ls ${BLENDER_BZ2_URL} | tar -xjv -C /opt && \
 
 ENV BLENDER_DEVICE_TYPE NVIDIA_GPU
 ENV PATH=/opt/blender:$PATH
+
+COPY entrypoints/ /golem/entrypoints/


### PR DESCRIPTION
Python3 and 'entrypoints' directory were missing in blender_nvgpu image