### PR TITLE
duplicate p2psession fix cherry-picked to b0.19

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -493,7 +493,6 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
 
             listener = ClientTaskComputerEventListener(self)
             self.task_server.task_computer.register_listener(listener)
-            self.p2pservice.connect_to_network()
 
             if self.monitor:
                 self.diag_service.register(self.p2pservice,
@@ -516,8 +515,6 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         gatherResults([p2p, task], consumeErrors=True).addCallbacks(connect,
                                                                     terminate)
 
-        self.resume()
-
         logger.info("Starting p2p server ...")
         self.p2pservice.task_server = self.task_server
         self.p2pservice.set_resource_server(self.resource_server)
@@ -527,6 +524,8 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         logger.info("Starting task server ...")
         self.task_server.start_accepting(listening_established=task.callback,
                                          listening_failure=task.errback)
+
+        self.resume()
 
     def _restore_locks(self) -> None:
         assert self.task_server is not None
@@ -580,9 +579,11 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
                 service.stop()
 
         if self.p2pservice:
+            logger.debug("Pausing p2pservice")
             self.p2pservice.pause()
             self.p2pservice.disconnect()
         if self.task_server:
+            logger.debug("Pausing task_server")
             yield self.task_server.pause()
             self.task_server.disconnect()
             self.task_server.task_computer.quit()

--- a/golem/network/p2p/p2pservice.py
+++ b/golem/network/p2p/p2pservice.py
@@ -142,9 +142,12 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
 
     def connect_to_network(self):
         # pylint: disable=singleton-comparison
+        logger.debug("Connecting to seeds")
         self.connect_to_seeds()
         if not self.connect_to_known_hosts:
             return
+
+        logger.debug("Connecting to known hosts")
 
         for host in KnownHosts.select() \
                 .where(KnownHosts.is_seed == False)\
@@ -153,10 +156,11 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
             ip_address = host.ip_address
             port = host.port
 
-            logger.debug("Connecting to {}:{}".format(ip_address, port))
+            logger.debug("Connecting to %s:%s ...", ip_address, port)
             try:
                 socket_address = tcpnetwork.SocketAddress(ip_address, port)
                 self.connect(socket_address)
+                logger.debug("Connected!")
             except Exception as exc:
                 logger.error("Cannot connect to host {}:{}: {}"
                              .format(ip_address, port, exc))
@@ -168,6 +172,7 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
 
         for _ in range(len(self.seeds)):
             ip_address, port = self._get_next_random_seed()
+            logger.debug("Connecting to %s:%s ...", ip_address, port)
             try:
                 socket_address = tcpnetwork.SocketAddress(ip_address, port)
                 self.connect(socket_address)
@@ -175,6 +180,7 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
                 logger.error("Cannot connect to seed %s:%s: %s",
                              ip_address, port, exc)
                 continue
+            logger.debug("Connected!")
             break  # connected
 
     def connect(self, socket_address):
@@ -220,7 +226,7 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
 
         except Exception as err:
             logger.error(
-                "Couldn't add known peer %r:%r : %s",
+                "Couldn't add known peer %s:%s - %s",
                 ip_address,
                 port,
                 err
@@ -329,8 +335,9 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
         """
         key_id = peer.key_id
         logger.info(
-            "Adding peer %s, key id difficulty: %r",
+            "Adding peer. node=%s, address=%s:%s, key_difficulty=%r",
             node_info_str(peer.node_name, key_id),
+            peer.address, peer.port,
             self.keys_auth.get_difficulty(key_id)
         )
         with self._peer_lock:
@@ -371,10 +378,10 @@ class P2PService(tcpserver.PendingConnectionsServer, DiagnosticsProvider):  # no
             return
 
         logger.info(
-            "add peer to incoming. address=%r:%r, node=%s",
+            "Adding peer to incoming. node=%s, address=%s:%s",
+            node_info_str(node_name, key_id),
             peer_info["address"],
             peer_info["port"],
-            node_info_str(node_name, key_id)
         )
 
         self.incoming_peers[key_id] = {

--- a/golem/network/p2p/peersession.py
+++ b/golem/network/p2p/peersession.py
@@ -150,7 +150,7 @@ class PeerSession(BasicSafeSession):
         if self.conn_type is None:
             raise Exception('Connection type (client/server) unknown')
         logger.info(
-            "Starting peer session %r:%r",
+            "Starting peer session. address=%s:%r",
             self.address,
             self.port
         )
@@ -280,7 +280,7 @@ class PeerSession(BasicSafeSession):
         if proto_id != variables.PROTOCOL_CONST.ID:
             logger.info(
                 "P2P protocol version mismatch %r vs %r (local)"
-                " for node %r:%r",
+                " for node %s:%r",
                 proto_id,
                 variables.PROTOCOL_CONST.ID,
                 self.address,
@@ -509,9 +509,6 @@ class PeerSession(BasicSafeSession):
         self.verified = True
 
         if self.p2p_service.enough_peers():
-            logger_msg = "TOO MANY PEERS, DROPPING CONNECTION: {} {}: {}" \
-                .format(self.node_name, self.address, self.port)
-            logger.info(logger_msg)
             self._send_peers(node_key_id=self.p2p_service.get_key_id())
             self.disconnect(message.base.Disconnect.REASON.TooManyPeers)
 
@@ -529,11 +526,12 @@ class PeerSession(BasicSafeSession):
         if p:
             if p != self and p.conn.opened:
                 logger.warning(
-                    "PEER DUPLICATED: %r %r : %r AND %r : %r",
+                    "Peer duplicated. new=%r (%s:%r), old=%r (%s:%r)",
                     p.node_name,
                     p.address,
                     p.port,
                     self.node_name,
+                    self.address,
                     self.port
                 )
                 self.disconnect(message.base.Disconnect.REASON.DuplicatePeers)

--- a/golem/network/transport/session.py
+++ b/golem/network/transport/session.py
@@ -98,12 +98,8 @@ class BasicSession(FileSession):
         """ Send "disconnect" message to the peer and drop the connection.
         :param string reason: Reason for disconnecting.
         """
-        logger.info(
-            "Disconnecting %r:%r reason: %r",
-            self.address,
-            self.port,
-            reason,
-        )
+        logger.info("Sending disconnect message. reason=%s, address=%s:%r",
+                    reason.name, self.address, self.port,)
         if self.conn.opened:
             self._send_disconnect(reason)
             self.dropped()
@@ -146,8 +142,8 @@ class BasicSession(FileSession):
         return True
 
     def _react_to_disconnect(self, msg):
-        logger.info("Disconnect reason: %r", msg.reason)
-        logger.info("Closing %s:%s", self.address, self.port)
+        logger.info("Received disconnect message. reason=%s, address=%s:%r",
+                    msg.reason.name, self.address, self.port)
         self.dropped()
 
 


### PR DESCRIPTION
Same as #4094 but with `b0.19` as target branch

Call p2pservice.connect_network() once on start