### PR TITLE
Use the correct option for passing audio bitrate to ffmpeg

### DIFF
--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_commands.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_commands.py
@@ -127,7 +127,7 @@ def transcode_video_command(track, output_playlist_name, targs, use_playlist):
         pass
     try:
         abitrate = targs['audio']['bitrate']
-        cmd.append("-c:a")
+        cmd.append("-b:a")
         cmd.append(abitrate)
     except:
         pass

--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_commands.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_commands.py
@@ -100,49 +100,41 @@ def transcode_video_command(track, output_playlist_name, targs, use_playlist):
         cmd.extend(playlist_cmd)
 
     # video settings
-    try:
+    if 'video' in targs and 'codec' in targs['video']:
         vcodec = targs['video']['codec']
         cmd.append("-c:v")
         cmd.append(get_video_encoder(vcodec))
-    except:
-        pass
-    try:
+
+    if 'frame_rate' in targs:
         fps = str(targs['frame_rate'])
         cmd.append("-r")
         cmd.append(fps)
-    except:
-        pass
-    try:
+
+    if 'video' in targs and 'bitrate' in targs['video']:
         vbitrate = targs['video']['bitrate']
         cmd.append("-b:v")
         cmd.append(vbitrate)
-    except:
-        pass
+
     # audio settings
-    try:
+    if 'audio' in targs and 'codec' in targs['audio']:
         acodec = targs['audio']['codec']
         cmd.append("-c:a")
         cmd.append(get_audio_encoder(acodec))
-    except:
-        pass
-    try:
+
+    if 'audio' in targs and 'bitrate' in targs['audio']:
         abitrate = targs['audio']['bitrate']
         cmd.append("-b:a")
         cmd.append(abitrate)
-    except:
-        pass
-    try:
+
+    if 'resolution' in targs:
         res = targs['resolution']
         cmd.append("-vf")
         cmd.append("scale={}:{}".format(res[0], res[1]))
-    except:
-        pass
-    try:
+
+    if 'scaling_alg' in targs:
         scale = targs["scaling_alg"]
         cmd.append("-sws_flags")
         cmd.append("{}".format(scale))
-    except:
-        pass
 
     cmd.append("{}".format(output_playlist_name))
 

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -223,7 +223,6 @@ class TranscodingTaskBuilder(CoreTaskBuilder):
         task_def.options.video_params = video_params
         task_def.options.output_container = output_container
         task_def.options.audio_params = audio_params
-        task_def.options.audio_params = audio_params
         task_def.options.name = dict.get('name', '')
         logger.debug('Transcoding task definition was build [definition={}]'
                      .format(task_def.__dict__))


### PR DESCRIPTION
This trivial change fixes the name of the option used to pass audio bitrate fo ffmpeg. The right option is `-b:a` or `-ab`. `-c:a` is for selecting the audio codec.

There is currently no mechanism in Golem for unit testing the code running in Docker containers so I could not add a failing test case for this. I tried to do this indirectly - by adding audio bitrate value to one of the test cases in `test_ffmpegintegration.py` but they use video files without audio tracks and it seems that ffmpeg silently ignores invalid `-c:a` values and does not fail in that case.

So I can only show that using this option manually in a ffmpeg command produces an error:
``` bash
ffmpeg -i ForBiggerBlazes-\[codec\=h264\].mp4 -c:v libx265 -r 25 -c:a aac -c:a 128k -vf scale=320:240 out.mp4
```
```
Unknown encoder '128k'
```

The test file is [ForBiggerBlazes-[codec=h264].mp4](https://github.com/golemfactory/transcoding-experiments/blob/master/tests/videos/different-codecs/ForBiggerBlazes-[codec%3Dh264].mp4).