### PR TITLE
StatusPublisher's events with message codes

### DIFF
--- a/golem/docker/hypervisor/hyperv.py
+++ b/golem/docker/hypervisor/hyperv.py
@@ -5,7 +5,7 @@ import os
 from pathlib import Path
 import subprocess
 import time
-from typing import Any, ClassVar, Dict, Iterable, List, Optional
+from typing import Any, ClassVar, Dict, Iterable, List, Optional, Union
 
 from os_win.constants import HOST_SHUTDOWN_ACTION_SAVE, \
     VM_SNAPSHOT_TYPE_DISABLED, HYPERV_VM_STATE_SUSPENDED, \
@@ -43,7 +43,7 @@ MESSAGES = {
     events.DISK: 'Not enough disk space. Creating VM with min memory',
 }
 
-EVENTS = {
+EVENTS: Dict[events, Dict[str, Union[str, Optional[Dict]]]] = {
     events.SMB: {
         'component': Component.hypervisor,
         'method': 'setup',

--- a/golem/docker/hypervisor/hyperv.py
+++ b/golem/docker/hypervisor/hyperv.py
@@ -400,13 +400,15 @@ class HyperVHypervisor(DockerMachineHypervisor):
 
     @staticmethod
     def _log_and_publish_event(name, **kwargs) -> None:
-        message = MESSAGES[name].format(**kwargs)
         event = EVENTS[name].copy()
-        event['data'] = message
+        data = next(iter(kwargs.values()))
+        message = MESSAGES[name].format(**kwargs)
 
         if event['stage'] == Stage.warning:
+            event['data'] = {"status": name, "value": data}
             logger.warning(message)
         else:
+            event['data'] = message
             logger.error(message)
 
         publish_event(event)

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1076,7 +1076,7 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
 
     def test_golem_status_no_publisher(self, *_):
         component = 'component'
-        status = 'method', 'stage', 'data'
+        status = 'method', 'stage', {'status': 'message', 'value': 'data'}
 
         # status published, no rpc publisher
         StatusPublisher.publish(component, *status)
@@ -1085,7 +1085,7 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
     @inlineCallbacks
     def test_golem_status_with_publisher(self, *_):
         component = 'component'
-        status = 'method', 'stage', 'data'
+        status = 'method', 'stage', {'status': 'message', 'value': 'data'}
 
         # status published, with rpc publisher
         StatusPublisher._rpc_publisher = Mock()


### PR DESCRIPTION
Events emitted by the StatusPublisher now contain message labels (codes), so that each error / warning can be more easily identified in the UI. This way the user may be presented with a solution to the occurring issue.

Data field carried by events is now equal to:
- `None`
- `{"status": _1, "value": _2}`, where:
    - when `_1 == "message"`, `_2` is a message provided by core
    - when `_1 != "message"`, `_1` is the message "label" with certain payload `_2`, understood by the UI