### PR TITLE
Fix some of the warnings from CGI/transcoding/master branch

### DIFF
--- a/apps/transcoding/common.py
+++ b/apps/transcoding/common.py
@@ -1,8 +1,5 @@
 import logging
-from enum import Enum
 from typing import Type
-
-from golem.core.common import HandleValueError
 
 logger = logging.getLogger(__name__)
 

--- a/apps/transcoding/common.py
+++ b/apps/transcoding/common.py
@@ -17,7 +17,7 @@ def file_io_error(path: str):
 
 
 def unsupported(name: str):
-    logger.warning('{} is not supported'.format(name))
+    logger.warning('%s is not supported', name)
     raise TranscodingTaskBuilderException('{} is not supported'.format(name))
 
 

--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
@@ -22,7 +22,7 @@ def do_split(path_to_stream, parts):
     video_metadata = commands.get_metadata_json(path_to_stream)
     video_length = meta.get_duration(video_metadata)
     split_file = commands.split_video(path_to_stream,
-                                    OUTPUT_DIR, video_length / parts)
+                                      OUTPUT_DIR, video_length / parts)
     m3u8_main_list = m3u8.load(split_file)
 
     results = dict()

--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
@@ -2,10 +2,10 @@ import json
 import os
 import sys
 
+from ffmpeg_tools import commands, meta
+
 # pylint: disable=import-error
 import m3u8
-
-from ffmpeg_tools import commands, meta
 from m3u8_utils import create_and_dump_m3u8, join_playlists
 
 OUTPUT_DIR = "/golem/output"

--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
@@ -3,8 +3,9 @@ import os
 import sys
 
 # pylint: disable=import-error
-from ffmpeg_tools import commands, meta
 import m3u8
+
+from ffmpeg_tools import commands, meta
 from m3u8_utils import create_and_dump_m3u8, join_playlists
 
 OUTPUT_DIR = "/golem/output"

--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
@@ -13,6 +13,10 @@ RESOURCES_DIR = "/golem/resources"
 PARAMS_FILE = "params.json"
 
 
+class InvalidCommand(Exception):
+    pass
+
+
 def do_split(path_to_stream, parts):
 
     video_metadata = commands.get_metadata_json(path_to_stream)
@@ -107,7 +111,7 @@ def run_ffmpeg(params):
         compute_metrics(
             params["metrics_params"])
     else:
-        print("Invalid command.")
+        raise InvalidCommand(f"Invalid command: {params['command']}")
 
 
 def run():

--- a/apps/transcoding/ffmpeg/resources/images/ffmpeg.Dockerfile
+++ b/apps/transcoding/ffmpeg/resources/images/ffmpeg.Dockerfile
@@ -6,12 +6,12 @@ MAINTAINER Artur Zawłocki <artur.zawlocki@imapp.pl>
 
 # Build ffmpeg
 RUN set -x \
-	# get dependencies 
-	&& apt-get update  \
-	&& apt-get -y install ffmpeg \
-	&& apt-get clean \
+    # get dependencies
+    && apt-get update  \
+    && apt-get -y install ffmpeg \
+    && apt-get clean \
     && apt-get -y autoremove \
