### PR TITLE
Only ask for new tETH donation when half of donated funds are used

### DIFF
--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -728,7 +728,7 @@ class TransactionSystem(LoopingCallService):
         self._sci: SmartContractsInterface
         if not self._config.FAUCET_ENABLED:
             return
-        if self._eth_balance < 0.01 * denoms.ether:
+        if self._eth_balance < 0.005 * denoms.ether:
             log.info("Requesting tETH from faucet")
             tETH_faucet_donate(self._sci.get_eth_address())
             return


### PR DESCRIPTION
While working on the node_integration_tests i noticed there are always 2 donations done on each new key. 

The donation amount (`0.01`) is equal to the threshold to request a new donation ( `0.01` ). Causing a new donation after a single transaction has been made.

