### PR TITLE
Upgrade SCI to 1.10.0

### DIFF
--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -164,8 +164,8 @@ class PaymentProcessor:
         gas_price = self._sci.get_current_gas_price()
 
         ind = 0
-        gas_limit = \
-            self._sci.get_latest_block().gas_limit * self.BLOCK_GAS_LIMIT_RATIO
+        gas_limit = self._sci.get_latest_confirmed_block().gas_limit * \
+            self.BLOCK_GAS_LIMIT_RATIO
         payees = set()
         for p in self._awaiting:
             if p.processed_ts > closure_time:

--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -312,11 +312,11 @@ class TransactionSystem(LoopingCallService):
     @sci_required()
     def _save_subscription_block_number(self) -> None:
         self._sci: SmartContractsInterface
-        block_number = self._sci.get_block_number() - self._sci.REQUIRED_CONFS
+        block_number = self._sci.get_latest_confirmed_block_number()
         kv, _ = model.GenericKeyValue.get_or_create(
             key=self.BLOCK_NUMBER_DB_KEY,
         )
-        kv.value = block_number - 1
+        kv.value = block_number + 1
         kv.save()
 
     def stop(self):
@@ -441,7 +441,7 @@ class TransactionSystem(LoopingCallService):
             'gnt_nonconverted': self._gnt_balance,
             'eth_available': self.get_available_eth(),
             'eth_locked': self.get_locked_eth(),
-            'block_number': self._sci.get_block_number(),
+            'block_number': self._sci.get_latest_confirmed_block_number(),
             'gnt_update_time': self._last_gnt_update,
             'eth_update_time': self._last_eth_update,
         }

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ eth-utils==1.0.3
 ethereum==1.6.1
 fs==2.4.4
 Golem-Messages==3.4.0
-Golem-Smart-Contracts-Interface==1.7.0
+Golem-Smart-Contracts-Interface==1.10.0
 greenlet==0.4.15
 h2==3.0.1
 hpack==3.0.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -16,7 +16,7 @@ enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
 Golem-Messages==3.4.0
-Golem-Smart-Contracts-Interface==1.7.0
+Golem-Smart-Contracts-Interface==1.10.0
 html2text==2018.1.9
 humanize==0.5.1
 incremental==17.5.0

--- a/tests/golem/ethereum/test_paymentprocessor.py
+++ b/tests/golem/ethereum/test_paymentprocessor.py
@@ -35,7 +35,7 @@ class PaymentProcessorBase(DatabaseFixture):
     def setUp(self):
         DatabaseFixture.setUp(self)
         self.addr = encode_hex(privtoaddr(urandom(32)))
-        self.sci = mock.Mock()
+        self.sci = mock.Mock(spec=golem_sci.SmartContractsInterface)
         self.sci.GAS_PRICE = 20
         self.sci.GAS_PER_PAYMENT = 300
         self.sci.GAS_BATCH_PAYMENT_BASE = 30
@@ -44,9 +44,9 @@ class PaymentProcessorBase(DatabaseFixture):
         self.sci.get_eth_address.return_value = self.addr
         self.sci.get_current_gas_price.return_value = self.sci.GAS_PRICE
         self.sci.get_gate_address.return_value = None
-        latest_block = mock.Mock()
+        latest_block = mock.Mock(golem_sci.Block)
         latest_block.gas_limit = 10 ** 10
-        self.sci.get_latest_block.return_value = latest_block
+        self.sci.get_latest_confirmed_block.return_value = latest_block
         self.tx_hash = '0xdead'
         self.sci.batch_transfer.return_value = self.tx_hash
 
@@ -158,7 +158,8 @@ class PaymentProcessorInternalTest(PaymentProcessorBase):
 
         tx_block_number = 1337
         tx_timestamp = 1541766000.5
-        self.sci.get_block_number.return_value = tx_block_number
+        self.sci.get_latest_confirmed_block_number.return_value = \
+            tx_block_number
         self.sci.get_block_by_number.return_value = mock.Mock(
             timestamp=tx_timestamp)
         receipt = TransactionReceipt({
@@ -432,7 +433,7 @@ class InteractionWithSmartContractInterfaceTest(PaymentProcessorBase):
         self.sci.get_eth_balance.return_value = denoms.ether
         self.sci.get_gnt_balance.return_value = 0
         self.sci.get_gntb_balance.return_value = 1000 * denoms.ether
-        self.sci.get_latest_block.return_value.gas_limit = \
+        self.sci.get_latest_confirmed_block.return_value.gas_limit = \
             (self.sci.GAS_BATCH_PAYMENT_BASE + self.sci.GAS_PER_PAYMENT) /\
             self.pp.BLOCK_GAS_LIMIT_RATIO
         self.pp.CLOSURE_TIME_DELAY = 0

--- a/tests/golem/ethereum/test_transactionsystem.py
+++ b/tests/golem/ethereum/test_transactionsystem.py
@@ -10,6 +10,7 @@ from ethereum.utils import denoms
 import faker
 from freezegun import freeze_time
 from golem_messages.factories import p2p as p2p_factory
+import golem_sci
 import golem_sci.contracts
 import golem_sci.structs
 
@@ -28,17 +29,15 @@ PASSWORD = 'derp'
 class TransactionSystemBase(testutils.DatabaseFixture):
     def setUp(self):
         super().setUp()
-        self.sci = Mock()
+        self.sci = Mock(spec=golem_sci.SmartContractsInterface)
         self.sci.GAS_PRICE = 10 ** 9
         self.sci.GAS_BATCH_PAYMENT_BASE = 30000
         self.sci.get_gate_address.return_value = None
-        self.sci.get_block_number.return_value = 1223
         self.sci.get_current_gas_price.return_value = self.sci.GAS_PRICE - 1
         self.sci.get_eth_balance.return_value = 0
         self.sci.get_gnt_balance.return_value = 0
         self.sci.get_gntb_balance.return_value = 0
         self.sci.GAS_PER_PAYMENT = 20000
-        self.sci.REQUIRED_CONFS = 6
         self.sci.get_deposit_locked_until.return_value = 0
         self.ets = self._make_ets()
 
@@ -82,6 +81,7 @@ class TestTransactionSystem(TransactionSystemBase):
             e = self._make_ets()
 
             mock_is_service_running.return_value = True
+            self.sci.get_latest_confirmed_block_number.return_value = 1223
             e._payment_processor = Mock()  # noqa pylint: disable=no-member
             e.stop()
             e._payment_processor.sendout.assert_called_once_with(0)  # noqa pylint: disable=no-member
@@ -288,7 +288,7 @@ class TestTransactionSystem(TransactionSystemBase):
         )
 
         block_number = 123
-        self.sci.get_block_number.return_value = block_number
+        self.sci.get_latest_confirmed_block_number.return_value = block_number
         with patch('golem.ethereum.transactionsystem.LoopingCallService.stop'):
             self.ets.stop()
 
@@ -297,7 +297,7 @@ class TestTransactionSystem(TransactionSystemBase):
         self.sci.subscribe_to_batch_transfers.assert_called_once_with(
             None,
             self.sci.get_eth_address(),
-            block_number - self.sci.REQUIRED_CONFS - 1,
+            block_number + 1,
             ANY,
         )
 


### PR DESCRIPTION
`get_latest_block` has been replaced with more descriptive `get_latest_confirmed_block`.