### PR TITLE
Implement subtasks restart cost estimation RPC

### DIFF
--- a/scripts/node_integration_tests/playbooks/golem/restart_failed_subtasks/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/restart_failed_subtasks/playbook.py
@@ -1,0 +1,56 @@
+import time
+import typing
+
+from ...base import NodeTestPlaybook
+from ...test_config_base import NodeId
+
+
+class Playbook(NodeTestPlaybook):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.previous_task_id = None
+
+    def step_restart_failed_subtasks(self):
+        def on_success(result):
+            print(f'Restarted failed subtasks.'
+                  f'task_id={self.previous_task_id}.')
+            self.next()
+
+        return self.call(NodeId.requestor,
+                         'comp.task.subtasks.restart',
+                         self.previous_task_id,
+                         [],
+                         on_success=on_success)
+
+    def step_wait_task_timeout(self):
+        def on_success(result):
+            if result['status'] == 'Timeout':
+                print("Task timed out as expected.")
+                self.previous_task_id = self.task_id
+                self.task_id = None
+                self.next()
+            elif result['status'] == 'Finished':
+                print("Task finished unexpectedly, failing test :(")
+                self.fail()
+            else:
+                print("Task status: {} ... ".format(result['status']))
+                time.sleep(10)
+
+        return self.call(NodeId.requestor, 'comp.task', self.task_id,
+                         on_success=on_success)
+
+    steps: typing.Tuple = NodeTestPlaybook.initial_steps + (
+        NodeTestPlaybook.step_create_task,
+        NodeTestPlaybook.step_get_task_id,
+        NodeTestPlaybook.step_get_task_status,
+        step_wait_task_timeout,
+        NodeTestPlaybook.step_stop_nodes,
+        NodeTestPlaybook.step_restart_nodes,
+    ) + NodeTestPlaybook.initial_steps + (
+        NodeTestPlaybook.step_get_known_tasks,
+        step_restart_failed_subtasks,
+        NodeTestPlaybook.step_get_task_id,
+        NodeTestPlaybook.step_get_task_status,
+        NodeTestPlaybook.step_wait_task_finished,
+        NodeTestPlaybook.step_verify_output,
+    )

--- a/scripts/node_integration_tests/playbooks/golem/restart_failed_subtasks/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/restart_failed_subtasks/test_config.py
@@ -1,0 +1,25 @@
+from ...test_config_base import (
+    TestConfigBase, make_node_config_from_env, NodeId)
+
+
+class TestConfig(TestConfigBase):
+    def __init__(self):
+        super().__init__()
+        provider_config = make_node_config_from_env(NodeId.provider.value, 0)
+        provider_config.script = 'provider/cannot_compute'
+        provider_config_2 = make_node_config_from_env(NodeId.provider.value, 0)
+
+        requestor_config = make_node_config_from_env(NodeId.requestor.value, 1)
+        requestor_config_2 = make_node_config_from_env(
+            NodeId.requestor.value, 1)
+        requestor_config_2.script = 'requestor/always_accept_provider'
+
+        self.nodes[NodeId.requestor] = [
+            requestor_config,
+            requestor_config_2,
+        ]
+
+        self.nodes[NodeId.provider] = [
+            provider_config,
+            provider_config_2
+        ]

--- a/scripts/node_integration_tests/playbooks/golem/restart_frame/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/restart_frame/playbook.py
@@ -1,4 +1,3 @@
-from functools import partial
 import typing
 
 from ...base import NodeTestPlaybook

--- a/scripts/node_integration_tests/tests/test_golem.py
+++ b/scripts/node_integration_tests/tests/test_golem.py
@@ -53,3 +53,6 @@ class GolemNodeTest(NodeTestBase):
             'golem.separate_hyperg',
             **{'task-package': 'cubes', 'task-settings': '4k'},
         )
+
+    def test_restart_failed_subtasks(self):
+        self._run_test('golem.restart_failed_subtasks')

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -551,6 +551,11 @@ class TestRestartSubtasks(ProviderBase):
                 rpc.enqueue_new_task(self.client, self.task),
             )
 
