### PR TITLE
Create a separate directory for every task's output

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -591,19 +591,19 @@ class CoreTaskBuilder(TaskBuilder):
     @classmethod
     def get_output_path(cls, dictionary, definition):
         options = dictionary['options']
+
         base_path = options['output_path']
+        output_dir_name = definition.name + \
+            datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
+        full_output_path = os.path.join(base_path, output_dir_name)
 
-        target_dir = definition.name + datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
-        output_path = os.path.join(base_path, target_dir)
-        os.makedirs(output_path, exist_ok=True)
+        os.makedirs(full_output_path, exist_ok=True)
 
-        absolute_path = cls.get_nonexistent_path(
-            output_path,
+        return cls.get_nonexistent_path(
+            full_output_path,
             definition.name,
             options.get('format', '')
         )
-
-        return absolute_path
 
     @classmethod
     def get_nonexistent_path(cls, path, name, extension=""):

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 import decimal
 import logging
 import os
@@ -590,11 +591,17 @@ class CoreTaskBuilder(TaskBuilder):
     @classmethod
     def get_output_path(cls, dictionary, definition):
         options = dictionary['options']
+        base_path = options['output_path']
+
+        target_dir = definition.name + datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
+        output_path = os.path.join(base_path, target_dir)
+        os.makedirs(output_path, exist_ok=True)
 
         absolute_path = cls.get_nonexistent_path(
-            options['output_path'],
+            output_path,
             definition.name,
-            options.get('format', ''))
+            options.get('format', '')
+        )
 
         return absolute_path
 

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -506,7 +506,7 @@ class CoreTask(Task):
 
 class CoreTaskBuilder(TaskBuilder):
     TASK_CLASS = CoreTask
