### PR TITLE
Suppress debug logs from Docker and urllib3 (used by requests)

### DIFF
--- a/loggingconfig.py
+++ b/loggingconfig.py
@@ -106,5 +106,13 @@ LOGGING = {
             'propagate': False,
             'handlers': ['console', 'file', ],
         },
+        'docker': {
+            'level': 'INFO',
+            'propagate': True,
+        },
+        'urllib3': {
+            'level': 'INFO',
+            'propagate': True,
+        },
     },
 }


### PR DESCRIPTION
Current logging configuration is a bit too verbose, especially in tests that run docker containers. Docker logs a lot of information about the images/registries it tried and did not end up using. This information does not seem useful in tests and obscures much more important output.

This pull request decreases `docker` and `urllib3` log level to `INFO` so that `DEBUG` messages are suppressed but useful information, errors and warnings are still shown.

### Example 1
Compare two examples of output from before and after this change. Both from running unit tests with `self.fail()` added at the end of `test_blender_scene_file_error()` on the current `develop` branch.

### Before
``` bash
pytest tests/golem/docker/ -k test_blender_scene_file_error --tb=short
```
``` pytest
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.6.8, pytest-3.3.1, py-1.5.3, pluggy-0.6.0
rootdir: /projects/golem/golem, inifile: setup.cfg
plugins: cov-2.5.1
collected 128 items                                                                                                                                                      

tests/golem/docker/test_docker_blender_task.py F                                                                                                                   [100%]

================================================================================ FAILURES ================================================================================
_______________________________________________________ TestDockerBlenderCyclesTask.test_blender_scene_file_error ________________________________________________________
tests/golem/docker/test_docker_blender_task.py:171: in test_blender_scene_file_error
    self.fail()
E   AssertionError: None
-------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------
INFO     [golem.db                           ] Creating tables, schema version 24 
INFO     [golem.task.taskarchiver            ] Task archive not loaded: [Errno 2] No such file or directory: '/tmp/golem-tests-c2klcb7n/test_blender_scene_file_errorzpscy9zm/task_archive.pickle' 
INFO     [golem.client                       ] Client 'None'(0xdeadbe..deadbeef), datadir: /tmp/golem-tests-c2klcb7n/test_blender_scene_file_errorzpscy9zm 
INFO     [golem.environments.environmentsmanager] Adding environment BLENDER supported=<SupportStatus ok ({})> 
INFO     [golem.environments.environmentsmanager] Adding environment BLENDER_NVGPU supported=<SupportStatus ok ({})> 
INFO     [golem.environments.environmentsmanager] Adding environment DUMMYPOW supported=<SupportStatus ok ({})> 
INFO     [golem.environments.environmentsmanager] Adding environment WASM supported=<SupportStatus ok ({})> 
INFO     [golem.marketplace.offerpool        ] Offer pooling interval set to 0.0 
ERROR    [golem.task.server.resources        ] ResourceManager not ready 
resources.py                83 ERROR    ResourceManager not ready 
INFO     [golem.task.taskcomputer            ] Starting computation of subtask 'f99d8652-5497-11e9-9e8c-ba72b37a1f0c' (task: '7220aa01-ad45-4fb4-b199-ba72b37a1f0c', deadline: 1554135031, docker images: [{'repository': 'golemfactory/blender', 'image_id': None, 'tag': '1.9'}]) 
WARNING  [golem.docker.task_thread           ] Task error - exit_code=1
stderr:
['blender', '-b', '/golem/resources/../../../../golem/node.py', '-y', '-P', '/golem/work/render-scripts/scriptfile-hel_1-[crop_num=0].py', '-o', '/golem/output/hel_1', '-noaudio', '-F', 'PNG', '-t', '8', '-f', '1,2,3,4,5']

tail of stdout:
found bundled python: /blender/2.79/python
Error: Cannot read file '/golem/resources/../../../../golem/node.py': No such file or directory

Blender quit

 
task_thread.py             219 WARNING  Task error - exit_code=1
stderr:
['blender', '-b', '/golem/resources/../../../../golem/node.py', '-y', '-P', '/golem/work/render-scripts/scriptfile-hel_1-[crop_num=0].py', '-o', '/golem/output/hel_1', '-noaudio', '-F', 'PNG', '-t', '8', '-f', '1,2,3,4,5']

tail of stdout:
found bundled python: /blender/2.79/python
Error: Cannot read file '/golem/resources/../../../../golem/node.py': No such file or directory

Blender quit

 
WARNING  [golem.task.taskthread              ] Task computing error Subtask computation failed with exit code 1 
taskthread.py              103 WARNING  Task computing error Subtask computation failed with exit code 1 
WARNING  [golem.task.taskkeeper              ] This is not my task None 
taskkeeper.py               94 WARNING  This is not my task None 
ERROR    [golem.task.taskserver              ] Finished subtask listener: AttributeError("'NoneType' object has no attribute 'environment'",) 
taskserver.py              592 ERROR    Finished subtask listener: AttributeError("'NoneType' object has no attribute 'environment'",) 
INFO     [golem.client                       ] Shutting down ... 
INFO     [golem.client                       ] Stopping network ... 
INFO     [golem.network.concent.client       ] Waiting for received messages queue to empty 
INFO     [golem.network.concent.client       ] <ConcentClientService(Thread-1, initial daemon)> stopped 
--------------------------------------------------------------------------- Captured log call ----------------------------------------------------------------------------
database.py                103 INFO     Creating tables, schema version 24 
taskarchiver.py             45 INFO     Task archive not loaded: [Errno 2] No such file or directory: '/tmp/golem-tests-c2klcb7n/test_blender_scene_file_errorzpscy9zm/task_archive.pickle' 
client.py                  127 INFO     Client 'None'(0xdeadbe..deadbeef), datadir: /tmp/golem-tests-c2klcb7n/test_blender_scene_file_errorzpscy9zm 
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/images/golemfactory/blender:1.9/json HTTP/1.1" 200 None
environmentsmanager.py      48 INFO     Adding environment BLENDER supported=<SupportStatus ok ({})> 
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/images/golemfactory/blender_nvgpu:1.2/json HTTP/1.1" 200 None
environmentsmanager.py      48 INFO     Adding environment BLENDER_NVGPU supported=<SupportStatus ok ({})> 
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/images/golemfactory/dummy:1.1/json HTTP/1.1" 200 None
environmentsmanager.py      48 INFO     Adding environment DUMMYPOW supported=<SupportStatus ok ({})> 
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/images/golemfactory/wasm:0.0.1/json HTTP/1.1" 200 None
environmentsmanager.py      48 INFO     Adding environment WASM supported=<SupportStatus ok ({})> 
offerpool.py                38 INFO     Offer pooling interval set to 0.0 
resources.py                83 ERROR    ResourceManager not ready 
taskcomputer.py            356 INFO     Starting computation of subtask 'f99d8652-5497-11e9-9e8c-ba72b37a1f0c' (task: '7220aa01-ad45-4fb4-b199-ba72b37a1f0c', deadline: 1554135031, docker images: [{'repository': 'golemfactory/blender', 'image_id': None, 'tag': '1.9'}]) 
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/images/golemfactory/blender:1.9/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/create HTTP/1.1" 201 90
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/8b5f2003e836f1e65456e674ba84191857461512cab3572ab9316094ae3b749d/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/8b5f2003e836f1e65456e674ba84191857461512cab3572ab9316094ae3b749d/start HTTP/1.1" 204 0
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/8b5f2003e836f1e65456e674ba84191857461512cab3572ab9316094ae3b749d/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/8b5f2003e836f1e65456e674ba84191857461512cab3572ab9316094ae3b749d/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/8b5f2003e836f1e65456e674ba84191857461512cab3572ab9316094ae3b749d/wait HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/8b5f2003e836f1e65456e674ba84191857461512cab3572ab9316094ae3b749d/logs?stderr=0&stdout=1&timestamps=0&follow=1&tail=all HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/8b5f2003e836f1e65456e674ba84191857461512cab3572ab9316094ae3b749d/json HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/8b5f2003e836f1e65456e674ba84191857461512cab3572ab9316094ae3b749d/logs?stderr=1&stdout=0&timestamps=0&follow=1&tail=all HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/8b5f2003e836f1e65456e674ba84191857461512cab3572ab9316094ae3b749d/json HTTP/1.1" 200 None
task_thread.py             219 WARNING  Task error - exit_code=1
stderr:
['blender', '-b', '/golem/resources/../../../../golem/node.py', '-y', '-P', '/golem/work/render-scripts/scriptfile-hel_1-[crop_num=0].py', '-o', '/golem/output/hel_1', '-noaudio', '-F', 'PNG', '-t', '8', '-f', '1,2,3,4,5']

tail of stdout:
found bundled python: /blender/2.79/python
Error: Cannot read file '/golem/resources/../../../../golem/node.py': No such file or directory

Blender quit

 
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "DELETE /v1.35/containers/8b5f2003e836f1e65456e674ba84191857461512cab3572ab9316094ae3b749d?v=False&link=False&force=True HTTP/1.1" 204 0
taskthread.py              103 WARNING  Task computing error Subtask computation failed with exit code 1 
taskkeeper.py               94 WARNING  This is not my task None 
taskserver.py              592 ERROR    Finished subtask listener: AttributeError("'NoneType' object has no attribute 'environment'",) 
client.py                  619 INFO     Shutting down ... 
client.py                  544 INFO     Stopping network ... 
client.py                  227 INFO     Waiting for received messages queue to empty 
client.py                  229 INFO     <ConcentClientService(Thread-1, initial daemon)> stopped
========================================================================== 127 tests deselected ==========================================================================
================================================================ 1 failed, 127 deselected in 3.17 seconds ================================================================
```

