### PR TITLE
Fix 'TaskComputer' object has no attribute 'session_closed'

### DIFF
--- a/golem/resource/resourcehandshake.py
+++ b/golem/resource/resourcehandshake.py
@@ -197,7 +197,6 @@ class ResourceHandshakeSessionMixin:
                     short_node_id(key_id), error)
         self._block_peer(key_id)
         self._finalize_handshake(key_id)
-        self.task_server.task_computer.session_closed()
         self.dropped()
 
     # ########################

--- a/tests/golem/resource/test_resourcehandshake.py
+++ b/tests/golem/resource/test_resourcehandshake.py
@@ -302,7 +302,6 @@ class TestResourceHandshakeSessionMixin(TempDirFixture):
         self.session._handshake_error(self.session.key_id, 'Test error')
         assert self.session._block_peer.called
         assert self.session._finalize_handshake.called
-        assert self.session.task_server.task_computer.session_closed.called
         assert not self.session.disconnect.called
 
     def test_get_set_remove_handshake(self, *_):


### PR DESCRIPTION
@jivan Related to commit https://github.com/golemfactory/golem/commit/20ef39696dec2ad3f5da44a2d3e303aa384e3f37