### PR TITLE
fix resource handshake

### DIFF
--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -294,6 +294,7 @@ class TaskServer(
                     task_id=theader.task_id,
                 )
                 return None
+            handshake.task_id = theader.task_id
             if not handshake.success():
                 logger.debug(
                     "Handshake still in progress. key_id=%r, task_id=%r",

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -976,7 +976,6 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
         if not (self.verified and self.key_id):
             self.dropped()
             return
-        self._remove_handshake(self.key_id)
         super().disconnect(reason)
 
     def send(self, msg, send_unverified=False):


### PR DESCRIPTION
Instead of removing handshake on disconnecting, update the handshake
data before sending WTCT. This way, if requestor starts handshake,
provider will have current task_id and computation will continue.

resolves #4399