### PR TITLE
Also initialize task resources on restarts

### DIFF
--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -262,9 +262,9 @@ class TestRestartTask(ProviderBase):
 
         task = self.client.task_manager.create_task(task_dict)
         golem_deferred.sync_wait(rpc.enqueue_new_task(self.client, task))
-        with mock.patch('golem.task.rpc.enqueue_new_task') as enq_mock:
+        with mock.patch('golem.task.rpc._prepare_task') as prep_mock:
             new_task_id, error = self.provider.restart_task(task.header.task_id)
-            enq_mock.assert_called_once()
+            prep_mock.assert_called_once()
 
         mock_validate_funds.assert_called_once_with(
             task.subtask_price,
@@ -463,7 +463,8 @@ class TestRuntTestTask(ProviderBase):
             _self.success_callback(result, estimated_memory, time_spent, **more)
 
         with mock.patch('golem.task.tasktester.TaskTester.run', _run):
-            golem_deferred.sync_wait(rpc._run_test_task(self.client, {}))
+            golem_deferred.sync_wait(rpc._run_test_task(self.client,
+                                                        {'name': 'test task'}))
 
         self.assertIsInstance(self.client.task_test_result, dict)
         self.assertEqual(self.client.task_test_result, {
@@ -484,7 +485,8 @@ class TestRuntTestTask(ProviderBase):
             _self.error_callback(*error, **more)
 
         with mock.patch('golem.client.TaskTester.run', _run):
-            golem_deferred.sync_wait(rpc._run_test_task(self.client, {}))
+            golem_deferred.sync_wait(rpc._run_test_task(self.client,
+                                                        {'name': 'test task'}))
 
         self.assertIsInstance(self.client.task_test_result, dict)
         self.assertEqual(self.client.task_test_result, {
@@ -505,6 +507,7 @@ class TestRuntTestTask(ProviderBase):
                     'type': 'blender',
                     'resources': ['_.blend'],
                     'subtasks_count': 1,
+                    'name': 'test task',
                 }))
 
 
@@ -1013,6 +1016,7 @@ class TestGetEstimatedSubtasksCost(ProviderBase):
                 },
             },
         )
+
 
 @mock.patch('golem.task.taskmanager.TaskManager.get_subtask_dict',
             return_value=Mock())


### PR DESCRIPTION
`node_integration_tests:test_golem::test_restart_frame` [failed this morning on develop](https://buildbot.golem.network/buildbot/#/builders/15/builds/756)

I think this was caused by #4324 

```
2019-06-19 04:17:00 CRITICAL twisted                             
Traceback (most recent call last):
  File "/home/buildbot-worker/worker/test_node_integration/build/.venv/lib/python3.6/site-packages/twisted/internet/defer.py", line 1386, in _inlineCallbacks
    result = g.send(result)
StopIteration: <Task: <TaskHeader: {'mask': b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00', 'timestamp': 1560917820, 'signature': b'\xa1f\xae\xee\x86\x8al\x97\x0c\x1d4\xea\x1c\x83\x03\xa5\xcf\x1b\xa8 \x00\xdb\xe2f\xd7\xa8S\x1c\xf9\xcb\xdeG9\x0c\xbd7\xc73a\x9e=v\x99M\x19\xf8\xd0@!\xea\xc9\xdb\x91\xeb\xff#\x9c\xab(\xb1-\x1d`\xd3\x01', 'task_id': '15618962-9249-11e9-bcfe-7f92a8bfc33d', 'task_owner': {'node_name': '', 'key': '7f92a8bfc33d82358f857c68980c60bf93123b6195f16267e0ff3ad2ebde613b5ac5b8a2d42efe6c1cd020c0b227a23eb81ac35d62002f210c595fc26d5826eb', 'prv_port': 40105, 'pub_port': 40105, 'p2p_prv_port': 40104, 'p2p_pub_port': 40104, 'prv_addr': '172.31.33.0', 'pub_addr': '18.185.112.88', 'prv_addresses': ['172.31.33.0', '172.17.0.1'], 'hyperdrive_prv_port': 3282, 'hyperdrive_pub_port': 3282, 'port_statuses': {40104: 'timeout', 40105: 'timeout', 3282: 'timeout'}, 'nat_type': []}, 'deadline': 1560918420, 'subtask_timeout': 590, 'environment': 'BLENDER', 'environment_prerequisites': None, 'min_version': '0.19.0', 'estimated_memory': 0, 'max_price': 1000000000000000000, 'subtasks_count': 1, 'concent_enabled': False}>>

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/buildbot-worker/worker/test_node_integration/build/.venv/lib/python3.6/site-packages/twisted/python/threadpool.py", line 250, in inContext
    result = inContext.theWork()
  File "/home/buildbot-worker/worker/test_node_integration/build/.venv/lib/python3.6/site-packages/twisted/python/threadpool.py", line 266, in <lambda>
    inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
  File "/home/buildbot-worker/worker/test_node_integration/build/.venv/lib/python3.6/site-packages/twisted/python/context.py", line 122, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/home/buildbot-worker/worker/test_node_integration/build/.venv/lib/python3.6/site-packages/twisted/python/context.py", line 85, in callWithContext
    return func(*args,**kw)
  File "/home/buildbot-worker/worker/test_node_integration/build/golem/task/rpc.py", line 193, in _restart_subtasks
    golem_deferred.sync_wait(deferred())
  File "/home/buildbot-worker/worker/test_node_integration/build/golem/core/deferred.py", line 57, in sync_wait
    result.raiseException()
  File "/home/buildbot-worker/worker/test_node_integration/build/.venv/lib/python3.6/site-packages/twisted/python/failure.py", line 385, in raiseException
    raise self.value.with_traceback(self.tb)
  File "/home/buildbot-worker/worker/test_node_integration/build/.venv/lib/python3.6/site-packages/twisted/internet/defer.py", line 1386, in _inlineCallbacks
    result = g.send(result)
  File "/home/buildbot-worker/worker/test_node_integration/build/golem/task/rpc.py", line 187, in deferred
    subtask_ids_to_copy=subtask_ids_to_copy
  File "/home/buildbot-worker/worker/test_node_integration/build/golem/task/taskmanager.py", line 610, in copy_results
    extra_data = new_task.query_extra_data(0, node_id=str(uuid.uuid4()))
  File "/home/buildbot-worker/worker/test_node_integration/build/apps/blender/task/blenderrendertask.py", line 440, in query_extra_data
    self._update_task_preview()
  File "/home/buildbot-worker/worker/test_node_integration/build/apps/rendering/task/renderingtask.py", line 149, in _update_task_preview
    preview_name))
  File "/usr/lib/python3.6/posixpath.py", line 80, in join
    a = os.fspath(a)
```

Local test passed on this branch
- [x] check if they are deferred enough