### PR TITLE
Added more detailed error info to task creation RPC

### DIFF
--- a/golem/ethereum/exceptions.py
+++ b/golem/ethereum/exceptions.py
@@ -1,23 +1,70 @@
+import typing
+
 from ethereum.utils import denoms
 import golem_sci.structs
 
 
 class EthereumError(Exception):
-    pass
+    def to_dict(self) -> dict:
+        return {
+            'error_type': self.__class__.__name__,
+            'error_msg': self.__str__(),
+            'error_details': {}
+        }
+
+
+class MissingFunds(typing.NamedTuple):
+    """
+    Represents a single entry for missing funds in a given currency.
+    """
+    required: int
+    available: int
+    extension: str
 
 
 class NotEnoughFunds(EthereumError):
-    def __init__(self, required: int, available: int, extension="GNT") -> None:
+    def __init__(
+            self,
+            missing_funds: typing.Optional[typing.List[MissingFunds]] = None,
+            required: int = -1,
+            available: int = -1,
+            extension: str = '') -> None:
         super().__init__()
-        self.required = required
-        self.available = available
-        self.extension = extension
+        if not missing_funds:
+            self.missing_funds = [
+                MissingFunds(
+                    required=required,
+                    available=available,
+                    extension=extension
+                )
+            ]
+        else:
+            self.missing_funds = missing_funds
 
-    def __str__(self):
-        return "Not enough %s available. Required: %f, available: %f" % \
-               (self.extension,
-                self.required / denoms.ether,
-                self.available / denoms.ether)
+    def __str__(self) -> str:
+        return "Not enough funds available." + self._missing_funds_to_str()
+
+    def to_dict(self) -> dict:
+        err_dict = super().to_dict()
+        err_dict['error_details']['missing_funds'] = \
+            [entry._asdict() for entry in self.missing_funds]
+
+        return err_dict
+
+    def _missing_funds_to_str(self) -> str:
+        res = ""
+        for required, available, extension in self.missing_funds:
+            res += f"\nRequired {extension}: {required / denoms.ether:f}, " \
+                f"available: {available / denoms.ether:f}"
+
+        return res
+
+
+class NotEnoughDepositFunds(NotEnoughFunds):
+    def __str__(self) -> str:
+        return "Not enough funds for Concent deposit." \
+               "Top up your account or create the task with Concent disabled." \
+               + self._missing_funds_to_str()
 
 
 class TransactionError(EthereumError):