-    && rm -rf /var/lib/apt/lists/* 
+    && rm -rf /var/lib/apt/lists/*
 
 COPY ffmpeg-scripts/requirements.txt /golem/scripts/requirements.txt
 RUN /golem/install_py_libs.sh -r /golem/scripts/requirements.txt

--- a/apps/transcoding/ffmpeg/task.py
+++ b/apps/transcoding/ffmpeg/task.py
@@ -77,8 +77,7 @@ class ffmpegTask(TranscodingTask):
 
 
 class ffmpegDefaults(TaskDefaults):
-    def __init__(self):
-        super(ffmpegDefaults, self).__init__()
+    pass
 
 
 class ffmpegTaskBuilder(TranscodingTaskBuilder):

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -96,15 +96,15 @@ class StreamOperator:
         return resources_dir, output_dir, work_dir, files
 
     @staticmethod
-    def _collect_files(dir, files, resources_dir):
+    def _collect_files(directory, files, resources_dir):
         # each chunk must be in the same directory
         results = list()
         for file in files:
             if not os.path.isfile(file):
                 raise ffmpegException("Missing result file: {}".format(file))
-            if os.path.dirname(file) != dir:
+            if os.path.dirname(file) != directory:
                 raise ffmpegException("Result file: {} should be in the \
-                proper directory: {}".format(file, dir))
+                proper directory: {}".format(file, directory))
 
             results.append(file)
 
@@ -117,7 +117,10 @@ class StreamOperator:
             shutil.move(result, target_filepath)
 
         # Translate paths to docker filesystem
-        return [path.replace(dir, DockerJob.RESOURCES_DIR) for path in results]
+        return [
+            path.replace(directory, DockerJob.RESOURCES_DIR)
+            for path in results
+        ]
 
     def merge_video(self, filename, task_dir, chunks):
         resources_dir, output_dir, work_dir, chunks = \

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -4,6 +4,7 @@ import logging
 import os
 from pathlib import Path
 import shutil
+from typing import Optional
 
 from apps.transcoding import common
 from apps.transcoding.common import ffmpegException
@@ -147,7 +148,7 @@ class StreamOperator:
 
     @staticmethod
     def _do_job_in_container(dir_mapping, extra_data: dict,
-                             env: Environment = None,
+                             env: Optional[Environment] = None,
                              timeout: int = 120):
 
         if env:

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -151,11 +151,16 @@ class StreamOperator:
             EnvironmentsManager().add_environment(env)
 
         dtt = DockerTaskThread(
-            docker_images=[DockerImage(
-                repository=FFMPEG_DOCKER_IMAGE, tag=FFMPEG_DOCKER_TAG)],
+            docker_images=[
+                DockerImage(
+                    repository=FFMPEG_DOCKER_IMAGE,
+                    tag=FFMPEG_DOCKER_TAG
+                )
+            ],
             extra_data=extra_data,
             dir_mapping=dir_mapping,
-            timeout=timeout)
+            timeout=timeout
+        )
 
         dtt.run()
         if dtt.error:

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -51,8 +51,7 @@ class StreamOperator:
             'path_to_stream': stream_container_path,
             'parts': parts
         }
-        logger.debug('Running video splitting [params = {}]'.\
-            format(extra_data))
+        logger.debug('Running video splitting [params = %s]', extra_data)
 
         result = self._do_job_in_container(
             self._get_dir_mapping(dir_manager, task_id),
@@ -65,8 +64,9 @@ class StreamOperator:
             raise ffmpegException('Result file {} does not exist'.
                                   format(split_result_file))
 
-        logger.debug('Split result file is = {} [parts = {}]'.
-                     format(split_result_file, parts))
+        logger.debug('Split result file is = %s [parts = %d]',
+                     split_result_file,
+                     parts)
 
         with open(split_result_file) as f:
             params = json.load(f)  # FIXME: check status of splitting
@@ -77,8 +77,9 @@ class StreamOperator:
                                                x.get('playlist')),
                                     params.get('segments', [])))
 
-            logger.info('Stream {} was successfully split to {}'
-                        .format(input_stream, streams_list))
+            logger.info('Stream %s was successfully split to %s',
+                        input_stream,
+                        streams_list)
 
             return streams_list, params.get('metadata', {})
 
@@ -134,7 +135,7 @@ class StreamOperator:
             'chunks': chunks,
         }
 
-        logger.debug('Merge params: {}'.format(extra_data))
+        logger.debug('Merge params: %s', extra_data)
 
         dir_mapping = DockerTaskThread.specify_dir_mapping(
             output=output_dir,

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -102,7 +102,7 @@ class StreamOperator:
         for file in files:
             if not os.path.isfile(file):
                 raise ffmpegException("Missing result file: {}".format(file))
-            elif os.path.dirname(file) != dir:
+            if os.path.dirname(file) != dir:
                 raise ffmpegException("Result file: {} should be in the \
                 proper directory: {}".format(file, dir))
 

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -69,7 +69,7 @@ class StreamOperator:
 
         with open(split_result_file) as f:
             params = json.load(f)  # FIXME: check status of splitting
-            if params.get('status', 'Success') is not 'Success':
+            if params.get('status', 'Success') != 'Success':
                 raise ffmpegException('Splitting video failed')
 
             streams_list = list(map(lambda x: (x.get('video_segment'),

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -34,7 +34,7 @@ class Commands(enum.Enum):
 
 class StreamOperator:
     @HandleError(ValueError, common.not_valid_json)
-    def split_video(self, input_stream: str, parts: int,
+    def split_video(self, input_stream: str, parts: int,  # noqa pylint: disable=too-many-locals
                     dir_manager: DirManager, task_id: str):
         name = os.path.basename(input_stream)
 

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -31,7 +31,7 @@ class TranscodingTaskOptions(Options):
     class AudioParams:
         def __init__(self,
                      codec: Optional[AudioCodec] = None,
-                     bitrate: Optional[str] = None):
+                     bitrate: Optional[str] = None) -> None:
             self.codec = codec
             self.bitrate = bitrate
 
@@ -40,7 +40,7 @@ class TranscodingTaskOptions(Options):
                      codec: Optional[VideoCodec] = None,
                      bitrate: Optional[str] = None,
                      frame_rate: Optional[int] = None,
-                     resolution: Optional[Tuple[int, int]] = None):
+                     resolution: Optional[Tuple[int, int]] = None) -> None:
             self.codec = codec
             self.bitrate = bitrate
             self.frame_rate = frame_rate

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -181,6 +181,7 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
         subtasks = self.subtasks_given.values()
         subtasks = filter(lambda sub: sub['status'] in [
             SubtaskStatus.failure, SubtaskStatus.restarted], subtasks)
+
         failed_subtask = next(iter(subtasks), None)
         if failed_subtask:
             logger.debug('Subtask {} was failed, so let resent it'
@@ -188,11 +189,11 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
             failed_subtask['status'] = SubtaskStatus.resent
             self.num_failed_subtasks -= 1
             return failed_subtask['subtask_num']
-        else:
-            assert self.last_task < self.total_tasks
-            curr = self.last_task + 1
-            self.last_task = curr
-            return curr - 1
+
+        assert self.last_task < self.total_tasks
+        curr = self.last_task + 1
+        self.last_task = curr
+        return curr - 1
 
     def query_extra_data(self, perf_index: float, node_id: Optional[str] = None,
                          node_name: Optional[str] = None) -> Task.ExtraData:

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -57,7 +57,7 @@ class TranscodingTaskDefinition(TaskDefinition):
         self.options = TranscodingTaskOptions()
 
 
-class TranscodingTask(CoreTask):
+class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
     def __init__(self, task_definition: TranscodingTaskDefinition, **kwargs):
         super(TranscodingTask, self).__init__(task_definition=task_definition,
                                               **kwargs)

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -213,14 +213,21 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
             self.subtasks_given[sid] = subtask
 
             return Task.ExtraData(ctd=self._get_task_computing_definition(
-                sid, transcoding_params, perf_index, resources=list(self.chunks[subtask_num])))
+                sid,
+                transcoding_params,
+                perf_index,
+                resources=list(self.chunks[subtask_num])))
 
     def query_extra_data_for_test_task(
             self) -> golem_messages.message.ComputeTaskDef:
         # TODO
         pass
 
-    def _get_task_computing_definition(self, sid, transcoding_params, perf_idx, resources):
+    def _get_task_computing_definition(self,
+                                       sid,
+                                       transcoding_params,
+                                       perf_idx,
+                                       resources):
         ctd = golem_messages.message.ComputeTaskDef()
         ctd['task_id'] = self.header.task_id
         ctd['subtask_id'] = sid

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -87,7 +87,7 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
         logger.debug('Initialization of FFmpegTask')
 
         task_id = self.task_definition.task_id
-        task_output_dir = dir_manager.get_task_output_dir(task_id)        
+        task_output_dir = dir_manager.get_task_output_dir(task_id)
 
         # results from providers are collected in tmp
         self.task_dir = dir_manager.get_task_temporary_dir(task_id)
@@ -243,12 +243,12 @@ class TranscodingTaskBuilder(CoreTaskBuilder):
 
     @classmethod
     def build_full_definition(cls, task_type: CoreTaskTypeInfo,
-                              dict: Dict[str, Any]):
-        task_def = super().build_full_definition(task_type, dict)
+                              dictionary: Dict[str, Any]):
+        task_def = super().build_full_definition(task_type, dictionary)
 
         try:
             presets = cls._get_presets(task_def.options.input_stream_path)
-            options = dict.get('options', {})
+            options = dictionary.get('options', {})
             video_options = options.get('video', {})
             audio_options = options.get('audio', {})
 
@@ -274,7 +274,7 @@ class TranscodingTaskBuilder(CoreTaskBuilder):
             task_def.options.video_params = video_params
             task_def.options.output_container = output_container
             task_def.options.audio_params = audio_params
-            task_def.options.name = dict.get('name', '')
+            task_def.options.name = dictionary.get('name', '')
 
             logger.debug(
                 'Transcoding task definition has been built [definition={}]'
@@ -303,10 +303,14 @@ class TranscodingTaskBuilder(CoreTaskBuilder):
 
     @classmethod
     def build_minimal_definition(cls, task_type: CoreTaskTypeInfo,
-                                 dict: Dict[str, Any]):
+                                 dictionary: Dict[str, Any]):
         df = super(TranscodingTaskBuilder, cls).build_minimal_definition(
-            task_type, dict)
-        stream = cls._get_required_field(dict, 'resources', is_type_of(list))[0]
+            task_type, dictionary)
+        stream = cls._get_required_field(
+            dictionary,
+            'resources',
+            is_type_of(list),
+        )[0]
         df.options.input_stream_path = stream
         return df
 
@@ -323,9 +327,11 @@ class TranscodingTaskBuilder(CoreTaskBuilder):
         return {'container': 'mp4'}
 
     @classmethod
-    def _get_required_field(cls, dict, key: str, validator=lambda _: True) \
-            -> Any:
-        v = dict.get(key)
+    def _get_required_field(cls,
+                            dictionary,
+                            key: str,
+                            validator=lambda _: True) -> Any:
+        v = dictionary.get(key)
         if not v or not validator(v):
             raise TranscodingTaskBuilderException(
                 'Field {} is required in the task definition'.format(key))

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -102,9 +102,10 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
             dir_manager, task_id)
 
         if len(chunks) < self.total_tasks:
-            logger.warning('{} subtasks was requested but video splitting '
-                           'process resulted in {} chunks.'
-                           .format(self.total_tasks, len(chunks)))
+            logger.warning('%d subtasks was requested but video splitting '
+                           'process resulted in %d chunks.',
+                           self.total_tasks,
+                           len(chunks))
 
         streams = list(map(lambda x: x[0] if os.path.isabs(x[0]) else os.path
                            .join(task_output_dir, x[0]), chunks))
@@ -145,10 +146,10 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
 
             self.num_tasks_received += 1
 
-            logger.info("Task {} - transcoded {} of {} chunks".
-                        format(self.task_definition.task_id,
-                               self.num_tasks_received,
-                               self.total_tasks))
+            logger.info("Task %s - transcoded %d of %d chunks",
+                        self.task_definition.task_id,
+                        self.num_tasks_received,
+                        self.total_tasks)
 
             if self.num_tasks_received == self.total_tasks:
                 self._merge_video()
@@ -157,8 +158,8 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
         self.collected_files.extend(results)
 
     def _merge_video(self):
-        logger.info('Merging video [task_id = {}]'.format(
-            self.task_definition.task_id))
+        logger.info('Merging video [task_id = %s]',
+                    self.task_definition.task_id)
 
         stream_operator = StreamOperator()
         path = stream_operator.merge_video(
@@ -170,22 +171,22 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
                     exist_ok=True)
         move(path, self.task_definition.output_file)
 
-        logger.info("Video merged successfully [task_id = {}]".format(
-            self.task_definition.task_id))
+        logger.info("Video merged successfully [task_id = %s]",
+                    self.task_definition.task_id)
 
         return True
 
     def _get_next_subtask(self):
-        logger.debug('Getting next task [type=trancoding, task_id={}]'.format(
-            self.task_definition.task_id))
+        logger.debug('Getting next task [type=trancoding, task_id=%s]',
+                     self.task_definition.task_id)
         subtasks = self.subtasks_given.values()
         subtasks = filter(lambda sub: sub['status'] in [
             SubtaskStatus.failure, SubtaskStatus.restarted], subtasks)
 
         failed_subtask = next(iter(subtasks), None)
         if failed_subtask:
-            logger.debug('Subtask {} was failed, so let resent it'
-                         .format(failed_subtask['subtask_id']))
+            logger.debug('Subtask %s was failed, so let resent it',
+                         failed_subtask['subtask_id'])
             failed_subtask['status'] = SubtaskStatus.resent
             self.num_failed_subtasks -= 1
             return failed_subtask['subtask_num']
@@ -285,8 +286,8 @@ class TranscodingTaskBuilder(CoreTaskBuilder):
             task_def.options.name = dictionary.get('name', '')
 
             logger.debug(
-                'Transcoding task definition has been built [definition={}]'
-                .format(task_def.__dict__))
+                'Transcoding task definition has been built [definition=%s]',
+                task_def.__dict__)
 
             return task_def
 

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -3,7 +3,7 @@ import logging
 import os
 from shutil import move
 from threading import Lock
-from typing import Any, Dict, Tuple, Optional
+from typing import Any, Dict, List, Tuple, Optional
 
 import golem_messages.message
 
@@ -29,14 +29,18 @@ logger = logging.getLogger(__name__)
 
 class TranscodingTaskOptions(Options):
     class AudioParams:
-        def __init__(self, codec: AudioCodec = None, bitrate: str = None):
+        def __init__(self,
+                     codec: Optional[AudioCodec] = None,
+                     bitrate: Optional[str] = None):
             self.codec = codec
             self.bitrate = bitrate
 
     class VideoParams:
-        def __init__(self, codec: VideoCodec = None, bitrate: str = None,
-                     frame_rate: int = None,
-                     resolution: Tuple[int, int] = None):
+        def __init__(self,
+                     codec: Optional[VideoCodec] = None,
+                     bitrate: Optional[str] = None,
+                     frame_rate: Optional[int] = None,
+                     resolution: Optional[Tuple[int, int]] = None):
             self.codec = codec
             self.bitrate = bitrate
             self.frame_rate = frame_rate
@@ -58,13 +62,14 @@ class TranscodingTaskDefinition(TaskDefinition):
 
 
 class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
-    def __init__(self, task_definition: TranscodingTaskDefinition, **kwargs):
+    def __init__(self, task_definition: TranscodingTaskDefinition, **kwargs) \
+            -> None:
         super(TranscodingTask, self).__init__(task_definition=task_definition,
                                               **kwargs)
         self.task_definition = task_definition
         self.lock = Lock()
-        self.chunks = list()
-        self.collected_files = list()
+        self.chunks: List[str] = list()
+        self.collected_files: List[str] = list()
         self.task_dir = ""
 
     def __getstate__(self):
@@ -195,7 +200,7 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
             sid = self.create_subtask_id()
 
             subtask_num = self._get_next_subtask()
-            subtask = {}
+            subtask: Dict[str, Any] = {}
             transcoding_params = self._get_extra_data(subtask_num)
             subtask['perf'] = perf_index
             subtask['node_id'] = node_id
@@ -232,10 +237,9 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
 
 
 class TranscodingTaskBuilder(CoreTaskBuilder):
-    SUPPORTED_FILE_TYPES = []
-    SUPPORTED_VIDEO_CODECS = []
-    SUPPORTED_AUDIO_CODECS = []
-    TASK_CLASS = TranscodingTask
+    SUPPORTED_FILE_TYPES: List[Container] = []
+    SUPPORTED_VIDEO_CODECS: List[VideoCodec] = []
+    SUPPORTED_AUDIO_CODECS: List[AudioCodec] = []
 
     @classmethod
     def build_full_definition(cls, task_type: CoreTaskTypeInfo,

--- a/tests/apps/ffmpeg/task/test_ffmpegtask.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegtask.py
@@ -249,10 +249,9 @@ class TestffmpegTask(TempDirFixture):
         self.assertEqual(ctd['extra_data'], subtask['transcoding_params'])
         self.assertEqual(ctd['docker_images'], [di.to_dict() for di in
                                                 ffmpeg_task.docker_images])
-        self.assertEqual(ctd['deadline'],
-                         min(timeout_to_deadline(
-                             ffmpeg_task.header.subtask_timeout),
-                             ffmpeg_task.header.deadline))
+        self.assertEqual(ctd['deadline'], min(
+            timeout_to_deadline(ffmpeg_task.header.subtask_timeout),
+            ffmpeg_task.header.deadline))
 
     def test_resources_distributed_per_subtasks(self):
         ffmpeg_task = self._build_ffmpeg_task(

--- a/tests/apps/ffmpeg/task/test_fmmpegtranscoding.py
+++ b/tests/apps/ffmpeg/task/test_fmmpegtranscoding.py
@@ -1,4 +1,3 @@
-import os
 import shutil
 import uuid
 from unittest import mock

--- a/tests/apps/ffmpeg/task/test_fmmpegtranscoding.py
+++ b/tests/apps/ffmpeg/task/test_fmmpegtranscoding.py
@@ -14,13 +14,12 @@ from golem.docker.task_thread import DockerTaskThread
 from golem.resource.dirmanager import DirManager
 from golem.testutils import TempDirFixture
 from golem.tools.ci import ci_skip
-from tests.golem.docker.test_docker_image import DockerTestCase
 from tests.golem.docker.test_docker_job import TestDockerJob
 
 
 
 @ci_skip
-class TestffmpegTranscoding(TempDirFixture, DockerTestCase):
+class TestffmpegTranscoding(TempDirFixture):
     def setUp(self):
         super(TestffmpegTranscoding, self).setUp()
         self.RESOURCES = os.path.join(os.path.dirname(

--- a/tests/apps/ffmpeg/task/test_fmmpegtranscoding.py
+++ b/tests/apps/ffmpeg/task/test_fmmpegtranscoding.py
@@ -123,16 +123,20 @@ class TestffmpegTranscoding(TempDirFixture):
         resource_dir, output_dir, work_dir, chunks = \
             self.stream_operator._prepare_merge_job(self.tempdir, [])
 
-        assert chunks == []
-        assert resource_dir == os.path.join(self.tempdir,
-                                            'merge', 'resources')
-        assert os.path.isdir(output_dir)
-        assert output_dir == os.path.join(self.tempdir,
-                                          'merge', 'output')
-        assert os.path.isdir(output_dir)
-        assert work_dir == os.path.join(self.tempdir,
-                                        'merge', 'work')
-        assert os.path.isdir(work_dir)
+        self.assertEqual(len(chunks), 0)
+        self.assertEqual(
+            resource_dir,
+            os.path.join(self.tempdir, 'merge', 'resources')
+        )
+        self.assertTrue(os.path.isdir(output_dir))
+        self.assertEqual(
+            output_dir,
+            os.path.join(self.tempdir, 'merge', 'output'))
+        self.assertTrue(os.path.isdir(output_dir))
+        self.assertEqual(
+            work_dir,
+            os.path.join(self.tempdir, 'merge', 'work'))
+        self.assertTrue(os.path.isdir(work_dir))
 
     def test_prepare_merge_job_nonexistent_results(self):
         with self.assertRaises(ffmpegException):


### PR DESCRIPTION
This pull request contains lots of small fixes for warnings that `lint.sh` finds on the `CGI/transcoding/master` branch. The fixes come from my other branches and I extracted them here because they're completely independent.

Only some of the warnings are fixed - those from files we actually modified. Others were left unchanged (there are too many of them and they are not the focus of my task).

When reviewing I recommend looking at the commits individually - each one usually fixes one type of warning and the description says what the problem was.

**Note**: my linter fixes changes merged into `develop` in #4092 are not in `CGI/transcoding/master` yet so to see the warnings you'll have to temporarily cherry-pick those commits into your branch and discard them afterwards:
``` bash
git cherry-pick 720d385058425a024fc18721163dffc277724b12..9ab6b5d8ac77d46dd60e336c97d7e95038d2d984
```