### PR TITLE
Configure gVisor to use host direct filesystem

### DIFF
--- a/Installer/Installer_Linux/install.sh
+++ b/Installer/Installer_Linux/install.sh
@@ -356,7 +356,10 @@ function install_dependencies()
 import json
 
 runtime_config = {
-    'path': '/usr/local/bin/runsc'
+    'path': '/usr/local/bin/runsc',
+    'runtimeArgs': [
+        '-file-access shared'
+    ]
 }
 
 with open('/etc/docker/daemon.json', 'w+') as f:


### PR DESCRIPTION
I can see two ways of fixing this:

- set +x permission on user's `.local` in the installation script (remember that GLambda app is enabled only on Linux providers, other OSes are not an issue). It's hard to tell what is the impact of loosening the permissions here, depends on what apps put in there, 
- configure gVisor to access host filesystem directly (this is what this PR introduces),
- move datadir to somewhere else e.g. `.cache`