### PR TITLE
Finished rename of processed_ts to creation_date

### DIFF
--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -39,7 +39,6 @@ from golem.ethereum.node import NodeProcess
 from golem.ethereum.paymentprocessor import PaymentProcessor
 from golem.ethereum.incomeskeeper import IncomesKeeper
 from golem.ethereum.paymentskeeper import PaymentsKeeper
-from golem.model import TaskPayment
 from golem.rpc import utils as rpc_utils
 from golem.utils import privkeytoaddr
 
@@ -344,7 +343,7 @@ class TransactionSystem(LoopingCallService):
             task_id: str,
             subtask_id: str,
             value: int,
-            eth_address: str) -> TaskPayment:
+            eth_address: str) -> model.TaskPayment:
         if not self._payment_processor:
             raise Exception('Start was not called')
         return self._payment_processor.add(

--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -39,6 +39,7 @@ from golem.ethereum.node import NodeProcess
 from golem.ethereum.paymentprocessor import PaymentProcessor
 from golem.ethereum.incomeskeeper import IncomesKeeper
 from golem.ethereum.paymentskeeper import PaymentsKeeper
+from golem.model import TaskPayment
 from golem.rpc import utils as rpc_utils
 from golem.utils import privkeytoaddr
 
@@ -343,7 +344,7 @@ class TransactionSystem(LoopingCallService):
             task_id: str,
             subtask_id: str,
             value: int,
-            eth_address: str) -> int:
+            eth_address: str) -> TaskPayment:
         if not self._payment_processor:
             raise Exception('Start was not called')
         return self._payment_processor.add(

--- a/golem/task/server/verification.py
+++ b/golem/task/server/verification.py
@@ -86,7 +86,7 @@ class VerificationMixin:
                     timeout_seconds=config_desc.disallow_ip_timeout_seconds,
                 )
 
-            payment_processed_ts = self.accept_result(
+            payment = self.accept_result(
                 subtask_id,
                 report_computed_task.provider_id,
                 task_to_compute.provider_ethereum_address,
@@ -97,7 +97,7 @@ class VerificationMixin:
 
             response_msg = message.tasks.SubtaskResultsAccepted(
                 report_computed_task=report_computed_task,
-                payment_ts=payment_processed_ts,
+                payment_ts=int(payment.created_date.timestamp()),
             )
 
             signed_response_msg = msg_utils.copy_and_sign(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-#git+https://github.com/golemfactory/golem-messages@<branchname>#egg=golem-messages
+#Golem-Messages==3.8.0
 --extra-index-url https://builds.golem.network --trusted-host build.golem.network
 appdirs==1.4.3
 argh==0.26.2
@@ -36,7 +36,7 @@ eth-tester==0.1.0-beta.24
 eth-utils==1.0.3
 ethereum==1.6.1
 fs==2.4.4
-Golem-Messages==3.8.0
+git+https://github.com/golemfactory/golem-messages@mwu/finish-rename-pay#egg=golem-messages
 Golem-Smart-Contracts-Interface==1.10.0
 greenlet==0.4.15
 h2==3.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-#Golem-Messages==3.8.0
+#git+https://github.com/golemfactory/golem-messages@<branchname>#egg=golem-messages
 --extra-index-url https://builds.golem.network --trusted-host build.golem.network
 appdirs==1.4.3
 argh==0.26.2
@@ -36,7 +36,7 @@ eth-tester==0.1.0-beta.24
 eth-utils==1.0.3
 ethereum==1.6.1
 fs==2.4.4
-git+https://github.com/golemfactory/golem-messages@mwu/finish-rename-pay#egg=golem-messages
+Golem-Messages==3.9.0
 Golem-Smart-Contracts-Interface==1.10.0
 greenlet==0.4.15
 h2==3.0.1

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -1,4 +1,4 @@
-#Golem-Messages==3.8.0
+#git+https://github.com/golemfactory/golem-messages@<branchname>#egg=golem-messages
 --extra-index-url https://builds.golem.network
 appdirs>=1.4
 asn1crypto==0.22.0
@@ -16,7 +16,7 @@ docker==3.5.0
 enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
-git+https://github.com/golemfactory/golem-messages@mwu/finish-rename-pay#egg=golem-messages
+Golem-Messages==3.9.0
 Golem-Smart-Contracts-Interface==1.10.0
 html2text==2018.1.9
 humanize==0.5.1

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -1,4 +1,4 @@
-#git+https://github.com/golemfactory/golem-messages@<branchname>#egg=golem-messages
+#Golem-Messages==3.8.0
 --extra-index-url https://builds.golem.network
 appdirs>=1.4
 asn1crypto==0.22.0
@@ -16,7 +16,7 @@ docker==3.5.0
 enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
-Golem-Messages==3.8.0
+git+https://github.com/golemfactory/golem-messages@mwu/finish-rename-pay#egg=golem-messages
 Golem-Smart-Contracts-Interface==1.10.0
 html2text==2018.1.9
 humanize==0.5.1

--- a/tests/golem/task/dummy/runner.py
+++ b/tests/golem/task/dummy/runner.py
@@ -30,6 +30,7 @@ from golem.resource.dirmanager import DirManager
 from golem.task import rpc as task_rpc
 from golem.model import db, DB_FIELDS, DB_MODELS
 from golem.network.transport.tcpnetwork import SocketAddress
+from tests.factories import model as model_factory
 from tests.golem.task.dummy.task import DummyTask, DummyTaskParameters
 
 REQUESTING_NODE_KIND = "requestor"
@@ -116,7 +117,7 @@ def _make_mock_ets():
     ets.eth_base_for_batch_payment.return_value = 0.001 * denoms.ether
     ets.get_payment_address.return_value = '0x' + 40 * '6'
     ets.get_nodes_with_overdue_payments.return_value = []
-    ets.add_payment_info.return_value = int(time.time())
+    ets.add_payment_info.return_value = model_factory.TaskPayment()
     return ets
 
 


### PR DESCRIPTION
Resolves #4290

~blocked by https://github.com/golemfactory/golem-messages/pull/350~

- Finishes change if signature from `add_payment_info(..) -> int` to `add_payment_info(..) -> TaskPayment`
- Also updated golem-messages so it uses the same timezone for `task.header.timestamp` as `TaskPayment.created_date` and `message.tasks. SubtaskResultsAccepted.payment_ts`

~Ready to be merged after golem-messages has been released~ golem-messages v3.9.0 was born
