### PR TITLE
Transcoding intermediate container independent of file extension

### DIFF
--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
@@ -36,6 +36,13 @@ def do_extract(input_file,
         selected_streams,
         container)
 
+    results = {
+        "metadata": video_metadata,
+    }
+    results_file = os.path.join(OUTPUT_DIR, "extract-results.json")
+    with open(results_file, 'w') as f:
+        json.dump(results, f)
+
 
 def do_split(path_to_stream, parts):
     video_metadata = commands.get_metadata_json(path_to_stream)
@@ -62,6 +69,8 @@ def do_split(path_to_stream, parts):
     with open(results_file, 'w') as f:
         json.dump(results, f)
 
+    return segment_list_path
+
 
 def do_extract_and_split(input_file, parts, container=None):
     input_basename = os.path.basename(input_file)
@@ -74,7 +83,20 @@ def do_extract_and_split(input_file, parts, container=None):
     video_metadata = commands.get_metadata_json(input_file)
 
     do_extract(input_file, intermediate_file, ['v'], container, video_metadata)
-    do_split(intermediate_file, parts)
+    segment_list_path = do_split(intermediate_file, parts)
+
+    with open(segment_list_path) as segment_list_file:
+        segment_filenames = segment_list_file.read().splitlines()
+
+    results = {
+        "main_list": segment_list_path,
+        "segments": [{"video_segment": s} for s in segment_filenames],
+        "metadata": video_metadata,
+    }
+
+    results_file = os.path.join(OUTPUT_DIR, "extract-and-split-results.json")
+    with open(results_file, 'w') as f:
+        json.dump(results, f)
 
 
 def do_transcode(track, targs, output):

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -31,7 +31,7 @@ logger = logging.getLogger(__name__)
 
 
 class Commands(enum.Enum):
-    EXTRACT_AND_SPLIT = ('extract-and-split', 'split-results.json')
+    EXTRACT_AND_SPLIT = ('extract-and-split', 'extract-and-split-results.json')
     TRANSCODE = ('transcode', '')
     MERGE_AND_REPLACE = ('merge-and-replace', '')
     COMPUTE_METRICS = ('compute-metrics', '')

--- a/tests/apps/ffmpeg/task/utils/test_fmmpegtranscoding.py
+++ b/tests/apps/ffmpeg/task/utils/test_fmmpegtranscoding.py
@@ -64,7 +64,7 @@ class TestffmpegTranscoding(TempDirFixture):
         self.assertEqual(len(chunks), parts)
         self.assertEqual(
             set(os.path.splitext(chunk)[1] for chunk in chunks),
-            {'.mp4'})
+            {''})
         segments = [os.path.join(output_dir, chunk) for chunk in chunks]
 
         assert len(segments) == parts

--- a/tests/apps/ffmpeg/task/utils/test_fmmpegtranscoding.py
+++ b/tests/apps/ffmpeg/task/utils/test_fmmpegtranscoding.py
@@ -54,7 +54,8 @@ class TestffmpegTranscoding(TempDirFixture):
     def test_extract_split_merge_and_replace_video(self):
         parts = 2
         task_id = str(uuid.uuid4())
-        output_name = 'test.mp4'
+        output_extension = ".mp4"
+        output_name = f"test{output_extension}"
         output_container = Container.c_MP4
         output_dir = self.dir_manager.get_task_output_dir(task_id)
 
@@ -70,9 +71,10 @@ class TestffmpegTranscoding(TempDirFixture):
         assert len(segments) == parts
         tc_segments = list()
         for segment in segments:
-            name, ext = os.path.splitext(os.path.basename(segment))
-            transcoded_segment = os.path.join(os.path.dirname(segment),
-                                              "{}_TC{}".format(name, ext))
+            name, _ = os.path.splitext(os.path.basename(segment))
+            transcoded_segment = os.path.join(
+                os.path.dirname(segment),
+                "{}_TC{}".format(name, output_extension))
             shutil.copy2(segment, transcoded_segment)
             assert os.path.isfile(transcoded_segment)
             tc_segments.append(transcoded_segment)


### PR DESCRIPTION
This pull request makes the split and extract commands detect the demuxer used by ffmpeg for the input file and use that information to explicitly select the output container format. The container type no longer depends on input file extension and files with missing or wrong extensions are now handled properly.

### Details
1) The split command used to create `split-results.json` that's supposed to contain the input file metadata. When using extract+split though, split's input is the video-only file produced by the extract command and not the original input file. Its metadata is incomplete (it has no audio, data or subtitles) and should not be used for validation. To fix this problem each command now produces its own file. The transcoding task now reads metadata from `extract-and-split-results.json` because that's the file produced by the command it explicitly calls.

### Dependencies
This pull request is based on #4315 and should be merged after it.

For the code to work you also need a `golemfactory/ffmpeg-experimental` image built with https://github.com/golemfactory/ffmpeg-tools/pull/7. Tests in the CI won't pass until it's released on DockerHub.

**NOTE**: I have set the base branch of this pull request to `transcoding-muxers-and-demuxers` (#4315) rather than `CGI/transcoding/master`. Please remember to change the base branch back to `CGI/transcoding/master` before you merge.