### PR TITLE
Patch GLambda app failing to report nonserializable task result

### DIFF
--- a/apps/glambda/glambdaenvironment.py
+++ b/apps/glambda/glambdaenvironment.py
@@ -8,7 +8,7 @@ from golem.environments.environment import SupportStatus, UnsupportReason
 
 class GLambdaTaskEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/glambda"
-    DOCKER_TAG = "1.4"
+    DOCKER_TAG = "1.5"
     ENV_ID = "glambda"
     SHORT_DESCRIPTION = "GLambda PoC"
 

--- a/apps/glambda/resources/scripts/job.py
+++ b/apps/glambda/resources/scripts/job.py
@@ -28,6 +28,7 @@ def run_job():
         result_obj['data'] = result
         write_result(json.dumps(result_obj))
     except Exception as e:  # pylint: disable=broad-except
+        result_obj = {}
         result_obj['error'] = '{}:{}'.format(e.__class__, str(e))
         write_result(json.dumps(result_obj))
 

--- a/apps/images.ini
+++ b/apps/images.ini
@@ -5,4 +5,4 @@ golemfactory/blender_verifier blender/resources/images/blender_verifier.Dockerfi
 golemfactory/blender_nvgpu blender/resources/images/blender_nvgpu.Dockerfile 1.4 . apps.core.nvgpu.is_supported
 golemfactory/dummy dummy/resources/images/Dockerfile 1.2 dummy/resources/images
 golemfactory/wasm wasm/resources/images/Dockerfile 0.3.0 wasm/resources/images
-golemfactory/glambda glambda/resources/images/Dockerfile 1.4 .
+golemfactory/glambda glambda/resources/images/Dockerfile 1.5 .


### PR DESCRIPTION
Fixes a broken test against release candidate `golem-0.20.0+dev1.g6fef143` in [golemrpc library]( https://github.com/golemfactory/golemrpc/blob/master/tests/test_invalid_task.py#L159).

The app did notcorrectly handle nonserializable result produced by requestors code. On serialization exception it was trying to serialiize the same data that previously failed. 

Since we do not have automated integration tests for GLambda app just yet, I have run test suite for `golemrpc` manually. The image I have uploaded has proven to pass most crucial test cases. There are some minor red tests, but I consider them not crucial for app well being. 