### PR TITLE
Decrease severity taskeeper maintenance logs #4201

### DIFF
--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -538,7 +538,7 @@ class TaskHeaderKeeper:
         # headers, remove the rest
         to_remove = by_age[self.max_tasks_per_requestor:]
 
-        logger.warning(
+        logger.debug(
             "Too many tasks, dropping %d tasks. owner=%s, ids_to_remove=%r",
             len(to_remove), common.short_node_id(owner_key_id), to_remove
         )
@@ -621,7 +621,7 @@ class TaskHeaderKeeper:
         for t in list(self.task_headers.values()):
             cur_time = common.get_timestamp_utc()
             if cur_time > t.deadline:
-                logger.warning("Task owned by %s dies, task_id: %s",
+                logger.debug("Task owned by %s dies, task_id: %s",
                                t.task_owner.key, t.task_id)
                 self.remove_task_header(t.task_id)
 

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -539,7 +539,7 @@ class TaskHeaderKeeper:
         to_remove = by_age[self.max_tasks_per_requestor:]
 
         logger.debug(
-            "Too many tasks, dropping %d tasks. owner=%s, ids_to_remove=%r",
+            "Limiting tasks for this node, dropping %d tasks. owner=%s, ids_to_remove=%r",
             len(to_remove), common.short_node_id(owner_key_id), to_remove
         )
 
@@ -621,7 +621,7 @@ class TaskHeaderKeeper:
         for t in list(self.task_headers.values()):
             cur_time = common.get_timestamp_utc()
             if cur_time > t.deadline:
-                logger.debug("Task owned by %s dies, task_id: %s",
+                logger.debug("Task owned by %s removed after deadline, task_id: %s",
                                t.task_owner.key, t.task_id)
                 self.remove_task_header(t.task_id)
 

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -539,7 +539,8 @@ class TaskHeaderKeeper:
         to_remove = by_age[self.max_tasks_per_requestor:]
 
         logger.debug(
-            "Limiting tasks for this node, dropping %d tasks. owner=%s, ids_to_remove=%r",
+            "Limiting tasks for this node, dropping %d tasks. "
+            "owner=%s, ids_to_remove=%r",
             len(to_remove), common.short_node_id(owner_key_id), to_remove
         )
 
@@ -621,8 +622,9 @@ class TaskHeaderKeeper:
         for t in list(self.task_headers.values()):
             cur_time = common.get_timestamp_utc()
             if cur_time > t.deadline:
-                logger.debug("Task owned by %s removed after deadline, task_id: %s",
-                               t.task_owner.key, t.task_id)
+                logger.debug("Task owned by %s removed after deadline, "
+                             "task_id: %s",
+                             t.task_owner.key, t.task_id)
                 self.remove_task_header(t.task_id)
 
         for task_id, remove_time in list(self.removed_tasks.items()):


### PR DESCRIPTION
Fixes #4201. TaskKeeper maintenance logs reduced in severity from WARNING to DEBUG and redacted to more explicitly state what happened.