### PR TITLE
node_integration_tests - Fix timeout test on buildbot

### DIFF
--- a/scripts/node_integration_tests/playbooks/golem/task_timeout/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/task_timeout/playbook.py
@@ -29,12 +29,15 @@ class Playbook(NodeTestPlaybook):
     def step_wait_subtask_completed(self):
         def on_success(result):
             if result:
-                statuses = map(lambda s: s.get('status'), result)
-                if any(map(lambda s: s == 'Finished', statuses)):
+                statuses = [s.get('status') for s in result]
+                if 'Finished' in statuses:
                     print("First subtask finished")
                     self.next()
-                    return
-                print("Subtasks status: {}".format(list(statuses)))
+                elif 'Failure' in statuses:
+                    print('Subtask failed :(')
+                    self.fail("Got status 'Failure', expected 'Finished'.")
+                else:
+                    print("Subtasks status: {}".format(statuses))
 
             time.sleep(10)
 

--- a/scripts/node_integration_tests/tasks/__init__.py
+++ b/scripts/node_integration_tests/tasks/__init__.py
@@ -23,8 +23,8 @@ _TASK_SETTINGS = {
     '2_short': {
         'type': "Blender",
         'name': 'test task',
-        'timeout': "0:04:00",
-        "subtask_timeout": "0:01:30",
+        'timeout': "0:08:00",
+        "subtask_timeout": "0:07:30",
         "subtasks_count": 2,
         "bid": 1.0,
         "resources": [],


### PR DESCRIPTION
- Increased timeout for slower machines like buildbot
- `task_timeout` test was hanging on `Finished` status, so made the check more simple