### PR TITLE
Fixed failed subtask count when restarting a finished task

### DIFF
--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -190,6 +190,9 @@ class RenderingTask(CoreTask):
         exec_cmd(cmd)
 
     def _get_next_task(self):
+        logger.debug(f"_get_next_task. last_task={self.last_task}, "
+                     f"total_tasks={self.total_tasks}, "
+                     f"num_failed_subtasks={self.num_failed_subtasks}")
         if self.last_task != self.total_tasks:
             self.last_task += 1
             start_task = self.last_task

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -593,7 +593,9 @@ class TaskManager(TaskEventListener):
                 .status = SubtaskStatus.failure
             new_task.subtasks_given[new_subtask_id]['status'] \
                 = SubtaskStatus.failure
-            new_task.num_failed_subtasks += 1
+
+        new_task.num_failed_subtasks = \
+            new_task.total_tasks - len(subtasks_to_copy)
 
         def handle_copy_error(subtask_id, error):
             logger.error(

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -1206,6 +1206,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
             new_task.last_task += 1
             return Task.ExtraData(ctd=ctd)
 
+        new_task.total_tasks = len(ctds)
         new_task.needs_computation = lambda: new_task.last_task < len(ctds)
         new_task.query_extra_data = query_extra_data
 
@@ -1266,6 +1267,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
             }
         }
         new_task.needs_computation.return_value = False
+        new_task.total_tasks = len(new_task.subtasks_given)
 
         with patch.object(self.tm, 'restart_subtask') as restart, \
                 patch.object(self.tm, '_copy_subtask_results') as copy:
@@ -1309,6 +1311,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
             }
         }
         new_task.needs_computation.return_value = False
+        new_task.total_tasks = len(new_task.subtasks_given)
 
         with patch.object(self.tm, 'restart_subtask') as restart, \
                 patch.object(self.tm, '_copy_subtask_results') as copy, \


### PR DESCRIPTION
Fixes: #3960

When copying the results of a restarted task, the number of failed subtasks
on the new task was being incorrectly set to the total subtasks count.
This resulted in the requestor attempting to assign more new subtasks
than necessary.