### PR TITLE
Fix linter breakage and warning filtering

### DIFF
--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -60,7 +60,7 @@ cleanup_artifacts() {
     git checkout "$CURRENT_BRANCH" -- || exit 1
 }
 
-diff-lines() {
+list-added-lines-from-diff() {
     # Function taken from: https://stackoverflow.com/questions/8259851/using-git-diff-how-can-i-get-added-and-modified-lines-numbers
     # Adjusted the 'echo' line to not print the line content.
     local path=
@@ -110,7 +110,7 @@ if [ -n "$diff" ]; then
 
     # Remove lines from findings based on lines changed
     diff_line_file="$(mktemp tmp-golem-changed-lines.XXXXXXXXXX -t)"
-    git diff --no-color --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | diff-lines > "$diff_line_file" || true
+    git diff --no-color --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | list-added-lines-from-diff > "$diff_line_file" || true
     CHANGED_DIFF="$(echo "$diff" | grep --fixed-strings --file "$diff_line_file")"
     rm "$diff_line_file"
 

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -63,16 +63,38 @@ cleanup_artifacts() {
 list-added-lines-from-diff() {
     # Function taken from: https://stackoverflow.com/questions/8259851/using-git-diff-how-can-i-get-added-and-modified-lines-numbers
     # Adjusted the 'echo' line to not print the line content.
+    # EDIT 2019-04-04: A few more fixes and tweaks but I won't be listing them here. See git log.
     local path=
     local line=
     while read; do
         if [[ $REPLY =~ ^---\ (a/)?.* ]]; then
+            # A line that looks like one of these:
+            # --- a/apps/rendering/resources/utils.py
+            # --- /dev/null
+            #
+            # Skip it. It does not provide any useful information here.
             continue
         elif [[ $REPLY =~ ^\+\+\+\ (b/)?([^[:blank:]]+).* ]]; then
+            # A line that looks like this:
+            # +++ a/apps/rendering/resources/utils.py
+            # +++ /dev/null
+            #
+            # It tells us which file now contains lines marked as added in the diff.
+            # If it's /dev/null, the file has been removed. We should just ignore the
+            # lines from a removed file but this will happen automatically because they
+            # all start with a - sign.
             path=${BASH_REMATCH[2]}
         elif [[ $REPLY =~ ^@@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,[0-9]+)?\ @@.* ]]; then
+            # A line that looks like this:
+            # @@ -6,2 +4,0 @@ from typing import Optional
+            #
+            # It tells us, among other things, the line number that the next line
+            # marked as added in the diff is located now at.
             line=${BASH_REMATCH[2]}
         elif [[ $REPLY =~ ^\+ ]]; then
+            # All the other lines should start either with + or -
+            # We're only interested in thos starting with + because only they exist
+            # in the code that has been fed to the linter.
             echo "$path:$line:"
             ((line++))
         fi

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -112,8 +112,10 @@ if [ -n "$diff" ]; then
     echo "$diff"
 
     # Remove lines from findings based on lines changed
-    DIFF_LINES=$(git diff --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | diff-lines) || true
-    CHANGED_DIFF=$(echo "$diff" | grep -F "$DIFF_LINES")
+    diff_line_file="$(mktemp tmp-golem-changed-lines.XXXXXXXXXX -t)"
+    git diff --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | diff-lines > "$diff_line_file" || true
+    CHANGED_DIFF="$(echo "$diff" | grep --fixed-strings --file "$diff_line_file")"
+    rm "$diff_line_file"
 
     echo -e "\n\nChanged lines findings:\n"
     echo "$CHANGED_DIFF"

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -66,11 +66,11 @@ diff-lines() {
     local path=
     local line=
     while read; do
-        if [[ $REPLY =~ ---\ (a/)?.* ]]; then
+        if [[ $REPLY =~ ^---\ (a/)?.* ]]; then
             continue
-        elif [[ $REPLY =~ \+\+\+\ (b/)?([^[:blank:]]+).* ]]; then
+        elif [[ $REPLY =~ ^\+\+\+\ (b/)?([^[:blank:]]+).* ]]; then
             path=${BASH_REMATCH[2]}
-        elif [[ $REPLY =~ @@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,[0-9]+)?\ @@.* ]]; then
+        elif [[ $REPLY =~ ^@@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,[0-9]+)?\ @@.* ]]; then
             line=${BASH_REMATCH[2]}
         elif [[ $REPLY =~ ^\+ ]]; then
             echo "$path:$line:"

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -66,14 +66,13 @@ diff-lines() {
     local path=
     local line=
     while read; do
-        esc=$'\033'
         if [[ $REPLY =~ ---\ (a/)?.* ]]; then
             continue
-        elif [[ $REPLY =~ \+\+\+\ (b/)?([^[:blank:]$esc]+).* ]]; then
+        elif [[ $REPLY =~ \+\+\+\ (b/)?([^[:blank:]]+).* ]]; then
             path=${BASH_REMATCH[2]}
         elif [[ $REPLY =~ @@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,[0-9]+)?\ @@.* ]]; then
             line=${BASH_REMATCH[2]}
-        elif [[ $REPLY =~ ^($esc\[[0-9;]+m)*\+ ]]; then
+        elif [[ $REPLY =~ ^\+ ]]; then
             echo "$path:$line:"
             ((line++))
         fi
@@ -111,7 +110,7 @@ if [ -n "$diff" ]; then
 
     # Remove lines from findings based on lines changed
     diff_line_file="$(mktemp tmp-golem-changed-lines.XXXXXXXXXX -t)"
-    git diff --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | diff-lines > "$diff_line_file" || true
+    git diff --no-color --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | diff-lines > "$diff_line_file" || true
     CHANGED_DIFF="$(echo "$diff" | grep --fixed-strings --file "$diff_line_file")"
     rm "$diff_line_file"
 

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -73,11 +73,9 @@ diff-lines() {
             path=${BASH_REMATCH[2]}
         elif [[ $REPLY =~ @@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,[0-9]+)?\ @@.* ]]; then
             line=${BASH_REMATCH[2]}
-        elif [[ $REPLY =~ ^($esc\[[0-9;]+m)*([\ +-]) ]]; then
+        elif [[ $REPLY =~ ^($esc\[[0-9;]+m)*\+ ]]; then
             echo "$path:$line:"
-            if [[ ${BASH_REMATCH[2]} != - ]]; then
-                ((line++))
-            fi
+            ((line++))
         fi
     done
 }


### PR DESCRIPTION
The current implementation of `lintdiff.sh` is broken in several ways:
1) If fails if there are too many differences between your branch and `develop`.
2) It silently ignores failures. E.g. when `grep` returns an error because it got too many patterns as input, it does not exit with a non-zero status. This way `lint.sh` assumes that there are no new warnings even if there are.
3) It does not filter the warnings correctly. It can sometimes include warnings from lines that were not modified in your branch.
4) It may parse the diff incorrectly if your code contains `---`, `+++` or `@@` sequences.
5) It does not report any warnings if the whole file is moved.

This pull request fixes problems 1-4. I'm not sure if 5 is a real issue in practice so I left it as is. See commit descriptions for details of each individual fix (I strongly recommend reviewing them individually rather than looking at the combined result). I have also added comments explaining the regexes in `diff-lines()` to make them easier to understand and decrease the likelihood of future bugs.

### Reproducing the problems
If you want to see the problem, just check out `CGI/transcoding/master` and run the linter:
``` bash
git checkout CGI/transcoding/master
./lint.sh`
```
Linting will end with nothing found even though there are tons of warning if you run `pylint` or `mypy` manually. That's because the `grep` call used to select only warnings on modified lines gets too many patterns and fails. You can even see the error in the output if you run `./lint.sh -v` and try to rerun the `lintdiff.sh` command it prints by yourself.

Rebase my branch locally on top of `CGI/transcoding/master` and run the linter again:
``` bash
git checkout fix-linter-breakage-and-warning-filtering
git checkout -b tmp
git rebase --onto CGI/transcoding/master origin/develop
./lint.sh
```

Now you can see all the warnings that used to be suppressed.