### PR TITLE
node_integration_tests - use granary for key reuse

### DIFF
--- a/scripts/node_integration_tests/conftest.py
+++ b/scripts/node_integration_tests/conftest.py
@@ -1,43 +1,10 @@
 from typing import List
 import _pytest
 
-REUSE_KEYS = True
+from .key_reuse import NodeKeyReuse
+
 DUMP_OUTPUT_ON_CRASH = False
 DUMP_OUTPUT_ON_FAIL = False
-
-
-class NodeKeyReuseException(Exception):
-    pass
-
-
-class NodeKeyReuse:
-    instance = None
-    _first_test = True
-
-    @classmethod
-    def get(cls):
-        if not cls.instance:
-            cls.instance = cls()
-        return cls.instance
-
-    @property
-    def keys_ready(self):
-        return not self._first_test
-
-    def mark_keys_ready(self):
-        if not self.enabled:
-            raise NodeKeyReuseException("Key reuse disabled.")
-        self._first_test = False
-
-    @staticmethod
-    def disable():
-        global REUSE_KEYS
-        REUSE_KEYS = False
-
-    @property
-    def enabled(self):
-        return REUSE_KEYS
-
 
 class DumpOutput:
     @staticmethod

--- a/scripts/node_integration_tests/conftest.py
+++ b/scripts/node_integration_tests/conftest.py
@@ -34,6 +34,10 @@ def pytest_addoption(parser: _pytest.config.Parser) -> None:
              "All node_integration_tests run with new, fresh keys."
     )
     parser.addoption(
+        "--granary-hostname", action="store",
+        help="The ssh hostname for the granary server to use."
+    )
+    parser.addoption(
         "--dump-output-on-fail", action="store_true",
         help="Dump the nodes' outputs on any test failure."
     )
@@ -47,6 +51,9 @@ def pytest_collection_modifyitems(config: _pytest.config.Config,
                                   items: List[_pytest.main.Item]) -> None:
     if config.getoption("--disable-key-reuse"):
         NodeKeyReuse.disable()
+    hostname = config.getoption("--granary-hostname")
+    if hostname:
+        NodeKeyReuse.set_granary(hostname)
     if config.getoption('--dump-output-on-crash'):
         DumpOutput.enable_on_crash()
     if config.getoption('--dump-output-on-fail'):

--- a/scripts/node_integration_tests/conftest.py
+++ b/scripts/node_integration_tests/conftest.py
@@ -1,7 +1,7 @@
 from typing import List
 import _pytest
 
-from .key_reuse import NodeKeyReuse
+from .key_reuse import NodeKeyReuseConfig
 
 DUMP_OUTPUT_ON_CRASH = False
 DUMP_OUTPUT_ON_FAIL = False
@@ -50,10 +50,10 @@ def pytest_addoption(parser: _pytest.config.Parser) -> None:
 def pytest_collection_modifyitems(config: _pytest.config.Config,
                                   items: List[_pytest.main.Item]) -> None:
     if config.getoption("--disable-key-reuse"):
-        NodeKeyReuse.disable()
+        NodeKeyReuseConfig.disable()
     hostname = config.getoption("--granary-hostname")
     if hostname:
-        NodeKeyReuse.set_granary(hostname)
+        NodeKeyReuseConfig.set_granary(hostname)
     if config.getoption('--dump-output-on-crash'):
         DumpOutput.enable_on_crash()
     if config.getoption('--dump-output-on-fail'):

--- a/scripts/node_integration_tests/helpers.py
+++ b/scripts/node_integration_tests/helpers.py
@@ -1,7 +1,7 @@
 import datetime
 import itertools
 import os
-import pathlib
+from pathlib import Path
 import queue
 import re
 import subprocess
@@ -15,13 +15,13 @@ from ethereum.utils import denoms
 from . import tasks
 
 
-def get_testdir() -> str:
+def get_testdir() -> Path:
     env_key = 'GOLEM_INTEGRATION_TEST_DIR'
     datadir = os.environ.get(env_key, None)
     if not datadir:
         datadir = tempfile.mkdtemp(prefix='golem-integration-test-')
         os.environ[env_key] = datadir
