### PR TITLE
Fix connection failure handler for verification

### DIFF
--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -1076,11 +1076,22 @@ class TaskServer(
         session.send_hello()
         session.result_received(subtask_id, full_path_files)
 
-    def __connection_for_task_verification_result_failure(  # noqa pylint:disable=no-self-use
-            self, _conn_id, _extracted_package, key_id, subtask_id: str):
+    @classmethod
+    def _connection_for_task_verification_result_failure(
+            cls,
+            conn_id,
+            extracted_package,
+            key_id,
+            subtask_id: str,
+        ):
         logger.warning("Failed to establish a session to deliver "
                        "the verification result for %s to the provider %s",
                        subtask_id, key_id)
+        logger.debug(
+            "conn_id=%r, extracted_package=%r",
+            conn_id,
+            extracted_package,
+        )
 
     # SYNC METHODS
     #############################
@@ -1206,7 +1217,7 @@ class TaskServer(
             TASK_CONN_TYPES['start_session']:
             self.__connection_for_start_session_failure,
             TASK_CONN_TYPES['task_verification_result']:
-                self.__connection_for_task_verification_result_failure,
+                self._connection_for_task_verification_result_failure,
         })
 
     def _set_conn_final_failure(self):
@@ -1220,7 +1231,7 @@ class TaskServer(
             TASK_CONN_TYPES['start_session']:
             self.__connection_for_start_session_final_failure,
             TASK_CONN_TYPES['task_verification_result']:
-                self.__connection_for_task_verification_result_failure,
+                self._connection_for_task_verification_result_failure,
         })
 
 

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1411,9 +1411,9 @@ class TaskVerificationResultTest(TaskServerTestBase):
             '__connection_for_task_verification_result_established')
         self.assertEqual(
             pc.failure.func.__name__,
-            '__connection_for_task_verification_result_failure',
+            '_connection_for_task_verification_result_failure',
         )
         self.assertEqual(
             pc.final_failure.func.__name__,
-            '__connection_for_task_verification_result_failure',
+            '_connection_for_task_verification_result_failure',
         )


### PR DESCRIPTION
Fixes
```!python
2019-04-03 15:20:30 CRITICAL twisted                             
Traceback (most recent call last):
  File "C:\BuildbotWorker\buildpackage_windows\build\.venv\lib\site-packages\twisted\internet\defer.py", line 653, in _runCallbacks
  File "C:\BuildbotWorker\buildpackage_windows\build\golem\network\transport\tcpnetwork.py", line 182, in __connection_failure
  File "C:\BuildbotWorker\buildpackage_windows\build\golem\network\transport\tcpnetwork.py", line 239, in __call_failure_callback
  File "C:\BuildbotWorker\buildpackage_windows\build\golem\network\transport\tcpnetwork.py", line 197, in __connection_to_address_failure
  File "C:\BuildbotWorker\buildpackage_windows\build\golem\network\transport\tcpnetwork.py", line 239, in __call_failure_callback
TypeError: __connection_for_task_verification_result_failure() got an unexpected keyword argument 'conn_id'

```