--- a/golem/ethereum/exceptions.py
+++ b/golem/ethereum/exceptions.py
@@ -19,7 +19,7 @@ class MissingFunds(typing.NamedTuple):
     """
     required: int
     available: int
-    extension: str
+    currency: str
 
 
 class NotEnoughFunds(EthereumError):
@@ -28,14 +28,14 @@ class NotEnoughFunds(EthereumError):
             missing_funds: typing.Optional[typing.List[MissingFunds]] = None,
             required: int = -1,
             available: int = -1,
-            extension: str = '') -> None:
+            currency: str = '') -> None:
         super().__init__()
         if not missing_funds:
             self.missing_funds = [
                 MissingFunds(
                     required=required,
                     available=available,
-                    extension=extension
+                    currency=currency
                 )
             ]
         else:
@@ -53,8 +53,8 @@ class NotEnoughFunds(EthereumError):
 
     def _missing_funds_to_str(self) -> str:
         res = ""
-        for required, available, extension in self.missing_funds:
-            res += f"\nRequired {extension}: {required / denoms.ether:f}, " \
+        for required, available, currency in self.missing_funds:
+            res += f"\nRequired {currency}: {required / denoms.ether:f}, " \
                 f"available: {available / denoms.ether:f}"
 
         return res

--- a/golem/ethereum/exceptions.py
+++ b/golem/ethereum/exceptions.py
@@ -23,23 +23,23 @@ class MissingFunds(typing.NamedTuple):
 
 
 class NotEnoughFunds(EthereumError):
-    def __init__(
-            self,
-            missing_funds: typing.Optional[typing.List[MissingFunds]] = None,
-            required: int = -1,
-            available: int = -1,
-            currency: str = '') -> None:
+    def __init__(self, missing_funds: typing.List[MissingFunds]) -> None:
         super().__init__()
-        if not missing_funds:
-            self.missing_funds = [
-                MissingFunds(
-                    required=required,
-                    available=available,
-                    currency=currency
-                )
-            ]
-        else:
-            self.missing_funds = missing_funds
+        self.missing_funds = missing_funds
+
+    @staticmethod
+    def single_currency(
+            required: int,
+            available: int,
+            currency: str
+    ) -> 'NotEnoughFunds':
+        return NotEnoughFunds([
+            MissingFunds(
+                required=required,
+                available=available,
+                currency=currency
+            )
+        ])
 
     def __str__(self) -> str:
         return "Not enough funds available.\n" + self._missing_funds_to_str()

--- a/golem/ethereum/exceptions.py
+++ b/golem/ethereum/exceptions.py
@@ -42,7 +42,7 @@ class NotEnoughFunds(EthereumError):
             self.missing_funds = missing_funds
 
     def __str__(self) -> str:
-        return "Not enough funds available." + self._missing_funds_to_str()
+        return "Not enough funds available.\n" + self._missing_funds_to_str()
 
     def to_dict(self) -> dict:
         err_dict = super().to_dict()
@@ -54,8 +54,8 @@ class NotEnoughFunds(EthereumError):
     def _missing_funds_to_str(self) -> str:
         res = ""
         for required, available, currency in self.missing_funds:
-            res += f"\nRequired {currency}: {required / denoms.ether:f}, " \
-                f"available: {available / denoms.ether:f}"
+            res += f"Required {currency}: {required / denoms.ether:f}, " \
+                f"available: {available / denoms.ether:f}\n"
 
         return res
 

--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -401,17 +401,27 @@ class TransactionSystem(LoopingCallService):
     def lock_funds_for_payments(self, price: int, num: int) -> None:
         if not self._payment_processor:
             raise Exception('Start was not called')
+        missing_funds: List[exceptions.MissingFunds] = []
+
         gnt = price * num
         if gnt > self.get_available_gnt():
-            raise exceptions.NotEnoughFunds(
-                gnt,
-                self.get_available_gnt(), 'GNT',
-            )
+            missing_funds.append(exceptions.MissingFunds(
+                required=gnt,
+                available=self.get_available_gnt(),
+                extension='GNT'
+            ))
 
         eth = self.eth_for_batch_payment(num)
         eth_available = self.get_available_eth()
         if eth > eth_available:
-            raise exceptions.NotEnoughFunds(eth, eth_available, 'ETH')
+            missing_funds.append(exceptions.MissingFunds(
+                required=eth,
+                available=eth_available,
+                extension='ETH'
+            ))
+
+        if missing_funds:
+            raise exceptions.NotEnoughFunds(missing_funds)
 
         log.info(
             "Locking %.3f GNTB and %.8f ETH for %d payments",
@@ -539,9 +549,9 @@ class TransactionSystem(LoopingCallService):
                 * gas_price
             if amount > self.get_available_eth():
                 raise exceptions.NotEnoughFunds(
-                    amount,
-                    self.get_available_eth(),
-                    currency,
+                    required=amount,
+                    available=self.get_available_eth(),
+                    extension=currency,
                 )
             return self._sci.transfer_eth(
                 destination,
@@ -552,9 +562,9 @@ class TransactionSystem(LoopingCallService):
         if currency == 'GNT':
             if amount > self.get_available_gnt():
                 raise exceptions.NotEnoughFunds(
-                    amount,
-                    self.get_available_gnt(),
-                    currency,
+                    required=amount,
+                    available=self.get_available_gnt(),
+                    extension=currency,
                 )
             tx_hash = self._sci.convert_gntb_to_gnt(
                 destination,
@@ -603,11 +613,8 @@ class TransactionSystem(LoopingCallService):
             tasks_num: int,
             force: bool = False,
     ) -> None:
-        required_deposit_difference = required - self.concent_balance()
+        missing_funds: List[exceptions.MissingFunds] = []
 
-        gntb_balance = self.get_available_gnt()
-        if gntb_balance < required_deposit_difference:
-            raise exceptions.NotEnoughFunds(required, gntb_balance, 'GNTB')
         if self.gas_price >= self.gas_price_limit:
             if not force:
                 raise exceptions.LongTransactionTime("Gas price too high")
@@ -615,12 +622,28 @@ class TransactionSystem(LoopingCallService):
                 'Gas price is high. It can take some time to mine deposit.',
             )
 
+        required_deposit_difference = required - self.concent_balance()
+        gntb_balance = self.get_available_gnt()
+        if gntb_balance < required_deposit_difference:
+            missing_funds.append(exceptions.MissingFunds(
+                required=required,
+                available=gntb_balance,
+                extension='GNTB'
+            ))
+
         eth_for_batch_payment_for_task = self.eth_for_batch_payment(tasks_num)
         eth_required = eth_for_batch_payment_for_task + self.eth_for_deposit()
 
         eth_available = self.get_available_eth()
         if eth_required > eth_available:
-            raise exceptions.NotEnoughFunds(eth_required, eth_available, 'ETH')
+            missing_funds.append(exceptions.MissingFunds(
+                required=eth_required,
+                available=eth_available,
+                extension='ETH'
+            ))
+
+        if missing_funds:
+            raise exceptions.NotEnoughDepositFunds(missing_funds)
 
     @defer.inlineCallbacks
     @gnt_deposit_required()

--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -408,7 +408,7 @@ class TransactionSystem(LoopingCallService):
             missing_funds.append(exceptions.MissingFunds(
                 required=gnt,
                 available=self.get_available_gnt(),
-                extension='GNT'
+                currency='GNT'
             ))
 
         eth = self.eth_for_batch_payment(num)
@@ -417,7 +417,7 @@ class TransactionSystem(LoopingCallService):
             missing_funds.append(exceptions.MissingFunds(
                 required=eth,
                 available=eth_available,
-                extension='ETH'
+                currency='ETH'
             ))
 
         if missing_funds:
@@ -551,7 +551,7 @@ class TransactionSystem(LoopingCallService):
                 raise exceptions.NotEnoughFunds(
                     required=amount,
                     available=self.get_available_eth(),
-                    extension=currency,
+                    currency=currency,
                 )
             return self._sci.transfer_eth(
                 destination,
@@ -564,7 +564,7 @@ class TransactionSystem(LoopingCallService):
                 raise exceptions.NotEnoughFunds(
                     required=amount,
                     available=self.get_available_gnt(),
-                    extension=currency,
+                    currency=currency,
                 )
             tx_hash = self._sci.convert_gntb_to_gnt(
                 destination,
@@ -628,7 +628,7 @@ class TransactionSystem(LoopingCallService):
             missing_funds.append(exceptions.MissingFunds(
                 required=required,
                 available=gntb_balance,
-                extension='GNTB'
+                currency='GNTB'
             ))
 
         eth_for_batch_payment_for_task = self.eth_for_batch_payment(tasks_num)
@@ -639,7 +639,7 @@ class TransactionSystem(LoopingCallService):
             missing_funds.append(exceptions.MissingFunds(
                 required=eth_required,
                 available=eth_available,
-                extension='ETH'
+                currency='ETH'
             ))
 
         if missing_funds:

--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -548,7 +548,7 @@ class TransactionSystem(LoopingCallService):
             gas_eth = self.get_withdraw_gas_cost(amount, destination, currency)\
                 * gas_price
             if amount > self.get_available_eth():
-                raise exceptions.NotEnoughFunds(
+                raise exceptions.NotEnoughFunds.single_currency(
                     required=amount,
                     available=self.get_available_eth(),
                     currency=currency,
@@ -561,7 +561,7 @@ class TransactionSystem(LoopingCallService):
 
         if currency == 'GNT':
             if amount > self.get_available_gnt():
-                raise exceptions.NotEnoughFunds(
+                raise exceptions.NotEnoughFunds.single_currency(
                     required=amount,
                     available=self.get_available_gnt(),
                     currency=currency,

--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -628,7 +628,7 @@ class TransactionSystem(LoopingCallService):
             missing_funds.append(exceptions.MissingFunds(
                 required=required,
                 available=gntb_balance,
-                currency='GNTB'
+                currency='GNT'
             ))
 
         eth_for_batch_payment_for_task = self.eth_for_batch_payment(tasks_num)

--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -169,6 +169,8 @@ class Tasks:
         with open(file_name) as f:
             task_id, error = self.__create_from_json(f.read(), force=force)
         if error:
+            if isinstance(error, dict):
+                error = error['error_msg']
             if task_id:
                 return CommandResult(error="task {} failed: {}"
                                      .format(task_id, error))

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -392,8 +392,13 @@ def enqueue_new_task(client, task, force=False) \
     return task
 
 
-def _create_task_error(e, _self, task_dict, **_kwargs):
+def _create_task_error(e, _self, task_dict, **_kwargs) \
+        -> typing.Tuple[None, typing.Union[str, typing.Dict]]:
     logger.error("Cannot create task %r: %s", task_dict, e)
+
+    if hasattr(e, 'to_dict'):
+        return None, e.to_dict()
+
     return None, str(e)
 
 
@@ -426,7 +431,8 @@ class ClientProvider:
     @rpc_utils.expose('comp.task.create')
     @safe_run(_create_task_error)
     def create_task(self, task_dict, force=False) \
-            -> typing.Tuple[typing.Optional[str], typing.Optional[str]]:
+            -> typing.Tuple[typing.Optional[str],
+                            typing.Optional[typing.Union[str, typing.Dict]]]:
         """
         :param force: if True will ignore warnings
         :return: (task_id, None) on success; (task_id or None, error_message)
