### PR TITLE
Fix ffmpeg.task._get_extra_data() truncating chunk names at the first dot

### DIFF
--- a/apps/transcoding/ffmpeg/task.py
+++ b/apps/transcoding/ffmpeg/task.py
@@ -1,6 +1,5 @@
 import logging
 import os
-import pathlib
 
 from ffmpeg_tools.codecs import VideoCodec, AudioCodec
 from ffmpeg_tools.formats import Container
@@ -42,10 +41,9 @@ class ffmpegTask(TranscodingTask):
         filename = os.path.splitext(os.path.basename(  # TODO: we trust foreign filename
             self.chunks[subtask_num][1]))[0]
 
-        output_stream_path = pathlib.Path(os.path.join(DockerJob.OUTPUT_DIR,
-                                                       filename + '_TC'))
-        output_stream_path = str(output_stream_path.with_suffix(
-            '.{}'.format('m3u8')))
+        output_stream = os.path.join(
+            DockerJob.OUTPUT_DIR,
+            filename + '_TC.m3u8')
 
         resolution = video_params.resolution
         resolution = [resolution[0], resolution[1]] if resolution else None
@@ -66,7 +64,7 @@ class ffmpegTask(TranscodingTask):
                 'frame_rate': video_params.frame_rate,
                 'format': transcoding_options.output_container.value
             },
-            'output_stream': output_stream_path,
+            'output_stream': output_stream,
             'use_playlist': transcoding_options.use_playlist,
             'command': Commands.TRANSCODE.value[0],
             'entrypoint': FFMPEG_ENTRYPOINT

--- a/tests/apps/ffmpeg/task/test_ffmpegtask.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegtask.py
@@ -1,5 +1,7 @@
 import os
+import shutil
 import uuid
+from tempfile import TemporaryDirectory
 from unittest import mock
 from freezegun import freeze_time
 
@@ -14,6 +16,7 @@ from apps.transcoding.common import TranscodingTaskBuilderException
 from apps.transcoding.ffmpeg.task import ffmpegTaskTypeInfo
 from apps.transcoding.ffmpeg.utils import Commands
 from golem.core.common import timeout_to_deadline
+from golem.docker.job import DockerJob
 from golem.docker.manager import DockerManager
 from golem.docker.task_thread import DockerTaskThread
 from golem.resource.dirmanager import DirManager
@@ -168,6 +171,27 @@ class TestffmpegTask(TempDirFixture):
         ffmpeg_task = self._build_ffmpeg_task()
         with self.assertRaises(AssertionError):
             ffmpeg_task._get_extra_data(1)
+
+    def test_extra_data_for_files_with_multiple_dots_in_name(self):
+        with TemporaryDirectory(prefix='test-with-dots') as tmp_dir:
+            resource_stream_with_dot = os.path.join(tmp_dir, 'test.video.mp4')
+            shutil.copyfile(self.RESOURCE_STREAM, resource_stream_with_dot)
+
+            ffmpeg_task = self._build_ffmpeg_task(
+                stream=resource_stream_with_dot
+            )
+
+            extra_data = ffmpeg_task._get_extra_data(0)
+            self.assertEqual(
+                extra_data['track'],
+                os.path.join(
+                    DockerJob.RESOURCES_DIR,
+                    'test.video[num=0].m3u8'))
+            self.assertEqual(
+                extra_data['output_stream'],
+                os.path.join(
+                    DockerJob.OUTPUT_DIR,
+                    'test.video[num=0]_TC.m3u8'))
 
     def test_extra_data(self):
         ffmpeg_task = self._build_ffmpeg_task()


### PR DESCRIPTION
If the input file name contains any dots other than the one indicating the extension (e.g. `test.video.mp4`) the names of the video segments used for subtasks are truncated (`test[num=0]_TC.m3u8` instead of `test.video[0]_TC.m3u8`).

This is because `pathlib.Path` expects to get a full file name, not just a fragment. If we give it a fragment without extension, any other dots are interpreted as the start of the extension.

The names that are generated this way don't match expectations in other parts of the code (e.g. in `join_playlists()`) and the transcoding fails.