### PR TITLE
Fix ffmpeg integration tests splitting file twice in setup

### DIFF
--- a/tests/apps/ffmpeg/task/test_ffmpegtask.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegtask.py
@@ -152,13 +152,6 @@ class TestffmpegTask(TempDirFixture):
 
         self.assertEqual(td.output_file, '/tmp/test task.mp4')
 
-    def test_build_ffmpeg_task(self):
-        td = self.tt.task_builder_type.build_definition(self.tt,
-                                                        self._task_dictionary)
-        builder = self.tt.task_builder_type(dt_p2p_factory.Node(), td,
-                                            DirManager(self.tempdir))
-        builder.build()
-
     def test_invalid_extra_data(self):
         with self.assertRaises(AssertionError):
             self.ffmpeg_task._get_extra_data(1)

--- a/tests/apps/ffmpeg/task/test_ffmpegtask.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegtask.py
@@ -32,11 +32,13 @@ class TestffmpegTask(TempDirFixture):
             done_callback=mock.Mock(),
             work_dir=self.new_path,
             in_background=True)
+
+    def _build_ffmpeg_task(self):
         td = self.tt.task_builder_type.build_definition(self.tt,
                                                         self._task_dictionary)
-        self.ffmpeg_task = self.tt.task_builder_type(dt_p2p_factory.Node(), td,
-                                                     DirManager(
-                                                         self.tempdir)).build()
+        return self.tt.task_builder_type(dt_p2p_factory.Node(), td,
+                                         DirManager(
+                                             self.tempdir)).build()
 
     @property
     def _task_dictionary(self):
@@ -153,12 +155,15 @@ class TestffmpegTask(TempDirFixture):
         self.assertEqual(td.output_file, '/tmp/test task.mp4')
 
     def test_invalid_extra_data(self):
+        ffmpeg_task = self._build_ffmpeg_task()
         with self.assertRaises(AssertionError):
-            self.ffmpeg_task._get_extra_data(1)
+            ffmpeg_task._get_extra_data(1)
 
     def test_extra_data(self):
+        ffmpeg_task = self._build_ffmpeg_task()
+
         d = self._task_dictionary
-        extra_data = self.ffmpeg_task._get_extra_data(0)
+        extra_data = ffmpeg_task._get_extra_data(0)
         self.assertEqual(extra_data['command'], Commands.TRANSCODE.value[0])
         self.assertEqual(extra_data['script_filepath'],
                          '/golem/scripts/ffmpeg_task.py')
@@ -191,11 +196,13 @@ class TestffmpegTask(TempDirFixture):
         self.assertEqual(task.total_tasks, 1)
 
     def test_query_extra_data(self):
+        ffmpeg_task = self._build_ffmpeg_task()
+
         node_id = uuid.uuid4()
-        self.ffmpeg_task.header.task_id = str(uuid.uuid4())
-        extra_data = self.ffmpeg_task.query_extra_data(0.5, node_id)
+        ffmpeg_task.header.task_id = str(uuid.uuid4())
+        extra_data = ffmpeg_task.query_extra_data(0.5, node_id)
         ctd = extra_data.ctd
-        subtask = next(iter(self.ffmpeg_task.subtasks_given.values()))
+        subtask = next(iter(ffmpeg_task.subtasks_given.values()))
 
         self.assertEqual(subtask['perf'], 0.5)
         self.assertEqual(subtask['node_id'], node_id)
@@ -207,7 +214,7 @@ class TestffmpegTask(TempDirFixture):
         self.assertEqual(ctd['subtask_id'], subtask['subtask_id'])
         self.assertEqual(ctd['extra_data'], subtask['transcoding_params'])
         self.assertEqual(ctd['docker_images'], [di.to_dict() for di in
-                                                self.ffmpeg_task.docker_images])
+                                                ffmpeg_task.docker_images])
         self.assertEqual(ctd['deadline'], min(timeout_to_deadline(
-            self.ffmpeg_task.header.subtask_timeout),
-            self.ffmpeg_task.header.deadline))
+            ffmpeg_task.header.subtask_timeout),
+            ffmpeg_task.header.deadline))


### PR DESCRIPTION
`TestffmpegTask.setUp()` prepares an ffmpeg task for use in individual tests. This involves splitting the input video into segments. Not all tests in `TestffmpegTask` use it though. Some of them just ignore it and build another task for themselves - all in the same temporary directory. This means that video is being split into segments again and segments and/or playlists may be overwritten.

This does not fail on `CGI/transcoding/master` because the split command used in the ffmpeg image right now seems happy to overwrite existing segments without asking when it's being told to use a M3U8 playlist as output. It does fail on my new branch where I split the video with a different method.

Even if it did not fail, it's unnecessary an makes the tests slower. My change extracts the part that builds the task into a function and makes only tests that need it call it. It also removes one of the tests which does not do anything beyond building a task.