+        self.task_id = self.task.header.task_id
+        self.subtask_ids = ['subtask-uuid-1', 'subtask-uuid-2']
+        self.provider.task_manager.subtask2task_mapping = \
+            {sub_id: self.task_id for sub_id in self.subtask_ids}
+
     @mock.patch('golem.task.taskstate.TaskStatus.is_active', return_value=True)
     @mock.patch('golem.client.Client.restart_subtask')
     @mock.patch('golem.task.rpc.ClientProvider.'
@@ -558,24 +563,23 @@ class TestRestartSubtasks(ProviderBase):
     def test_task_active(self, validate_funds_mock, restart_mock, *_):
         ignore_gas_price = fake.pybool()
         disable_concent = fake.pybool()
-        subtask_ids = ['subtask-uuid-1', 'subtask-uuid-2']
 
         self.provider.restart_subtasks(
-            task_id=self.task.header.task_id,
-            subtask_ids=subtask_ids,
+            task_id=self.task_id,
+            subtask_ids=self.subtask_ids,
             ignore_gas_price=ignore_gas_price,
             disable_concent=disable_concent,
         )
 
         validate_funds_mock.assert_called_once_with(
             self.task.subtask_price,
-            len(subtask_ids),
+            len(self.subtask_ids),
             self.task.header.concent_enabled,
             ignore_gas_price
         )
 
         restart_mock.assert_has_calls(
-            map(lambda subtask_id: call(subtask_id), subtask_ids)
+            map(lambda subtask_id: call(subtask_id), self.subtask_ids)
         )
 
     @mock.patch('golem.task.taskstate.TaskStatus.is_active', return_value=False)
@@ -585,39 +589,49 @@ class TestRestartSubtasks(ProviderBase):
     def test_task_inactive(self, validate_funds_mock, restart_mock, *_):
         ignore_gas_price = fake.pybool()
         disable_concent = fake.pybool()
-        subtask_ids = ['subtask-uuid-1', 'subtask-uuid-2']
 
         self.provider.restart_subtasks(
-            task_id=self.task.header.task_id,
-            subtask_ids=subtask_ids,
+            task_id=self.task_id,
+            subtask_ids=self.subtask_ids,
             ignore_gas_price=ignore_gas_price,
             disable_concent=disable_concent,
         )
 
         validate_funds_mock.assert_called_once_with(
             self.task.subtask_price,
-            len(subtask_ids),
+            len(self.subtask_ids),
             self.task.header.concent_enabled,
             ignore_gas_price
         )
 
         restart_mock.assert_called_once_with(
-            self.task.header.task_id,
-            subtask_ids,
+            self.task_id,
+            self.subtask_ids,
             ignore_gas_price,
             disable_concent
         )
 
     def test_task_unknown(self, *_):
         task_id = 'unknown-task-uuid'
-        subtask_ids = ['subtask-uuid-1', 'subtask-uuid-2']
 
         error = self.provider.restart_subtasks(
             task_id=task_id,
-            subtask_ids=subtask_ids
+            subtask_ids=self.subtask_ids
         )
 
         self.assertIn(task_id, error)
+
+    def test_subtask_mismatch(self, *_):
+        subtask_ids = ['im-not-from-this-task']
+
+        error = self.provider.restart_subtasks(
+            task_id=self.task_id,
+            subtask_ids=subtask_ids
+        )
+
+        self.assertEqual(error, f'Subtask does not belong to the given task.'
+                                f'task_id: {self.task_id}, '
+                                f'subtask_id: {subtask_ids[0]}')
 
     @mock.patch('golem.task.rpc.ClientProvider.'
                 '_validate_enough_funds_to_pay_for_task')
@@ -662,8 +676,8 @@ class TestRestartFrameSubtasks(ProviderBase):
 
         mock_restart.assert_not_called()
 
-    @mock.patch('golem.task.rpc.logger')
-    def test_task_unknown(self, mock_logger, *_):
+    def test_task_unknown(self, *_):
+        task_id = 'unknown-task-id'
         mock_subtask_id_1 = 'mock-subtask-id-1'
         mock_subtask_id_2 = 'mock-subtask-id-2'
         mock_frame_subtasks = {
@@ -675,12 +689,12 @@ class TestRestartFrameSubtasks(ProviderBase):
             'golem.task.taskmanager.TaskManager.get_frame_subtasks',
             return_value=mock_frame_subtasks
         ):
-            self.provider.restart_frame_subtasks(
-                task_id='unknown-task-id',
+            error = self.provider.restart_frame_subtasks(
+                task_id=task_id,
                 frame=1
             )
 
-        mock_logger.error.assert_called_once()
+        self.assertEqual(error, f'Task not found: {task_id!r}')
 
 
 @mock.patch('os.path.getsize')
@@ -734,6 +748,10 @@ class TestGetEstimatedCost(ProviderBase):
         ts.eth_for_batch_payment.return_value = 10000
         ts.eth_for_deposit.return_value = 20000
 
+        self.task_id = 'task-uuid'
+        self.task = Mock()
+        self.provider.task_manager.tasks[self.task_id] = self.task
+
     def test_basic(self, *_):
         subtasks = 5
 
@@ -765,15 +783,12 @@ class TestGetEstimatedCost(ProviderBase):
         self.transaction_system.eth_for_deposit.assert_called_once_with()
 
     def test_full_restart(self, *_):
-        task_id = 'task-uuid'
-        mock_task = Mock()
-        mock_task.get_total_tasks.return_value = 10
-        mock_task.subtask_price = 1
-        self.provider.task_manager.tasks[task_id] = mock_task
+        self.task.get_total_tasks.return_value = 10
+        self.task.subtask_price = 1
 
         result, error = self.provider.get_estimated_cost(
             "task_type",
-            task_id=task_id
+            task_id=self.task_id
         )
 
         self.assertIsNone(error)
@@ -791,15 +806,12 @@ class TestGetEstimatedCost(ProviderBase):
         )
 
     def test_partial_restart(self, *_):
-        task_id = 'task-uuid'
-        mock_task = Mock()
-        mock_task.get_tasks_left.return_value = 2
-        mock_task.subtask_price = 2
-        self.provider.task_manager.tasks[task_id] = mock_task
+        self.task.get_tasks_left.return_value = 2
+        self.task.subtask_price = 2
 
         result, error = self.provider.get_estimated_cost(
             'task_type',
-            task_id=task_id,
+            task_id=self.task_id,
             partial=True
         )
 
@@ -838,6 +850,123 @@ class TestGetEstimatedCost(ProviderBase):
             'You must pass either a task ID or task options.'
         )
 