@@ -474,16 +480,27 @@ class ClientProvider:
             total_price_gnt: int,
             number_of_tasks: int) -> None:
         transaction_system = self.client.transaction_system
-        if total_price_gnt > transaction_system.get_available_gnt():
-            raise eth_exceptions.NotEnoughFunds(
-                total_price_gnt,
-                transaction_system.get_available_gnt(), 'GNT',
-            )
+        missing_funds: typing.List[eth_exceptions.MissingFunds] = []
+
+        gnt_available = transaction_system.get_available_gnt()
+        if total_price_gnt > gnt_available:
+            missing_funds.append(eth_exceptions.MissingFunds(
+                required=total_price_gnt,
+                available=gnt_available,
+                extension='GNT'
+            ))
 
         eth = transaction_system.eth_for_batch_payment(number_of_tasks)
         eth_available = transaction_system.get_available_eth()
         if eth > eth_available:
-            raise eth_exceptions.NotEnoughFunds(eth, eth_available, 'ETH')
+            missing_funds.append(eth_exceptions.MissingFunds(
+                required=eth,
+                available=eth_available,
+                extension='ETH'
+            ))
+
+        if missing_funds:
+            raise eth_exceptions.NotEnoughFunds(missing_funds)
 
     @rpc_utils.expose('comp.task.restart')
     @safe_run(_restart_task_error)

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -487,7 +487,7 @@ class ClientProvider:
             missing_funds.append(eth_exceptions.MissingFunds(
                 required=total_price_gnt,
                 available=gnt_available,
-                extension='GNT'
+                currency='GNT'
             ))
 
         eth = transaction_system.eth_for_batch_payment(number_of_tasks)
