### PR TITLE
treat retrieval of an incompatible message from history as a "message…

### DIFF
--- a/golem/network/history.py
+++ b/golem/network/history.py
@@ -119,7 +119,13 @@ class MessageHistoryService(IService):
         if not db_result:
             raise MessageNotFound()
         db_msg = db_result[0]
-        return db_msg.as_message()
+        try:
+            return db_msg.as_message()
+        except AttributeError:
+            # in case an incompatible message from an earlier version of
+            # golem-messages is retrieved, just treat it the same
+            # as if the message was not found
+            raise MessageNotFound()
 
     def add(self, msg_dict: dict) -> None:
         """

--- a/tests/golem/network/test_history.py
+++ b/tests/golem/network/test_history.py
@@ -285,10 +285,8 @@ class TestMessageHistoryGet(MessageHistoryServiceTestBase):
         self.assertEqual(self.msg, msg_retrieved)
 
     def test_get_pickle_fail(self):
-        with mock.patch(
-                'golem.model.pickle.loads',
-                mock.Mock(side_effect=AttributeError)
-        ):
+        with mock.patch('golem.model.pickle.loads',
+                        mock.Mock(side_effect=AttributeError)):
             msg_retrieved = history.get(
                 'TaskToCompute',
                 subtask_id=self.msg.subtask_id,

--- a/tests/golem/network/test_history.py
+++ b/tests/golem/network/test_history.py
@@ -21,6 +21,7 @@ fake = Faker()
 def message_count():
     return NetworkMessage.select().count()
 
+
 class MessageHistoryServiceTestBase(DatabaseFixture):
 
     def setUp(self):

--- a/tests/golem/network/test_history.py
+++ b/tests/golem/network/test_history.py
@@ -21,8 +21,7 @@ fake = Faker()
 def message_count():
     return NetworkMessage.select().count()
 
-
-class TestMessageHistoryService(DatabaseFixture):
+class MessageHistoryServiceTestBase(DatabaseFixture):
 
     def setUp(self):
         super().setUp()
@@ -32,6 +31,8 @@ class TestMessageHistoryService(DatabaseFixture):
         super().tearDown()
         history.MessageHistoryService.instance = None
 
+
+class TestMessageHistoryService(MessageHistoryServiceTestBase):
     @staticmethod
     def _build_dict(task=None, subtask=None):
         return dict(
@@ -254,6 +255,46 @@ class TestMessageHistoryService(DatabaseFixture):
         self.service.remove_sync.reset_mock()
         self.service._loop()
         assert not self.service.remove_sync.called
+
+
+class TestMessageHistoryGet(MessageHistoryServiceTestBase):
+    def setUp(self):
+        super().setUp()
+        self.msg = msg_factories.tasks.TaskToComputeFactory()
+        self.msg._fake_sign()
+        self.node_id = fake.binary(length=64)
+        self.local_role = fake.random_element(Actor)
+        self.remote_role = fake.random_element(Actor)
+
+        history.add(
+            msg=self.msg,
+            node_id=self.node_id,
+            local_role=self.local_role,
+            remote_role=self.remote_role,
+            sync=True
+        )
+
+    def test_get(self):
+        msg_retrieved = history.get(
+            'TaskToCompute',
+            subtask_id=self.msg.subtask_id,
+            node_id=self.node_id,
+        )
+
+        self.assertEqual(self.msg, msg_retrieved)
+
+    def test_get_pickle_fail(self):
+        with mock.patch(
+                'golem.model.pickle.loads',
+                mock.Mock(side_effect=AttributeError)
+        ):
+            msg_retrieved = history.get(
+                'TaskToCompute',
+                subtask_id=self.msg.subtask_id,
+                node_id=self.node_id,
+            )
+
+        self.assertIsNone(msg_retrieved)
 
 
 @mock.patch("golem.network.history.MessageHistoryService.add")


### PR DESCRIPTION
… not found"

closes: https://github.com/golemfactory/golem/issues/4303