+
+class TestGetEstimatedSubtasksCost(ProviderBase):
+    def setUp(self):
+        super().setUp()
+        self.transaction_system = ts = self.client.transaction_system
+        ts.eth_for_batch_payment.return_value = 10000
+        ts.eth_for_deposit.return_value = 20000
+
+        self.task_id = 'mock-task-uuid'
+        self.task = Mock()
+        self.task.subtask_price = 2
+        self.provider.task_manager.tasks[self.task_id] = self.task
+
+        self.subtask_ids = ['subtask-uuid-1', 'subtask-uuid-2']
+        self.provider.task_manager.subtask2task_mapping = \
+            {sub_id: self.task_id for sub_id in self.subtask_ids}
+
+    @mock.patch('golem.task.taskmanager.TaskManager.task_finished',
+                return_value=False)
+    def test_active_task(self, *_):
+        result, error = self.provider.get_estimated_subtasks_cost(
+            task_id=self.task_id,
+            subtask_ids=self.subtask_ids
+        )
+
+        self.assertIsNone(error)
+        self.assertEqual(
+            result,
+            {
+                'GNT': '4',
+                'ETH': '10000',
+                'deposit': {
+                    'GNT_required': '8',
+                    'GNT_suggested': '16',
+                    'ETH': '20000',
+                },
+            },
+        )
+
+    @mock.patch('golem.task.taskmanager.TaskManager.task_finished',
+                return_value=True)
+    def test_finished_task(self, *_):
+        subtasks_given = {
+            'failed-subtask-uuid': {'status': taskstate.SubtaskStatus.failure}
+        }
+        self.provider.task_manager.subtask2task_mapping = \
+            {sub_id: self.task_id for sub_id in self.subtask_ids}
+        self.task.subtasks_given = subtasks_given
+
+        result, error = self.provider.get_estimated_subtasks_cost(
+            task_id=self.task_id,
+            subtask_ids=self.subtask_ids
+        )
+
+        self.assertIsNone(error)
+        self.assertEqual(
+            result,
+            {
+                'GNT': '6',
+                'ETH': '10000',
+                'deposit': {
+                    'GNT_required': '12',
+                    'GNT_suggested': '24',
+                    'ETH': '20000',
+                },
+            },
+        )
+
+    def test_subtask_mismatch(self, *_):
+        subtask_ids = ['im-not-from-this-task']
+
+        result, error = self.provider.get_estimated_subtasks_cost(
+            task_id=self.task_id,
+            subtask_ids=subtask_ids
+        )
+
+        self.assertIsNone(result)
+        self.assertEqual(error, f'Subtask does not belong to the given task.'
+                                f'task_id: {self.task_id}, '
+                                f'subtask_id: {subtask_ids[0]}')
+
+    def test_task_not_found(self, *_):
+        task_id = 'task-which-doesnt-exist'
+
+        result, error = self.provider.get_estimated_subtasks_cost(
+            task_id=task_id,
+            subtask_ids=self.subtask_ids
+        )
+
+        self.assertIsNone(result)
+        self.assertEqual(error, f'Task not found: {task_id}')
+
+    @mock.patch('golem.task.taskmanager.TaskManager.task_finished',
+                return_value=False)
+    def test_removing_duplicate_subtasks(self, *_):
+        subtask_ids = ['subtask-uuid-1', 'subtask-uuid-1', 'subtask-uuid-2']
+        self.provider.task_manager.subtask2task_mapping = \
+            {sub_id: self.task_id for sub_id in subtask_ids}
+
+        result, error = self.provider.get_estimated_subtasks_cost(
+            task_id=self.task_id,
+            subtask_ids=subtask_ids
+        )
+
+        self.assertIsNone(error)
+        self.assertEqual(
+            result,
+            {
+                'GNT': '4',
+                'ETH': '10000',
+                'deposit': {
+                    'GNT_required': '8',
+                    'GNT_suggested': '16',
+                    'ETH': '20000',
+                },
+            },
+        )
 
 @mock.patch('golem.task.taskmanager.TaskManager.get_subtask_dict',
             return_value=Mock())


### PR DESCRIPTION
- Added the RPC endpoint `comp.task.subtasks.estimated.cost`.
- Added `disable_concent` flag to the `comp.task.restart` endpoint.
- Fixed funds checking when performing a partial restart of a task (including previously failed subtasks).