-    return datadir
+    return Path(datadir)
 
 
 def mkdatadir(role: str) -> str:
@@ -63,10 +63,10 @@ def _params_from_dict(d: typing.Dict[str, typing.Any]) -> typing.List[str]:
 def run_golem_node(
         node_type: str,
         args: typing.Dict[str, typing.Any],
-        nodes_root: typing.Optional[pathlib.Path] = None
+        nodes_root: typing.Optional[Path] = None
         ) -> subprocess.Popen:
     node_file = node_type + '.py'
-    cwd = pathlib.Path(__file__).resolve().parent
+    cwd = Path(__file__).resolve().parent
     node_script = str(cwd / 'nodes' / node_file)
     return subprocess.Popen(
         args=['python', node_script, *_params_from_dict(args)],
@@ -121,7 +121,7 @@ def search_output(q: queue.Queue, pattern) -> typing.Optional[typing.Match]:
 def construct_test_task(task_package_name: str, task_settings: str) \
         -> typing.Dict[str, typing.Any]:
     settings = tasks.get_settings(task_settings)
-    cwd = pathlib.Path(__file__).resolve().parent
+    cwd = Path(__file__).resolve().parent
     tasks_path = (cwd / 'tasks' / task_package_name).glob('**/*')
     settings['resources'] = [str(f) for f in tasks_path if f.is_file()]
     return settings

--- a/scripts/node_integration_tests/key_reuse.py
+++ b/scripts/node_integration_tests/key_reuse.py
@@ -1,12 +1,20 @@
+import json
 import os
 from pathlib import Path
 import shutil
 from typing import Dict, Optional
 
+from eth_keyfile import create_keyfile_json, decode_keyfile_json
+
+from golem.core.keysauth import WrongPassword
+from tests.factories.granary import Granary, Account
 
 from scripts.node_integration_tests.playbooks.test_config_base import NodeId
+
 KEYSTORE_DIR = 'rinkeby/keys'
 KEYSTORE_FILE = 'keystore.json'
+TRANSACTION_FILE = 'tx.json'
+PASSWORD = 'dupa.8'
 
 _logging = False
 
@@ -15,6 +23,7 @@ class NodeKeyReuse:
     instance = None
     provider = None
     enabled = True
+    granary_hostname = None
 
     @classmethod
     def get(cls, test_dir: Path):
@@ -23,7 +32,10 @@ class NodeKeyReuse:
                 print("NodeKeyReuse.get() called, no instance. "
                       "dir= ", test_dir)
             cls.instance = cls()
-            cls.provider = NodeKeyReuseLocalFolder(test_dir, cls.instance)
+            if cls.granary_hostname:
+                cls.provider = NodeKeyReuseGranary(cls.granary_hostname)
+            else:
+                cls.provider = NodeKeyReuseLocalFolder(test_dir)
         return cls.instance
 
     @classmethod
@@ -47,6 +59,11 @@ class NodeKeyReuse:
     @classmethod
     def enable(cls):
         cls.enabled = True
+
+    @classmethod
+    def set_granary(cls, hostname):
+        cls.granary_hostname = hostname
+
 
 class NodeKeyReuseLocalFolder():
     def __init__(self, test_dir: Path):
@@ -124,3 +141,96 @@ class NodeKeyReuseLocalFolder():
             print("NodeKeyReuseLocalFolder._copy_keystore() file. "
                   "src=", src, ", dst=", dst)
         shutil.copyfile(src, dst)
+
+
+class NodeKeyReuseGranary():
+    def __init__(self, hostname: str):
+        self.datadirs: Dict[NodeId, Path] = {}
+        self.granary = Granary(hostname)
+
+    def begin_test(self, datadirs: Dict[NodeId, Path]) -> None:
+        self.datadirs = datadirs
+        if _logging:
+            print("NodeKeyReuseGranary.begin_test() called.")
+        if _logging:
+            print("Moving keys from granary to data-dirs")
+            self._recycle_keys()
+
+    def end_test(self) -> None:
+        print("NodeKeyReuseGranary.end_test() called.")
+        try:
+            if _logging:
+                print("Moving keys from data-dirs to granary")
+            self._copy_keystores()
+        except FileNotFoundError:
+            print('Copying keystores failed...')
+            return
+
+    def _recycle_keys(self) -> None:
+        print("Recycle keys")
+        # this is run before running second and later tests
+        for i, node_id in enumerate(self.datadirs):
+            account = self.granary.request_account()
+            if account is not None:
+                self._replace_keystore(
+                    account, self.datadirs[node_id]
+                )
+
+    def _replace_keystore(self, account: Account, dst: Path) -> None:
+        dst_key_dir = dst / KEYSTORE_DIR
+        dst_key_file = dst_key_dir / KEYSTORE_FILE
+        dst_trans_file = dst_key_dir / TRANSACTION_FILE
+        os.makedirs(str(dst_key_dir))
+        self._save_private_key(account.raw_key, dst_key_file, PASSWORD)
+        if account.transaction_store:
+            dst_trans_file.write_text(account.transaction_store)
+
+    def _copy_keystores(self):
+        # this is run after tests
+        # return key to granary as binary private key and transactions.json
+
+        for i, node_id in enumerate(self.datadirs):
+            account = self._copy_keystore(self.datadirs[node_id])
+            if account:
+                self.granary.return_account(account)
+
+    @staticmethod
+    def _copy_keystore(datadir: Path) -> Optional[Account]:
+
+        src_key_dir = datadir / KEYSTORE_DIR
+        src_ts_file = src_key_dir / TRANSACTION_FILE
+        src_key_file = src_key_dir / KEYSTORE_FILE
+        ts = None
+        keystore = None
+
+        try:  # read tx.json
+            with open(src_ts_file, 'r') as f:
+                ts = f.read()
+        except FileNotFoundError:
+            print('No tx.json, continue')
+        try:  # read keystore.json
+            with open(src_key_file, 'r') as f:
+                keystore = f.read()
+        except FileNotFoundError:
+            print('No File, no key')
+            return None
+        keystore = json.loads(keystore)
+
+        try:  # unlock the key
+            priv_key = decode_keyfile_json(keystore, PASSWORD.encode('utf-8'))
+        except ValueError:
+            raise WrongPassword
+
+        return Account(priv_key, ts)
+
+    @staticmethod
+    def _save_private_key(key, key_path: Path, password: str) -> None:
+        print("_save_private_key")
+        print(password)
+        keystore = create_keyfile_json(
+            key,
+            password.encode('utf-8'),
+            iterations=1024,
+        )
+        with open(key_path, 'w') as f:
+            f.write(json.dumps(keystore))

--- a/scripts/node_integration_tests/key_reuse.py
+++ b/scripts/node_integration_tests/key_reuse.py
@@ -26,7 +26,7 @@ def _log(*args):
 
 
 class NodeKeyReuseBase:
-    ### Base class for key reuse providers
+    # Base class for key reuse providers
     def begin_test(self, datadirs: Dict[NodeId, Path]) -> None:
         raise NotImplementedError()
 
@@ -39,12 +39,12 @@ class NodeKeyReuseConfig:
     # Selects the right provider ( subclass of NodeKeyReuseBase )
     # Based on command line arguments ( TBA: and enviromnet vars )
     instance: 'Optional[NodeKeyReuseConfig]' = None
-    provider: Optional[NodeKeyReuseBase]  = None
+    provider: Optional[NodeKeyReuseBase] = None
     enabled: bool = True
 
     # Provider specific variables
     granary_hostname: Optional[str] = None
-    local_reuse_dir : Optional[Path] = None
+    local_reuse_dir: Optional[Path] = None
 
     @classmethod
     def get(cls):
@@ -170,7 +170,7 @@ class NodeKeyReuseLocalFolder(NodeKeyReuseBase):
         src = str(datadir / KEYSTORE_DIR / KEYSTORE_FILE)
         dst = str(reuse_dir / KEYSTORE_FILE)
         _log("NodeKeyReuseLocalFolder._copy_keystore() file. "
-                  "src=", src, ", dst=", dst)
+             "src=", src, ", dst=", dst)
         shutil.copyfile(src, dst)
 
 
