### PR TITLE
Cherry pick of: Keep Golem running after Docker error at startup (#3991)

### DIFF
--- a/golem/docker/manager.py
+++ b/golem/docker/manager.py
@@ -52,11 +52,11 @@ class DockerManager(DockerConfigManager):
                 ***************************************************************
                 No supported VM hypervisor was found.
                 Golem will not be able to compute anything.
-                hypervisor.setup() returned {}
+                hypervisor.setup() returned {!r}
                 ***************************************************************
                 """.format(e)
             )
-            raise EnvironmentError
+            raise EnvironmentError("No VM hypervisor found.")
 
         try:
             # We're checking the availability of "docker" command line utility
@@ -69,11 +69,11 @@ class DockerManager(DockerConfigManager):
                 ***************************************************************
                 Docker is not available, not building images.
                 Golem will not be able to compute anything.
-                Command 'docker info' returned {}
+                Command 'docker info' returned {!r}
                 ***************************************************************
                 """.format(err)
             )
-            raise EnvironmentError
+            raise EnvironmentError("Docker unavailable.")
 
         try:
             self.pull_images()

--- a/golem/node.py
+++ b/golem/node.py
@@ -14,7 +14,7 @@ from typing import (
 
 from pathlib import Path
 from twisted.internet import threads
-from twisted.internet.defer import gatherResults, Deferred
+from twisted.internet.defer import gatherResults, Deferred, FirstError
 from twisted.python.failure import Failure
 
 from apps.appsmanager import AppsManager
@@ -161,9 +161,21 @@ class Node(HardwarePresetsMixin):
                 docker = self._start_docker()
                 return gatherResults([terms_, keys, docker], consumeErrors=True)
 
+            def on_start_error(failure: FirstError):
+                sub_failure: Failure = failure.value.subFailure
+                sub_failure.trap(EnvironmentError)
+
+                logger.error(
+                    """
+                    There was a problem setting up the environment: {}
+                    Golem will run with limited functionality to support
+                    communication with local clients.
+                    """.format(sub_failure.getErrorMessage())
+                )
+
             chain_function(rpc, on_rpc_ready).addCallbacks(
                 self._setup_client,
-                self._error('keys or docker'),
+                on_start_error,
             ).addErrback(self._error('setup client'))
             self._reactor.run()
         except Exception:  # pylint: disable=broad-except

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -99,7 +99,7 @@ def validate_client(client: Client):
     if client.config_desc.in_shutdown:
         raise CreateTaskError(
             'Can not enqueue task: shutdown is in progress, '
-            'toggle shutdown mode off to create a new tasks.')
+            'toggle shutdown mode off to create new tasks.')
     if client.task_server is None:
         raise CreateTaskError("Golem is not ready")
 


### PR DESCRIPTION
This is a cherry pick of #3991. Compared to the original change, minor changes were applied to the tests.