### PR TITLE
Move Ethereum RPC logic to its module

### DIFF
--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -39,7 +39,6 @@ from golem.ethereum.node import NodeProcess
 from golem.ethereum.paymentprocessor import PaymentProcessor
 from golem.ethereum.incomeskeeper import IncomesKeeper
 from golem.ethereum.paymentskeeper import PaymentsKeeper
-from golem.rpc import utils as rpc_utils
 from golem.utils import privkeytoaddr
 
 from . import exceptions
@@ -141,13 +140,6 @@ class TransactionSystem(LoopingCallService):
     def gas_price_limit(self) -> int:
         self._sci: SmartContractsInterface
         return self._sci.GAS_PRICE
-
-    @rpc_utils.expose('pay.gas_price')
-    def get_gas_price(self) -> Dict[str, str]:
-        return {
-            "current_gas_price": str(self.gas_price),
-            "gas_price_limit": str(self.gas_price_limit)
-        }
 
     @property
     def contract_addresses(self):
@@ -354,13 +346,11 @@ class TransactionSystem(LoopingCallService):
             value=value,
         )
 
-    @rpc_utils.expose('pay.ident')
     @sci_required()
-    def get_payment_address(self):
+    def get_payment_address(self) -> str:
         """ Human readable Ethereum address for incoming payments."""
         self._sci: SmartContractsInterface
-        address = self._sci.get_eth_address()
-        return str(address) if address else None
+        return self._sci.get_eth_address()
 
     def get_payments_list(
             self,
@@ -369,29 +359,14 @@ class TransactionSystem(LoopingCallService):
     ) -> List[Dict[str, Any]]:
         return self._payments_keeper.get_list_of_all_payments(num, interval)
 
-    @rpc_utils.expose('pay.deposit_payments')
     @classmethod
     def get_deposit_payments_list(cls, limit=1000, offset=0)\
-            -> List[Dict[str, Any]]:
+            -> List[model.DepositPayment]:
         query = model.DepositPayment.select() \
             .order_by('id') \
             .limit(limit) \
             .offset(offset)
-        result = []
-        for dpayment in query:
-            entry = {}
-            entry['value'] = common.to_unicode(dpayment.value)
-            entry['status'] = common.to_unicode(dpayment.status.name)
-            entry['fee'] = common.to_unicode(dpayment.fee)
-            entry['transaction'] = common.to_unicode(dpayment.tx)
-            entry['created'] = common.datetime_to_timestamp_utc(
-                dpayment.created_date,
-            )
-            entry['modified'] = common.datetime_to_timestamp_utc(
-                dpayment.modified_date,
-            )
-            result.append(entry)
-        return result
+        return list(query)
 
     def get_subtasks_payments(
             self,
@@ -744,15 +719,13 @@ class TransactionSystem(LoopingCallService):
         dpayment.save()
         return dpayment.tx
 
-    @rpc_utils.expose('pay.deposit.relock')
     @gnt_deposit_required()
     @sci_required()
-    def concent_relock(self):
+    def concent_relock(self) -> None:
         if self.concent_balance() == 0:
             return
         self._sci.lock_deposit()
 
-    @rpc_utils.expose('pay.deposit.unlock')
     @gnt_deposit_required()
     @sci_required()
     def concent_unlock(self):

--- a/golem/rpc/api/ethereum_.py
+++ b/golem/rpc/api/ethereum_.py
@@ -14,10 +14,12 @@ if typing.TYPE_CHECKING:
     # pylint: disable=unused-import
     from golem.ethereum.transactionsystem import TransactionSystem
 
+
 def lru_node_factory():
     # Our version of peewee (2.10.2) doesn't support
     # .join(attr='XXX'). So we'll have to join manually
     lru_node = functools.lru_cache()(nodeskeeper.get)
+
     def _inner(node_id):
         if node_id is None:
             return None
@@ -26,6 +28,7 @@ def lru_node_factory():
             node = dt_p2p.Node(key=node_id)
         return node.to_dict()
     return _inner
+
 
 class ETSProvider:
     """Provides ethereum related remote procedures that require ETS"""
@@ -67,3 +70,44 @@ class ETSProvider:
             }
 
         return [item(income) for income in incomes]