@@ -230,7 +230,7 @@ class NodeKeyReuseGranary(NodeKeyReuseBase):
         src_key_dir = datadir / KEYSTORE_DIR
         src_ts_file = src_key_dir / TRANSACTION_FILE
         src_key_file = src_key_dir / KEYSTORE_FILE
-        ts = None
+        ts = '{}'
         keystore = None
 
         try:  # read tx.json

--- a/scripts/node_integration_tests/key_reuse.py
+++ b/scripts/node_integration_tests/key_reuse.py
@@ -1,0 +1,126 @@
+import os
+from pathlib import Path
+import shutil
+from typing import Dict, Optional
+
+
+from scripts.node_integration_tests.playbooks.test_config_base import NodeId
+KEYSTORE_DIR = 'rinkeby/keys'
+KEYSTORE_FILE = 'keystore.json'
+
+_logging = False
+
+
+class NodeKeyReuse:
+    instance = None
+    provider = None
+    enabled = True
+
+    @classmethod
+    def get(cls, test_dir: Path):
+        if not cls.instance:
+            if _logging:
+                print("NodeKeyReuse.get() called, no instance. "
+                      "dir= ", test_dir)
+            cls.instance = cls()
+            cls.provider = NodeKeyReuseLocalFolder(test_dir, cls.instance)
+        return cls.instance
+
+    @classmethod
+    def begin_test(cls, datadirs: Dict[NodeId, Path]):
+        if cls.enabled and cls.provider:
+            if _logging:
+                print("NodeKeyReuse.begin_test() called. dirs= ", datadirs)
+            cls.provider.begin_test(datadirs)
+
+    @classmethod
+    def end_test(cls):
+        if cls.enabled and cls.provider:
+            if _logging:
+                print("NodeKeyReuse.end_test() called.")
+            cls.provider.end_test()
+
+    @classmethod
+    def disable(cls):
+        cls.enabled = False
+
+    @classmethod
+    def enable(cls):
+        cls.enabled = True
+
+class NodeKeyReuseLocalFolder():
+    def __init__(self, test_dir: Path):
+        self.dir: Path = test_dir / 'key_reuse'
+        self.datadirs: Dict[NodeId, Path] = {}
+        self._first_test = True
+
+    def begin_test(self, datadirs: Dict[NodeId, Path]) -> None:
+        self.datadirs = datadirs
+        if _logging:
+            print("NodeKeyReuseLocalFolder.begin_test() called.")
+        if not self._first_test:
+            if _logging:
+                print("Moving keys from reuse-dirs to data-dirs")
+            self._recycle_keys()
+
+    def end_test(self) -> None:
+        print("NodeKeyReuseLocalFolder.end_test() called.")
+        try:
+            if _logging:
+                print("Moving keys from data-dirs to reuse-dirs")
+            self._copy_keystores()
+        except FileNotFoundError:
+            print('Copying keystores failed...')
+            return
+
+        self._first_test = False
+
+    def _recycle_keys(self) -> None:
+        # this is run before running second and later tests
+        for i, node_id in enumerate(self.datadirs):
+            datadir = self.datadirs[node_id]
+            reuse_dir = self.dir / str(i)
+            if not reuse_dir.exists():
+                continue
+            if _logging:
+                print("NodeKeyReuseLocalFolder._copy_keystores() loop. "
+                      "dir= ", datadir)
+            self._replace_keystore(reuse_dir, datadir)
+
+    @staticmethod
+    def _replace_keystore(src: Path, dst: Path) -> None:
+        src_file = src / KEYSTORE_FILE
+        dst_file = dst / KEYSTORE_DIR / KEYSTORE_FILE
+        os.makedirs(str(dst / KEYSTORE_DIR))
+        shutil.copyfile(str(src_file), str(dst_file))
+
+    def _copy_keystores(self) -> None:
+        # this is run after tests
+        self._prepare_keystore_reuse_folders()
+        for i, node_id in enumerate(self.datadirs):
+            datadir = self.datadirs[node_id]
+            if _logging:
+                print("NodeKeyReuseLocalFolder._copy_keystores() loop. "
+                      "dir= ", datadir)
+            self._copy_keystore(
+                datadir, self.dir / str(i))
+
+    def _prepare_keystore_reuse_folders(self) -> None:
+        # this is run after tests
+        try:
+            for i in range(len(self.datadirs)):
+                reuse_dir = self.dir / str(i)
+                shutil.rmtree(reuse_dir, ignore_errors=True)
+                os.makedirs(reuse_dir)
+        except OSError:
+            print('Unexpected problem with creating folders for keystore')
+            raise
+
+    @staticmethod
+    def _copy_keystore(datadir: Path, reuse_dir: Path) -> None:
+        src = str(datadir / KEYSTORE_DIR / KEYSTORE_FILE)
+        dst = str(reuse_dir / KEYSTORE_FILE)
+        if _logging:
+            print("NodeKeyReuseLocalFolder._copy_keystore() file. "
+                  "src=", src, ", dst=", dst)
+        shutil.copyfile(src, dst)

