### PR TITLE
'TaskServer' object has no attribute 'key_id'

### DIFF
--- a/golem/task/server/resources.py
+++ b/golem/task/server/resources.py
@@ -211,17 +211,17 @@ class TaskResourcesMixin:
             return
 
         self.resource_handshakes[key_id] = handshake
-        self._start_handshake_timer()
+        self._start_handshake_timer(key_id)
         self._share_handshake_nonce(key_id)
 
-    def _start_handshake_timer(self):
+    def _start_handshake_timer(self, key_id):
         from twisted.internet import task
         from twisted.internet import reactor
 
         task.deferLater(
             reactor,
             self.HANDSHAKE_TIMEOUT,
-            lambda *_: self._handshake_timeout(self.key_id)
+            lambda *_: self._handshake_timeout(key_id)
         )
 
     def _handshake_timeout(self, key_id):

--- a/tests/golem/task/server/test_resources.py
+++ b/tests/golem/task/server/test_resources.py
@@ -59,7 +59,7 @@ class TestResourceHandhsake(TestWithClient):
             self.key_id,
             self.server.resource_handshakes,
         )
-        mock_timer.assert_called_once_with()
+        mock_timer.assert_called_once_with(self.key_id)
         mock_share.assert_called_once_with(self.key_id)
 
     @mock.patch(


### PR DESCRIPTION
self.key_id did not exist, so passed it as parameter