@@ -496,7 +496,7 @@ class ClientProvider:
             missing_funds.append(eth_exceptions.MissingFunds(
                 required=eth,
                 available=eth_available,
-                extension='ETH'
+                currency='ETH'
             ))
 
         if missing_funds:

--- a/tests/golem/ethereum/test_exceptions.py
+++ b/tests/golem/ethereum/test_exceptions.py
@@ -14,8 +14,8 @@ class TestNotEnoughFunds(TestCase):
                 currency='GNT'
             )
         except NotEnoughFunds as err:
-            expected = f'Not enough funds available.' \
-                f'\nRequired GNT: 5.000000, available: 1.000000'
+            expected = f'Not enough funds available.\n' \
+                f'Required GNT: 5.000000, available: 1.000000\n'
             self.assertIn(str(err), expected)
 
     def test_error_message_multiple_currencies(self):
@@ -35,9 +35,9 @@ class TestNotEnoughFunds(TestCase):
         try:
             raise NotEnoughFunds(missing_funds)
         except NotEnoughFunds as err:
-            expected = f'Not enough funds available.' \
-                f'\nRequired ETH: 5.000000, available: 1.000000' \
-                f'\nRequired GNT: 1.000000, available: 0.000000'
+            expected = f'Not enough funds available.\n' \
+                f'Required ETH: 5.000000, available: 1.000000\n' \
+                f'Required GNT: 1.000000, available: 0.000000\n'
             self.assertIn(str(err), expected)
 
     def test_error_to_dict(self):