-    OUTPUT_DIR_TIME_FORMAT = '_%Y-%m-%d_%H:%M:%S'
+    OUTPUT_DIR_TIME_FORMAT = '_%Y-%m-%d_%H-%M-%S'
 
     def __init__(self,
                  owner: 'dt_p2p.Node',

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -506,6 +506,7 @@ class CoreTask(Task):
 
 class CoreTaskBuilder(TaskBuilder):
     TASK_CLASS = CoreTask
+    OUTPUT_DIR_TIME_FORMAT = '_%Y-%m-%d_%H:%M:%S'
 
     def __init__(self,
                  owner: 'dt_p2p.Node',
@@ -589,12 +590,15 @@ class CoreTaskBuilder(TaskBuilder):
         return definition.to_dict()
 
     @classmethod
-    def get_output_path(cls, dictionary, definition):
+    def get_output_path(
+            cls,
+            dictionary: Dict[str, Any],
+            definition: 'TaskDefinition') -> str:
         options = dictionary['options']
 
         base_path = options['output_path']
         output_dir_name = definition.name + \
-            datetime.now().strftime('%Y-%m-%d_%H:%M:%S')
+            datetime.now().strftime(cls.OUTPUT_DIR_TIME_FORMAT)
         full_output_path = os.path.join(base_path, output_dir_name)
 
         os.makedirs(full_output_path, exist_ok=True)

--- a/scripts/node_integration_tests/playbooks/base.py
+++ b/scripts/node_integration_tests/playbooks/base.py
@@ -358,10 +358,14 @@ class NodeTestPlaybook:
 
     def step_verify_output(self):
         settings = self.task_settings_dict
-        output_file = self.output_path + '/' + \
-            settings.get('name') + '.' + self.output_extension
-        print("Verifying the output file: {}".format(output_file))
-        if Path(output_file).is_file():
+        output_file_name = settings.get('name') + '.' + self.output_extension
+
+        print("Verifying output file: {}".format(output_file_name))
+        found_files = list(
+            Path(self.output_path).glob(f'**/{output_file_name}')
+        )
+
+        if len(found_files) > 0 and found_files[0].is_file():
             print("Output present :)")
             self.next()
         else:

--- a/tests/apps/core/task/test_coretask.py
+++ b/tests/apps/core/task/test_coretask.py
@@ -1,9 +1,12 @@
 import os
 import shutil
 from copy import copy
+from tempfile import TemporaryDirectory
+from typing import Optional
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock
 
+from freezegun import freeze_time
 from golem_messages.factories.datastructures import p2p as dt_p2p_factory
 
 from apps.core.task.coretask import (
@@ -499,8 +502,21 @@ class TestTaskTypeInfo(TestCase):
 
 class TestCoreTaskBuilder(TestCase):
 
-    def _get_core_task_builder(self):
+    @staticmethod
+    def _get_core_task_builder():
         return CoreTaskBuilder(MagicMock(), MagicMock(), MagicMock())
+
+    @staticmethod
+    def _get_task_def_dict(
+            output_path: str,
+            output_format: Optional[str] = ''
+    ) -> dict:
+        return {
+            'options': {
+                'output_path': output_path,
+                'format': output_format
+            }
+        }
 
     def test_init(self):
         builder = self._get_core_task_builder()
@@ -530,17 +546,52 @@ class TestCoreTaskBuilder(TestCase):
         with self.assertRaises(TypeError):
             builder.build()
 
-    def test_get_output_path(self):
+    @freeze_time('2019-01-01 00:00:00')
+    def test_get_output_path_creates_target_dir(self):
         builder = self._get_core_task_builder()
-        mockDict = {}
-        mockDict['options'] = dict(
-            [("output_path", os.getcwd()), ("format", "py")])
+        task_name = 'test_task'
+        task_dir_name = f'{task_name}_2019-01-01_00:00:00'
 
-        class Definition:
-            name = "test_file"  # something doesn't exist
+        with TemporaryDirectory() as output_path:
+            task_def = self._get_task_def_dict(output_path, 'png')
+            mock_definition = MagicMock()
+            mock_definition.name = task_name
 
-        definition = Definition()
-        absolute_path = builder.get_output_path(mockDict, definition)
-        assert absolute_path == os.path.join(os.getcwd(), definition.name)
-        definition.name = "test_coretask"  # something already exist
-        assert absolute_path != os.path.join(os.getcwd(), definition.name)
+            result_path = builder.get_output_path(task_def, mock_definition)
+
+            self.assertEquals(
+                result_path,
+                os.path.join(output_path, task_dir_name, task_name)
+            )
+
+    @freeze_time('2019-01-01 00:00:00')
+    def test_get_output_path_creates_intermediate_dirs(self):
+        builder = self._get_core_task_builder()
+        task_name = 'test_task'
+        task_dir_name = f'{task_name}_2019-01-01_00:00:00'
+        output_suffix = 'some/new/dirs'
+
+        with TemporaryDirectory() as output_path:
+            task_def = self._get_task_def_dict(
+                os.path.join(output_path, output_suffix), 'png')
+            mock_definition = MagicMock()
+            mock_definition.name = task_name
+
+            result_path = builder.get_output_path(task_def, mock_definition)
+
+            self.assertEquals(
+                result_path,
+                os.path.join(output_path, output_suffix,
+                             task_dir_name, task_name)
+            )
+
+    def test_get_output_path_fails_without_permissions(self):
+        builder = self._get_core_task_builder()
+        task_name = 'test_task'
+        output_path = '/new/path/without/permission'
+        task_def = self._get_task_def_dict(output_path, 'png')
+        mock_definition = MagicMock()
+        mock_definition.name = task_name
+
+        with self.assertRaises(PermissionError):
+            builder.get_output_path(task_def, mock_definition)

--- a/tests/apps/core/task/test_coretask.py
+++ b/tests/apps/core/task/test_coretask.py
@@ -4,7 +4,7 @@ from copy import copy
 from tempfile import TemporaryDirectory
 from typing import Optional
 from unittest import TestCase
-from unittest.mock import MagicMock, Mock
+from unittest.mock import MagicMock, Mock, patch
 
 from freezegun import freeze_time
 from golem_messages.factories.datastructures import p2p as dt_p2p_factory
@@ -585,7 +585,8 @@ class TestCoreTaskBuilder(TestCase):
                              task_dir_name, task_name)
             )
 
-    def test_get_output_path_fails_without_permissions(self):
+    @patch('os.makedirs', side_effect=PermissionError)
+    def test_get_output_path_fails_without_permissions(self, *_):
         builder = self._get_core_task_builder()
         task_name = 'test_task'
         output_path = '/new/path/without/permission'

--- a/tests/apps/core/task/test_coretask.py
+++ b/tests/apps/core/task/test_coretask.py
@@ -550,7 +550,7 @@ class TestCoreTaskBuilder(TestCase):
     def test_get_output_path_creates_target_dir(self):
         builder = self._get_core_task_builder()
         task_name = 'test_task'
-        task_dir_name = f'{task_name}_2019-01-01_00:00:00'
+        task_dir_name = f'{task_name}_2019-01-01_00-00-00'
 
         with TemporaryDirectory() as output_path:
             task_def = self._get_task_def_dict(output_path, 'png')
@@ -568,7 +568,7 @@ class TestCoreTaskBuilder(TestCase):
     def test_get_output_path_creates_intermediate_dirs(self):
         builder = self._get_core_task_builder()
         task_name = 'test_task'
-        task_dir_name = f'{task_name}_2019-01-01_00:00:00'
+        task_dir_name = f'{task_name}_2019-01-01_00-00-00'
         output_suffix = 'some/new/dirs'
 
         with TemporaryDirectory() as output_path:

--- a/tests/apps/rendering/task/test_renderingtask.py
+++ b/tests/apps/rendering/task/test_renderingtask.py
@@ -341,13 +341,6 @@ class TestRenderingTaskBuilder(TestDirFixture, LogTestCase):
         with self.assertNoLogs(logger_render, level="WARNING"):
             assert builder._calculate_total(defaults) == 33
 
-    def test_get_output_path(self):
-        td = TaskDefinition()
-        td.name = "MY task"
-        tdict = {'options': {'output_path': '/dir3/dir4', 'format': 'txt'}}
-        assert RenderingTaskBuilder.get_output_path(tdict, td) == \
-            path.join("/dir3/dir4", "MY task.txt")
-
     def test_build_definition_minimal(self):
         # given
         tti = CoreTaskTypeInfo("TESTTASK", RenderingTaskDefinition,

--- a/tests/apps/rendering/task/test_renderingtask.py
+++ b/tests/apps/rendering/task/test_renderingtask.py
@@ -395,9 +395,6 @@ class TestBuildDefinition(TestDirFixture, LogTestCase):
         assert definition.max_price == 250000000000000000
         assert definition.timeout == 3600
         assert definition.subtask_timeout == 1500
-        output_file = self.task_dict['name'] + "." + \
-            self.task_dict['options']['format']
-        assert definition.output_file == self.path + os.sep + output_file
 
     def test_timeout_too_short(self):
         # given

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -1,5 +1,6 @@
 # pylint: disable=protected-access,too-many-ancestors
 import copy
+from tempfile import TemporaryDirectory
 import unittest
 from unittest import mock
 
@@ -25,6 +26,7 @@ from tests.golem import test_client
 from tests.golem.test_client import TestClientBase
 
 fake = faker.Faker()
+task_output_path = TemporaryDirectory(prefix='golem-test-output-').name
 
 
 class ProviderBase(test_client.TestClientBase):
@@ -46,7 +48,7 @@ class ProviderBase(test_client.TestClientBase):
             'resolution': [1920, 1080],
             'frames': '1-10',
             'format': 'EXR',
-            'output_path': '/Users/user/Desktop/',
+            'output_path': task_output_path,
             'compositing': True,
         },
         'concent_enabled': False,
@@ -224,7 +226,7 @@ class TestRestartTask(ProviderBase):
             'name': 'test task',
             'options': {
                 'difficulty': 1337,
-                'output_path': '',
+                'output_path': task_output_path,
             },
             'resources': [str(some_file_path)],
             'subtask_timeout': common.timeout_to_string(3),


### PR DESCRIPTION
Fixes: #3785

This changes the way output paths for tasks are handled. For each new task, a directory gets created in the output path from the task definition. The new directories' names are based on the task's name and their time of creation, e.g. `some_task_2019-01-01_12-00-00`.