### PR TITLE
Transcoding: extract and replace commands

### DIFF
--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
@@ -21,6 +21,10 @@ class InvalidCommand(Exception):
     pass
 
 
+def do_extract(input_file, output_file, selected_streams):
+    commands.extract_streams(input_file, output_file, selected_streams)
+
+
 def do_split(path_to_stream, parts):
 
     video_metadata = commands.get_metadata_json(path_to_stream)
@@ -119,6 +123,18 @@ def do_merge(chunks, outputfilename):
     commands.merge_videos(ffconcat_list_filename, outputfilename)
 
 
+def do_replace(input_file,
+               replacement_source,
+               output_file,
+               stream_type):
+
+    commands.replace_streams(
+        input_file,
+        replacement_source,
+        output_file,
+        stream_type)
+
+
 def compute_metric(cmd, function):
     video_path = os.path.join(RESOURCES_DIR, cmd["video"])
     reference_path = os.path.join(RESOURCES_DIR, cmd["reference"])
@@ -148,7 +164,12 @@ def compute_metrics(metrics_params):
 
 
 def run_ffmpeg(params):
-    if params['command'] == "split":
+    if params['command'] == "extract":
+        do_extract(
+            params['input_file'],
+            params['output_file'],
+            params['selected_streams'])
+    elif params['command'] == "split":
         do_split(
             params['path_to_stream'],
             params['parts'])
@@ -162,6 +183,12 @@ def run_ffmpeg(params):
         do_merge(
             params['chunks'],
             params['output_stream'])
+    elif params['command'] == "replace":
+        do_replace(
+            params['input_file'],
+            params['replacement_source'],
+            params['output_file'],
+            params['stream_type'])
     elif params['command'] == "compute-metrics":
         compute_metrics(
             params["metrics_params"])

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -31,8 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 class Commands(enum.Enum):
-    EXTRACT = ('extract', '')
-    SPLIT = ('split', 'split-results.json')
+    EXTRACT_AND_SPLIT = ('extract-and-split', 'split-results.json')
     TRANSCODE = ('transcode', '')
     MERGE = ('merge', '')
     REPLACE = ('replace', '')
@@ -40,10 +39,12 @@ class Commands(enum.Enum):
 
 
 class StreamOperator:
-    def extract_video_streams(self,
-                              input_file_on_host: str,
-                              dir_manager: DirManager,
-                              task_id: str):
+    @HandleError(ValueError, common.not_valid_json)
+    def extract_video_streams_and_split(self, # noqa pylint: disable=too-many-locals
+                                        input_file_on_host: str,
+                                        parts: int,
+                                        dir_manager: DirManager,
+                                        task_id: str):
 
         host_dirs = {
             'tmp': dir_manager.get_task_temporary_dir(task_id),
@@ -58,19 +59,6 @@ class StreamOperator:
             host_dirs['tmp'],
             input_file_basename)
 
