### PR TITLE
Fixes potential overwriting bug in WasmTask

### DIFF
--- a/apps/wasm/task.py
+++ b/apps/wasm/task.py
@@ -141,6 +141,19 @@ class WasmTask(CoreTask):
             subtask_id=self.create_subtask_id(), extra_data=next_extra_data
         )
 
+    def filter_task_results(self, task_results, subtask_id, log_ext=".log",
+                            err_log_ext="err.log"):
+        filtered_task_results = []
+        for tr in task_results:
+            if tr.endswith(err_log_ext):
+                self.stderr[subtask_id] = tr
+            elif tr.endswith(log_ext):
+                self.stdout[subtask_id] = tr
+            else:
+                filtered_task_results.append(tr)
+
+        return filtered_task_results
+
 
 class WasmTaskBuilder(CoreTaskBuilder):
     TASK_CLASS: Type[WasmTask] = WasmTask


### PR DESCRIPTION
This PR fixes potential overwriting of results bug in `WasmTask`. It was possible until now to have the results from different `WasmTask` subtasks get their results overwritten if the output had overlapping names.

This was due to the fact that the results were moved up a level in the output workspace in `filter_task_results` method of `CoreTask`. This PR addresses it by overloading the said method, and leaving the results in the subtasks folders.

To summarise

WAS:

```
ComputeRes/xxx-xxx-xxx/xxx-sub1/{stdout, stderr}
ComputeRes/xxx-xxx-xxx/xxx-sub2/{stdout, stderr}
ComputeRes/xxx-xxx-xxx/in.wav <--- potential for overwriting
```

IS:

```
ComputeRes/xxx-xxx-xxx/xxx-sub1/{in.wav, stdout, stderr}
ComputeRes/xxx-xxx-xxx/xxx-sub2/{in.wav, stdout, stderr}
```