### PR TITLE
Remove the 'duration' field from RPC Task dict representation

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -1062,7 +1062,6 @@ class TaskManager(TaskEventListener):
         state = self.query_task_state(task.header.task_id)
 
         dictionary = {
-            'duration': state.elapsed_time,
             # single=True retrieves one preview file. If rendering frames,
             # it's the preview of the most recently computed frame.
             'preview': task_type.get_preview(task, single=True)


### PR DESCRIPTION
Due to performance issues that the frequent changes of `duration` are causing in the UI, this field is being removed.

`duration` is also redundant, since computation start time is already available and duration can be calculated manually.