--- a/tests/golem/ethereum/test_exceptions.py
+++ b/tests/golem/ethereum/test_exceptions.py
@@ -11,7 +11,7 @@ class TestNotEnoughFunds(TestCase):
             raise NotEnoughFunds(
                 required=5 * denoms.ether,
                 available=1 * denoms.ether,
-                extension='GNT'
+                currency='GNT'
             )
         except NotEnoughFunds as err:
             expected = f'Not enough funds available.' \
@@ -23,12 +23,12 @@ class TestNotEnoughFunds(TestCase):
             MissingFunds(
                 required=5 * denoms.ether,
                 available=1 * denoms.ether,
-                extension='ETH'
+                currency='ETH'
             ),
             MissingFunds(
                 required=1 * denoms.ether,
                 available=0,
-                extension='GNT'
+                currency='GNT'
             )
         ]
 
@@ -45,12 +45,12 @@ class TestNotEnoughFunds(TestCase):
             MissingFunds(
                 required=5 * denoms.ether,
                 available=1 * denoms.ether,
-                extension='ETH'
+                currency='ETH'
             ),
             MissingFunds(
                 required=1 * denoms.ether,
                 available=0,
-                extension='GNT'
+                currency='GNT'
             )
         ]
 

--- a/tests/golem/ethereum/test_exceptions.py
+++ b/tests/golem/ethereum/test_exceptions.py
@@ -2,14 +2,64 @@ from unittest import TestCase
 
 from ethereum.utils import denoms
 
-from golem.ethereum.exceptions import NotEnoughFunds
+from golem.ethereum.exceptions import NotEnoughFunds, MissingFunds
 
 
 class TestNotEnoughFunds(TestCase):
-    def test_exception(self):
+    def test_error_message_single_currency(self):
         try:
-            raise NotEnoughFunds(10 * denoms.ether, 2 * denoms.ether)
+            raise NotEnoughFunds(
+                required=5 * denoms.ether,
+                available=1 * denoms.ether,
+                extension='GNT'
+            )
         except NotEnoughFunds as err:
-            expected_str = "Not enough GNT available. Required: 10.000000, " \
-                           "available: 2.000000"
-            assert expected_str in str(err)
+            expected = f'Not enough funds available.' \
+                f'\nRequired GNT: 5.000000, available: 1.000000'
+            self.assertIn(str(err), expected)
+
+    def test_error_message_multiple_currencies(self):
+        missing_funds = [
+            MissingFunds(
+                required=5 * denoms.ether,
+                available=1 * denoms.ether,
+                extension='ETH'
+            ),
+            MissingFunds(
+                required=1 * denoms.ether,
+                available=0,
+                extension='GNT'
+            )
+        ]
+
+        try:
+            raise NotEnoughFunds(missing_funds)
+        except NotEnoughFunds as err:
+            expected = f'Not enough funds available.' \
+                f'\nRequired ETH: 5.000000, available: 1.000000' \
+                f'\nRequired GNT: 1.000000, available: 0.000000'
+            self.assertIn(str(err), expected)
+
+    def test_error_to_dict(self):
+        missing_funds = [
+            MissingFunds(
+                required=5 * denoms.ether,
+                available=1 * denoms.ether,
+                extension='ETH'
+            ),
+            MissingFunds(
+                required=1 * denoms.ether,
+                available=0,
+                extension='GNT'
+            )
+        ]
+
+        try:
+            raise NotEnoughFunds(missing_funds)
+        except NotEnoughFunds as err:
+            err_dict = err.to_dict()
+
+            self.assertEqual(err_dict['error_type'], 'NotEnoughFunds')
+            for i in range(2):
+                self.assertEqual(err_dict['error_details']['missing_funds'][i],
+                                 missing_funds[i]._asdict())

--- a/tests/golem/ethereum/test_exceptions.py
+++ b/tests/golem/ethereum/test_exceptions.py
@@ -8,7 +8,7 @@ from golem.ethereum.exceptions import NotEnoughFunds, MissingFunds
 class TestNotEnoughFunds(TestCase):
     def test_error_message_single_currency(self):
         try:
