### PR TITLE
Fixed virtualization detection on Windows

### DIFF
--- a/golem/core/virtualization.py
+++ b/golem/core/virtualization.py
@@ -6,12 +6,14 @@ from golem.core.common import get_golem_path, is_linux, is_windows
 from golem.core.windows import run_powershell
 from golem.rpc import utils as rpc_utils
 
-WIN_SCRIPT_PATH = os.path.join(
+SCRIPTS_PATH = os.path.join(
     get_golem_path(),
     'scripts',
-    'virtualization',
-    'get-virtualization-state.ps1'
+    'virtualization'
 )
+
+VIRTUALIZATION_SCRIPT_NAME = 'get-virtualization-state.ps1'
+HYPERV_SCRIPT_NAME = 'get-hyperv-state.ps1'
 
 
 @rpc_utils.expose('env.hw.virtualization')
@@ -37,5 +39,9 @@ def _check_vt_unix() -> bool:
 
 
 def _check_vt_windows() -> bool:
-    virtualization_state = run_powershell(script=WIN_SCRIPT_PATH)
+    hyperv_state = run_powershell(script=os.path.join(SCRIPTS_PATH, HYPERV_SCRIPT_NAME))
+    if hyperv_state == 'True':
+        return True
+
+    virtualization_state = run_powershell(script=os.path.join(SCRIPTS_PATH, VIRTUALIZATION_SCRIPT_NAME))
     return virtualization_state == 'True'

--- a/golem/core/virtualization.py
+++ b/golem/core/virtualization.py
@@ -39,9 +39,13 @@ def _check_vt_unix() -> bool:
 
 
 def _check_vt_windows() -> bool:
-    hyperv_state = run_powershell(script=os.path.join(SCRIPTS_PATH, HYPERV_SCRIPT_NAME))
+    hyperv_state = run_powershell(
+        script=os.path.join(SCRIPTS_PATH, HYPERV_SCRIPT_NAME)
+    )
     if hyperv_state == 'True':
         return True
 
-    virtualization_state = run_powershell(script=os.path.join(SCRIPTS_PATH, VIRTUALIZATION_SCRIPT_NAME))
+    virtualization_state = run_powershell(
+        script=os.path.join(SCRIPTS_PATH, VIRTUALIZATION_SCRIPT_NAME)
+    )
     return virtualization_state == 'True'

--- a/golem/docker/hypervisor/hyperv.py
+++ b/golem/docker/hypervisor/hyperv.py
@@ -91,9 +91,11 @@ class HyperVHypervisor(DockerMachineHypervisor):
     VOLUME_DRIVER = "cifs"
     SMB_PORT = "445"
 
-    SCRIPTS_PATH = os.path.join(get_golem_path(), 'scripts', 'docker')
+    SCRIPTS_PATH = os.path.join(get_golem_path(), 'scripts')
     GET_VSWITCH_SCRIPT_PATH = \
-        os.path.join(SCRIPTS_PATH, 'get-default-vswitch.ps1')
+        os.path.join(SCRIPTS_PATH, 'docker', 'get-default-vswitch.ps1')
+    GET_HYPERV_SCRIPT_PATH = \
+        os.path.join(SCRIPTS_PATH, 'virtualization', 'get-hyperv-state.ps1')
     START_VM_RETRIES = 2  # retries, not start attempts
 
     def __init__(self, *args, **kwargs):
@@ -186,15 +188,7 @@ class HyperVHypervisor(DockerMachineHypervisor):
     @classmethod
     def is_available(cls) -> bool:
         try:
-            output = run_powershell(
-                script=os.path.join(
-                    get_golem_path(),
-                    'scripts',
-                    'virtualization',
-                    'get-hyperv-state.ps1'
-                )
-            )
-            return output == 'True'
+            return run_powershell(script=cls.GET_HYPERV_SCRIPT_PATH) == 'True'
         except (RuntimeError, OSError) as e:
             logger.warning(f"Error checking Hyper-V availability: {e}")
             return False

--- a/golem/docker/hypervisor/hyperv.py
+++ b/golem/docker/hypervisor/hyperv.py
@@ -185,10 +185,16 @@ class HyperVHypervisor(DockerMachineHypervisor):
 
     @classmethod
     def is_available(cls) -> bool:
-        command = "@(Get-Module -ListAvailable hyper-v).Name | Get-Unique"
         try:
-            output = run_powershell(command=command)
-            return output == "Hyper-V"
+            output = run_powershell(
+                script=os.path.join(
+                    get_golem_path(),
+                    'scripts',
+                    'virtualization',
+                    'get-hyperv-state.ps1'
+                )
+            )
+            return output == 'True'
         except (RuntimeError, OSError) as e:
             logger.warning(f"Error checking Hyper-V availability: {e}")
             return False

--- a/scripts/pyinstaller/hooks/hook-golem.py
+++ b/scripts/pyinstaller/hooks/hook-golem.py
@@ -37,5 +37,6 @@ datas = [
     ('scripts/docker/create-share.ps1', 'scripts/docker/'),
     ('scripts/docker/get-default-vswitch.ps1', 'scripts/docker/'),
     ('scripts/virtualization/get-virtualization-state.ps1',
-     'scripts/virtualization')
+     'scripts/virtualization'),
+    ('scripts/virtualization/get-hyperv-state.ps1', 'scripts/virtualization')
 ]