#### After
``` bash
pytest tests/golem/docker/ -k test_blender_scene_file_error --tb=short
```
``` pytest
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.6.8, pytest-3.3.1, py-1.5.3, pluggy-0.6.0
rootdir: /projects/golem/golem, inifile: setup.cfg
plugins: cov-2.5.1
collected 128 items                                                                                                                                                      

tests/golem/docker/test_docker_blender_task.py F                                                                                                                   [100%]

================================================================================ FAILURES ================================================================================
_______________________________________________________ TestDockerBlenderCyclesTask.test_blender_scene_file_error ________________________________________________________
tests/golem/docker/test_docker_blender_task.py:171: in test_blender_scene_file_error
    self.fail()
E   AssertionError: None
-------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------
INFO     [golem.db                           ] Creating tables, schema version 24 
INFO     [golem.task.taskarchiver            ] Task archive not loaded: [Errno 2] No such file or directory: '/tmp/golem-tests-fkanrbpz/test_blender_scene_file_errorj1ecr808/task_archive.pickle' 
INFO     [golem.client                       ] Client 'None'(0xdeadbe..deadbeef), datadir: /tmp/golem-tests-fkanrbpz/test_blender_scene_file_errorj1ecr808 
INFO     [golem.environments.environmentsmanager] Adding environment BLENDER supported=<SupportStatus ok ({})> 
INFO     [golem.environments.environmentsmanager] Adding environment BLENDER_NVGPU supported=<SupportStatus ok ({})> 
INFO     [golem.environments.environmentsmanager] Adding environment DUMMYPOW supported=<SupportStatus ok ({})> 
INFO     [golem.environments.environmentsmanager] Adding environment WASM supported=<SupportStatus ok ({})> 
INFO     [golem.marketplace.offerpool        ] Offer pooling interval set to 0.0 
ERROR    [golem.task.server.resources        ] ResourceManager not ready 
resources.py                83 ERROR    ResourceManager not ready 
INFO     [golem.task.taskcomputer            ] Starting computation of subtask '070d2682-5498-11e9-a004-ba72b37a1f0c' (task: '7220aa01-ad45-4fb4-b199-ba72b37a1f0c', deadline: 1554135054, docker images: [{'repository': 'golemfactory/blender', 'image_id': None, 'tag': '1.9'}]) 
WARNING  [golem.docker.task_thread           ] Task error - exit_code=1
stderr:
['blender', '-b', '/golem/resources/../../../../golem/node.py', '-y', '-P', '/golem/work/render-scripts/scriptfile-hel_1-[crop_num=0].py', '-o', '/golem/output/hel_1', '-noaudio', '-F', 'PNG', '-t', '8', '-f', '1,2,3,4,5']

tail of stdout:
found bundled python: /blender/2.79/python
Error: Cannot read file '/golem/resources/../../../../golem/node.py': No such file or directory

Blender quit

 
task_thread.py             219 WARNING  Task error - exit_code=1
stderr:
['blender', '-b', '/golem/resources/../../../../golem/node.py', '-y', '-P', '/golem/work/render-scripts/scriptfile-hel_1-[crop_num=0].py', '-o', '/golem/output/hel_1', '-noaudio', '-F', 'PNG', '-t', '8', '-f', '1,2,3,4,5']

tail of stdout:
found bundled python: /blender/2.79/python
Error: Cannot read file '/golem/resources/../../../../golem/node.py': No such file or directory

Blender quit

 
WARNING  [golem.task.taskthread              ] Task computing error Subtask computation failed with exit code 1 
taskthread.py              103 WARNING  Task computing error Subtask computation failed with exit code 1 
WARNING  [golem.task.taskkeeper              ] This is not my task None 
taskkeeper.py               94 WARNING  This is not my task None 
ERROR    [golem.task.taskserver              ] Finished subtask listener: AttributeError("'NoneType' object has no attribute 'environment'",) 
taskserver.py              592 ERROR    Finished subtask listener: AttributeError("'NoneType' object has no attribute 'environment'",) 
INFO     [golem.client                       ] Shutting down ... 
INFO     [golem.client                       ] Stopping network ... 
INFO     [golem.network.concent.client       ] Waiting for received messages queue to empty 
INFO     [golem.network.concent.client       ] <ConcentClientService(Thread-1, initial daemon)> stopped 
--------------------------------------------------------------------------- Captured log call ----------------------------------------------------------------------------
database.py                103 INFO     Creating tables, schema version 24 
taskarchiver.py             45 INFO     Task archive not loaded: [Errno 2] No such file or directory: '/tmp/golem-tests-fkanrbpz/test_blender_scene_file_errorj1ecr808/task_archive.pickle' 
client.py                  127 INFO     Client 'None'(0xdeadbe..deadbeef), datadir: /tmp/golem-tests-fkanrbpz/test_blender_scene_file_errorj1ecr808 
environmentsmanager.py      48 INFO     Adding environment BLENDER supported=<SupportStatus ok ({})> 
environmentsmanager.py      48 INFO     Adding environment BLENDER_NVGPU supported=<SupportStatus ok ({})> 
environmentsmanager.py      48 INFO     Adding environment DUMMYPOW supported=<SupportStatus ok ({})> 
environmentsmanager.py      48 INFO     Adding environment WASM supported=<SupportStatus ok ({})> 
offerpool.py                38 INFO     Offer pooling interval set to 0.0 
resources.py                83 ERROR    ResourceManager not ready 
taskcomputer.py            356 INFO     Starting computation of subtask '070d2682-5498-11e9-a004-ba72b37a1f0c' (task: '7220aa01-ad45-4fb4-b199-ba72b37a1f0c', deadline: 1554135054, docker images: [{'repository': 'golemfactory/blender', 'image_id': None, 'tag': '1.9'}]) 
task_thread.py             219 WARNING  Task error - exit_code=1
stderr:
['blender', '-b', '/golem/resources/../../../../golem/node.py', '-y', '-P', '/golem/work/render-scripts/scriptfile-hel_1-[crop_num=0].py', '-o', '/golem/output/hel_1', '-noaudio', '-F', 'PNG', '-t', '8', '-f', '1,2,3,4,5']

tail of stdout:
found bundled python: /blender/2.79/python
Error: Cannot read file '/golem/resources/../../../../golem/node.py': No such file or directory

Blender quit


taskthread.py              103 WARNING  Task computing error Subtask computation failed with exit code 1
taskkeeper.py               94 WARNING  This is not my task None
taskserver.py              592 ERROR    Finished subtask listener: AttributeError("'NoneType' object has no attribute 'environment'",)
client.py                  619 INFO     Shutting down ...
client.py                  544 INFO     Stopping network ...
client.py                  227 INFO     Waiting for received messages queue to empty
client.py                  229 INFO     <ConcentClientService(Thread-1, initial daemon)> stopped
========================================================================== 127 tests deselected ==========================================================================
================================================================ 1 failed, 127 deselected in 3.26 seconds ================================================================
```