-        (input_file_stem, input_file_extension) = os.path.splitext(
-            input_file_basename)
-        output_file_basename = (
-            input_file_stem +
-            VIDEO_ONLY_CONTAINER_SUFFIX +
-            input_file_extension)
-        output_file_on_host = os.path.join(
-            host_dirs['output'],
-            output_file_basename)
-        output_file_in_container = os.path.join(
-            DockerJob.OUTPUT_DIR,
-            output_file_basename)
-
         # FIXME: The environment is stored globally. Changing it will affect
         # containers started by other functions that do not do it themselves.
         env = ffmpegEnvironment(binds=[DockerBind(
@@ -80,47 +68,22 @@ class StreamOperator:
 
         extra_data = {
             'entrypoint': FFMPEG_ENTRYPOINT,
-            'command': Commands.EXTRACT.value[0],
+            'command': Commands.EXTRACT_AND_SPLIT.value[0],
             'input_file': input_file_in_container,
-            'output_file': output_file_in_container,
-            'selected_streams': ['v'],
+            'parts': parts,
         }
 
         logger.debug(
-            f'Running video stream extraction [params = {extra_data}]')
-        self._do_job_in_container(
+            'Running video stream extraction and splitting '
+            '[params = %s]',
+            extra_data)
+        result = self._do_job_in_container(
             self._get_dir_mapping(dir_manager, task_id),
             extra_data,
             env)
 
-        return output_file_on_host
-
-    @HandleError(ValueError, common.not_valid_json)
-    def split_video(self, input_stream: str, parts: int,  # noqa pylint: disable=too-many-locals
-                    dir_manager: DirManager, task_id: str):
-        name = os.path.basename(input_stream)
-
-        tmp_task_dir = dir_manager.get_task_temporary_dir(task_id)
-        stream_container_path = os.path.join(tmp_task_dir, name)
-        task_output_dir = dir_manager.get_task_output_dir(task_id)
-
-        env = ffmpegEnvironment(binds=[
-            DockerBind(Path(input_stream), stream_container_path, 'ro')])
-
-        extra_data = {
-            'entrypoint': FFMPEG_ENTRYPOINT,
-            'command': Commands.SPLIT.value[0],
-            'path_to_stream': stream_container_path,
-            'parts': parts
-        }
-        logger.debug('Running video splitting [params = %s]', extra_data)
-
-        result = self._do_job_in_container(
-            self._get_dir_mapping(dir_manager, task_id),
-            extra_data, env)
-
-        split_result_file = os.path.join(task_output_dir,
-                                         Commands.SPLIT.value[1])
+        split_result_file = os.path.join(host_dirs['output'],
+                                         Commands.EXTRACT_AND_SPLIT.value[1])
         output_files = result.get('data', [])
         if split_result_file not in output_files:
             raise ffmpegException('Result file {} does not exist'.
@@ -138,11 +101,11 @@ class StreamOperator:
             streams_list = list(map(lambda x: (x.get('video_segment'),
                                                x.get('playlist')),
                                     params.get('segments', [])))
-
-            logger.info('Stream %s was successfully split to %s',
-                        input_stream,
-                        streams_list)
-
+            logger.info(
+                "Stream %s has successfully passed the "
+                "extract+split operation. Segments: %s",
+                input_file_on_host,
+                streams_list)
             return streams_list, params.get('metadata', {})
 
     def _prepare_merge_job(self, task_dir, chunks):

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -98,12 +98,8 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
         input_file = self.task_resources[0]
 
         stream_operator = StreamOperator()
-        video_only_file = stream_operator.extract_video_streams(
+        chunks, video_metadata = stream_operator.extract_video_streams_and_split(
             input_file,
-            dir_manager,
-            task_id)
-        chunks, video_metadata = stream_operator.split_video(
-            video_only_file,
             self.task_definition.subtasks_count,
             dir_manager,
             task_id)

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -16,8 +16,7 @@ import apps.transcoding.common
 from apps.core.task.coretask import CoreTask, CoreTaskBuilder, CoreTaskTypeInfo
 from apps.core.task.coretaskstate import Options, TaskDefinition
 from apps.transcoding.common import TranscodingException
-from apps.transcoding.ffmpeg.utils import StreamOperator, \
-    VIDEO_ONLY_CONTAINER_SUFFIX
+from apps.transcoding.ffmpeg.utils import StreamOperator
 from golem.core.common import HandleError, timeout_to_deadline
 from golem.resource.dirmanager import DirManager
 from golem.task.taskbase import Task
@@ -164,24 +163,15 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
                     self.task_definition.task_id)
 
         output_basename = os.path.basename(self.task_definition.output_file)
-        (output_stem, output_extension) = os.path.splitext(output_basename)
-        merged_basename = (
-            output_stem +
-            VIDEO_ONLY_CONTAINER_SUFFIX + '_TC' +
-            output_extension)
 
         assert len(self.task_definition.resources) == 1, \
             "Assumption: input file is the only resource in a transcoding task"
         input_file = next(iter(self.task_definition.resources))
 
         stream_operator = StreamOperator()
-        stream_operator.merge_video(
-            merged_basename,
-            self.task_dir,
-            self.collected_files)
-        output_file = stream_operator.replace_video_streams(
+        output_file = stream_operator.merge_and_replace_video_streams(
             input_file,
-            merged_basename,
+            self.collected_files,
             output_basename,
             self.task_dir)
 

--- a/tests/apps/ffmpeg/task/test_ffmpegtask.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegtask.py
@@ -186,12 +186,12 @@ class TestffmpegTask(TempDirFixture):
                 extra_data['track'],
                 os.path.join(
                     DockerJob.RESOURCES_DIR,
-                    'test.video_0.mp4'))
+                    'test.video[video-only]_0.mp4'))
             self.assertEqual(
                 extra_data['output_stream'],
                 os.path.join(
                     DockerJob.OUTPUT_DIR,
-                    'test.video_0_TC.mp4'))
+                    'test.video[video-only]_0_TC.mp4'))
 
     def test_extra_data(self):
         ffmpeg_task = self._build_ffmpeg_task()
