### PR TITLE
Environment refactoring cleanup

### DIFF
--- a/golem/envs/__init__.py
+++ b/golem/envs/__init__.py
@@ -270,7 +270,7 @@ class Runtime(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def cleanup(self) -> Deferred:
+    def clean_up(self) -> Deferred:
         """ Clean up after the Runtime has finished running. Assumes current
             status is 'STOPPED' or 'FAILURE'. In the latter case it is not
             guaranteed that the cleanup will be successful. """
@@ -445,7 +445,7 @@ class Environment(ABC):
         raise NotImplementedError
 
     @abstractmethod
-    def cleanup(self) -> Deferred:
+    def clean_up(self) -> Deferred:
         """ Deactivate the Environment. Assumes current status is 'ENABLED' or
             'ERROR'. """
         raise NotImplementedError

--- a/golem/envs/docker/cpu.py
+++ b/golem/envs/docker/cpu.py
@@ -15,7 +15,6 @@ from urllib3.contrib.pyopenssl import WrappedSocket
 from golem import hardware
 from golem.core.common import is_linux, is_windows, is_osx
 from golem.docker.client import local_client
-from golem.docker.commands.docker import DockerCommandHandler
 from golem.docker.config import CONSTRAINT_KEYS
 from golem.docker.hypervisor import Hypervisor
 from golem.docker.hypervisor.docker_for_mac import DockerForMac
@@ -403,8 +402,6 @@ class DockerCPUEnvironment(Environment):
     ENV_ID: ClassVar[EnvId] = 'docker_cpu'
     ENV_DESCRIPTION: ClassVar[str] = 'Docker environment using CPU'
 
-    SUPPORTED_DOCKER_VERSIONS: ClassVar[List[str]] = ['18.06.1-ce']
-
     MIN_MEMORY_MB: ClassVar[int] = 1024
     MIN_CPU_COUNT: ClassVar[int] = 1
 
@@ -438,29 +435,10 @@ class DockerCPUEnvironment(Environment):
     @classmethod
     def supported(cls) -> EnvSupportStatus:
         logger.info('Checking environment support status...')
-        if not DockerCommandHandler.docker_available():
-            return EnvSupportStatus(False, "Docker executable not found")
-        if not cls._check_docker_version():
-            return EnvSupportStatus(False, "Wrong docker version")
         if cls._get_hypervisor_class() is None:
             return EnvSupportStatus(False, "No supported hypervisor found")
         logger.info('Environment supported.')
         return EnvSupportStatus(True)
-
-    @classmethod
-    def _check_docker_version(cls) -> bool:
-        logger.info('Checking docker version...')
-        try:
-            version_string = DockerCommandHandler.run("version")
-        except SubprocessError:
-            logger.exception('Checking docker version failed.')
-            return False
-        if version_string is None:
-            logger.error('Docker version returned no output.')
-            return False
-        version = version_string.lstrip("Docker version ").split(",")[0]
-        logger.info('Found docker version: %s', version)
-        return version in cls.SUPPORTED_DOCKER_VERSIONS
 
     @classmethod
     def _get_hypervisor_class(cls) -> Optional[Type[Hypervisor]]:

--- a/tests/golem/envs/docker/cpu/test_env.py
+++ b/tests/golem/envs/docker/cpu/test_env.py
@@ -54,60 +54,13 @@ def patch_hypervisors(linux=False, windows=False, mac_os=False, hyperv=False,
 
 class TestSupported(TestCase):
 
-    @patch_handler('docker_available', return_value=False)
-    def test_docker_unavailable(self, *_):
-        self.assertFalse(DockerCPUEnvironment.supported().supported)
-
-    @patch_handler('docker_available', return_value=True)
-    @patch_env('_check_docker_version', return_value=False)
-    def test_wrong_docker_version(self, *_):
-        self.assertFalse(DockerCPUEnvironment.supported().supported)
-
-    @patch_handler('docker_available', return_value=True)
-    @patch_env('_check_docker_version', return_value=True)
     @patch_env('_get_hypervisor_class', return_value=None)
     def test_no_hypervisor(self, *_):
         self.assertFalse(DockerCPUEnvironment.supported().supported)
 
-    @patch_handler('docker_available', return_value=True)
-    @patch_env('_check_docker_version', return_value=True)
     @patch_env('_get_hypervisor_class')
     def test_ok(self, *_):
         self.assertTrue(DockerCPUEnvironment.supported().supported)
-
-
-class TestCheckDockerVersion(TestCase):
-
-    @patch('logger')
-    @patch_handler('run', side_effect=SubprocessError)
-    def test_command_error(self, run, logger):
-        self.assertFalse(DockerCPUEnvironment._check_docker_version())
-        run.assert_called_with('version')
-        logger.exception.assert_called_once()
-
-    @patch('logger')
-    @patch_handler('run', return_value=None)
-    def test_no_version(self, run, logger):
-        self.assertFalse(DockerCPUEnvironment._check_docker_version())
-        run.assert_called_with('version')
-        logger.error.assert_called_once()
-
-    @patch_handler('run', return_value='(╯°□°)╯︵ ┻━┻')
-    def test_invalid_version_string(self, run):
-        self.assertFalse(DockerCPUEnvironment._check_docker_version())
-        run.assert_called_with('version')
-
-    @patch_env('SUPPORTED_DOCKER_VERSIONS', ['1.2.1'])
-    @patch_handler('run', return_value='Docker version 1.2.3, build abcdef\n')
-    def test_unsupported_version(self, run, *_):
-        self.assertFalse(DockerCPUEnvironment._check_docker_version())
-        run.assert_called_with('version')
-
-    @patch_env('SUPPORTED_DOCKER_VERSIONS', ['1.2.1', '1.2.3'])
-    @patch_handler('run', return_value='Docker version 1.2.3, build abcdef\n')
-    def test_supported_version(self, run, *_):
-        self.assertTrue(DockerCPUEnvironment._check_docker_version())
-        run.assert_called_with('version')
 
 
 class TestGetHypervisorClass(TestCase):

--- a/tests/golem/envs/docker/cpu/test_env.py
+++ b/tests/golem/envs/docker/cpu/test_env.py
@@ -216,17 +216,17 @@ class TestCleanup(TestDockerCPUEnv):
 
     def test_disabled_status(self):
         with self.assertRaises(ValueError):
-            self.env.cleanup()
+            self.env.clean_up()
 
     def test_preparing_status(self):
         self.env._status = EnvStatus.PREPARING
         with self.assertRaises(ValueError):
-            self.env.cleanup()
+            self.env.clean_up()
 
     def test_cleaning_up_status(self):
         self.env._status = EnvStatus.CLEANING_UP
         with self.assertRaises(ValueError):
-            self.env.cleanup()
+            self.env.clean_up()
 
     def test_hypervisor_quit_error(self):
         self.env._status = EnvStatus.ENABLED
@@ -234,7 +234,7 @@ class TestCleanup(TestDockerCPUEnv):
         self.hypervisor.quit.side_effect = error
         error_occurred = self._patch_env_async('_error_occurred')
 
-        deferred = self.env.cleanup()
+        deferred = self.env.clean_up()
         self.assertEqual(self.env.status(), EnvStatus.CLEANING_UP)
         deferred = self.assertFailure(deferred, OSError)
 
@@ -247,7 +247,7 @@ class TestCleanup(TestDockerCPUEnv):
         self.env._status = EnvStatus.ENABLED
         env_disabled = self._patch_env_async('_env_disabled')
 
-        deferred = self.env.cleanup()
+        deferred = self.env.clean_up()
         self.assertEqual(self.env.status(), EnvStatus.CLEANING_UP)
 
         def _check(_):

--- a/tests/golem/envs/docker/cpu/test_integration.py
+++ b/tests/golem/envs/docker/cpu/test_integration.py
@@ -29,7 +29,7 @@ class TestIntegration(TestCase, DatabaseFixture):
         # Add environment cleanup to clean it if test goes wrong
         def _clean_up_env():
             if env.status() != EnvStatus.DISABLED:
-                env.cleanup()
+                env.clean_up()
         self.addCleanup(_clean_up_env)
 
         # Download image
@@ -55,7 +55,7 @@ class TestIntegration(TestCase, DatabaseFixture):
         # Add runtime cleanup to clean it if test goes wrong
         def _clean_up_runtime():
             if runtime.status() != RuntimeStatus.TORN_DOWN:
-                runtime.cleanup()
+                runtime.clean_up()
         self.addCleanup(_clean_up_runtime)
 
         # Start container
@@ -75,9 +75,9 @@ class TestIntegration(TestCase, DatabaseFixture):
         while runtime.status() == RuntimeStatus.RUNNING:
             time.sleep(1)
         self.assertEqual(runtime.status(), RuntimeStatus.STOPPED)
-        yield runtime.cleanup()
+        yield runtime.clean_up()
         self.assertEqual(runtime.status(), RuntimeStatus.TORN_DOWN)
 
         # Clean up the environment
-        yield env.cleanup()
+        yield env.clean_up()
         self.assertEqual(env.status(), EnvStatus.DISABLED)

--- a/tests/golem/envs/docker/cpu/test_runtime.py
+++ b/tests/golem/envs/docker/cpu/test_runtime.py
@@ -362,7 +362,7 @@ class TestCleanup(TestDockerCPURuntime):
 
     def test_invalid_status(self):
         self._generic_test_invalid_status(
-            method=self.runtime.cleanup,
+            method=self.runtime.clean_up,
             valid_statuses={RuntimeStatus.STOPPED, RuntimeStatus.FAILURE})
 
     def test_client_error(self):
@@ -374,7 +374,7 @@ class TestCleanup(TestDockerCPURuntime):
         torn_down = self._patch_runtime_async('_torn_down')
         error_occurred = self._patch_runtime_async('_error_occurred')
 
-        deferred = self.runtime.cleanup()
+        deferred = self.runtime.clean_up()
         self.assertEqual(self.runtime.status(), RuntimeStatus.CLEANING_UP)
         deferred = self.assertFailure(deferred, APIError)
 
@@ -395,7 +395,7 @@ class TestCleanup(TestDockerCPURuntime):
         torn_down = self._patch_runtime_async('_torn_down')
         error_occurred = self._patch_runtime_async('_error_occurred')
 
-        deferred = self.runtime.cleanup()
+        deferred = self.runtime.clean_up()
         self.assertEqual(self.runtime.status(), RuntimeStatus.CLEANING_UP)
 
         def _check(_):


### PR DESCRIPTION
* Don't use `DockerCommandHandler` because don't need this. All commands are executed via docker-py. This means we can completely drop the `docker.exe` binary later.
* Renamed `cleanup()` methods to `clean_up()` because 'cleanup' is a noun and method names should be verbs.