### PR TITLE
Improved checking Hyper-V status on Windows

### DIFF
--- a/scripts/virtualization/get-hyperv-state.ps1
+++ b/scripts/virtualization/get-hyperv-state.ps1
@@ -1,4 +1,20 @@
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
 
-return (gwmi Win32_ComputerSystem).HypervisorPresent
+$IsHypervisorPresent = (gwmi Win32_ComputerSystem).HypervisorPresent
+
+if ($IsHypervisorPresent) {
+    $HyperVServices = @("vmms", "vmcompute")
+
+    try {
+        foreach ($Service in $HyperVServices) {
+            if ((Get-Service -Name $Service).Status -ne "Running") {
+                return "False"
+            }
+        }
+
+        return "True"
+    } catch { }
+}
+
+return "False"

--- a/scripts/virtualization/get-hyperv-state.ps1
+++ b/scripts/virtualization/get-hyperv-state.ps1
@@ -1,14 +1,4 @@
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [Text.UTF8Encoding]::UTF8
 
-$HyperVModule = @(Get-Module -ListAvailable hyper-v).Name | Get-Unique
-# Is Hyper-V module installed?
-If ($HyperVModule -eq "Hyper-V") {
-    # Is Hyper-V management service running?
-    try {
-        Get-Process -Name vmms | Out-Null
-        return "True"
-    } catch { }
-}
-
-return "False"
+return (gwmi Win32_ComputerSystem).HypervisorPresent


### PR DESCRIPTION
Resolves: #4024

Updated the relevant Powershell script to use the field
HypervisorPresent from Win32_ComputerSystem WMI object. This provides a
more reliable way of determining hypervisor availability on the system.