-            raise NotEnoughFunds(
+            raise NotEnoughFunds.single_currency(
                 required=5 * denoms.ether,
                 available=1 * denoms.ether,
                 currency='GNT'

--- a/tests/golem/ethereum/test_transactionsystem.py
+++ b/tests/golem/ethereum/test_transactionsystem.py
@@ -504,6 +504,7 @@ class ConcentDepositTest(TransactionSystemBase):
         self.sci.lock_deposit.assert_called()
 
     def test_not_enough(self):
+        self.sci.GAS_TRANSFER_AND_CALL = 9999
         self.sci.get_deposit_value.return_value = 0
         self.ets._gntb_balance = 0
         with self.assertRaises(exceptions.NotEnoughFunds):

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -149,7 +149,7 @@ class TestCreateTask(ProviderBase, TestClientBase):
 
     @mock.patch(
         'golem.task.rpc.ClientProvider._validate_lock_funds_possibility',
-        side_effect=exceptions.NotEnoughFunds(
+        side_effect=exceptions.NotEnoughFunds.single_currency(
             required=0.166667 * denoms.ether,
             available=0,
             currency='GNT'

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -152,7 +152,7 @@ class TestCreateTask(ProviderBase, TestClientBase):
         side_effect=exceptions.NotEnoughFunds(
             required=0.166667 * denoms.ether,
             available=0,
-            extension='GNT'
+            currency='GNT'
         ))
     def test_create_task_fail_if_not_enough_gnt_available(self, mocked, *_):
         t = dummytaskstate.DummyTaskDefinition()

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -152,36 +152,51 @@ class TestCreateTask(ProviderBase, TestClientBase):
         side_effect=exceptions.NotEnoughFunds(
             required=0.166667 * denoms.ether,
             available=0,
+            extension='GNT'
         ))
     def test_create_task_fail_if_not_enough_gnt_available(self, mocked, *_):
         t = dummytaskstate.DummyTaskDefinition()
         t.name = "test"
 
         result = self.provider.create_task(t.to_dict())
+
         rpc.enqueue_new_task.assert_not_called()
         self.assertIn('validate_lock_funds_possibility', str(mocked))
         mocked.assert_called()
-        self.assertEqual(result, (None, 'Not enough GNT available. Required: '
-                                        '0.166667, available: 0.000000'))
+
+        self.assertIsNone(result[0])
+        error = result[1]
+        # noqa pylint:disable=unsubscriptable-object
+        self.assertEqual(error['error_type'], 'NotEnoughFunds')
+        self.assertEqual(error['error_msg'], 'Not enough funds available.'
+                                             '\nRequired GNT: '
+                                             '0.166667, available: 0.000000')
 
 
 class ConcentDepositLockPossibilityTest(unittest.TestCase):
 
-    def test_validate_lock_funds_possibility_raises_if_not_enough_gnt(self):
-        available = 0.0001 * denoms.ether
-        required = 0.0005 * denoms.ether
+    def test_validate_lock_funds_possibility_raises_if_not_enough_funds(self):
+        available_gnt = 0.0001 * denoms.ether
+        required_gnt = 0.0005 * denoms.ether
+        available_eth = 0.0002 * denoms.ether
+        required_eth = 0.0006 * denoms.ether
         client = Mock()
-        client.transaction_system.get_available_gnt.return_value = available
+        client.transaction_system.get_available_gnt.return_value = available_gnt
+        client.transaction_system.get_available_eth.return_value = available_eth
+        client.transaction_system.eth_for_batch_payment.return_value = \
+            required_eth
         client_provider = ClientProvider(client)
 
         with self.assertRaises(exceptions.NotEnoughFunds) as e:
             client_provider._validate_lock_funds_possibility(
-                total_price_gnt=required,
+                total_price_gnt=required_gnt,
                 number_of_tasks=1
             )
-        expected = f'Not enough GNT available. ' \
-            f'Required: {required / denoms.ether:.6f}, ' \
-            f'available: {available / denoms.ether:.6f}'
+        expected = f'Not enough funds available.' \
+            f'\nRequired GNT: {required_gnt / denoms.ether:f}, ' \
+            f'available: {available_gnt / denoms.ether:f}' \
+            f'\nRequired ETH: {required_eth / denoms.ether:f}, ' \
+            f'available: {available_eth / denoms.ether:f}'
         self.assertIn(str(e.exception), expected)
 
 

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -168,9 +168,9 @@ class TestCreateTask(ProviderBase, TestClientBase):
         error = result[1]
         # noqa pylint:disable=unsubscriptable-object
         self.assertEqual(error['error_type'], 'NotEnoughFunds')
-        self.assertEqual(error['error_msg'], 'Not enough funds available.'
-                                             '\nRequired GNT: '
-                                             '0.166667, available: 0.000000')
+        self.assertEqual(error['error_msg'], 'Not enough funds available.\n'
+                                             'Required GNT: '
+                                             '0.166667, available: 0.000000\n')
 
 
 class ConcentDepositLockPossibilityTest(unittest.TestCase):
@@ -192,11 +192,11 @@ class ConcentDepositLockPossibilityTest(unittest.TestCase):
                 total_price_gnt=required_gnt,
                 number_of_tasks=1
             )
-        expected = f'Not enough funds available.' \
-            f'\nRequired GNT: {required_gnt / denoms.ether:f}, ' \
-            f'available: {available_gnt / denoms.ether:f}' \
-            f'\nRequired ETH: {required_eth / denoms.ether:f}, ' \
-            f'available: {available_eth / denoms.ether:f}'
+        expected = f'Not enough funds available.\n' \
+            f'Required GNT: {required_gnt / denoms.ether:f}, ' \
+            f'available: {available_gnt / denoms.ether:f}\n' \
+            f'Required ETH: {required_eth / denoms.ether:f}, ' \
+            f'available: {available_eth / denoms.ether:f}\n'
         self.assertIn(str(e.exception), expected)
 
 


### PR DESCRIPTION
Resolves: #3881

The exceptions related to insufficient ETH and GNT funds have been
reworked. They can now include info about multiple missing currencies and have a corresponding dict representation.