--- a/scripts/node_integration_tests/key_reuse.py
+++ b/scripts/node_integration_tests/key_reuse.py
@@ -128,9 +128,9 @@ class NodeKeyReuseLocalFolder(NodeKeyReuseBase):
 
     def _recycle_keys(self) -> None:
         # this is run before running second and later tests
-        for i, (node_id, datadir) in enumerate(self.datadirs.items()):
+        for i, datadir in enumerate(self.datadirs.values()):
             _log("NodeKeyReuseLocalFolder._recycle_keys() loop. "
-                 "i", i, 'node_id', node_id, 'datadir', datadir)
+                 "i", i, 'datadir', datadir)
             reuse_dir = self.dir / str(i)
             if not reuse_dir.exists():
                 continue
@@ -146,9 +146,9 @@ class NodeKeyReuseLocalFolder(NodeKeyReuseBase):
     def _copy_keystores(self) -> None:
         # this is run after tests
         self._prepare_keystore_reuse_folders()
-        for i, (node_id, datadir) in enumerate(self.datadirs.items()):
+        for i, datadir in enumerate(self.datadirs.values()):
             _log("NodeKeyReuseLocalFolder._copy_keystores() loop. "
-                 "i", i, 'node_id', node_id, 'datadir', datadir)
+                 "i", i, 'datadir', datadir)
             self._copy_keystore(
                 datadir, self.dir / str(i))
 
