### PR TITLE
Models for new environment performance

### DIFF
--- a/golem/database/database.py
+++ b/golem/database/database.py
@@ -55,7 +55,7 @@ class GolemSqliteDatabase(peewee.SqliteDatabase):
 
 
 class Database:
-    SCHEMA_VERSION = 32
+    SCHEMA_VERSION = 33
 
     def __init__(self,  # noqa pylint: disable=too-many-arguments
                  db: peewee.Database,

--- a/golem/database/schemas/033_new_performance.py
+++ b/golem/database/schemas/033_new_performance.py
@@ -1,0 +1,27 @@
+# pylint: disable=no-member
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+import datetime as dt
+import peewee as pw
+
+SCHEMA_VERSION = 33
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_fields('knownhosts', performance=pw.JsonField(default='{}'))
+
+    @migrator.create_model
+    class EnvironmentPerformance(pw.Model):
+        environment = pw.CharField(max_length=255, primary_key=True)
+        created_date = pw.UTCDateTimeField(default=dt.datetime.now)
+        modified_date = pw.UTCDateTimeField(default=dt.datetime.now)
+        performance = pw.FloatField()
+
+        class Meta:
+            db_table = "environmentperformance"
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.remove_fields('knownhosts', 'performance')
+    migrator.remove_model('environmentperformance')

--- a/golem/model.py
+++ b/golem/model.py
@@ -432,6 +432,7 @@ class KnownHosts(BaseModel):
     last_connected = DateTimeField(default=datetime.datetime.now)
     is_seed = BooleanField(default=False)
     metadata = JsonField(default='{}')
+    performance = JsonField(default='{}')  # [env id -> performance] mapping
 
     class Meta:
         database = db
@@ -517,6 +518,12 @@ class Performance(BaseModel):
         except Performance.DoesNotExist:
             perf = Performance(environment_id=env_id, value=performance)
             perf.save()
+
+
+class EnvironmentPerformance(BaseModel):
+    """ Essentially the same as `Performance` but for new environments """
+    environment = CharField(primary_key=True)
+    performance = FloatField(null=False)
 
 
 class DockerWhitelist(BaseModel):


### PR DESCRIPTION
As we will be introducing new environments we need to adjust the database schema to store performance scores for them. `Performance` model cannot be re-used because a clean separation between old and new environments is needed during transition period. For the same reason performance field was introduced to the `KnownHosts` model.