### PR TITLE
Non-hypervised Docker CPU Environment

### DIFF
--- a/golem/docker/hypervisor/dummy.py
+++ b/golem/docker/hypervisor/dummy.py
@@ -28,13 +28,13 @@ class DummyHypervisor(Hypervisor):
         pass
 
     def stop_vm(self, name: Optional[str] = None) -> bool:
-        pass
+        return True
 
     def create(self, vm_name: Optional[str] = None, **params) -> bool:
-        pass
+        return True
 
     def constrain(self, name: Optional[str] = None, **params) -> None:
         pass
 
     def constraints(self, name: Optional[str] = None) -> Dict:
-        pass
+        return {}

--- a/golem/envs/docker/non_hypervised.py
+++ b/golem/envs/docker/non_hypervised.py
@@ -1,0 +1,14 @@
+from golem.docker.hypervisor.dummy import DummyHypervisor
+from golem.envs.docker.cpu import DockerCPUEnvironment
+
+
+class NonHypervisedDockerCPUEnvironment(DockerCPUEnvironment):
+    """ This is a temporary class that never uses a hypervisor. It just assumes
+        that Docker VM is properly configured if needed. The purpose of this
+        class is to use Docker CPU Environment alongside with DockerManager. """
+
+    # TODO: Remove when DockerManager is removed
+
+    @classmethod
+    def _get_hypervisor_class(cls):
+        return DummyHypervisor

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -17,6 +17,9 @@ from golem.core.statskeeper import IntStatsKeeper
 from golem.docker.image import DockerImage
 from golem.docker.manager import DockerManager
 from golem.docker.task_thread import DockerTaskThread
+from golem.envs.docker.cpu import DockerCPUConfig
+from golem.envs.docker.non_hypervised import NonHypervisedDockerCPUEnvironment
+from golem.hardware import scale_memory, MemSize
 from golem.manager.nodestatesnapshot import ComputingSubtaskStateSnapshot
 from golem.resource.dirmanager import DirManager
 from golem.task.timer import ProviderTimer
@@ -67,9 +70,14 @@ class TaskComputer(object):
 
         self.docker_manager: DockerManager = DockerManager.install()
         if use_docker_manager:
-            self.docker_manager.check_environment()
-
+            self.docker_manager.check_environment()  # pylint: disable=no-member
         self.use_docker_manager = use_docker_manager
+
+        os.makedirs(self.dir_manager.root_path)
+        self.docker_cpu_env = NonHypervisedDockerCPUEnvironment(
+            DockerCPUConfig(work_dir=Path(self.dir_manager.root_path)))
+        sync_wait(self.docker_cpu_env.prepare())
+
         run_benchmarks = self.task_server.benchmark_manager.benchmarks_needed()
         deferred = self.change_config(
             task_server.config_desc, in_background=False,
@@ -271,6 +279,18 @@ class TaskComputer(object):
         dm = self.docker_manager
         assert isinstance(dm, DockerManager)
         dm.build_config(config_desc)
+
+        sync_wait(self.docker_cpu_env.clean_up())
+        self.docker_cpu_env.update_config(DockerCPUConfig(
+            work_dir=work_dir,
+            cpu_count=config_desc.num_cores,
+            memory_mb=scale_memory(
+                config_desc.max_memory_size,
+                unit=MemSize.kibi,
+                to_unit=MemSize.mebi
+            )
+        ))
+        sync_wait(self.docker_cpu_env.prepare())
 
         deferred = Deferred()
         if not dm.hypervisor and run_benchmarks:


### PR DESCRIPTION
A temporary subclass of `DockerCPUEnvironment` that always uses `DummyHypervisor` and therefore performs no operations on Docker virtual machine. It is meant to enable usage of the new Environment API without removing `DockerManager` yet. Using standard `DockerCPUEnvironment` would cause potential conflicts during VM reconfiguration.