### PR TITLE
catch exception for `taskcomputer.get_progress` for non-blender tasks

### DIFF
--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -221,7 +221,7 @@ class TaskComputer(object):
             )[0].get(
                 'outfilebasename'
             )
-        except (IndexError, KeyError):
+        except (IndexError, KeyError, TypeError):
             outfilebasename = ''
 
         tcss = ComputingSubtaskStateSnapshot(


### PR DESCRIPTION
ugh... another example where this: https://github.com/golemfactory/golem/issues/4318 is an issue :/