### Example 2
Output before and after from running unit tests with `self.fail()` added at the end of `test_simple_case()` on the current `CGI/transcoding/master` branch.

#### Before
```bash
pytest tests/apps/ffmpeg/task/ -k test_simple_case --tb=short
```

```pytest
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.6.8, pytest-3.3.1, py-1.5.3, pluggy-0.6.0
rootdir: /projects/golem/golem, inifile: setup.cfg
plugins: cov-2.5.1
collected 32 items                                                                                                                                                       

tests/apps/ffmpeg/task/test_ffmpegintegration.py F                                                                                                                 [100%]

================================================================================ FAILURES ================================================================================
_________________________________________________________________ TestffmpegIntegration.test_simple_case _________________________________________________________________
tests/apps/ffmpeg/task/test_ffmpegintegration.py:44: in test_simple_case
    self.fail()
E   AssertionError: None
-------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------
INFO     [golem.core.keysauth                ] Generating new key pair 
INFO     [golem.core.keysauth                ] Keys generated in 0.00s 
INFO     [golem.environments.environmentsmanager] Adding environment FFMPEG supported=<SupportStatus ok ({})>
INFO     [apps.transcoding.ffmpeg.utils      ] Stream /projects/golem/golem/tests/apps/ffmpeg/resources/test_video2.mp4 was successfully splitted to [('test_video2_0.ts', 'test_video2[num=0].m3u8'), ('test_video2_1.ts', 'test_video2[num=1].m3u8')]
INFO     [golem.task.taskmanager             ] Task 1eb69692-5494-11e9-9e6c-5114f7b750b5 added 
INFO     [golem.task.taskmanager             ] Task 1eb69692-5494-11e9-9e6c-5114f7b750b5 started 
INFO     [apps.core.verification_queue       ] Running verification of subtask '1f2a12a6-5494-11e9-836d-5114f7b750b5'
INFO     [apps.transcoding.task              ] Transcoded 1 of 2 chunks
INFO     [apps.transcoding.task              ] Transcoded 2 of 2 chunks
INFO     [apps.transcoding.ffmpeg.utils      ] Merging video
INFO     [apps.transcoding.ffmpeg.utils      ] Video merged successfully!
--------------------------------------------------------------------------- Captured log call ----------------------------------------------------------------------------
keysauth.py                154 INFO     Generating new key pair 
keysauth.py                167 INFO     Keys generated in 0.00s 
task.py                    229 DEBUG    Transcoding task definition was build [definition={'task_id': '', 'timeout': 600, 'subtask_timeout': 590, 'resources': {'/projects/golem/golem/tests/apps/ffmpeg/resources/test_video2.mp4'}, 'estimated_memory': 0, 'subtasks_count': 2, 'optimize_total': False, 'output_file': '/tmp/golem-tests-iegw7h2w/test_simple_case.mp4', 'task_type': 'FFMPEG', 'name': 'test_simple_case', 'max_price': 1000000000000000000, 'verification_options': None, 'options': <apps.transcoding.ffmpeg.task.ffmpegTaskOptions object at 0x7f83c9acd710>, 'docker_images': None, 'compute_on': 'cpu', 'concent_enabled': False}]
task.py                     77 DEBUG    Initialization of FFmpegTask
utils.py                    48 DEBUG    Running video splitting [params = {'script_filepath': '/golem/scripts/ffmpeg_task.py', 'command': 'split', 'path_to_stream': '/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/tmp/test_video2.mp4', 'parts': 2}]
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/images/golemfactory/ffmpeg:1.0/json HTTP/1.1" 200 None
environmentsmanager.py      48 INFO     Adding environment FFMPEG supported=<SupportStatus ok ({})>
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/images/golemfactory/ffmpeg:1.0/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/create HTTP/1.1" 201 90
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f0eec5fbbfbe05e88336b3713eef857db1811f485ca524952f41e01d2192a13d/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/f0eec5fbbfbe05e88336b3713eef857db1811f485ca524952f41e01d2192a13d/start HTTP/1.1" 204 0
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f0eec5fbbfbe05e88336b3713eef857db1811f485ca524952f41e01d2192a13d/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f0eec5fbbfbe05e88336b3713eef857db1811f485ca524952f41e01d2192a13d/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/f0eec5fbbfbe05e88336b3713eef857db1811f485ca524952f41e01d2192a13d/wait HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f0eec5fbbfbe05e88336b3713eef857db1811f485ca524952f41e01d2192a13d/logs?stderr=0&stdout=1&timestamps=0&follow=1&tail=all HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f0eec5fbbfbe05e88336b3713eef857db1811f485ca524952f41e01d2192a13d/json HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f0eec5fbbfbe05e88336b3713eef857db1811f485ca524952f41e01d2192a13d/logs?stderr=1&stdout=0&timestamps=0&follow=1&tail=all HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f0eec5fbbfbe05e88336b3713eef857db1811f485ca524952f41e01d2192a13d/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "DELETE /v1.35/containers/f0eec5fbbfbe05e88336b3713eef857db1811f485ca524952f41e01d2192a13d?v=False&link=False&force=True HTTP/1.1" 204 0
utils.py                    60 DEBUG    Split result file is = /tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/output/split-results.json [parts = 2]
utils.py                    69 INFO     Stream /projects/golem/golem/tests/apps/ffmpeg/resources/test_video2.mp4 was successfully splitted to [('test_video2_0.ts', 'test_video2[num=0].m3u8'), ('test_video2_1.ts', 'test_video2[num=1].m3u8')]
taskmanager.py             187 INFO     Task 1eb69692-5494-11e9-9e6c-5114f7b750b5 added 
taskmanager.py             225 INFO     Task 1eb69692-5494-11e9-9e6c-5114f7b750b5 started 
task.py                    130 DEBUG    Getting next task [type=trancoding, task_id=1eb69692-5494-11e9-9e6c-5114f7b750b5]
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/images/golemfactory/ffmpeg:1.0/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/create HTTP/1.1" 201 90
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/6ce14e86abc1e8660f290215323b4d5f1d570d757fbc36b272192265f3add35c/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/6ce14e86abc1e8660f290215323b4d5f1d570d757fbc36b272192265f3add35c/start HTTP/1.1" 204 0
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/6ce14e86abc1e8660f290215323b4d5f1d570d757fbc36b272192265f3add35c/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/6ce14e86abc1e8660f290215323b4d5f1d570d757fbc36b272192265f3add35c/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/6ce14e86abc1e8660f290215323b4d5f1d570d757fbc36b272192265f3add35c/wait HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/6ce14e86abc1e8660f290215323b4d5f1d570d757fbc36b272192265f3add35c/logs?stderr=0&stdout=1&timestamps=0&follow=1&tail=all HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/6ce14e86abc1e8660f290215323b4d5f1d570d757fbc36b272192265f3add35c/json HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/6ce14e86abc1e8660f290215323b4d5f1d570d757fbc36b272192265f3add35c/logs?stderr=1&stdout=0&timestamps=0&follow=1&tail=all HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/6ce14e86abc1e8660f290215323b4d5f1d570d757fbc36b272192265f3add35c/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "DELETE /v1.35/containers/6ce14e86abc1e8660f290215323b4d5f1d570d757fbc36b272192265f3add35c?v=False&link=False&force=True HTTP/1.1" 204 0
verification_queue.py       41 DEBUG    Verification Queue submit: (verifier_class: <class 'golem.verificator.ffmpeg_verifier.FFmpegVerifier'>, subtask: 1f2a12a6-5494-11e9-836d-5114f7b750b5, deadline: 1554133675, kwargs: {'subtask_info': {'perf': 1000, 'node_id': 'n3crdjqc', 'subtask_id': '1f2a12a6-5494-11e9-836d-5114f7b750b5', 'transcoding_params': {'track': '/golem/resources/test_video2[num=0].m3u8', 'targs': {'video': {'codec': 'h265'}, 'audio': {}, 'resolution': [320, 240], 'frame_rate': '25'}, 'output_stream': '/golem/output/test_video2[num=0]_TC.m3u8', 'use_playlist': True, 'command': 'transcode', 'script_filepath': '/golem/scripts/ffmpeg_task.py', 'RESOURCES_DIR': '/golem/resources', 'WORK_DIR': '/golem/work', 'OUTPUT_DIR': '/golem/output'}, 'subtask_num': 0, 'status': <SubtaskStatus.verifying: 'Verifying'>, 'owner': '00adbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'}, 'results': ['/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/tmp/test_video2[num=0]_TC.m3u8', '/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/tmp/test_video2[num=0]_TC0.ts'], 'resources': ['/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/output/test_video2_0.ts', '/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/output/test_video2_1.ts', '/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/output/test_video2[num=0].m3u8', '/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/output/test_video2[num=1].m3u8'], 'reference_data': []})
verification_queue.py       78 INFO     Running verification of subtask '1f2a12a6-5494-11e9-836d-5114f7b750b5'
task.py                    110 INFO     Transcoded 1 of 2 chunks
task.py                    130 DEBUG    Getting next task [type=trancoding, task_id=1eb69692-5494-11e9-9e6c-5114f7b750b5]
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/images/golemfactory/ffmpeg:1.0/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/create HTTP/1.1" 201 90
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/d7e7aa1548a05803694834bb9dbcd1ac4915866a87a456a4378756ee485aa641/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/d7e7aa1548a05803694834bb9dbcd1ac4915866a87a456a4378756ee485aa641/start HTTP/1.1" 204 0
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/d7e7aa1548a05803694834bb9dbcd1ac4915866a87a456a4378756ee485aa641/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/d7e7aa1548a05803694834bb9dbcd1ac4915866a87a456a4378756ee485aa641/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/d7e7aa1548a05803694834bb9dbcd1ac4915866a87a456a4378756ee485aa641/wait HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/d7e7aa1548a05803694834bb9dbcd1ac4915866a87a456a4378756ee485aa641/logs?stderr=0&stdout=1&timestamps=0&follow=1&tail=all HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/d7e7aa1548a05803694834bb9dbcd1ac4915866a87a456a4378756ee485aa641/json HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/d7e7aa1548a05803694834bb9dbcd1ac4915866a87a456a4378756ee485aa641/logs?stderr=1&stdout=0&timestamps=0&follow=1&tail=all HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/d7e7aa1548a05803694834bb9dbcd1ac4915866a87a456a4378756ee485aa641/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "DELETE /v1.35/containers/d7e7aa1548a05803694834bb9dbcd1ac4915866a87a456a4378756ee485aa641?v=False&link=False&force=True HTTP/1.1" 204 0
verification_queue.py       41 DEBUG    Verification Queue submit: (verifier_class: <class 'golem.verificator.ffmpeg_verifier.FFmpegVerifier'>, subtask: 1fccecee-5494-11e9-9d6f-5114f7b750b5, deadline: 1554133675, kwargs: {'subtask_info': {'perf': 1000, 'node_id': 'n3crdjqc', 'subtask_id': '1fccecee-5494-11e9-9d6f-5114f7b750b5', 'transcoding_params': {'track': '/golem/resources/test_video2[num=1].m3u8', 'targs': {'video': {'codec': 'h265'}, 'audio': {}, 'resolution': [320, 240], 'frame_rate': '25'}, 'output_stream': '/golem/output/test_video2[num=1]_TC.m3u8', 'use_playlist': True, 'command': 'transcode', 'script_filepath': '/golem/scripts/ffmpeg_task.py', 'RESOURCES_DIR': '/golem/resources', 'WORK_DIR': '/golem/work', 'OUTPUT_DIR': '/golem/output'}, 'subtask_num': 1, 'status': <SubtaskStatus.verifying: 'Verifying'>, 'owner': '00adbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'}, 'results': ['/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/tmp/test_video2[num=1]_TC.m3u8', '/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/tmp/test_video2[num=1]_TC0.ts'], 'resources': ['/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/output/test_video2_0.ts', '/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/output/test_video2_1.ts', '/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/output/test_video2[num=0].m3u8', '/tmp/golem-tests-iegw7h2w/1eb69692-5494-11e9-9e6c-5114f7b750b5/output/test_video2[num=1].m3u8'], 'reference_data': []})
task.py                    110 INFO     Transcoded 2 of 2 chunks
utils.py                   114 INFO     Merging video
utils.py                   115 DEBUG    Merge params: {'script_filepath': '/golem/scripts/ffmpeg_task.py', 'command': 'merge', 'output_stream': '/golem/output/test_simple_case.mp4', 'chunks': ['/golem/resources/test_video2[num=0]_TC.m3u8', '/golem/resources/test_video2[num=0]_TC0.ts', '/golem/resources/test_video2[num=1]_TC.m3u8', '/golem/resources/test_video2[num=1]_TC0.ts']}
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/images/golemfactory/ffmpeg:1.0/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/create HTTP/1.1" 201 90
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f2ed11d03b9d99db451731b217310b89065ebe5706ec97a5c98d46fb6e7ea74c/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/f2ed11d03b9d99db451731b217310b89065ebe5706ec97a5c98d46fb6e7ea74c/start HTTP/1.1" 204 0
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f2ed11d03b9d99db451731b217310b89065ebe5706ec97a5c98d46fb6e7ea74c/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f2ed11d03b9d99db451731b217310b89065ebe5706ec97a5c98d46fb6e7ea74c/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "POST /v1.35/containers/f2ed11d03b9d99db451731b217310b89065ebe5706ec97a5c98d46fb6e7ea74c/wait HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f2ed11d03b9d99db451731b217310b89065ebe5706ec97a5c98d46fb6e7ea74c/logs?stderr=0&stdout=1&timestamps=0&follow=1&tail=all HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f2ed11d03b9d99db451731b217310b89065ebe5706ec97a5c98d46fb6e7ea74c/json HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f2ed11d03b9d99db451731b217310b89065ebe5706ec97a5c98d46fb6e7ea74c/logs?stderr=1&stdout=0&timestamps=0&follow=1&tail=all HTTP/1.1" 200 None
connectionpool.py          393 DEBUG    http://localhost:None "GET /v1.35/containers/f2ed11d03b9d99db451731b217310b89065ebe5706ec97a5c98d46fb6e7ea74c/json HTTP/1.1" 200 None
config.py                   21 DEBUG    Trying paths: ['/home/cameel/.docker/config.json', '/home/cameel/.dockercfg']
config.py                   25 DEBUG    Found file at path: /home/cameel/.dockercfg
auth.py                    270 DEBUG    Couldn't find auth-related section ; attempting to interpretas auth-only file
auth.py                    218 DEBUG    Found entry (registry='https://mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://l.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://launcher.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://eu-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://asia-mirror.gcr.io', username='oauth2accesstoken')
auth.py                    218 DEBUG    Found entry (registry='https://us.gcr.io', username='oauth2accesstoken')
connectionpool.py          393 DEBUG    http://localhost:None "DELETE /v1.35/containers/f2ed11d03b9d99db451731b217310b89065ebe5706ec97a5c98d46fb6e7ea74c?v=False&link=False&force=True HTTP/1.1" 204 0
utils.py                   125 INFO     Video merged successfully!
========================================================================== 31 tests deselected ===========================================================================
================================================================ 1 failed, 31 deselected in 5.10 seconds =================================================================```
```

#### After
```bash
pytest tests/apps/ffmpeg/task/ -k test_simple_case --tb=short
```
```pytest
========================================================================== test session starts ===========================================================================
platform linux -- Python 3.6.8, pytest-3.3.1, py-1.5.3, pluggy-0.6.0
rootdir: /projects/golem/golem, inifile: setup.cfg
plugins: cov-2.5.1
collected 32 items                                                                                                                                                       