@@ -197,7 +197,7 @@ class NodeKeyReuseGranary(NodeKeyReuseBase):
 
     def _recycle_keys(self) -> None:
         # this is run before tests
-        for i, (node_id, datadir) in enumerate(self.datadirs.items()):
+        for datadir in self.datadirs.values():
             account = self.granary.request_account()
             if account is not None:
                 self._replace_keystore(
@@ -219,7 +219,7 @@ class NodeKeyReuseGranary(NodeKeyReuseBase):
         # this is run after tests
         # return key to granary as binary private key and transactions.json
 
-        for i, (node_id, datadir) in enumerate(self.datadirs.items()):
+        for datadir in self.datadirs.values():
             account = self._copy_keystore(datadir)
             if account:
                 self.granary.return_account(account)

--- a/scripts/node_integration_tests/playbooks/test_config_base.py
+++ b/scripts/node_integration_tests/playbooks/test_config_base.py
@@ -27,7 +27,7 @@ class NodeConfig:
         self.log_level: Optional[str] = None
         self.mainnet = False
         self.opts: Dict[str, Any] = {}
-        self.password = 'dupa.8'
+        self.password = 'goleM.8'
         self.protocol_id = 1337
         self.rpc_port = 61000
         self.script = 'node'

--- a/scripts/node_integration_tests/tests/base.py
+++ b/scripts/node_integration_tests/tests/base.py
@@ -7,6 +7,7 @@ from typing import (
     Callable,
     Dict,
     List,
+    Optional,
     TYPE_CHECKING
 )
 
@@ -33,7 +34,15 @@ def disable_key_reuse(test_function: Callable) -> Callable:
 
 
 class NodeTestBase(unittest.TestCase):
-    reuse_keys = NodeKeyReuse.get(get_testdir())
+    reuse_keys: Optional[NodeKeyReuse] = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.reuse_keys = NodeKeyReuse.get(get_testdir())
+
+    @classmethod
+    def tearDownClass(cls):
+        NodeKeyReuse.reset()
 
     def setUp(self):
         self.test_dir = get_testdir() / self._relative_id()
@@ -76,6 +85,7 @@ class NodeTestBase(unittest.TestCase):
         if conftest.DumpOutput.enabled_on_crash():
             test_args.append('--dump-output-on-crash')
 
+        assert self.reuse_keys is not None, "reuse_keys is not configured"
         self.reuse_keys.begin_test(self.datadirs)
         exit_code = subprocess.call(args=test_args)
         self.reuse_keys.end_test()

--- a/scripts/node_integration_tests/tests/base.py
+++ b/scripts/node_integration_tests/tests/base.py
@@ -12,7 +12,7 @@ from typing import (
 )
 
 from scripts.node_integration_tests import conftest
-from scripts.node_integration_tests.key_reuse import NodeKeyReuse
+from scripts.node_integration_tests.key_reuse import NodeKeyReuseConfig
 
 from ..helpers import get_testdir
 from ..playbook_loader import get_config
@@ -34,15 +34,15 @@ def disable_key_reuse(test_function: Callable) -> Callable:
 
 
 class NodeTestBase(unittest.TestCase):
-    reuse_keys: Optional[NodeKeyReuse] = None
+    reuse_keys: Optional[NodeKeyReuseConfig] = None
 
     @classmethod
     def setUpClass(cls):
-        cls.reuse_keys = NodeKeyReuse.get(get_testdir())
+        cls.reuse_keys = NodeKeyReuseConfig.get(get_testdir())
 
     @classmethod
     def tearDownClass(cls):
-        NodeKeyReuse.reset()
+        NodeKeyReuseConfig.reset()
 
     def setUp(self):
         self.test_dir = get_testdir() / self._relative_id()

--- a/scripts/node_integration_tests/tests/base.py
+++ b/scripts/node_integration_tests/tests/base.py
@@ -38,7 +38,8 @@ class NodeTestBase(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.reuse_keys = NodeKeyReuseConfig.get(get_testdir())
+        NodeKeyReuseConfig.set_dir(get_testdir())
+        cls.reuse_keys = NodeKeyReuseConfig.get()
 
     @classmethod
     def tearDownClass(cls):

--- a/scripts/node_integration_tests/tests/base.py
+++ b/scripts/node_integration_tests/tests/base.py
@@ -1,6 +1,5 @@
 import os
-import pathlib
-import shutil
+from pathlib import Path
 import subprocess
 import unittest
 from functools import wraps
@@ -12,6 +11,7 @@ from typing import (
 )
 
 from scripts.node_integration_tests import conftest
+from scripts.node_integration_tests.key_reuse import NodeKeyReuse
 
 from ..helpers import get_testdir
 from ..playbook_loader import get_config
@@ -20,39 +20,26 @@ if TYPE_CHECKING:
     from ..playbooks.test_config_base import NodeId
 
 
-KEYSTORE_DIR = 'rinkeby/keys'
-
-
 def disable_key_reuse(test_function: Callable) -> Callable:
     @wraps(test_function)
     def wrap(*args, **kwargs) -> None:
-        args[0].reuse_keys = False
+        reuse_keys = args[0].reuse_keys
+        was_enabled = reuse_keys.enabled
+        reuse_keys.disable()
         test_function(*args, **kwargs)
+        if was_enabled:
+            reuse_keys.enable()
     return wrap
 
 
 class NodeTestBase(unittest.TestCase):
+    reuse_keys = NodeKeyReuse.get(get_testdir())
+
     def setUp(self):
-        self.test_dir = pathlib.Path(get_testdir()) / self._relative_id()
-        self.reuse_keys = True
-        self.key_reuse_dir = self.test_dir.parent / 'key_reuse'
-
-    def tearDown(self):
-        key_reuse = conftest.NodeKeyReuse.get()
-        if key_reuse.enabled and not key_reuse.keys_ready:
-            try:
-                self._copy_keystores()
-            except FileNotFoundError:
-                print('Copying keystores failed...')
-                return
-
-            key_reuse.mark_keys_ready()
+        self.test_dir = get_testdir() / self._relative_id()
 
     def _relative_id(self):
         return self.id().replace(__name__ + '.', '')
-
-    def _can_recycle_keys(self) -> bool:
-        return conftest.NodeKeyReuse.get().keys_ready and self.reuse_keys
 
     @staticmethod
     def _get_nodes_ids(test_path: str) -> 'List[NodeId]':
@@ -68,7 +55,7 @@ class NodeTestBase(unittest.TestCase):
             self.datadirs[node_id] = datadir
             os.makedirs(datadir)
 
-        cwd = pathlib.Path(__file__).resolve().parent.parent
+        cwd = Path(__file__).resolve().parent.parent
         test_args = [
             str(cwd / 'run_test.py'),
             test_path,
@@ -89,48 +76,7 @@ class NodeTestBase(unittest.TestCase):
         if conftest.DumpOutput.enabled_on_crash():
             test_args.append('--dump-output-on-crash')
 
-        if self._can_recycle_keys():
-            self._recycle_keys()
-
+        self.reuse_keys.begin_test(self.datadirs)
         exit_code = subprocess.call(args=test_args)
+        self.reuse_keys.end_test()
         self.assertEqual(exit_code, 0)
-
-    @staticmethod
-    def _replace_keystore(src: pathlib.Path, dst: pathlib.Path) -> None:
-        src_file = src / 'keystore.json'
-        dst_file = dst / KEYSTORE_DIR / 'keystore.json'
-        os.makedirs(str(dst / KEYSTORE_DIR))
-        shutil.copyfile(str(src_file), str(dst_file))
-
-    def _recycle_keys(self):
-        # this is run before running second and later tests
-        for i, node_id in enumerate(self.nodes):
-            reuse_dir = self.key_reuse_dir / str(i)
-            if not reuse_dir.exists():
-                continue
-            NodeTestBase._replace_keystore(
-                reuse_dir, self.datadirs[node_id])
-
-    def _copy_keystores(self):
-        # this is run after tests
-        self._prepare_keystore_reuse_folders()
-        for i, node_id in enumerate(self.nodes):
-            NodeTestBase._copy_keystore(
-                self.datadirs[node_id], self.key_reuse_dir / str(i))
-
-    def _prepare_keystore_reuse_folders(self) -> None:
-        # this is run after tests
-        try:
-            for i in range(len(self.nodes)):
-                reuse_dir = self.key_reuse_dir / str(i)
-                shutil.rmtree(reuse_dir, ignore_errors=True)
-                os.makedirs(reuse_dir)
-        except OSError:
-            print('Unexpected problem with creating folders for keystore')
-            raise
-
-    @staticmethod
-    def _copy_keystore(datadir: pathlib.Path, reuse_dir: pathlib.Path) -> None:
-        src = str(datadir / KEYSTORE_DIR / 'keystore.json')
-        dst = str(reuse_dir / 'keystore.json')
-        shutil.copyfile(src, dst)

--- a/scripts/node_integration_tests/tests/test_fails.py
+++ b/scripts/node_integration_tests/tests/test_fails.py
@@ -1,0 +1,3 @@
+class TestFails:
+    def test_fails(self):
+        self.fail()

--- a/tests/factories/granary.py
+++ b/tests/factories/granary.py
@@ -1,4 +1,3 @@
-import random
 import subprocess
 from typing import Optional
 
@@ -53,7 +52,7 @@ class Granary:
 
         key = decode_hex(raw_key)
         _log('raw_key:', raw_key, 'key:', key)
-        return Account(key, out_lines[1] or None)
+        return Account(key, out_lines[1] or '{}')
 
     def return_account(self, account: Account):
         _log("Granary called, account returned. account=", account)

--- a/tests/factories/granary.py
+++ b/tests/factories/granary.py
@@ -15,7 +15,6 @@ _logging = False
 class Account:
     def __init__(self, raw_key, ts):
         self.key = ECCx(raw_key)
-        random.seed()
         assert self.key.raw_privkey == raw_key
         self.raw_key = self.key.raw_privkey
         if _logging:
@@ -39,35 +38,28 @@ class Granary:
             universal_newlines=True)
         if _logging:
             print('returncode:', completed.returncode)
-
-        if _logging:
             if completed.stderr:
                 print('stderr:', completed.stderr)
             else:
                 print('stderr: EMPTY')
 
-        if completed.stdout:
-            if _logging:
-                print('stdout:', completed.stdout)
-            out_lines = completed.stdout.split('\n')
-            raw_key = out_lines[0].strip()
-
-            if _logging:
-                print('raw_key:', raw_key)
-            key = decode_hex(raw_key)
-            if _logging:
-                print('key:', key)
-            return Account(key, out_lines[1] or None)
-        elif _logging:
+        if not completed.stdout:
             print('stdout: EMPTY')
-        return None
+            return None
+        elif _logging:
+            print('stdout:', completed.stdout)
+
+        out_lines = completed.stdout.split('\n')
+        raw_key = out_lines[0].strip()
+
+        key = decode_hex(raw_key)
+        if _logging:
+            print('raw_key:', raw_key, 'key:', key)
+        return Account(key, out_lines[1] or None)
 
     def return_account(self, account):
         if _logging:
-            print("Granary called, account returned")
-            print(account)
-            print(account.raw_key)
-            print(account.transaction_store)
+            print("Granary called, account returned. account=", account)
 
         key_pub_addr = encode_hex(sha3(account.key.raw_pubkey)[12:])
 

--- a/tests/factories/granary.py
+++ b/tests/factories/granary.py
@@ -1,0 +1,98 @@
+import random
+import subprocess
+from typing import Optional
+
+import shlex
+
+from eth_utils import encode_hex, decode_hex
+from ethereum.utils import sha3
+
+from golem_messages.cryptography import ECCx
+
+_logging = False
+
+
+class Account:
+    def __init__(self, raw_key, ts):
+        self.key = ECCx(raw_key)
+        random.seed()
+        assert self.key.raw_privkey == raw_key
+        self.raw_key = self.key.raw_privkey
+        if _logging:
+            print("Account created: " + str(self.raw_key))
+        self.transaction_store = ts
+
+
+class Granary:
+    def __init__(self, hostname):
+        self.hostname = hostname
+
+    def request_account(self) -> Optional[Account]:
+        if _logging:
+            print("Granary called, account requested")
+        cmd = ['ssh', self.hostname, 'golem-granary', 'get_used_account']
+
+        completed = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True)
+        if _logging:
+            print('returncode:', completed.returncode)
+
+        if _logging:
+            if completed.stderr:
+                print('stderr:', completed.stderr)
+            else:
+                print('stderr: EMPTY')
+
+        if completed.stdout:
+            if _logging:
+                print('stdout:', completed.stdout)
+            out_lines = completed.stdout.split('\n')
+            raw_key = out_lines[0].strip()
+
+            if _logging:
+                print('raw_key:', raw_key)
+            key = decode_hex(raw_key)
+            if _logging:
+                print('key:', key)
+            return Account(key, out_lines[1] or None)
+        elif _logging:
+            print('stdout: EMPTY')
+        return None
+
+    def return_account(self, account):
+        if _logging:
+            print("Granary called, account returned")
+            print(account)
+            print(account.raw_key)
+            print(account.transaction_store)
+
+        key_pub_addr = encode_hex(sha3(account.key.raw_pubkey)[12:])
+
+        ts = account.transaction_store or '{}'
+        ts = shlex.quote(ts)
+
+        cmd = ['ssh', self.hostname, 'golem-granary', 'return_used_account',
+               '-p', key_pub_addr, '-P', encode_hex(account.raw_key), '-t', ts]
+
+        if _logging:
+            print(cmd)
+        completed = subprocess.run(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            universal_newlines=True)
+        if _logging:
+            print('returncode:', completed.returncode)
+            if completed.stdout:
+                print('stdout:', completed.stdout)
+            else:
+                print('stdout: EMPTY')
+
+            if completed.stderr:
+                print('stderr:', completed.stderr)
+            else:
+                print('stderr: EMPTY')
+        return


### PR DESCRIPTION
- Separated out the key reuse feature in its own file ( commit 1 )
- Extended it to pick between local files and the remote granary by specifying the granary hostname ( commit 2).

The granary is disabled by default.