### PR TITLE
Add hook for numpy in pyinstaller

### DIFF
--- a/scripts/pyinstaller/hooks/hook-numpy.core.py
+++ b/scripts/pyinstaller/hooks/hook-numpy.core.py
@@ -1,11 +1,11 @@
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # Copyright (c) 2013-2018, PyInstaller Development Team.
 #
 # Distributed under the terms of the GNU General Public License with exception
 # for distributing bootloader.
 #
 # The full license is in the file COPYING.txt, distributed with this software.
-#-----------------------------------------------------------------------------
+# -----------------------------------------------------------------------------
 # If numpy is built with MKL support it depends on a set of libraries loaded
 # at runtime. Since PyInstaller's static analysis can't find them they must be
 # included manually.
@@ -19,30 +19,18 @@ import os.path
 import re
 from PyInstaller.utils.hooks import get_package_paths
 from PyInstaller import log as logging
-from PyInstaller import compat
+from typing import List
 
-binaries = []
+binaries: List = []
+
+logger = logging.getLogger(__name__)
 
 # look for libraries in numpy package path
-pkg_base, pkg_dir = get_package_paths('numpy.core')
-re_anylib = re.compile(r'\w+\.(?:dll|so|dylib)', re.IGNORECASE)
-dlls_pkg = [f for f in os.listdir(pkg_dir) if re_anylib.match(f)]
-binaries += [(os.path.join(pkg_dir, f), '.') for f in dlls_pkg]
-
-# look for MKL libraries in pythons lib directory
-# TODO: check numpy.__config__ if numpy is actually depending on MKL
-# TODO: determine which directories are searched by the os linker
-if compat.is_win:
-    if os.path.exists(os.path.join(compat.base_prefix, 'Lib\\site-packages\\numpy\\core')):
-        lib_dir = os.path.join(compat.base_prefix, 'Lib\\site-packages\\numpy\\core')
-    else:
-        lib_dir = os.path.join(compat.base_prefix, "Library", "bin")
-else:
-    lib_dir = os.path.join(compat.base_prefix, "lib")
-if os.path.isdir(lib_dir):
-    re_mkllib = re.compile(r'^(?:lib)?mkl\w+\.(?:dll|so|dylib)', re.IGNORECASE)
-    dlls_mkl = [f for f in os.listdir(lib_dir) if re_mkllib.match(f)]
-    if dlls_mkl:
-        logger = logging.getLogger(__name__)
-        logger.info("MKL libraries found when importing numpy. Adding MKL to binaries")
-        binaries += [(os.path.join(lib_dir, f), '.') for f in dlls_mkl]
+pkg_base, pkg_dir = get_package_paths('numpy')
+dll_dir = os.path.join(pkg_dir, 'DLLs')
+logger.info("pkg_base=%r, pkg_dir=%r, dll_dir=%r", pkg_base, pkg_dir, dll_dir)
+if os.exists(dll_dir):
+    re_anylib = re.compile(r'\w+\.(?:dll|so|dylib)', re.IGNORECASE)
+    dlls_pkg = [f for f in os.listdir(dll_dir) if re_anylib.match(f)]
+    logger.info("dlls_pkg=%r", dlls_pkg)
+    binaries += [(os.path.join(dll_dir, f), '.') for f in dlls_pkg]

--- a/scripts/pyinstaller/hooks/hook-numpy.core.py
+++ b/scripts/pyinstaller/hooks/hook-numpy.core.py
@@ -14,7 +14,6 @@
 # https://github.com/pyinstaller/pyinstaller/issues/1881
 # https://github.com/pyinstaller/pyinstaller/issues/1969
 # for more information
-import os
 import os.path
 import re
 from PyInstaller.utils.hooks import get_package_paths
@@ -29,7 +28,7 @@ logger = logging.getLogger(__name__)
 pkg_base, pkg_dir = get_package_paths('numpy')
 dll_dir = os.path.join(pkg_dir, 'DLLs')
 logger.info("pkg_base=%r, pkg_dir=%r, dll_dir=%r", pkg_base, pkg_dir, dll_dir)
-if os.exists(dll_dir):
+if os.path.exists(dll_dir):
     re_anylib = re.compile(r'\w+\.(?:dll|so|dylib)', re.IGNORECASE)
     dlls_pkg = [f for f in os.listdir(dll_dir) if re_anylib.match(f)]
     logger.info("dlls_pkg=%r", dlls_pkg)

--- a/scripts/pyinstaller/hooks/hook-numpy.core.py
+++ b/scripts/pyinstaller/hooks/hook-numpy.core.py
@@ -1,0 +1,48 @@
+#-----------------------------------------------------------------------------
+# Copyright (c) 2013-2018, PyInstaller Development Team.
+#
+# Distributed under the terms of the GNU General Public License with exception
+# for distributing bootloader.
+#
+# The full license is in the file COPYING.txt, distributed with this software.
+#-----------------------------------------------------------------------------
+# If numpy is built with MKL support it depends on a set of libraries loaded
+# at runtime. Since PyInstaller's static analysis can't find them they must be
+# included manually.
+#
+# See
+# https://github.com/pyinstaller/pyinstaller/issues/1881
+# https://github.com/pyinstaller/pyinstaller/issues/1969
+# for more information
+import os
+import os.path
+import re
+from PyInstaller.utils.hooks import get_package_paths
+from PyInstaller import log as logging
+from PyInstaller import compat
+
+binaries = []
+
+# look for libraries in numpy package path
+pkg_base, pkg_dir = get_package_paths('numpy.core')
+re_anylib = re.compile(r'\w+\.(?:dll|so|dylib)', re.IGNORECASE)
+dlls_pkg = [f for f in os.listdir(pkg_dir) if re_anylib.match(f)]
+binaries += [(os.path.join(pkg_dir, f), '.') for f in dlls_pkg]
+
+# look for MKL libraries in pythons lib directory
+# TODO: check numpy.__config__ if numpy is actually depending on MKL
+# TODO: determine which directories are searched by the os linker
+if compat.is_win:
+    if os.path.exists(os.path.join(compat.base_prefix, 'Lib\\site-packages\\numpy\\core')):
+        lib_dir = os.path.join(compat.base_prefix, 'Lib\\site-packages\\numpy\\core')
+    else:
+        lib_dir = os.path.join(compat.base_prefix, "Library", "bin")
+else:
+    lib_dir = os.path.join(compat.base_prefix, "lib")
+if os.path.isdir(lib_dir):
+    re_mkllib = re.compile(r'^(?:lib)?mkl\w+\.(?:dll|so|dylib)', re.IGNORECASE)
+    dlls_mkl = [f for f in os.listdir(lib_dir) if re_mkllib.match(f)]
+    if dlls_mkl:
+        logger = logging.getLogger(__name__)
+        logger.info("MKL libraries found when importing numpy. Adding MKL to binaries")
+        binaries += [(os.path.join(lib_dir, f), '.') for f in dlls_mkl]


### PR DESCRIPTION
The dll files have moved since the latest update of numpy, updated the hook accordingly

resolves #4323