### PR TITLE
Add paging to get-slow-argument.py

### DIFF
--- a/scripts/get-slow-argument.py
+++ b/scripts/get-slow-argument.py
@@ -3,6 +3,7 @@
 # - input: pull_id from CI ( argv )
 # - output: argument to use for this test ( stdout )
 
+import os
 import sys
 import requests
 
@@ -13,9 +14,31 @@ run_slow = True
 # config vars
 required_approvals = 1
 
+_logging = os.environ.get('LOGGING', False)
+
 
 class ApprovalError(Exception):
     pass
+
+
+def _log(msg, *args):
+    if _logging:
+        sys.stderr.write(msg.format(*args) + '\n')
+
+
+def _get_json_data(link):
+    _log("_get_json_data: {}", link)
+    # Github API requires user agent.
+    req = requests.get(url, headers={'User-Agent': 'build-bot'})
+    json_data = req.json()
+
+    if "message" in json_data \
+            and json_data["message"].startswith("API rate"):
+
+        sys.stderr.write("Raw reply:{}".format(json_data))
+        raise ApprovalError
+
+    return req, json_data
 
 
 # When build is not a PR the input is: "" or "false"
@@ -25,23 +48,26 @@ if pull_request_id not in ["", "false"]:
     url = base_url.format(pull_request_id)
 
     try:
-        # Github API requires user agent.
-        req = requests.get(url, headers={'User-Agent': 'build-bot'})
+        req, json_data = _get_json_data(url)
 
-        json_data = req.json()
+        while 'next' in req.links:
+            _log("got link: {}", req.links)
+            url = req.links['next']['url']
+            req, new_json_data = _get_json_data(url)
+            json_data += new_json_data
 
-        if "message" in json_data \
-                and json_data["message"].startswith("API rate"):
-
-            sys.stderr.write("Raw reply:{}".format(json_data))
-            raise ApprovalError
+        # _log("Raw json_data: {}", json_data)
+        _log("len json_data: {}", len(json_data))
 
         check_states = ["APPROVED", "CHANGES_REQUESTED"]
         review_states = [a for a in json_data if a["state"] in check_states]
         unique_reviews = {x['user']['login']: x for x in review_states}.values()
+        _log("unique_reviews: {}", unique_reviews)
 
         result = [a for a in unique_reviews if a["state"] == "APPROVED"]
+        _log("result: {}", result)
         approvals = len(result)
+        _log("approvals: {}", approvals)
         run_slow = approvals >= required_approvals
     except(requests.HTTPError, requests.Timeout, ApprovalError) as e:
         sys.stderr.write("Error calling github, run all tests. {}".format(url))


### PR DESCRIPTION
When pull requests got too big buildbot stopped building them.

Changed it so it reads the next pages of the review comments too.