### PR TITLE
Fix linter breakage and warning filtering (attempt 2)

### DIFF
--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -133,14 +133,14 @@ if [ -n "$diff" ]; then
     # Remove lines from findings based on lines changed
     diff_line_file="$(mktemp tmp-golem-changed-lines.XXXXXXXXXX -t)"
     git diff --no-color --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | list-added-lines-from-diff > "$diff_line_file" || true
-    CHANGED_DIFF="$(echo "$diff" | grep --fixed-strings --file "$diff_line_file")"
+    CHANGED_DIFF="$(echo "$diff" | grep --fixed-strings --file "$diff_line_file")" || true
     rm "$diff_line_file"
 
     echo -e "\n\nChanged lines findings:\n"
     echo "$CHANGED_DIFF"
 
     # Remove warning lines starting with W
-    CHANGED_ERR=$(echo "$CHANGED_DIFF" | grep -v -e '^W')
+    CHANGED_ERR=$(echo "$CHANGED_DIFF" | grep -v -e '^W') || true
     if [ -n "$CHANGED_ERR" ]; then
         exit 1
     fi

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -60,7 +60,7 @@ cleanup_artifacts() {
     git checkout "$CURRENT_BRANCH" -- || exit 1
 }
 
-diff-lines() {
+list-added-lines-from-diff() {
     # Function taken from: https://stackoverflow.com/questions/8259851/using-git-diff-how-can-i-get-added-and-modified-lines-numbers
     # Adjusted the 'echo' line to not print the line content.
     local path=
@@ -110,7 +110,7 @@ if [ -n "$diff" ]; then
 
     # Remove lines from findings based on lines changed
     diff_line_file="$(mktemp tmp-golem-changed-lines.XXXXXXXXXX -t)"
-    git diff --no-color --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | diff-lines > "$diff_line_file" || true
+    git diff --no-color --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | list-added-lines-from-diff > "$diff_line_file" || true
     CHANGED_DIFF="$(echo "$diff" | grep --fixed-strings --file "$diff_line_file")"
     rm "$diff_line_file"
 

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -63,16 +63,38 @@ cleanup_artifacts() {
 list-added-lines-from-diff() {
     # Function taken from: https://stackoverflow.com/questions/8259851/using-git-diff-how-can-i-get-added-and-modified-lines-numbers
     # Adjusted the 'echo' line to not print the line content.
+    # EDIT 2019-04-04: A few more fixes and tweaks but I won't be listing them here. See git log.
     local path=
     local line=
     while read; do
         if [[ $REPLY =~ ^---\ (a/)?.* ]]; then
+            # A line that looks like one of these:
+            # --- a/apps/rendering/resources/utils.py
+            # --- /dev/null
+            #
+            # Skip it. It does not provide any useful information here.
             continue
         elif [[ $REPLY =~ ^\+\+\+\ (b/)?([^[:blank:]]+).* ]]; then
+            # A line that looks like this:
+            # +++ a/apps/rendering/resources/utils.py
+            # +++ /dev/null
+            #
+            # It tells us which file now contains lines marked as added in the diff.
+            # If it's /dev/null, the file has been removed. We should just ignore the
+            # lines from a removed file but this will happen automatically because they
+            # all start with a - sign.
             path=${BASH_REMATCH[2]}
         elif [[ $REPLY =~ ^@@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,[0-9]+)?\ @@.* ]]; then
+            # A line that looks like this:
+            # @@ -6,2 +4,0 @@ from typing import Optional
+            #
+            # It tells us, among other things, the line number that the next line
+            # marked as added in the diff is located now at.
             line=${BASH_REMATCH[2]}
         elif [[ $REPLY =~ ^\+ ]]; then
+            # All the other lines should start either with + or -
+            # We're only interested in thos starting with + because only they exist
+            # in the code that has been fed to the linter.
             echo "$path:$line:"
             ((line++))
         fi

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -112,8 +112,10 @@ if [ -n "$diff" ]; then
     echo "$diff"
 
     # Remove lines from findings based on lines changed
-    DIFF_LINES=$(git diff --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | diff-lines) || true
-    CHANGED_DIFF=$(echo "$diff" | grep -F "$DIFF_LINES")
+    diff_line_file="$(mktemp tmp-golem-changed-lines.XXXXXXXXXX -t)"
+    git diff --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | diff-lines > "$diff_line_file" || true
+    CHANGED_DIFF="$(echo "$diff" | grep --fixed-strings --file "$diff_line_file")"
+    rm "$diff_line_file"
 
     echo -e "\n\nChanged lines findings:\n"
     echo "$CHANGED_DIFF"

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -66,11 +66,11 @@ diff-lines() {
     local path=
     local line=
     while read; do
-        if [[ $REPLY =~ ---\ (a/)?.* ]]; then
+        if [[ $REPLY =~ ^---\ (a/)?.* ]]; then
             continue
-        elif [[ $REPLY =~ \+\+\+\ (b/)?([^[:blank:]]+).* ]]; then
+        elif [[ $REPLY =~ ^\+\+\+\ (b/)?([^[:blank:]]+).* ]]; then
             path=${BASH_REMATCH[2]}
-        elif [[ $REPLY =~ @@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,[0-9]+)?\ @@.* ]]; then
+        elif [[ $REPLY =~ ^@@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,[0-9]+)?\ @@.* ]]; then
             line=${BASH_REMATCH[2]}
         elif [[ $REPLY =~ ^\+ ]]; then
             echo "$path:$line:"

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -66,14 +66,13 @@ diff-lines() {
     local path=
     local line=
     while read; do
-        esc=$'\033'
         if [[ $REPLY =~ ---\ (a/)?.* ]]; then
             continue
-        elif [[ $REPLY =~ \+\+\+\ (b/)?([^[:blank:]$esc]+).* ]]; then
+        elif [[ $REPLY =~ \+\+\+\ (b/)?([^[:blank:]]+).* ]]; then
             path=${BASH_REMATCH[2]}
         elif [[ $REPLY =~ @@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,[0-9]+)?\ @@.* ]]; then
             line=${BASH_REMATCH[2]}
-        elif [[ $REPLY =~ ^($esc\[[0-9;]+m)*\+ ]]; then
+        elif [[ $REPLY =~ ^\+ ]]; then
             echo "$path:$line:"
             ((line++))
         fi
@@ -111,7 +110,7 @@ if [ -n "$diff" ]; then
 
     # Remove lines from findings based on lines changed
     diff_line_file="$(mktemp tmp-golem-changed-lines.XXXXXXXXXX -t)"
-    git diff --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | diff-lines > "$diff_line_file" || true
+    git diff --no-color --unified=0 "$REF_BRANCH" "$CURRENT_BRANCH" | diff-lines > "$diff_line_file" || true
     CHANGED_DIFF="$(echo "$diff" | grep --fixed-strings --file "$diff_line_file")"
     rm "$diff_line_file"
 

--- a/lintdiff.sh
+++ b/lintdiff.sh
@@ -73,11 +73,9 @@ diff-lines() {
             path=${BASH_REMATCH[2]}
         elif [[ $REPLY =~ @@\ -[0-9]+(,[0-9]+)?\ \+([0-9]+)(,[0-9]+)?\ @@.* ]]; then
             line=${BASH_REMATCH[2]}
-        elif [[ $REPLY =~ ^($esc\[[0-9;]+m)*([\ +-]) ]]; then
+        elif [[ $REPLY =~ ^($esc\[[0-9;]+m)*\+ ]]; then
             echo "$path:$line:"
-            if [[ ${BASH_REMATCH[2]} != - ]]; then
-                ((line++))
-            fi
+            ((line++))
         fi
     done
 }


### PR DESCRIPTION
I'm submitting #4089 again with a hotfix. It turns out that `grep` fails with non-zero status if the filtered list turns out empty. This means that `lintdiff.sh` would fail when it discovered that none of the reported warnings were on the the lines that were modified.

The previous pull request was reverted in #4091. This one contains all the commits from the previous one and one extra hotfix commit on top of them.