### PR TITLE
Disable Task.initialize execution timeout

### DIFF
--- a/golem/core/deferred.py
+++ b/golem/core/deferred.py
@@ -39,10 +39,9 @@ def chain_function(deferred, fn, *args, **kwargs):
     return result
 
 
-def sync_wait(
-    deferred: defer.Deferred,
-    timeout: Optional[Union[int, float]] = 10.
-) -> Any:
+def sync_wait(deferred: defer.Deferred,
+              timeout: Optional[Union[int, float]] = 10.) -> Any:
+
     if not isinstance(deferred, defer.Deferred):
         return deferred
 

--- a/golem/core/deferred.py
+++ b/golem/core/deferred.py
@@ -1,5 +1,5 @@
 from queue import Queue, Empty
-from typing import Any, Callable, Dict, Tuple, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 from twisted.internet import defer
 from twisted.internet.task import deferLater
@@ -39,7 +39,10 @@ def chain_function(deferred, fn, *args, **kwargs):
     return result
 
 
-def sync_wait(deferred: defer.Deferred, timeout: Optional[int] = 10) -> Any:
+def sync_wait(
+    deferred: defer.Deferred,
+    timeout: Optional[Union[int, float]] = 10.
+) -> Any:
     if not isinstance(deferred, defer.Deferred):
         return deferred
 

--- a/golem/core/deferred.py
+++ b/golem/core/deferred.py
@@ -1,5 +1,5 @@
 from queue import Queue, Empty
-from typing import Any, Callable, Dict, Tuple, List
+from typing import Any, Callable, Dict, Tuple, List, Optional
 
 from twisted.internet import defer
 from twisted.internet.task import deferLater
@@ -16,7 +16,7 @@ class DeferredSeq:
         return self
 
     def execute(self) -> defer.Deferred:
-        return deferToThread(lambda: sync_wait(self._execute()))
+        return deferToThread(lambda: sync_wait(self._execute(), timeout=None))
 
     @defer.inlineCallbacks
     def _execute(self) -> Any:
@@ -39,7 +39,7 @@ def chain_function(deferred, fn, *args, **kwargs):
     return result
 
 
-def sync_wait(deferred, timeout=10):
+def sync_wait(deferred: defer.Deferred, timeout: Optional[int] = 10) -> Any:
     if not isinstance(deferred, defer.Deferred):
         return deferred
 


### PR DESCRIPTION
Set timeout to `None` in `DeferredSeq.execute -> sync_wait` instead on relying on the default value (10 seconds)