### PR TITLE
Use last confirmed block instead of genesis with new eth account

### DIFF
--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -278,7 +278,8 @@ class TransactionSystem(LoopingCallService):
         self._sci: SmartContractsInterface
         values = model.GenericKeyValue.select().where(
             model.GenericKeyValue.key == self.BLOCK_NUMBER_DB_KEY)
-        from_block = int(values.get().value) if values.count() == 1 else 0
+        from_block = int(values.get().value) if values.count() == 1 else \
+            self._sci.get_latest_confirmed_block_number()
 
         ik = self._incomes_keeper
         self._sci.subscribe_to_batch_transfers(

--- a/tests/golem/ethereum/test_transactionsystem.py
+++ b/tests/golem/ethereum/test_transactionsystem.py
@@ -278,7 +278,7 @@ class TestTransactionSystem(TransactionSystemBase):
         self.sci.subscribe_to_batch_transfers.assert_called_once_with(
             None,
             self.sci.get_eth_address(),
-            0,
+            self.sci.get_latest_confirmed_block_number(),
             ANY,
         )
 


### PR DESCRIPTION
This morning the integration tests failed with timeouts on the `eth_getLogs` call

https://buildbot.golem.network/buildbot/#/builders/15/builds/788

This PR makes the timeout less likely by using the last confirmed block to scan for new transactions instead of the genesis block