### PR TITLE
Finish rename of rpc command comp.task.subtasks.restart

### DIFF
--- a/golem/interface/client/tasks.py
+++ b/golem/interface/client/tasks.py
@@ -137,7 +137,7 @@ class Tasks:
              help="Restart given subtasks from a task")
     def restart_subtasks(self, id, subtask_ids, force: bool):
         deferred = Tasks.client._call(  # pylint: disable=protected-access
-            'comp.task.restart_subtasks',
+            'comp.task.subtasks.restart',
             id,
             subtask_ids,
             force=force,

--- a/scripts/node_integration_tests/playbooks/golem/task_timeout/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/task_timeout/playbook.py
@@ -17,7 +17,7 @@ class Playbook(NodeTestPlaybook):
     * afterwards, the nodes are restarted, this time both as unmodified
       Golem nodes,
     * the timed-out task (with only one subtask successfully finished) is then
-      restarted using the `comp.task.restart_subtasks` call - the result is a
+      restarted using the `comp.task.subtasks.restart` call - the result is a
       new task which contains one already-completed subtask and another,
       failed one,
     * the Provider should then be able to pick up that second subtask, thus
@@ -69,7 +69,7 @@ class Playbook(NodeTestPlaybook):
         if not self.task_in_creation:
             print("Restarting subtasks for {}".format(self.previous_task_id))
             self.task_in_creation = True
-            return self.call(NodeId.requestor, 'comp.task.restart_subtasks',
+            return self.call(NodeId.requestor, 'comp.task.subtasks.restart',
                              self.previous_task_id, [],
                              on_success=on_success)
 


### PR DESCRIPTION
Broken by #4247 

Found by [integration tests](https://buildbot.golem.network/buildbot/#/builders/15/builds/707)

@zakaprov:
- Please use a global find in the project when you rename a rpc command
- Maybe keep the old command with a deprecation warning
- Please also check other projects that use this rpc like golem-electron and golemcli-rust