### PR TITLE
Add funds validation to task/subtask restart endpoints

### DIFF
--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -545,6 +545,14 @@ class ClientProvider:
         # Create new task that is a copy of the definition of the old one.
         # It has a new deadline and a new task id.
         try:
+            task = self.task_manager.tasks[task_id]
+            self._validate_enough_funds_to_pay_for_task(
+                task.subtask_price,
+                task.get_total_tasks(),
+                task.header.concent_enabled,
+                force
+            )
+
             task_dict = copy.deepcopy(
                 self.task_manager.get_task_definition_dict(
                     self.task_manager.tasks[task_id],

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -19,7 +19,6 @@ from golem.core import golem_async
 from golem.core import common
 from golem.core import deferred as golem_deferred
 from golem.core import simpleserializer
-from golem.client import Client
 from golem.ethereum import exceptions as eth_exceptions
 from golem.resource import resource
 from golem.rpc import utils as rpc_utils
@@ -156,7 +155,7 @@ def _run_test_task(client, task_dict):
 
 @golem_async.deferred_run()
 def _restart_subtasks(
-        client: Client,
+        client,
         old_task_id: str,
         task_dict: dict,
         subtask_ids_to_copy: typing.Iterable[str],

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -601,7 +601,8 @@ class ClientProvider:
         :param disable_concent: setting this flag to True will result in forcing
         Concent to be disabled for the task. This only has effect when the task
         is already finished and needs to be restarted.
-        :return:
+        :return: In case of any errors, returns the representation of the error
+        (either a string or a dict). Otherwise, returns None.
         """
         try:
             task = self.task_manager.tasks[task_id]

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -416,8 +416,8 @@ def _restart_task_error(e, _self, task_id, **_kwargs):
 
 def _restart_subtasks_error(e, _self, task_id, subtask_ids, **_kwargs) \
         -> typing.Union[str, typing.Dict]:
-    logger.error("Failed to restart subtasks from task: %r, subtask_ids: %r,"
-                 "%s", task_id, subtask_ids, e)
+    logger.error("Failed to restart subtasks. task_id: %r, subtask_ids: %r, %s",
+                 task_id, subtask_ids, e)
 
     if hasattr(e, 'to_dict'):
         return e.to_dict()
@@ -606,17 +606,17 @@ class ClientProvider:
         """
         try:
             task = self.task_manager.tasks[task_id]
-
-            self._validate_enough_funds_to_pay_for_task(
-                task.subtask_price,
-                len(subtask_ids),
-                False if disable_concent else task.header.concent_enabled,
-                ignore_gas_price
-            )
         except KeyError:
             err_msg = f'Task not found: {task_id!r}'
             logger.error(err_msg)
             return err_msg
+
+        self._validate_enough_funds_to_pay_for_task(
+            task.subtask_price,
+            len(subtask_ids),
+            False if disable_concent else task.header.concent_enabled,
+            ignore_gas_price
+        )
 
         logger.debug('restart_subtasks. task_id=%r, subtask_ids=%r, '
                      'ignore_gas_price=%r, disable_concent=%r', task_id,

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -411,6 +411,17 @@ def _restart_task_error(e, _self, task_id, **_kwargs):
     return None, str(e)
 
 
+def _restart_subtasks_error(e, _self, task_id, subtask_ids, **_kwargs) \
+        -> typing.Union[str, typing.Dict]:
+    logger.error("Failed to restart subtasks from task: %r, subtask_ids: %r,"
+                 "%s", task_id, subtask_ids, e)
+
+    if hasattr(e, 'to_dict'):
+        return e.to_dict()
+
+    return str(e)
+
+
 def _test_task_error(e, self, task_dict, **_kwargs):
     logger.error("Test task error: %s", e)
     logger.debug("Test task details. task_dict=%s", task_dict)
@@ -446,7 +457,12 @@ class ClientProvider:
         prepare_and_validate_task_dict(self.client, task_dict)
 
         task: taskbase.Task = self.task_manager.create_task(task_dict)
-        self._validate_enough_funds_to_pay_for_task(task, force)
+        self._validate_enough_funds_to_pay_for_task(
+            task.subtask_price,
+            task.get_total_tasks(),
+            task.header.concent_enabled,
+            force
+        )
         task_id = task.header.task_id
 
         deferred = enqueue_new_task(self.client, task, force=force)
@@ -463,26 +479,28 @@ class ClientProvider:
         return task_id, None
 
     def _validate_enough_funds_to_pay_for_task(
-            self, task: taskbase.Task, force: bool
+            self,
+            subtask_price: int,
+            subtask_count: int,
+            concent_enabled: bool,
+            force: bool
     ):
-        self._validate_lock_funds_possibility(
-            total_price_gnt=task.price,
-            number_of_tasks=task.get_total_tasks(),
-        )
-        min_amount, _ = msg_helpers.requestor_deposit_amount(task.price)
-        concent_enabled = task.header.concent_enabled
+        self._validate_lock_funds_possibility(subtask_price, subtask_count)
+
         concent_available = self.client.concent_service.available
         if concent_enabled and concent_available:
+            min_amount, _ = msg_helpers.requestor_deposit_amount(subtask_price)
             self.client.transaction_system.validate_concent_deposit_possibility(
                 required=min_amount,
-                tasks_num=task.get_total_tasks(),
+                tasks_num=subtask_count,
                 force=force,
             )
 
     def _validate_lock_funds_possibility(
             self,
-            total_price_gnt: int,
-            number_of_tasks: int) -> None:
+            subtask_price: int,
+            subtask_count: int) -> None:
+        total_price_gnt: int = subtask_price * subtask_count
         transaction_system = self.client.transaction_system
         missing_funds: typing.List[eth_exceptions.MissingFunds] = []
 
@@ -494,7 +512,7 @@ class ClientProvider:
                 currency='GNT'
             ))
 
-        eth = transaction_system.eth_for_batch_payment(number_of_tasks)
+        eth = transaction_system.eth_for_batch_payment(subtask_count)
         eth_available = transaction_system.get_available_eth()
         if eth > eth_available:
             missing_funds.append(eth_exceptions.MissingFunds(
@@ -552,6 +570,53 @@ class ClientProvider:
         self.task_manager.put_task_in_restarted_state(task_id)
         return new_task.header.task_id, None
 
+    @rpc_utils.expose('comp.task.subtasks.restart')
+    @safe_run(_restart_subtasks_error)
+    def restart_subtasks(
+            self,
+            task_id: str,
+            subtask_ids: typing.List[str],
+            ignore_gas_price: bool = False,
+            disable_concent: bool = False
+    ) -> typing.Optional[typing.Union[str, typing.Dict]]:
+        """
+        TODO
+        :param task_id:
+        :param subtask_ids:
+        :param ignore_gas_price:
+        :param disable_concent:
+        :return:
+        """
+        try:
+            task = self.task_manager.tasks[task_id]
+
+            self._validate_enough_funds_to_pay_for_task(
+                task.subtask_price,
+                len(subtask_ids),
+                False if disable_concent else task.header.concent_enabled,
+                ignore_gas_price
+            )
+        except KeyError:
+            logger.error('Task not found: %r', task_id)
+
+        logger.debug('restart_subtasks. TODO',
+                     task_id)
+
+        task_state = self.client.task_manager.tasks_states[task_id]
+
+        if task_state.status.is_active():
+            for subtask_id in subtask_ids:
+                self.client.restart_subtask(subtask_id)
+
+            return None
+        else:
+            return self.restart_subtasks_from_task(
+                task_id,
+                subtask_ids,
+                ignore_gas_price,
+                disable_concent
+            )
+
     @rpc_utils.expose('comp.task.subtasks.frame.restart')
     @safe_run(
         lambda e, _self, task_id, frame: logger.error(
@@ -575,27 +640,17 @@ class ClientProvider:
                          'task_id=%r, frame=%r', task_id, frame)
             return
 
-        task_state = self.client.task_manager.tasks_states[task_id]
-
-        if task_state.status.is_active():
-            for subtask_id in frame_subtasks:
-                self.client.restart_subtask(subtask_id)
-        else:
-            self.restart_subtasks_from_task(task_id, frame_subtasks)
+        self.restart_subtasks(task_id, frame_subtasks)
 
     @rpc_utils.expose('comp.task.restart_subtasks')
-    @safe_run(
-        lambda e, _self, task_id, subtask_ids: logger.error(
-            'Task restart failed. e=%s, task_id=%s subtask_ids=%s',
-            e, task_id, subtask_ids
-        ),
-    )
+    @safe_run(_restart_subtasks_error)
     def restart_subtasks_from_task(
             self,
             task_id: str,
             subtask_ids: typing.Iterable[str],
             force: bool = False,
-    ):
+            disable_concent: bool = False
+    ) -> typing.Optional[typing.Union[str, typing.Dict]]:
         logger.debug('restart_subtasks_from_task. task_id=%r, subtask_ids=%r,'
                      'force=%r', task_id, subtask_ids, force)
 
@@ -604,25 +659,33 @@ class ClientProvider:
                 task_id,
                 clear_tmp=False,
             )
+
             old_task = self.task_manager.tasks[task_id]
+
             finished_subtask_ids = set(
                 sub_id for sub_id, sub in old_task.subtasks_given.items()
                 if sub['status'] == taskstate.SubtaskStatus.finished
             )
             subtask_ids_to_copy = finished_subtask_ids - set(subtask_ids)
+
             logger.debug('restart_subtasks_from_task. subtask_ids_to_copy=%r',
                          subtask_ids_to_copy)
         except self.task_manager.AlreadyRestartedError:
-            logger.error('Task already restarted: %r', task_id)
-            return
+            err_msg = f'Task already restarted: {task_id!r}'
+            logger.error(err_msg)
+            return err_msg
         except KeyError:
-            logger.error('Task not found: %r', task_id)
-            return
+            err_msg = f'Task not found: {task_id!r}'
+            logger.error(err_msg)
+            return err_msg
 
         task_dict = copy.deepcopy(
             self.task_manager.get_task_definition_dict(old_task),
         )
         del task_dict['id']
+        if disable_concent:
+            task_dict['concent_enabled'] = False
+
         logger.debug('Restarting task. task_dict=%s', task_dict)
         prepare_and_validate_task_dict(self.client, task_dict)
         _restart_subtasks(
@@ -633,6 +696,8 @@ class ClientProvider:
             force=force,
         )
         # Don't wait for deferred
+
+        return None
 
     @rpc_utils.expose('comp.tasks.check')
     @safe_run(_test_task_error)

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -24,6 +24,9 @@ from golem.resource import resource
 from golem.rpc import utils as rpc_utils
 from golem.task import taskbase, taskkeeper, taskstate, tasktester
 
+if typing.TYPE_CHECKING:
+    from golem.client import Client # noqa pylint: disable=unused-import
+
 logger = logging.getLogger(__name__)
 TASK_NAME_RE = re.compile(r"(\w|[\-\. ])+$")
 
@@ -155,7 +158,7 @@ def _run_test_task(client, task_dict):
 
 @golem_async.deferred_run()
 def _restart_subtasks(
-        client,
+        client: 'Client',
         old_task_id: str,
         task_dict: dict,
         subtask_ids_to_copy: typing.Iterable[str],
@@ -623,8 +626,6 @@ class ClientProvider:
         if task_state.status.is_active():
             for subtask_id in subtask_ids:
                 self.client.restart_subtask(subtask_id)
-
-            return None
         else:
             return self._restart_finished_task_subtasks(
                 task_id,
@@ -632,6 +633,8 @@ class ClientProvider:
                 ignore_gas_price,
                 disable_concent
             )
+
+        return None
 
     @rpc_utils.expose('comp.task.subtasks.frame.restart')
     @safe_run(

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -8,7 +8,7 @@ import uuid
 import faker
 from ethereum.utils import denoms
 from golem_messages.factories.datastructures import p2p as dt_p2p_factory
-from mock import Mock
+from mock import call, Mock
 from twisted.internet import defer
 
 from apps.dummy.task import dummytaskstate
@@ -189,8 +189,8 @@ class ConcentDepositLockPossibilityTest(unittest.TestCase):
 
         with self.assertRaises(exceptions.NotEnoughFunds) as e:
             client_provider._validate_lock_funds_possibility(
-                total_price_gnt=required_gnt,
-                number_of_tasks=1
+                subtask_price=required_gnt,
+                subtask_count=1
             )
         expected = f'Not enough funds available.\n' \
             f'Required GNT: {required_gnt / denoms.ether:f}, ' \
@@ -204,8 +204,10 @@ class TestRestartTask(ProviderBase):
     @mock.patch('os.path.getsize', return_value=123)
     @mock.patch('golem.network.concent.client.ConcentClientService.start')
     @mock.patch('golem.client.SystemMonitor')
+    @mock.patch('golem.task.rpc.ClientProvider.'
+                '_validate_enough_funds_to_pay_for_task')
     @mock.patch('golem.client.P2PService.connect_to_network')
-    def test_restart_task(self, connect_to_network, *_):
+    def test_restart_task(self, connect_to_network, mock_validate_funds, *_):
         self.client.apps_manager.load_all_apps()
 
         deferred = defer.Deferred()
@@ -258,6 +260,14 @@ class TestRestartTask(ProviderBase):
         with mock.patch('golem.task.rpc.enqueue_new_task') as enq_mock:
             new_task_id, error = self.provider.restart_task(task.header.task_id)
             enq_mock.assert_called_once()
+
+        mock_validate_funds.assert_called_once_with(
+            task.subtask_price,
+            task.get_total_tasks(),
+            task.header.concent_enabled,
+            False
+        )
+
         assert new_task_id
         assert not error
 
@@ -532,7 +542,6 @@ class TestValidateTaskDict(ProviderBase):
 
 @mock.patch('os.path.getsize')
 @mock.patch('golem.task.taskmanager.TaskManager.dump_task')
-@mock.patch("golem.task.rpc._restart_subtasks")
 class TestRestartSubtasks(ProviderBase):
     def setUp(self):
         super().setUp()
@@ -542,20 +551,73 @@ class TestRestartSubtasks(ProviderBase):
                 rpc.enqueue_new_task(self.client, self.task),
             )
 
-    def test_empty(self, restart_mock, *_):
-        force = fake.pybool()
-        self.provider.restart_subtasks_from_task(
+    @mock.patch('golem.task.taskstate.TaskStatus.is_active', return_value=True)
+    @mock.patch('golem.client.Client.restart_subtask')
+    @mock.patch('golem.task.rpc.ClientProvider.'
+                '_validate_enough_funds_to_pay_for_task')
+    def test_task_active(self, validate_funds_mock, restart_mock, *_):
+        ignore_gas_price = fake.pybool()
+        disable_concent = fake.pybool()
+        subtask_ids = ['subtask-uuid-1', 'subtask-uuid-2']
+
+        self.provider.restart_subtasks(
             task_id=self.task.header.task_id,
-            subtask_ids=[],
-            force=force,
+            subtask_ids=subtask_ids,
+            ignore_gas_price=ignore_gas_price,
+            disable_concent=disable_concent,
         )
+
+        validate_funds_mock.assert_called_once_with(
+            self.task.subtask_price,
+            len(subtask_ids),
+            self.task.header.concent_enabled,
+            ignore_gas_price
+        )
+
+        restart_mock.assert_has_calls(
+            map(lambda subtask_id: call(subtask_id), subtask_ids)
+        )
+
+    @mock.patch('golem.task.taskstate.TaskStatus.is_active', return_value=False)
+    @mock.patch("golem.task.rpc.ClientProvider._restart_finished_task_subtasks")
+    @mock.patch('golem.task.rpc.ClientProvider.'
+                '_validate_enough_funds_to_pay_for_task')
+    def test_task_inactive(self, validate_funds_mock, restart_mock, *_):
+        ignore_gas_price = fake.pybool()
+        disable_concent = fake.pybool()
+        subtask_ids = ['subtask-uuid-1', 'subtask-uuid-2']
+
+        self.provider.restart_subtasks(
+            task_id=self.task.header.task_id,
+            subtask_ids=subtask_ids,
+            ignore_gas_price=ignore_gas_price,
+            disable_concent=disable_concent,
+        )
+
+        validate_funds_mock.assert_called_once_with(
+            self.task.subtask_price,
+            len(subtask_ids),
+            self.task.header.concent_enabled,
+            ignore_gas_price
+        )
+
         restart_mock.assert_called_once_with(
-            client=self.client,
-            subtask_ids_to_copy=set(),
-            old_task_id=self.task.header.task_id,
-            task_dict=mock.ANY,
-            force=force,
+            self.task.header.task_id,
+            subtask_ids,
+            ignore_gas_price,
+            disable_concent
         )
+
+    def test_task_unknown(self, *_):
+        task_id = 'unknown-task-uuid'
+        subtask_ids = ['subtask-uuid-1', 'subtask-uuid-2']
+
+        error = self.provider.restart_subtasks(
+            task_id=task_id,
+            subtask_ids=subtask_ids
+        )
+
+        self.assertIn(task_id, error)
 
 
 class TestRestartFrameSubtasks(ProviderBase):
@@ -567,9 +629,8 @@ class TestRestartFrameSubtasks(ProviderBase):
                 rpc.enqueue_new_task(self.client, self.task),
             )
 
-    @mock.patch('golem.task.rpc.ClientProvider.restart_subtasks_from_task')
-    @mock.patch('golem.client.Client.restart_subtask')
-    def test_no_frames(self, mock_restart_single, mock_restart_multiple, *_):
+    @mock.patch('golem.task.rpc.ClientProvider.restart_subtasks')
+    def test_no_frames(self, mock_restart, *_):
         with mock.patch(
             'golem.task.taskmanager.TaskManager.get_frame_subtasks',
             return_value=None
@@ -579,70 +640,10 @@ class TestRestartFrameSubtasks(ProviderBase):
                 frame=1
             )
 
-        mock_restart_single.assert_not_called()
-        mock_restart_multiple.assert_not_called()
+        mock_restart.assert_not_called()
 
-    @mock.patch('golem.task.taskstate.TaskStatus.is_active', return_value=True)
-    @mock.patch('golem.task.rpc.ClientProvider.restart_subtasks_from_task')
-    @mock.patch('golem.client.Client.restart_subtask')
-    def test_task_active(self, mock_restart_single, mock_restart_multiple, *_):
-        mock_subtask_id_1 = 'mock-subtask-id-1'
-        mock_subtask_id_2 = 'mock-subtask-id-2'
-        mock_frame_subtasks = {
-            mock_subtask_id_1: Mock(),
-            mock_subtask_id_2: Mock()
-        }
-
-        with mock.patch(
-            'golem.task.taskmanager.TaskManager.get_frame_subtasks',
-            return_value=mock_frame_subtasks
-        ):
-            self.provider.restart_frame_subtasks(
-                task_id=self.task.header.task_id,
-                frame=1
-            )
-
-        mock_restart_multiple.assert_not_called()
-        mock_restart_single.assert_has_calls(
-            [mock.call(mock_subtask_id_1), mock.call(mock_subtask_id_2)]
-        )
-
-    @mock.patch('golem.task.taskstate.TaskStatus.is_active', return_value=False)
-    @mock.patch('golem.task.rpc.ClientProvider.restart_subtasks_from_task')
-    @mock.patch('golem.client.Client.restart_subtask')
-    def test_task_finished(
-            self, mock_restart_single, mock_restart_multiple, *_):
-        mock_subtask_id_1 = 'mock-subtask-id-1'
-        mock_subtask_id_2 = 'mock-subtask-id-2'
-        mock_frame_subtasks = frozenset((
-            mock_subtask_id_1,
-            mock_subtask_id_2,
-        ))
-
-        with mock.patch(
-            'golem.task.taskmanager.TaskManager.get_frame_subtasks',
-            return_value=mock_frame_subtasks
-        ):
-            self.provider.restart_frame_subtasks(
-                task_id=self.task.header.task_id,
-                frame=1
-            )
-
-        mock_restart_single.assert_not_called()
-        mock_restart_multiple.assert_called_once_with(
-            self.task.header.task_id,
-            mock_frame_subtasks,
-        )
-
-    @mock.patch('golem.task.rpc.ClientProvider.restart_subtasks_from_task')
-    @mock.patch('golem.client.Client.restart_subtask')
     @mock.patch('golem.task.rpc.logger')
-    def test_task_unknown(
-            self,
-            mock_logger,
-            mock_restart_single,
-            mock_restart_multiple,
-            *_):
+    def test_task_unknown(self, mock_logger, *_):
         mock_subtask_id_1 = 'mock-subtask-id-1'
         mock_subtask_id_2 = 'mock-subtask-id-2'
         mock_frame_subtasks = {
@@ -660,8 +661,6 @@ class TestRestartFrameSubtasks(ProviderBase):
             )
 
         mock_logger.error.assert_called_once()
-        mock_restart_single.assert_not_called()
-        mock_restart_multiple.assert_not_called()
 
 
 @mock.patch('os.path.getsize')


### PR DESCRIPTION
Resolves: #4180
Also fixes: #3895

Replaced the RPC endpoint `comp.task.restart_subtasks` with `comp.task.subtasks.restart`. Updated the endpoint to handle both finished and active tasks. Added error reporting via the method's return value.
Added funds validation for both subtask and whole task restarts.