@@ -202,7 +202,7 @@ class TestffmpegTask(TempDirFixture):
         self.assertEqual(extra_data['entrypoint'],
                          'python3 /golem/scripts/ffmpeg_task.py')
         self.assertEqual(extra_data['track'],
-                         '/golem/resources/test_video_0.mp4')
+                         '/golem/resources/test_video[video-only]_0.mp4')
         vargs = extra_data['targs']['video']
         aargs = extra_data['targs']['audio']
         self.assertEqual(vargs['codec'], d['options']['video']['codec'])
@@ -214,7 +214,7 @@ class TestffmpegTask(TempDirFixture):
         self.assertEqual(aargs['codec'], d['options']['audio']['codec'])
         self.assertEqual(aargs['bitrate'], d['options']['audio']['bit_rate'])
         self.assertEqual(extra_data['output_stream'],
-                         '/golem/output/test_video_0_TC.mp4')
+                         '/golem/output/test_video[video-only]_0_TC.mp4')
 
     def test_less_subtasks_than_requested(self):
         d = self._task_dictionary()

--- a/tests/apps/ffmpeg/task/utils/test_fmmpegtranscoding.py
+++ b/tests/apps/ffmpeg/task/utils/test_fmmpegtranscoding.py
@@ -118,29 +118,34 @@ class TestffmpegTranscoding(TempDirFixture):
                                               self.RESOURCE_STREAM))
 
     def test_prepare_merge_job(self):
-        resource_dir, output_dir, work_dir, chunks = \
-            self.stream_operator._prepare_merge_job(self.tempdir, [])
+        merge_job_info = self.stream_operator._prepare_merge_job(
+            self.tempdir,
+            [])
+        (host_dirs, chunks_in_container) = merge_job_info
 
-        self.assertEqual(len(chunks), 0)
+        self.assertEqual(len(chunks_in_container), 0)
         self.assertEqual(
-            resource_dir,
+            host_dirs['resources'],
             os.path.join(self.tempdir, 'merge', 'resources')
         )
-        self.assertTrue(os.path.isdir(output_dir))
+        self.assertTrue(os.path.isdir(host_dirs['output']))
         self.assertEqual(
-            output_dir,
+            host_dirs['output'],
             os.path.join(self.tempdir, 'merge', 'output'))
-        self.assertTrue(os.path.isdir(output_dir))
+        self.assertTrue(os.path.isdir(host_dirs['output']))
         self.assertEqual(
-            work_dir,
+            host_dirs['work'],
             os.path.join(self.tempdir, 'merge', 'work'))
-        self.assertTrue(os.path.isdir(work_dir))
+        self.assertTrue(os.path.isdir(host_dirs['work']))
 
     def test_prepare_merge_job_nonexistent_results(self):
         with self.assertRaises(ffmpegException):
-            self.stream_operator._prepare_merge_job(self.tempdir,
-                                                    ['/tmp/testtest_TC.m3u8',
-                                                     '/tmp/testtest_TC.ts'])
+            self.stream_operator._prepare_merge_job(
+                self.tempdir,
+                [
+                    '/tmp/testtest_TC.m3u8',
+                    '/tmp/testtest_TC.ts',
+                ])
 
     def test_merge_nonexistent_files(self):
         with self.assertRaises(ffmpegException):

--- a/tests/apps/ffmpeg/task/utils/test_fmmpegtranscoding.py
+++ b/tests/apps/ffmpeg/task/utils/test_fmmpegtranscoding.py
@@ -50,7 +50,7 @@ class TestffmpegTranscoding(TempDirFixture):
                 1, self.dir_manager,
                 str(uuid.uuid4()))
 
-    def test_extract_split_and_merge_video(self):
+    def test_extract_split_merge_and_replace_video(self):
         parts = 2
         task_id = str(uuid.uuid4())
         output_name = 'test.mp4'
@@ -75,13 +75,21 @@ class TestffmpegTranscoding(TempDirFixture):
             assert os.path.isfile(transcoded_segment)
             tc_segments.append(transcoded_segment)
 