--- a/scripts/virtualization/get-hyperv-state.ps1
+++ b/scripts/virtualization/get-hyperv-state.ps1
@@ -1,0 +1,14 @@
+$ErrorActionPreference = "Stop"
+[Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
+
+$HyperVModule = @(Get-Module -ListAvailable hyper-v).Name | Get-Unique
+# Is Hyper-V module installed?
+If ($HyperVModule -eq "Hyper-V") {
+    # Is Hyper-V management service running?
+    try {
+        Get-Process -Name vmms | Out-Null
+        return "True"
+    } catch { }
+}
+
+return "False"

--- a/scripts/virtualization/get-virtualization-state.ps1
+++ b/scripts/virtualization/get-virtualization-state.ps1
@@ -1,10 +1,17 @@
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
 
+# Is Hyper-V module installed?
 $HyperVModule = @(Get-Module -ListAvailable hyper-v).Name | Get-Unique
-If ($HyperVModule -eq "Hyper-V") {
-    return "True"
+If (!($HyperVModule -eq "Hyper-V")) {
+    return "False"
 }
 
-$SystemInfo = (GWMI Win32_Processor)
-return $SystemInfo.VMMonitorModeExtensions -and $SystemInfo.VirtualizationFirmwareEnabled
+# Is Hyper-V management service running?
+try {
+    Get-Process -Name vmms | Out-Null
+} catch {
+    return "False"
+}
+
+return "True"

--- a/scripts/virtualization/get-virtualization-state.ps1
+++ b/scripts/virtualization/get-virtualization-state.ps1
@@ -1,16 +1,6 @@
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
 
-$HyperVModule = @(Get-Module -ListAvailable hyper-v).Name | Get-Unique
-# Is Hyper-V module installed?
-If ($HyperVModule -eq "Hyper-V") {
-    # Is Hyper-V management service running?
-    try {
-        Get-Process -Name vmms | Out-Null
-        return "True"
-    } catch { }
-}
-
 # Is hardware virtualization available and enabled?
 $SystemInfo = (GWMI Win32_Processor)
 return $SystemInfo.VMMonitorModeExtensions -and $SystemInfo.VirtualizationFirmwareEnabled

--- a/scripts/virtualization/get-virtualization-state.ps1
+++ b/scripts/virtualization/get-virtualization-state.ps1
@@ -1,17 +1,16 @@
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
 
-# Is Hyper-V module installed?
 $HyperVModule = @(Get-Module -ListAvailable hyper-v).Name | Get-Unique
-If (!($HyperVModule -eq "Hyper-V")) {
-    return "False"
+# Is Hyper-V module installed?
+If ($HyperVModule -eq "Hyper-V") {
+    # Is Hyper-V management service running?
+    try {
+        Get-Process -Name vmms | Out-Null
+        return "True"
+    } catch { }
 }
 
-# Is Hyper-V management service running?
-try {
-    Get-Process -Name vmms | Out-Null
-} catch {
-    return "False"
-}
-
-return "True"
+# Is hardware virtualization available and enabled?
+$SystemInfo = (GWMI Win32_Processor)
+return $SystemInfo.VMMonitorModeExtensions -and $SystemInfo.VirtualizationFirmwareEnabled

--- a/tests/golem/core/test_virtualization.py
+++ b/tests/golem/core/test_virtualization.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from golem.core.virtualization import is_virtualization_satisfied,\
-    WIN_SCRIPT_PATH
+    SCRIPTS_PATH
 
 
 def get_mock_cpuinfo_output(vt_supported=True) -> dict:
@@ -55,4 +55,4 @@ class VirtualizationTestWindows(TestCase):
         self.assertFalse(is_virtualization_satisfied())
 
     def test_script_path(self, *_):
-        self.assertTrue(Path(WIN_SCRIPT_PATH).exists())
+        self.assertTrue(Path(SCRIPTS_PATH).exists())


### PR DESCRIPTION
Resolves: #4024

Adds handling of a scenario where Hyper-V is installed, but has been
manually disabled by the user. Additionally, this removes the call to
WMI, since when Hyper-V is on it reports hardware virtualization as disabled.