### PR TITLE
Task computer "stuck" on subtask

### DIFF
--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -139,6 +139,7 @@ class TaskComputer(object):
 
         work_wall_clock_time = task_thread.end_time - task_thread.start_time
         fallback_error = "Wrong result format"
+        has_header = False
         try:
             subtask = self.assigned_subtask
             assert subtask is not None
@@ -149,6 +150,7 @@ class TaskComputer(object):
             # get paid for max working time,
             # thus task withholding won't make profit
             work_time_to_be_paid = task_header.subtask_timeout
+            has_header = True
 
         except KeyError:
             fallback_error = "Task header not found in task keeper"
@@ -169,7 +171,7 @@ class TaskComputer(object):
                     task_thread.error_msg,
                 )
 
-        elif task_thread.result and 'data' in task_thread.result:
+        elif has_header and task_thread.result and 'data' in task_thread.result:
 
             logger.info("Task %r computed, work_wall_clock_time %s",
                         subtask_id,

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -123,6 +123,7 @@ class TaskComputer(object):
 
     def resource_failure(self, res_id, reason):
         subtask = self.assigned_subtask
+        self.assigned_subtask = None
         if not subtask or subtask['task_id'] != res_id:
             logger.error("Resource failure for a wrong task, %s", res_id)
             return

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -538,8 +538,10 @@ class TaskHeaderKeeper:
         # headers, remove the rest
         to_remove = by_age[self.max_tasks_per_requestor:]
 
-        logger.warning("Too many tasks from %s, dropping %d tasks",
-                       owner_key_id, len(to_remove))
+        logger.warning(
+            "Too many tasks, dropping %d tasks. owner=%s, ids_to_remove=%r",
+            len(to_remove), common.short_node_id(owner_key_id), to_remove
+        )
 
         for tid in to_remove:
             self.remove_task_header(tid)
@@ -549,6 +551,11 @@ class TaskHeaderKeeper:
         return: False if task was already removed
         """
         if task_id in self.removed_tasks:
+            return False
+
+        if task_id in self.running_tasks:
+            logger.warning("Can not remove task header, task is running. "
+                           "task_id=%s", task_id)
             return False
 
         try:

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -334,6 +334,8 @@ class TaskHeaderKeeper:
         self.task_headers: typing.Dict[str, dt_tasks.TaskHeader] = {}
         # ids of tasks that this node may try to compute
         self.supported_tasks: typing.List[str] = []
+        # ids of tasks that are computing on this node
+        self.running_tasks = []
         # results of tasks' support checks
         self.support_status: typing.Dict[str, SupportStatus] = {}
         # tasks that were removed from network recently, so they won't
@@ -527,7 +529,9 @@ class TaskHeaderKeeper:
         if len(owner_task_set) <= self.max_tasks_per_requestor:
             return
 
-        by_age = sorted(owner_task_set,
+        not_running = [x for x in owner_task_set if x not in self.running_tasks]
+
+        by_age = sorted(not_running,
                         key=lambda tid: self.last_checking[tid])
 
         # leave alone the first (oldest) max_tasks_per_requestor
@@ -649,3 +653,14 @@ class TaskHeaderKeeper:
                 avg = None
             ret.append({'reason': reason.value, 'ntasks': count, 'avg': avg})
         return ret
+
+    def task_started(self, task_id):
+        self.running_tasks.append(task_id)
+
+    def task_ended(self, task_id):
+        try:
+            self.running_tasks.remove(task_id)
+        except ValueError:
+            logger.warning("Can not remove running task, already removed. "
+                           "Maybe the callback is called twice. task_id=%r",
+                           task_id)

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -335,7 +335,7 @@ class TaskHeaderKeeper:
         # ids of tasks that this node may try to compute
         self.supported_tasks: typing.List[str] = []
         # ids of tasks that are computing on this node
-        self.running_tasks = []
+        self.running_tasks: typing.List[str] = []
         # results of tasks' support checks
         self.support_status: typing.Dict[str, SupportStatus] = {}
         # tasks that were removed from network recently, so they won't

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -335,7 +335,7 @@ class TaskHeaderKeeper:
         # ids of tasks that this node may try to compute
         self.supported_tasks: typing.List[str] = []
         # ids of tasks that are computing on this node
-        self.running_tasks: typing.List[str] = []
+        self.running_tasks: typing.Set[str] = set()
         # results of tasks' support checks
         self.support_status: typing.Dict[str, SupportStatus] = {}
         # tasks that were removed from network recently, so they won't
@@ -526,10 +526,10 @@ class TaskHeaderKeeper:
     def check_max_tasks_per_owner(self, owner_key_id):
         owner_task_set = self._get_tasks_by_owner_set(owner_key_id)
 
-        if len(owner_task_set) <= self.max_tasks_per_requestor:
-            return
+        not_running = owner_task_set - self.running_tasks
 
-        not_running = [x for x in owner_task_set if x not in self.running_tasks]
+        if len(not_running) <= self.max_tasks_per_requestor:
+            return
 
         by_age = sorted(not_running,
                         key=lambda tid: self.last_checking[tid])
@@ -655,7 +655,7 @@ class TaskHeaderKeeper:
         return ret
 
     def task_started(self, task_id):
-        self.running_tasks.append(task_id)
+        self.running_tasks.add(task_id)
 
     def task_ended(self, task_id):
         try:


### PR DESCRIPTION
My golem node got stuck on a subtask:
```
provider_state: {'status': 'Computing', 'subtask': {'subtask_id': 'SUB-ABC', 'progress': 0.0, 'seconds_to_timeout': -416547.8222870827, 'running_time_seconds': 419350.25729084015, 'outfilebasename': 'test_task', 'output_format': 'PNG', 'scene_file': 'bmw.blend', 'frames': [0], 'start_task': 5, 'total_tasks': 50}, 'environment': None}
```

When investigating i think the header was already deleted by the `check_max_tasks_per_owner()` cleanup, while the task was computing:
```
2019-04-11 12:25:21 INFO     golem.task.taskcomputer             Starting computation of subtask 'SUB-ABC' (task: 'TASK-DEF', deadline: 1554988323, docker images: [{'repository': 'golemfactory/blender', 'image_id': None, 'tag': '1.4'}])
2019-04-11 12:27:31 WARNING  golem.task.taskkeeper               Too many tasks from 839b...9cba, dropping 1 tasks
2019-04-11 12:30:20 ERROR    golem.task.taskcomputer             No subtask with id 'SUB-ABC'
```

This PR solves it 2x:
- Better errors in `task_computer`, no longer return on error but let it clean up like other failures.
- Knowledge in `task_keeper` of what tasks are running, so they are not removed during cleanup.

~Blocked by: #4122 ( lint errors )~