-        self.stream_operator.merge_video(output_name, output_dir, tc_segments)
+        self.stream_operator.merge_and_replace_video_streams(
+            self.RESOURCE_STREAM,
+            tc_segments,
+            output_name,
+            output_dir)
         assert os.path.isfile(os.path.join(output_dir, 'merge',
                                            'output', output_name))
 
-    def test_merge_video_empty_dir(self):
+    def test_merge_and_replace_video_empty_dir(self):
         with self.assertRaises(ffmpegException):
-            self.stream_operator.merge_video('output.mp4', self.tempdir, [])
+            self.stream_operator.merge_and_replace_video_streams(
+                self.RESOURCE_STREAM,
+                [],
+                'output.mp4',
+                self.tempdir)
 
     def test_collect_nonexistent_results(self):
         with self.assertRaises(ffmpegException):
@@ -147,12 +155,13 @@ class TestffmpegTranscoding(TempDirFixture):
                     '/tmp/testtest_TC.ts',
                 ])
 
-    def test_merge_nonexistent_files(self):
+    def test_merge_and_replace_nonexistent_files(self):
         with self.assertRaises(ffmpegException):
-            self.stream_operator.merge_video('output.mp4',
-                                             self.tempdir,
-                                             ['test_TC.m3u8', 'test_TC.ts'])
-
+            self.stream_operator.merge_and_replace_video_streams(
+                self.RESOURCE_STREAM,
+                ['test_TC.m3u8', 'test_TC.ts'],
+                'output.mp4',
+                self.tempdir)
 
 class TestffmpegDockerJob(TestDockerJob):
     def _get_test_repository(self):

--- a/tests/apps/ffmpeg/task/utils/test_fmmpegtranscoding.py
+++ b/tests/apps/ffmpeg/task/utils/test_fmmpegtranscoding.py
@@ -34,29 +34,29 @@ class TestffmpegTranscoding(TempDirFixture):
             work_dir=self.new_path,
             in_background=True)
 
-    def test_split_video(self):
+    def test_extract_and_split_video(self):
         for parts in [1, 2]:
             with self.subTest('Testing splitting', parts=parts):
-                chunks, _ = self.stream_operator.split_video(
+                chunks, _ = self.stream_operator.extract_video_streams_and_split(
                     self.RESOURCE_STREAM, parts, self.dir_manager,
                     str(uuid.uuid4()))
                 self.assertEqual(len(chunks), parts)
 
-    def test_split_invalid_video(self):
+    def test_extract_and_split_invalid_video(self):
         with self.assertRaises(ffmpegException):
-            self.stream_operator.split_video(
+            self.stream_operator.extract_video_streams_and_split(
                 os.path.join(self.RESOURCES,
                              'invalid_test_video2.mp4'),
                 1, self.dir_manager,
                 str(uuid.uuid4()))
 
-    def test_split_and_merge_video(self):
+    def test_extract_split_and_merge_video(self):
         parts = 2
         task_id = str(uuid.uuid4())
         output_name = 'test.mp4'
         output_dir = self.dir_manager.get_task_output_dir(task_id)
 
-        chunks, _ = self.stream_operator.split_video(
+        chunks, _ = self.stream_operator.extract_video_streams_and_split(
             self.RESOURCE_STREAM, parts,
             self.dir_manager, task_id)
         self.assertEqual(len(chunks), parts)


### PR DESCRIPTION
This pull request updates the `ffmpeg-experimental` Docker image with new commands that allow extracting video streams from the input file before split and inserting them back after merge. It then changes the transcoding task implementation to use those new commands.

### Dependencies
This pull request depends on #4255, which enables the new split and merge methods.

For the code to work you also need a `golemfactory/ffmpeg-experimental` image built with https://github.com/golemfactory/ffmpeg-tools/pull/4 (extract and replace command implementation).

**NOTE**: I have set the base branch of this pull request to `transcoding-segment-split-and-concat-demuxer-merge` (#4255) rather than `CGI/transcoding/master`. Otherwise you would see changes from that branch here. The downside is that github now expects it to be merged into that base branch rather than into `CGI/transcoding/master` and will simply close the pull request (instead or marking it as "merged") if you merge it into master. To prevent this please remember to change the base branch back to `CGI/transcoding/master` before you merge.