### PR TITLE
fix incorrect volumes

### DIFF
--- a/golem/verificator/blender_verifier.py
+++ b/golem/verificator/blender_verifier.py
@@ -1,4 +1,6 @@
+import shutil
 from datetime import datetime
+from pathlib import Path
 from typing import Type
 
 import logging
@@ -72,10 +74,18 @@ class BlenderVerifier(FrameRenderingVerifier):
         self.finished.addErrback(failure)
 
         subtask_info = self.verification_data['subtask_info']
-        work_dir = os.path.dirname(self.verification_data['results'][0])
+        work_dir = Path(os.path.dirname(self.verification_data['results'][0])).parent
+        res_dir = os.path.join(work_dir, 'resources')
+        tmp_dir = os.path.join(work_dir, "tmp")
+
+        assert(len(self.verification_data['resources']) > 0)
+
+        shutil.copy(self.verification_data['resources'][0], res_dir)
+        shutil.copy(self.verification_data['results'][0], work_dir)
+
         dir_mapping = self.docker_task_cls.specify_dir_mapping(
-            resources=subtask_info['path_root'],
-            temporary=os.path.dirname(work_dir),
+            resources=res_dir,
+            temporary=tmp_dir,
             work=work_dir,
             output=os.path.join(work_dir, "output"),
             logs=os.path.join(work_dir, "logs"),

--- a/golem/verificator/blender_verifier.py
+++ b/golem/verificator/blender_verifier.py
@@ -74,11 +74,12 @@ class BlenderVerifier(FrameRenderingVerifier):
         self.finished.addErrback(failure)
 
         subtask_info = self.verification_data['subtask_info']
-        work_dir = Path(os.path.dirname(self.verification_data['results'][0])).parent
+        work_dir = Path(os.path.dirname(
+            self.verification_data['results'][0])).parent
         res_dir = os.path.join(work_dir, 'resources')
         tmp_dir = os.path.join(work_dir, "tmp")
 
-        assert(len(self.verification_data['resources']) > 0)
+        assert self.verification_data['resources']
 
         shutil.copy(self.verification_data['resources'][0], res_dir)
         shutil.copy(self.verification_data['results'][0], work_dir)

--- a/golem/verificator/blender_verifier.py
+++ b/golem/verificator/blender_verifier.py
@@ -87,7 +87,8 @@ class BlenderVerifier(FrameRenderingVerifier):
         else:
             shutil.copy(self.verification_data['resources'][0], res_dir)
 
-        shutil.copy(self.verification_data['results'][0], work_dir)
+        for result_file in self.verification_data['results']:
+            shutil.copy(result_file, work_dir)
 
         dir_mapping = self.docker_task_cls.specify_dir_mapping(
             resources=res_dir,

--- a/golem/verificator/blender_verifier.py
+++ b/golem/verificator/blender_verifier.py
@@ -81,6 +81,7 @@ class BlenderVerifier(FrameRenderingVerifier):
 
         assert self.verification_data['resources']
 
+        os.makedirs(res_dir, exist_ok=True)
         if os.path.isdir(self.verification_data['resources'][0]):
             shutil.copytree(self.verification_data['resources'][0], res_dir)
         else:

--- a/golem/verificator/blender_verifier.py
+++ b/golem/verificator/blender_verifier.py
@@ -81,7 +81,11 @@ class BlenderVerifier(FrameRenderingVerifier):
 
         assert self.verification_data['resources']
 
-        shutil.copy(self.verification_data['resources'][0], res_dir)
+        if os.path.isdir(self.verification_data['resources'][0]):
+            shutil.copytree(self.verification_data['resources'][0], res_dir)
+        else:
+            shutil.copy(self.verification_data['resources'][0], res_dir)
+
         shutil.copy(self.verification_data['results'][0], work_dir)
 
         dir_mapping = self.docker_task_cls.specify_dir_mapping(


### PR DESCRIPTION
It looks like someone was trying to introduce the following optimization: 
> Let's avoid copying resources before sending them to provider and just pack them to the ZIP _in place_. 

However, it does not work when it comes to the verification process. A verificator assumes that resources are copied to `ComputerRes`. 

Issue was resolved by copying needed resources to `ComputerRes` but, in the future, we need to resolve that in another way. From the other hand, mounting user directories directly to virtualmachine / docker filesystem seems to be not reasonable.