### PR TITLE
Fixed Hyper-V VM remaining in invalid state

### DIFF
--- a/golem/docker/commands/docker_machine.py
+++ b/golem/docker/commands/docker_machine.py
@@ -9,7 +9,8 @@ class DockerMachineCommandHandler(DockerCommandHandler):
         start=['docker-machine', '--native-ssh', 'start'],
         stop=['docker-machine', '--native-ssh', 'stop'],
         active=['docker-machine', '--native-ssh', 'active'],
-        list=['docker-machine', '--native-ssh', 'ls', '-q'],
+        # DON'T use the '-q' option. It doesn't list VMs in invalid state
+        list=['docker-machine', '--native-ssh', 'ls'],
         env=['docker-machine', '--native-ssh', 'env'],
         status=['docker-machine', '--native-ssh', 'status'],
         inspect=['docker-machine', '--native-ssh', 'inspect'],

--- a/golem/docker/hypervisor/docker_machine.py
+++ b/golem/docker/hypervisor/docker_machine.py
@@ -87,12 +87,16 @@ class DockerMachineHypervisor(Hypervisor, metaclass=ABCMeta):
     @property
     def vms(self):
         try:
+            # DON'T use the '-q' option. It doesn't list VMs in invalid state
             output = self.command('list')
         except subprocess.CalledProcessError as e:
             logger.warning("DockerMachine: failed to list VMs: %r", e)
         else:
             if output:
-                return [i.strip() for i in output.split("\n") if i]
+                # Skip first line (header) and last (empty)
+                lines = output.split('\n')[1:-1]
+                # Get the first word of each line
+                return [l.strip().split()[0] for l in lines]
         return []
 
     @property


### PR DESCRIPTION
If creating the machine failed during virtual disk creation then the VM would remain in a an invalid state (actually not the VM but some config files used by docker-machine). This in turn would make it impossible to re-create the VM.
The error had been unsuccessfully mitigated against by adding a remove command in `HyperVHypervisor._failed_to_create()` method. This was not effective because removing the VM sometimes fails if it done shortly after the unsuccessful creation.
To make the cleanup more robust a retry loop was added. It required changing the logic of `DockerMachineHypervisor.vms()` because `docker-machine remove -q` doesn't print out VMs in invalid states.