+
+    @rpc_utils.expose('pay.gas_price')
+    def get_gas_price(self) -> typing.Dict[str, str]:
+        return {
+            "current_gas_price": str(self.ets.gas_price),
+            "gas_price_limit": str(self.ets.gas_price_limit)
+        }
+
+    @rpc_utils.expose('pay.ident')
+    def get_payment_address(self) -> str:
+        return self.ets.get_payment_address()
+
+    @rpc_utils.expose('pay.deposit_payments')
+    def get_deposit_payments_list(
+            self,
+            limit=1000,
+            offset=0,
+    ) -> typing.List[typing.Dict[str, typing.Any]]:
+        result = []
+        for dpayment in self.ets.get_deposit_payments_list():
+            entry = {}
+            entry['value'] = common.to_unicode(dpayment.value)
+            entry['status'] = common.to_unicode(dpayment.status.name)
+            entry['fee'] = common.to_unicode(dpayment.fee)
+            entry['transaction'] = common.to_unicode(dpayment.tx)
+            entry['created'] = common.datetime_to_timestamp_utc(
+                dpayment.created_date,
+            )
+            entry['modified'] = common.datetime_to_timestamp_utc(
+                dpayment.modified_date,
+            )
+            result.append(entry)
+        return result
+
+    @rpc_utils.expose('pay.deposit.relock')
+    def concent_relock(self) -> None:
+        self.ets.concent_relock()
+
+    @rpc_utils.expose('pay.deposit.unlock')
+    def concent_unlock(self) -> None:
+        self.ets.concent_unlock()

--- a/tests/golem/ethereum/test_transactionsystem.py
+++ b/tests/golem/ethereum/test_transactionsystem.py
@@ -148,17 +148,6 @@ class TestTransactionSystem(TransactionSystemBase):
 
         self.assertEqual(self.ets.gas_price, test_gas_price)
 
-    def test_get_gas_price(self, *_):
-        test_gas_price = 1234
-        test_price_limit = 12345
-        self.sci.get_current_gas_price.return_value = test_gas_price
-        self.sci.GAS_PRICE = test_price_limit
-
-        result = self.ets.get_gas_price()
-
-        self.assertEqual(result["current_gas_price"], str(test_gas_price))
-        self.assertEqual(result["gas_price_limit"], str(test_price_limit))
-
     def test_get_gas_price_limit(self):
         ets = self._make_ets()
 
@@ -750,24 +739,14 @@ class DepositPaymentsListTest(TransactionSystemBase):
             ts,
             tz=datetime.timezone.utc,
         )
-        model.DepositPayment.create(
+        deposit_payment = model.DepositPayment.create(
             value=value,
             tx=tx_hash,
             created_date=dt,
             modified_date=dt,
         )
-        expected = [
-            {
-                'created': ts,
-                'modified': ts,
-                'fee': None,
-                'status': 'awaiting',
-                'transaction': tx_hash,
-                'value': str(value),
-            },
-        ]
         self.assertEqual(
-            expected,
+            [deposit_payment],
             self.ets.get_deposit_payments_list(),
         )
 

--- a/tests/golem/rpc/api/test_ethereum.py
+++ b/tests/golem/rpc/api/test_ethereum.py
@@ -1,0 +1,56 @@
+import datetime
+from unittest import TestCase, mock
+
+from golem import model
+from golem.ethereum.transactionsystem import TransactionSystem
+from golem.rpc.api.ethereum_ import ETSProvider
+
+
+class TestEthereum(TestCase):
+    def setUp(self):
+        self.ets = mock.Mock(spec_set=TransactionSystem)
+        self.ets_provider = ETSProvider(self.ets)
+
+    def test_get_gas_price(self):
+        test_gas_price = 1234
+        test_price_limit = 12345
+        self.ets.gas_price = test_gas_price
+        self.ets.gas_price_limit = test_price_limit
+
+        result = self.ets_provider.get_gas_price()
+
+        self.assertEqual(result["current_gas_price"], str(test_gas_price))
+        self.assertEqual(result["gas_price_limit"], str(test_price_limit))
+
+    def test_one(self):
+        tx_hash = \
+            '0x5e9880b3e9349b609917014690c7a0afcdec6dbbfbef3812b27b60d246ca10ae'
+        value = 31337
+        ts = 1514761200.0
+        dt = datetime.datetime.fromtimestamp(
+            ts,
+            tz=datetime.timezone.utc,
+        )
+        deposit_payment = mock.Mock(spec_set=model.DepositPayment)
+        deposit_payment.value = value
+        deposit_payment.tx = tx_hash
+        deposit_payment.created_date = dt
+        deposit_payment.modified_date = dt
+        deposit_payment.fee = None
+        deposit_payment.status = model.PaymentStatus.awaiting
+        self.ets.get_deposit_payments_list.return_value = [deposit_payment]
+
+        expected = [
+            {
+                'created': ts,
+                'modified': ts,
+                'fee': None,
+                'status': 'awaiting',
+                'transaction': tx_hash,
+                'value': str(value),
+            },
+        ]
+        self.assertEqual(
+            expected,
+            self.ets_provider.get_deposit_payments_list(),
+        )


### PR DESCRIPTION
So that RPC related formatting and dependencies are outside main ethereum module.