tests/apps/ffmpeg/task/test_ffmpegintegration.py F                                                                                                                 [100%]

================================================================================ FAILURES ================================================================================
_________________________________________________________________ TestffmpegIntegration.test_simple_case _________________________________________________________________
tests/apps/ffmpeg/task/test_ffmpegintegration.py:44: in test_simple_case
    self.fail()
E   AssertionError: None
-------------------------------------------------------------------------- Captured stderr call --------------------------------------------------------------------------
INFO     [golem.core.keysauth                ] Generating new key pair 
INFO     [golem.core.keysauth                ] Keys generated in 0.00s 
INFO     [golem.environments.environmentsmanager] Adding environment FFMPEG supported=<SupportStatus ok ({})>
INFO     [apps.transcoding.ffmpeg.utils      ] Stream /projects/golem/golem/tests/apps/ffmpeg/resources/test_video2.mp4 was successfully splitted to [('test_video2_0.ts', 'test_video2[num=0].m3u8'), ('test_video2_1.ts', 'test_video2[num=1].m3u8')]
INFO     [golem.task.taskmanager             ] Task f32e6e9e-5493-11e9-b2ee-7031fb62403a added 
INFO     [golem.task.taskmanager             ] Task f32e6e9e-5493-11e9-b2ee-7031fb62403a started 
INFO     [apps.core.verification_queue       ] Running verification of subtask 'f3a091e4-5493-11e9-addd-7031fb62403a'
INFO     [apps.transcoding.task              ] Transcoded 1 of 2 chunks
INFO     [apps.transcoding.task              ] Transcoded 2 of 2 chunks
INFO     [apps.transcoding.ffmpeg.utils      ] Merging video
INFO     [apps.transcoding.ffmpeg.utils      ] Video merged successfully!
--------------------------------------------------------------------------- Captured log call ----------------------------------------------------------------------------
keysauth.py                154 INFO     Generating new key pair 
keysauth.py                167 INFO     Keys generated in 0.00s 
task.py                    229 DEBUG    Transcoding task definition was build [definition={'task_id': '', 'timeout': 600, 'subtask_timeout': 590, 'resources': {'/projects/golem/golem/tests/apps/ffmpeg/resources/test_video2.mp4'}, 'estimated_memory': 0, 'subtasks_count': 2, 'optimize_total': False, 'output_file': '/tmp/golem-tests-wfya71le/test_simple_case.mp4', 'task_type': 'FFMPEG', 'name': 'test_simple_case', 'max_price': 1000000000000000000, 'verification_options': None, 'options': <apps.transcoding.ffmpeg.task.ffmpegTaskOptions object at 0x7f010d80e6d8>, 'docker_images': None, 'compute_on': 'cpu', 'concent_enabled': False}]
task.py                     77 DEBUG    Initialization of FFmpegTask
utils.py                    48 DEBUG    Running video splitting [params = {'script_filepath': '/golem/scripts/ffmpeg_task.py', 'command': 'split', 'path_to_stream': '/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/tmp/test_video2.mp4', 'parts': 2}]
environmentsmanager.py      48 INFO     Adding environment FFMPEG supported=<SupportStatus ok ({})>
utils.py                    60 DEBUG    Split result file is = /tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/output/split-results.json [parts = 2]
utils.py                    69 INFO     Stream /projects/golem/golem/tests/apps/ffmpeg/resources/test_video2.mp4 was successfully splitted to [('test_video2_0.ts', 'test_video2[num=0].m3u8'), ('test_video2_1.ts', 'test_video2[num=1].m3u8')]
taskmanager.py             187 INFO     Task f32e6e9e-5493-11e9-b2ee-7031fb62403a added
taskmanager.py             225 INFO     Task f32e6e9e-5493-11e9-b2ee-7031fb62403a started
task.py                    130 DEBUG    Getting next task [type=trancoding, task_id=f32e6e9e-5493-11e9-b2ee-7031fb62403a]
verification_queue.py       41 DEBUG    Verification Queue submit: (verifier_class: <class 'golem.verificator.ffmpeg_verifier.FFmpegVerifier'>, subtask: f3a091e4-5493-11e9-addd-7031fb62403a, deadline: 1554133602, kwargs: {'subtask_info': {'perf': 1000, 'node_id': '3cts2xog', 'subtask_id': 'f3a091e4-5493-11e9-addd-7031fb62403a', 'transcoding_params': {'track': '/golem/resources/test_video2[num=0].m3u8', 'targs': {'video': {'codec': 'h265'}, 'audio': {}, 'resolution': [320, 240], 'frame_rate': '25'}, 'output_stream': '/golem/output/test_video2[num=0]_TC.m3u8', 'use_playlist': True, 'command': 'transcode', 'script_filepath': '/golem/scripts/ffmpeg_task.py', 'RESOURCES_DIR': '/golem/resources', 'WORK_DIR': '/golem/work', 'OUTPUT_DIR': '/golem/output'}, 'subtask_num': 0, 'status': <SubtaskStatus.verifying: 'Verifying'>, 'owner': '00adbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'}, 'results': ['/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/tmp/test_video2[num=0]_TC.m3u8', '/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/tmp/test_video2[num=0]_TC0.ts'], 'resources': ['/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/output/test_video2_0.ts', '/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/output/test_video2_1.ts', '/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/output/test_video2[num=0].m3u8', '/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/output/test_video2[num=1].m3u8'], 'reference_data': []})
verification_queue.py       78 INFO     Running verification of subtask 'f3a091e4-5493-11e9-addd-7031fb62403a'
task.py                    110 INFO     Transcoded 1 of 2 chunks
task.py                    130 DEBUG    Getting next task [type=trancoding, task_id=f32e6e9e-5493-11e9-b2ee-7031fb62403a]
verification_queue.py       41 DEBUG    Verification Queue submit: (verifier_class: <class 'golem.verificator.ffmpeg_verifier.FFmpegVerifier'>, subtask: f44a4368-5493-11e9-9b30-7031fb62403a, deadline: 1554133602, kwargs: {'subtask_info': {'perf': 1000, 'node_id': '3cts2xog', 'subtask_id': 'f44a4368-5493-11e9-9b30-7031fb62403a', 'transcoding_params': {'track': '/golem/resources/test_video2[num=1].m3u8', 'targs': {'video': {'codec': 'h265'}, 'audio': {}, 'resolution': [320, 240], 'frame_rate': '25'}, 'output_stream': '/golem/output/test_video2[num=1]_TC.m3u8', 'use_playlist': True, 'command': 'transcode', 'script_filepath': '/golem/scripts/ffmpeg_task.py', 'RESOURCES_DIR': '/golem/resources', 'WORK_DIR': '/golem/work', 'OUTPUT_DIR': '/golem/output'}, 'subtask_num': 1, 'status': <SubtaskStatus.verifying: 'Verifying'>, 'owner': '00adbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef'}, 'results': ['/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/tmp/test_video2[num=1]_TC.m3u8', '/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/tmp/test_video2[num=1]_TC0.ts'], 'resources': ['/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/output/test_video2_0.ts', '/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/output/test_video2_1.ts', '/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/output/test_video2[num=0].m3u8', '/tmp/golem-tests-wfya71le/f32e6e9e-5493-11e9-b2ee-7031fb62403a/output/test_video2[num=1].m3u8'], 'reference_data': []})
task.py                    110 INFO     Transcoded 2 of 2 chunks
utils.py                   114 INFO     Merging video
utils.py                   115 DEBUG    Merge params: {'script_filepath': '/golem/scripts/ffmpeg_task.py', 'command': 'merge', 'output_stream': '/golem/output/test_simple_case.mp4', 'chunks': ['/golem/resources/test_video2[num=0]_TC.m3u8', '/golem/resources/test_video2[num=0]_TC0.ts', '/golem/resources/test_video2[num=1]_TC.m3u8', '/golem/resources/test_video2[num=1]_TC0.ts']}
utils.py                   125 INFO     Video merged successfully!
========================================================================== 31 tests deselected ===========================================================================
================================================================ 1 failed, 31 deselected in 5.15 seconds =================================================================
```