### PR TITLE
node_integration_tests - Made 'cubes' the default scene

### DIFF
--- a/scripts/node_integration_tests/playbooks/golem/jpg/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/jpg/test_config.py
@@ -1,6 +1,17 @@
+from scripts.node_integration_tests import helpers
+
+
 from ...test_config_base import TestConfigBase
 
 
 class TestConfig(TestConfigBase):
     def __init__(self):
         super().__init__(task_settings='jpg')
+
+    def update_task_dict(self):
+        self.task_package = 'test_task_1'
+        super().update_task_dict()
+        self.task_dict['main_scene_file'] = helpers.scene_file_path(
+            task_package_name='test_task_1',
+            file_path='wlochaty3.blend',
+        )

--- a/scripts/node_integration_tests/playbooks/test_config_base.py
+++ b/scripts/node_integration_tests/playbooks/test_config_base.py
@@ -97,7 +97,7 @@ class TestConfigBase:
             self.nodes[node_id] = make_node_config_from_env(node_id.value, i)
         self._nodes_index = 0
         self.nodes_root: 'Optional[Path]' = None
-        self.task_package = 'test_task_1'
+        self.task_package = 'cubes'
         self.task_settings = task_settings
         self.update_task_dict()
 


### PR DESCRIPTION
... this saves 200mb per test

The node_integration_tests are now generating a ~1GB zip file extracting to ~4GB

While investigating i found the default scene used is 43MB and its stored 3 to ~8 times per test

This PR changes:
- the default scene to `cubes` 
- the `test_jpg()` use the old default 43MB scene

results on `test_regular_task_run`
```
before:
223M	./node_integration_test

---

after:
12M	./node_integration_test
```