### PR TITLE
Extended interval between remove VM attempts

### DIFF
--- a/golem/docker/hypervisor/hyperv.py
+++ b/golem/docker/hypervisor/hyperv.py
@@ -247,7 +247,7 @@ class HyperVHypervisor(DockerMachineHypervisor):
             except subprocess.CalledProcessError:
                 logger.warning(f'{self.DRIVER_NAME}: Attempt to remove '
                                f'machine "{name}" failed')
-            time.sleep(0.1)
+            time.sleep(0.5)
 
         else:
             # Log error if all attempts failed


### PR DESCRIPTION
The interval was extended to 0.5 sec. The retry loop will therefore go for 5 sec. I hope this is enough.