### PR TITLE
DockerJob: Fix container command for Windows

### DIFF
--- a/golem/docker/job.py
+++ b/golem/docker/job.py
@@ -126,6 +126,8 @@ class DockerJob:
 
         host_cfg = client.create_host_config(**self.host_config)
 
+        # FIXME: Make the entrypoint.sh behaviour consistent between Windows
+        #  and other OSes. See issue #4102
         if is_windows():
             command = self.entrypoint
         else:

--- a/golem/docker/job.py
+++ b/golem/docker/job.py
@@ -130,7 +130,7 @@ class DockerJob:
             image=self.image.name,
             volumes=self.volumes,
             host_config=host_cfg,
-            command=[self.entrypoint],
+            command=self.entrypoint,
             working_dir=self.WORK_DIR,
             environment=self.environment,
         )

--- a/golem/docker/job.py
+++ b/golem/docker/job.py
@@ -126,11 +126,16 @@ class DockerJob:
 
         host_cfg = client.create_host_config(**self.host_config)
 
+        if is_windows():
+            command = self.entrypoint
+        else:
+            command = [self.entrypoint]
+
         self.container = client.create_container(
             image=self.image.name,
             volumes=self.volumes,
             host_config=host_cfg,
-            command=self.entrypoint,
+            command=command,
             working_dir=self.WORK_DIR,
             environment=self.environment,
         )


### PR DESCRIPTION
`entrypoint.sh` behaviour is different between Windows and other OSes. The command invocation line `$@` exclusive for Windows behaves differently than `exec su-exec sh -c "$@"` (shortened here) in case of Linux and macOS. Without this patch, starting a container results in an error described in https://github.com/golemfactory/golem/issues/4102.

Because the entrypoint change would require updating all docker images, this solution should work as a temporary fix until an entrypoint change is required.