### PR TITLE
Remove redundant provider client checks

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -471,8 +471,7 @@ class CoreTask(Task):
 
     def should_accept_client(self,
                              node_id: str,
-                             offer_hash: Optional[bytes] = None) \
-            -> AcceptClientVerdict:
+                             offer_hash: str) -> AcceptClientVerdict:
         client = TaskClient.get_or_initialize(node_id, self.counting_nodes)
         if client.rejected():
             return AcceptClientVerdict.REJECTED
@@ -483,9 +482,8 @@ class CoreTask(Task):
 
     def accept_client(self,
                       node_id: str,
-                      offer_hash: Optional[bytes] = None,
-                      num_subtasks: int = 1) \
-            -> AcceptClientVerdict:
+                      offer_hash: str,
+                      num_subtasks: int = 1) -> AcceptClientVerdict:
         verdict = self.should_accept_client(node_id, offer_hash)
 
         if verdict == AcceptClientVerdict.ACCEPTED:
@@ -501,7 +499,7 @@ class CoreTask(Task):
         new_subtask['ctd']['performance'] = \
             old_subtask_info['ctd']['performance']
 
-        self.accept_client(new_subtask['node_id'])
+        self.accept_client(new_subtask['node_id'], '')
         self.result_incoming(subtask_id)
         self.interpret_task_results(
             subtask_id=subtask_id,

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -471,26 +471,26 @@ class CoreTask(Task):
 
     def should_accept_client(self,
                              node_id: str,
-                             wtct_hash: Optional[bytes] = None) \
+                             offer_hash: Optional[bytes] = None) \
             -> AcceptClientVerdict:
         client = TaskClient.get_or_initialize(node_id, self.counting_nodes)
         if client.rejected():
             return AcceptClientVerdict.REJECTED
-        elif client.should_wait(wtct_hash):
+        elif client.should_wait(offer_hash):
             return AcceptClientVerdict.SHOULD_WAIT
 
         return AcceptClientVerdict.ACCEPTED
 
     def accept_client(self,
                       node_id: str,
-                      wtct_hash: Optional[bytes] = None,
+                      offer_hash: Optional[bytes] = None,
                       num_subtasks: int = 1) \
             -> AcceptClientVerdict:
-        verdict = self.should_accept_client(node_id, wtct_hash)
+        verdict = self.should_accept_client(node_id, offer_hash)
 
         if verdict == AcceptClientVerdict.ACCEPTED:
             client = TaskClient.get_or_initialize(node_id, self.counting_nodes)
-            client.start(wtct_hash, num_subtasks)
+            client.start(offer_hash, num_subtasks)
 
         return verdict
 

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -338,16 +338,14 @@ class Task(abc.ABC):
     @abc.abstractmethod
     def should_accept_client(self,
                              node_id: str,
-                             offer_hash: Optional[bytes] = None) \
-            -> AcceptClientVerdict:
+                             offer_hash: str) -> AcceptClientVerdict:
         pass
 
     @abc.abstractmethod
     def accept_client(self,
                       node_id: str,
-                      offer_hash: Optional[bytes] = None,
-                      num_subtasks: int = 1) \
-            -> AcceptClientVerdict:
+                      offer_hash: str,
+                      num_subtasks: int = 1) -> AcceptClientVerdict:
         pass
 
     # pylint: disable=unused-argument, no-self-use

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -338,14 +338,14 @@ class Task(abc.ABC):
     @abc.abstractmethod
     def should_accept_client(self,
                              node_id: str,
-                             wtct_hash: Optional[bytes] = None) \
+                             offer_hash: Optional[bytes] = None) \
             -> AcceptClientVerdict:
         pass
 
     @abc.abstractmethod
     def accept_client(self,
                       node_id: str,
-                      wtct_hash: Optional[bytes] = None,
+                      offer_hash: Optional[bytes] = None,
                       num_subtasks: int = 1) \
             -> AcceptClientVerdict:
         pass

--- a/golem/task/taskclient.py
+++ b/golem/task/taskclient.py
@@ -19,7 +19,7 @@ class TaskClient(object):
         self._started: int = 0
         self._accepted: int = 0
         self._rejected: int = 0
-        self._wtct_hash: Optional[bytes] = None
+        self._offer_hash: Optional[bytes] = None
         self._wtct_num_subtasks: int = 0
 
     def __setstate__(self, state):
@@ -45,15 +45,15 @@ class TaskClient(object):
     def _reset(self):
         self._started = 0
         self._accepted = 0
-        self._wtct_hash = None
+        self._offer_hash = None
         self._wtct_num_subtasks = 0
 
-    def start(self, wtct_hash: Optional[bytes], num_subtasks: int) -> bool:
-        if self.should_wait(wtct_hash) or self.rejected():
+    def start(self, offer_hash: Optional[bytes], num_subtasks: int) -> bool:
+        if self.should_wait(offer_hash) or self.rejected():
             return False
 
         with self._lock:
-            self._wtct_hash = wtct_hash
+            self._offer_hash = offer_hash
             self._wtct_num_subtasks = num_subtasks
             self._started += 1
 
@@ -82,17 +82,17 @@ class TaskClient(object):
 
             return False
 
-    def should_wait(self, wtct_hash: Optional[bytes] = None):
+    def should_wait(self, offer_hash: Optional[bytes] = None):
         with self._lock:
-            if self._wtct_hash is not None:
-                if self._wtct_hash != wtct_hash:
-                    logger.debug('already processing another WTCT (%s vs %s)',
-                                 self._wtct_hash, wtct_hash)
+            if self._offer_hash is not None:
+                if self._offer_hash != offer_hash:
+                    logger.debug('already processing another offer (%s vs %s)',
+                                 self._offer_hash, offer_hash)
                     return True
 
                 if self._started == self._wtct_num_subtasks:
                     logger.info('all subtasks for %s have been started',
-                                self._wtct_hash)
+                                self._offer_hash)
                     return True
 
             return False

--- a/golem/task/taskclient.py
+++ b/golem/task/taskclient.py
@@ -19,7 +19,7 @@ class TaskClient(object):
         self._started: int = 0
         self._accepted: int = 0
         self._rejected: int = 0
-        self._offer_hash: Optional[bytes] = None
+        self._offer_hash: Optional[str] = None
         self._wtct_num_subtasks: int = 0
 
     def __setstate__(self, state):
@@ -48,7 +48,7 @@ class TaskClient(object):
         self._offer_hash = None
         self._wtct_num_subtasks = 0
 
-    def start(self, offer_hash: Optional[bytes], num_subtasks: int) -> bool:
+    def start(self, offer_hash: str, num_subtasks: int) -> bool:
         if self.should_wait(offer_hash) or self.rejected():
             return False
 
@@ -77,12 +77,12 @@ class TaskClient(object):
     def rejected(self):
         with self._lock:
             if self._rejected:
-                logger.info('%s has rejected subtask', self._offer_hash)
+                logger.info('`%s` has rejected subtask', self._offer_hash)
                 return True
 
             return False
 
-    def should_wait(self, offer_hash: Optional[bytes] = None):
+    def should_wait(self, offer_hash: str):
         with self._lock:
             if self._offer_hash is not None:
                 if self._offer_hash != offer_hash:
@@ -91,7 +91,7 @@ class TaskClient(object):
                     return True
 
                 if self._started == self._wtct_num_subtasks:
-                    logger.info('all subtasks for %s have been started',
+                    logger.info('all subtasks for `%s` have been started',
                                 self._offer_hash)
                     return True
 

--- a/golem/task/taskclient.py
+++ b/golem/task/taskclient.py
@@ -77,7 +77,7 @@ class TaskClient(object):
     def rejected(self):
         with self._lock:
             if self._rejected:
-                logger.warning('%s has rejected subtask', self._wtct_hash)
+                logger.info('%s has rejected subtask', self._offer_hash)
                 return True
 
             return False
@@ -86,13 +86,13 @@ class TaskClient(object):
         with self._lock:
             if self._wtct_hash is not None:
                 if self._wtct_hash != wtct_hash:
-                    logger.warning('already processing another WTCT (%s vs %s)',
-                                   self._wtct_hash, wtct_hash)
+                    logger.debug('already processing another WTCT (%s vs %s)',
+                                 self._wtct_hash, wtct_hash)
                     return True
 
                 if self._started == self._wtct_num_subtasks:
-                    logger.warning('all subtasks for %s have been started',
-                                   self._wtct_hash)
+                    logger.info('all subtasks for %s have been started',
+                                self._wtct_hash)
                     return True
 
             return False

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -394,7 +394,7 @@ class TaskManager(TaskEventListener):
                          task_id: str,
                          estimated_performance: float,
                          price: int,
-                         offer_hash: bytes) \
+                         offer_hash: str) \
             -> Optional[ComputeTaskDef]:
         """ Assign next subtask from task <task_id> to node with given
         id <node_id>.
@@ -477,7 +477,7 @@ class TaskManager(TaskEventListener):
     def should_wait_for_node(self,
                              task_id: str,
                              node_id: str,
-                             offer_hash: Optional[bytes]) -> bool:
+                             offer_hash: str) -> bool:
         """ Check if the node has too many tasks assigned already """
         if not self.is_my_task(task_id):
             logger.debug(

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -394,7 +394,7 @@ class TaskManager(TaskEventListener):
                          task_id: str,
                          estimated_performance: float,
                          price: int,
-                         wtct_hash: Optional[bytes]) \
+                         wtct_hash: bytes) \
             -> Optional[ComputeTaskDef]:
         """ Assign next subtask from task <task_id> to node with given
         id <node_id>.

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -394,7 +394,7 @@ class TaskManager(TaskEventListener):
                          task_id: str,
                          estimated_performance: float,
                          price: int,
-                         wtct_hash: bytes) \
+                         offer_hash: bytes) \
             -> Optional[ComputeTaskDef]:
         """ Assign next subtask from task <task_id> to node with given
         id <node_id>.
@@ -420,7 +420,7 @@ class TaskManager(TaskEventListener):
         if not self.task_needs_computation(task_id):
             return None
 
-        if self.should_wait_for_node(task_id, node_id, wtct_hash):
+        if self.should_wait_for_node(task_id, node_id, offer_hash):
             return None
 
         task = self.tasks[task_id]
@@ -477,7 +477,7 @@ class TaskManager(TaskEventListener):
     def should_wait_for_node(self,
                              task_id: str,
                              node_id: str,
-                             wtct_hash: Optional[bytes]) -> bool:
+                             offer_hash: Optional[bytes]) -> bool:
         """ Check if the node has too many tasks assigned already """
         if not self.is_my_task(task_id):
             logger.debug(
@@ -489,7 +489,7 @@ class TaskManager(TaskEventListener):
 
         task = self.tasks[task_id]
 
-        verdict = task.should_accept_client(node_id, wtct_hash)
+        verdict = task.should_accept_client(node_id, offer_hash)
         logger.debug(
             "Should accept client verdict. verdict=%s, task=%s, node=%s",
             verdict,

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -704,7 +704,7 @@ class TaskServer(
         netmask = 'netmask'
         not_accepted = 'not accepted'
 
-    def should_accept_provider(  # pylint: too-many-return-statements
+    def should_accept_provider(  # pylint: disable=too-many-return-statements
             self,
             node_id: str,
             ip_addr: str,

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -711,7 +711,7 @@ class TaskServer(
             task_id: str,
             provider_perf: float,
             max_memory_size: int,
-            offer_hash: bytes) -> bool:
+            offer_hash: str) -> bool:
 
         node_name_id = short_node_id(node_id)
         ids = f'provider={node_name_id}, task_id={task_id}'

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -710,7 +710,8 @@ class TaskServer(
             ip_addr: str,
             task_id: str,
             provider_perf: float,
-            max_memory_size: int) -> bool:
+            max_memory_size: int,
+            wtct_hash: bytes) -> bool:
 
         node_name_id = short_node_id(node_id)
         ids = f'provider={node_name_id}, task_id={task_id}'
@@ -782,7 +783,7 @@ class TaskServer(
             return False
 
         accept_client_verdict: AcceptClientVerdict \
-            = task.should_accept_client(node_id)
+            = task.should_accept_client(node_id, wtct_hash)
         if accept_client_verdict != AcceptClientVerdict.ACCEPTED:
             logger.info(f'provider {node_id} is not allowed'
                         f' for this task at this moment '

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -480,11 +480,11 @@ class TaskServer(
         self.requested_tasks.discard(task_id)
         return self.task_keeper.remove_task_header(task_id)
 
-    def set_last_message(self, type_, t, msg, address, port):
+    def set_last_message(self, type_, t, msg, ip_addr, port):
         if len(self.last_messages) >= 5:
             self.last_messages = self.last_messages[-4:]
 
-        self.last_messages.append([type_, t, address, port, msg])
+        self.last_messages.append([type_, t, ip_addr, port, msg])
 
     def get_node_name(self):
         return self.config_desc.node_name
@@ -711,7 +711,7 @@ class TaskServer(
             task_id: str,
             provider_perf: float,
             max_memory_size: int,
-            wtct_hash: bytes) -> bool:
+            offer_hash: bytes) -> bool:
 
         node_name_id = short_node_id(node_id)
         ids = f'provider={node_name_id}, task_id={task_id}'
@@ -783,7 +783,7 @@ class TaskServer(
             return False
 
         accept_client_verdict: AcceptClientVerdict \
-            = task.should_accept_client(node_id, wtct_hash)
+            = task.should_accept_client(node_id, offer_hash)
         if accept_client_verdict != AcceptClientVerdict.ACCEPTED:
             logger.info(f'provider {node_id} is not allowed'
                         f' for this task at this moment '

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -25,7 +25,7 @@ from twisted.internet.defer import inlineCallbacks
 from apps.appsmanager import AppsManager
 from apps.core.task.coretask import CoreTask
 from golem.clientconfigdescriptor import ClientConfigDescriptor
-from golem.core.common import node_info_str, short_node_id
+from golem.core.common import short_node_id
 from golem.core.variables import MAX_CONNECT_SOCKET_ADDRESSES
 from golem.environments.environment import SupportStatus, UnsupportReason
 from golem.marketplace import OfferPool
@@ -704,14 +704,13 @@ class TaskServer(
         netmask = 'netmask'
         not_accepted = 'not accepted'
 
-    def should_accept_provider(  # noqa pylint: disable=too-many-arguments,too-many-return-statements,unused-argument
+    def should_accept_provider(  # pylint: too-many-return-statements
             self,
-            node_id,
-            address,
-            task_id,
-            provider_perf,
-            max_resource_size,
-            max_memory_size):
+            node_id: str,
+            ip_addr: str,
+            task_id: str,
+            provider_perf: float,
+            max_memory_size: int) -> bool:
 
         node_name_id = short_node_id(node_id)
         ids = f'provider={node_name_id}, task_id={task_id}'
@@ -753,7 +752,7 @@ class TaskServer(
 
         allowed, reason = self.acl.is_allowed(node_id)
         if allowed:
-            allowed, reason = self.acl_ip.is_allowed(address)
+            allowed, reason = self.acl_ip.is_allowed(ip_addr)
         if not allowed:
             logger.info(f'provider is {reason.value}; {ids}')
             self.notify_provider_rejected(

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -1,5 +1,5 @@
 # pylint: disable=too-many-lines
-
+import binascii
 import datetime
 import enum
 import functools
@@ -283,9 +283,10 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
 
         self.task_manager.got_wants_to_compute(msg.task_id)
 
+        offer_hash = binascii.hexlify(msg.get_short_hash()).decode('utf8')
         if not self.task_server.should_accept_provider(
                 self.key_id, self.address, msg.task_id, msg.perf_index,
-                msg.max_memory_size, msg.get_short_hash()):
+                msg.max_memory_size, offer_hash):
             self._cannot_assign_task(msg.task_id, reasons.NoMoreSubtasks)
             return
 
@@ -352,7 +353,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             msg.price,
             task.header.subtask_timeout,
         )
-        offer_hash = msg.get_short_hash()
+        offer_hash = binascii.hexlify(msg.get_short_hash()).decode('utf8')
         for _i in range(msg.num_subtasks):
             ctd = self.task_manager.get_next_subtask(
                 node_id, msg.task_id, msg.perf_index, msg.price, offer_hash)

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -569,17 +569,6 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             return False
         return True
 
-    def _react_to_waiting_for_results(
-            self,
-            msg: message.tasks.WaitingForResults,
-    ):
-        if not self.verify_owners(msg, my_role=Actor.Provider):
-            return
-        self.task_server.subtask_waiting(
-            task_id=msg.task_id,
-            subtask_id=msg.subtask_id,
-        )
-
     def _react_to_cannot_compute_task(self, msg):
         if not self.check_provider_for_subtask(msg.subtask_id):
             self.dropped()
@@ -1023,8 +1012,6 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 self._react_to_rand_val,
             message.tasks.StartSessionResponse:
                 self._react_to_start_session_response,
-            message.tasks.WaitingForResults:
-                self._react_to_waiting_for_results,
 
             # Concent messages
             message.tasks.AckReportComputedTask:

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -285,7 +285,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
 
         if not self.task_server.should_accept_provider(
                 self.key_id, self.address, msg.task_id, msg.perf_index,
-                msg.max_memory_size):
+                msg.max_memory_size, msg.get_short_hash()):
             self._cannot_assign_task(msg.task_id, reasons.NoMoreSubtasks)
             return
 

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -352,10 +352,10 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             msg.price,
             task.header.subtask_timeout,
         )
-        wtct_hash = msg.get_short_hash()
+        offer_hash = msg.get_short_hash()
         for _i in range(msg.num_subtasks):
             ctd = self.task_manager.get_next_subtask(
-                node_id, msg.task_id, msg.perf_index, msg.price, wtct_hash)
+                node_id, msg.task_id, msg.perf_index, msg.price, offer_hash)
 
             logger.debug(
                 "CTD generated. task_id=%s, node=%s ctd=%s",
@@ -368,7 +368,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 self._cannot_assign_task(msg.task_id, reasons.NoMoreSubtasks)
                 return
 
-            task.accept_client(node_id, wtct_hash, msg.num_subtasks)
+            task.accept_client(node_id, offer_hash, msg.num_subtasks)
 
             resources_result = None
             if ctd["resources"]:

--- a/tests/apps/blender/task/test_blenderrendertask.py
+++ b/tests/apps/blender/task/test_blenderrendertask.py
@@ -346,12 +346,12 @@ class TestBlenderTask(TempDirFixture, LogTestCase):
         self.assertEqual(self.bt.main_scene_file,
                          path.join(self.path, "example.blend"))
         extra_data = self.bt.query_extra_data(1000, "ABC", "abc")
-        self.bt.accept_client("ABC", b'wtct hash')
+        self.bt.accept_client("ABC", 'offer hash')
         ctd = extra_data.ctd
         assert ctd['extra_data']['start_task'] == 1
         self.bt.last_task = self.bt.total_tasks
         self.bt.subtasks_given[1] = {'status': SubtaskStatus.finished}
-        assert self.bt.should_accept_client("ABC", b'wtct hash') != \
+        assert self.bt.should_accept_client("ABC", 'offer hash') != \
             AcceptClientVerdict.ACCEPTED
 
     def test_get_min_max_y(self):

--- a/tests/apps/core/benchmark/test_benchmarkrunner.py
+++ b/tests/apps/core/benchmark/test_benchmarkrunner.py
@@ -68,13 +68,13 @@ class DummyTask(Task):
     def query_extra_data_for_test_task(self):
         pass
 
-    def should_accept_client(self, node_id, wtct_hash=None):
+    def should_accept_client(self, node_id, offer_hash=None):
         pass
 
     def to_dictionary(self):
         pass
 
-    def accept_client(self, node_id, wtct_hash=None, num_subtasks=1):
+    def accept_client(self, node_id, offer_hash=None, num_subtasks=1):
         pass
 
 

--- a/tests/apps/core/benchmark/test_benchmarkrunner.py
+++ b/tests/apps/core/benchmark/test_benchmarkrunner.py
@@ -68,13 +68,13 @@ class DummyTask(Task):
     def query_extra_data_for_test_task(self):
         pass
 
-    def should_accept_client(self, node_id, offer_hash=None):
+    def should_accept_client(self, node_id, offer_hash):
         pass
 
     def to_dictionary(self):
         pass
 
-    def accept_client(self, node_id, offer_hash=None, num_subtasks=1):
+    def accept_client(self, node_id, offer_hash, num_subtasks=1):
         pass
 
 

--- a/tests/apps/core/task/test_coretask.py
+++ b/tests/apps/core/task/test_coretask.py
@@ -414,22 +414,21 @@ class TestCoreTask(LogTestCase, TestDirFixture):
 
     def test_result_incoming_rejected(self):
         c = self._get_core_task()
-        assert c.accept_client("Node 1") == AcceptClientVerdict.ACCEPTED
-        c.subtasks_given["subtask1"] = {"node_id": "Node 1"}
+        assert c.accept_client("nod1", 'oh') == AcceptClientVerdict.ACCEPTED
+        c.subtasks_given["subtask1"] = {"node_id": "nod1"}
         c.result_incoming("subtask1")
-        assert c.accept_client("Node 1") == AcceptClientVerdict.ACCEPTED
+        assert c.accept_client("nod1", 'oh') == AcceptClientVerdict.SHOULD_WAIT
         c._mark_subtask_failed("subtask1")
-        assert c.accept_client("Node 1") == AcceptClientVerdict.REJECTED
+        assert c.accept_client("nod1", 'oh') == AcceptClientVerdict.REJECTED
 
     def test_result_incoming_accepted(self):
         c = self._get_core_task()
-        assert c.accept_client("Node 1") == AcceptClientVerdict.ACCEPTED
-        c.subtasks_given["subtask1"] = {"node_id": "Node 1"}
+        assert c.accept_client("nod1", 'oh') == AcceptClientVerdict.ACCEPTED
+        c.subtasks_given["subtask1"] = {"node_id": "nod1"}
         c.result_incoming("subtask1")
-        assert c.accept_client("Node 1") == AcceptClientVerdict.ACCEPTED
+        assert c.accept_client("nod1", 'oh') == AcceptClientVerdict.SHOULD_WAIT
         c.accept_results("subtask1", None)
-        assert c.accept_client("Node 1") == AcceptClientVerdict.ACCEPTED
-
+        assert c.accept_client("nod1", 'oh') == AcceptClientVerdict.ACCEPTED
 
     def test_accept_results(self):
         c = self._get_core_task()

--- a/tests/apps/rendering/task/test_framerenderingtask.py
+++ b/tests/apps/rendering/task/test_framerenderingtask.py
@@ -67,7 +67,7 @@ class TestFrameRenderingTask(TestDirFixture, LogTestCase):
 
     def test_accept_results(self):
         task = self._get_frame_task(use_frames=False)
-        task.accept_client("NODE 1")
+        task.accept_client("NODE 1", 'oh')
         task.tmp_dir = self.path
         task.subtasks_given["SUBTASK1"] = {"start_task": 3, "node_id": "NODE 1",
                                            "parts": 1, "frames": [1],
@@ -99,7 +99,7 @@ class TestFrameRenderingTask(TestDirFixture, LogTestCase):
 
         task = self._get_frame_task()
         task.tmp_dir = self.path
-        task.accept_client("NODE 1")
+        task.accept_client("NODE 1", 'oh')
         task.subtasks_given["SUBTASK1"] = {"start_task": 3,
                                            "node_id": "NODE 1",
                                            "parts": 1,

--- a/tests/apps/rendering/task/test_renderingtask.py
+++ b/tests/apps/rendering/task/test_renderingtask.py
@@ -143,13 +143,13 @@ class TestRenderingTask(TestDirFixture, LogTestCase):
         with self.assertLogs(core_logger, level="WARNING"):
             task.restart_subtask("Not existing")
 
-        task.accept_client("node_ABC")
+        task.accept_client("node_ABC", 'oh')
         task.subtasks_given["ABC"] = {'status': SubtaskStatus.starting,
                                       'start_task': 3, "node_id": "node_ABC"}
         task.restart_subtask("ABC")
         assert task.subtasks_given["ABC"]["status"] == SubtaskStatus.restarted
 
-        task.accept_client("node_DEF")
+        task.accept_client("node_DEF", 'oh')
         task.subtasks_given["DEF"] = {'status': SubtaskStatus.finished,
                                       'start_task': 3, "node_id": "node_DEF"}
         task.restart_subtask("DEF")
@@ -158,19 +158,19 @@ class TestRenderingTask(TestDirFixture, LogTestCase):
         assert path.isfile(task.preview_file_path)
         assert task.num_tasks_received == -1
 
-        task.accept_client("node_GHI")
+        task.accept_client("node_GHI", 'oh')
         task.subtasks_given["GHI"] = {'status': SubtaskStatus.failure,
                                       'start_task': 3, "node_id": "node_GHI"}
         task.restart_subtask("GHI")
         assert task.subtasks_given["GHI"]["status"] == SubtaskStatus.failure
 
-        task.accept_client("node_JKL")
+        task.accept_client("node_JKL", 'oh')
         task.subtasks_given["JKL"] = {'status': SubtaskStatus.resent,
                                       'start_task': 3, "node_id": "node_JKL"}
         task.restart_subtask("JKL")
         assert task.subtasks_given["JKL"]["status"] == SubtaskStatus.resent
 
-        task.accept_client("node_MNO")
+        task.accept_client("node_MNO", 'oh')
         task.subtasks_given["MNO"] = {'status': SubtaskStatus.restarted,
                                       'start_task': 3, "node_id": "node_MNO"}
         task.restart_subtask("MNO")

--- a/tests/golem/task/dummy/task.py
+++ b/tests/golem/task/dummy/task.py
@@ -303,7 +303,7 @@ class DummyTask(Task):
     def query_extra_data_for_test_task(self):
         pass
 
-    def should_accept_client(self, node_id, offer_hash=None):
+    def should_accept_client(self, node_id, offer_hash):
         if node_id in self.assigned_nodes:
             return AcceptClientVerdict.SHOULD_WAIT
         return AcceptClientVerdict.ACCEPTED
@@ -314,7 +314,7 @@ class DummyTask(Task):
         except KeyError:
             return []
 
-    def accept_client(self, node_id, offer_hash=None, num_subtasks=1):
+    def accept_client(self, node_id, offer_hash, num_subtasks=1):
         print(
             "DummyTask.accept_client called"
             f" node_id={common.short_node_id(node_id)}"

--- a/tests/golem/task/dummy/task.py
+++ b/tests/golem/task/dummy/task.py
@@ -303,7 +303,7 @@ class DummyTask(Task):
     def query_extra_data_for_test_task(self):
         pass
 
-    def should_accept_client(self, node_id, wtct_hash=None):
+    def should_accept_client(self, node_id, offer_hash=None):
         if node_id in self.assigned_nodes:
             return AcceptClientVerdict.SHOULD_WAIT
         return AcceptClientVerdict.ACCEPTED
@@ -314,7 +314,7 @@ class DummyTask(Task):
         except KeyError:
             return []
 
-    def accept_client(self, node_id, wtct_hash=None, num_subtasks=1):
+    def accept_client(self, node_id, offer_hash=None, num_subtasks=1):
         print(
             "DummyTask.accept_client called"
             f" node_id={common.short_node_id(node_id)}"

--- a/tests/golem/task/test_taskclient.py
+++ b/tests/golem/task/test_taskclient.py
@@ -22,7 +22,7 @@ class TestTaskClient(unittest.TestCase):
         tc = TaskClient()
 
         # then
-        assert not tc.should_wait(b'the hash')
+        assert not tc.should_wait('the hash')
         assert not tc.rejected()
 
     def test_state_after_start(self):
@@ -30,117 +30,113 @@ class TestTaskClient(unittest.TestCase):
         tc = TaskClient()
 
         # when
-        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
+        assert tc.start(offer_hash='the hash', num_subtasks=3)
 
         # then
-        assert not tc.should_wait(b'the hash')
+        assert not tc.should_wait('the hash')
         assert not tc.rejected()
-        assert tc.should_wait(b'other hash')
-        assert tc.should_wait()
+        assert tc.should_wait('other hash')
 
     def test_do_not_allow_to_start_other_WTCT(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
+        assert tc.start(offer_hash='the hash', num_subtasks=3)
 
         # then
-        assert not tc.start(offer_hash=b'other hash', num_subtasks=7)
+        assert not tc.start(offer_hash='other hash', num_subtasks=7)
 
     def test_do_allow_to_start_same_WTCT(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
-        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
+        assert tc.start(offer_hash='the hash', num_subtasks=3)
+        assert tc.start(offer_hash='the hash', num_subtasks=3)
 
         # then
-        assert not tc.should_wait(b'the hash')
+        assert not tc.should_wait('the hash')
         assert not tc.rejected()
-        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
+        assert tc.start(offer_hash='the hash', num_subtasks=3)
 
     def test_num_subtasks_decrease_allowed_starts(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
-        assert tc.start(offer_hash=b'the hash', num_subtasks=2)
+        assert tc.start(offer_hash='the hash', num_subtasks=3)
+        assert tc.start(offer_hash='the hash', num_subtasks=2)
 
         # then
-        assert tc.should_wait(b'the hash')
+        assert tc.should_wait('the hash')
         assert not tc.rejected()
-        assert not tc.start(offer_hash=b'the hash', num_subtasks=1)
+        assert not tc.start(offer_hash='the hash', num_subtasks=1)
 
     def test_do_not_allow_to_start_more_subtasks_than_requested(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(offer_hash=b'the hash', num_subtasks=1)
+        assert tc.start(offer_hash='the hash', num_subtasks=1)
 
         # then
-        assert tc.should_wait(b'the hash')
+        assert tc.should_wait('the hash')
         assert not tc.rejected()
-        assert not tc.start(offer_hash=b'the hash', num_subtasks=3)
+        assert not tc.start(offer_hash='the hash', num_subtasks=3)
 
     def test_cancel_allows_more_starts(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(offer_hash=b'the hash', num_subtasks=1)
+        assert tc.start(offer_hash='the hash', num_subtasks=1)
         tc.cancel()
 
         # then
-        assert not tc.should_wait(b'the hash')
+        assert not tc.should_wait('the hash')
         assert not tc.rejected()
-        assert tc.start(offer_hash=b'the hash', num_subtasks=1)
+        assert tc.start(offer_hash='the hash', num_subtasks=1)
 
     def test_not_last_accept_not_resets_state(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(offer_hash=b'the hash', num_subtasks=2)
-        assert tc.start(offer_hash=b'the hash', num_subtasks=2)
+        assert tc.start(offer_hash='the hash', num_subtasks=2)
+        assert tc.start(offer_hash='the hash', num_subtasks=2)
         tc.accept()
 
         # then
-        assert tc.should_wait(b'the hash')
-        assert tc.should_wait(b'other hash')
-        assert tc.should_wait()
+        assert tc.should_wait('the hash')
+        assert tc.should_wait('other hash')
         assert not tc.rejected()
-        assert not tc.start(offer_hash=b'the hash', num_subtasks=2)
-        assert not tc.start(offer_hash=b'other hash', num_subtasks=17)
+        assert not tc.start(offer_hash='the hash', num_subtasks=2)
+        assert not tc.start(offer_hash='other hash', num_subtasks=17)
 
     def test_last_accept_resets_state(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(offer_hash=b'the hash', num_subtasks=1)
+        assert tc.start(offer_hash='the hash', num_subtasks=1)
         tc.accept()
 
         # then
-        assert not tc.should_wait(b'the hash')
-        assert not tc.should_wait(b'other hash')
-        assert not tc.should_wait()
+        assert not tc.should_wait('the hash')
+        assert not tc.should_wait('other hash')
         assert not tc.rejected()
-        assert tc.start(offer_hash=b'other hash', num_subtasks=17)
+        assert tc.start(offer_hash='other hash', num_subtasks=17)
 
     def test_reject_block_all_starts(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(offer_hash=b'the hash', num_subtasks=1)
+        assert tc.start(offer_hash='the hash', num_subtasks=1)
         tc.reject()
 
         # then
         assert tc.rejected()
-        assert not tc.start(offer_hash=b'the hash', num_subtasks=1)
-        assert not tc.start(offer_hash=b'other hash', num_subtasks=17)
-        assert not tc.start(offer_hash=None, num_subtasks=17)
+        assert not tc.start(offer_hash='the hash', num_subtasks=1)
+        assert not tc.start(offer_hash='other hash', num_subtasks=17)

--- a/tests/golem/task/test_taskclient.py
+++ b/tests/golem/task/test_taskclient.py
@@ -30,7 +30,7 @@ class TestTaskClient(unittest.TestCase):
         tc = TaskClient()
 
         # when
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=3)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
 
         # then
         assert not tc.should_wait(b'the hash')
@@ -43,69 +43,69 @@ class TestTaskClient(unittest.TestCase):
         tc = TaskClient()
 
         # when
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=3)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
 
         # then
-        assert not tc.start(wtct_hash=b'other hash', num_subtasks=7)
+        assert not tc.start(offer_hash=b'other hash', num_subtasks=7)
 
     def test_do_allow_to_start_same_WTCT(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=3)
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=3)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
 
         # then
         assert not tc.should_wait(b'the hash')
         assert not tc.rejected()
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=3)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
 
     def test_num_subtasks_decrease_allowed_starts(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=3)
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=2)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=3)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=2)
 
         # then
         assert tc.should_wait(b'the hash')
         assert not tc.rejected()
-        assert not tc.start(wtct_hash=b'the hash', num_subtasks=1)
+        assert not tc.start(offer_hash=b'the hash', num_subtasks=1)
 
     def test_do_not_allow_to_start_more_subtasks_than_requested(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=1)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=1)
 
         # then
         assert tc.should_wait(b'the hash')
         assert not tc.rejected()
-        assert not tc.start(wtct_hash=b'the hash', num_subtasks=3)
+        assert not tc.start(offer_hash=b'the hash', num_subtasks=3)
 
     def test_cancel_allows_more_starts(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=1)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=1)
         tc.cancel()
 
         # then
         assert not tc.should_wait(b'the hash')
         assert not tc.rejected()
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=1)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=1)
 
     def test_not_last_accept_not_resets_state(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=2)
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=2)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=2)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=2)
         tc.accept()
 
         # then
@@ -113,15 +113,15 @@ class TestTaskClient(unittest.TestCase):
         assert tc.should_wait(b'other hash')
         assert tc.should_wait()
         assert not tc.rejected()
-        assert not tc.start(wtct_hash=b'the hash', num_subtasks=2)
-        assert not tc.start(wtct_hash=b'other hash', num_subtasks=17)
+        assert not tc.start(offer_hash=b'the hash', num_subtasks=2)
+        assert not tc.start(offer_hash=b'other hash', num_subtasks=17)
 
     def test_last_accept_resets_state(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=1)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=1)
         tc.accept()
 
         # then
@@ -129,18 +129,18 @@ class TestTaskClient(unittest.TestCase):
         assert not tc.should_wait(b'other hash')
         assert not tc.should_wait()
         assert not tc.rejected()
-        assert tc.start(wtct_hash=b'other hash', num_subtasks=17)
+        assert tc.start(offer_hash=b'other hash', num_subtasks=17)
 
     def test_reject_block_all_starts(self):
         # given
         tc = TaskClient()
 
         # when
-        assert tc.start(wtct_hash=b'the hash', num_subtasks=1)
+        assert tc.start(offer_hash=b'the hash', num_subtasks=1)
         tc.reject()
 
         # then
         assert tc.rejected()
-        assert not tc.start(wtct_hash=b'the hash', num_subtasks=1)
-        assert not tc.start(wtct_hash=b'other hash', num_subtasks=17)
-        assert not tc.start(wtct_hash=None, num_subtasks=17)
+        assert not tc.start(offer_hash=b'the hash', num_subtasks=1)
+        assert not tc.start(offer_hash=b'other hash', num_subtasks=17)
+        assert not tc.start(offer_hash=None, num_subtasks=17)

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -362,7 +362,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         assert not checked
 
     def test_should_wait_for_node_not_my_task(self, *_):
-        should_wait = self.tm.should_wait_for_node("aaa", "aaa", None)
+        should_wait = self.tm.should_wait_for_node("aaa", "aaa", 'oh')
         assert not should_wait
 
     def test_delete_task_with_dump(self, *_):
@@ -430,11 +430,10 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
             def restart_subtask(self, subtask_id):
                 self.restarted[subtask_id] = True
 
-            def should_accept_client(self, node_id, offer_hash=None):
+            def should_accept_client(self, node_id, offer_hash):
                 return AcceptClientVerdict.ACCEPTED
 
-            def accept_client(self, node_id, offer_hash=None,
-                              num_subtasks: int = 1):
+            def accept_client(self, node_id, offer_hash, num_subtasks=1):
                 return AcceptClientVerdict.ACCEPTED
 
         t = TestTask(th, ["xxyyzz"],
@@ -442,8 +441,8 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(t)
         self.tm.start_task(t.header.task_id)
         assert self.tm.is_my_task("xyz")
-        should_wait = self.tm.should_wait_for_node("xyz", "DEF", None)
-        ctd = self.tm.get_next_subtask("DEF", "xyz", 1030, 10, b'')
+        should_wait = self.tm.should_wait_for_node("xyz", "DEF", 'oh')
+        ctd = self.tm.get_next_subtask("DEF", "xyz", 1030, 10, 'oh')
         assert ctd['subtask_id'] == "xxyyzz"
         assert not should_wait
         task_id = self.tm.subtask2task_mapping["xxyyzz"]
@@ -471,8 +470,8 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         progress = self.tm.get_progresses()
         assert progress != {}
         assert self.tm.is_my_task("abc")
-        should_wait = self.tm.should_wait_for_node("abc", "DEF", None, )
-        ctd = self.tm.get_next_subtask("DEF", "abc", 1030, 10, b'')
+        should_wait = self.tm.should_wait_for_node("abc", "DEF", 'oh')
+        ctd = self.tm.get_next_subtask("DEF", "abc", 1030, 10, 'oh')
         assert ctd['subtask_id'] == "aabbcc"
         assert not should_wait
         (handler, checker) = self._connect_signal_handler()
@@ -495,8 +494,8 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(t3)
         self.tm.start_task(t3.header.task_id)
         assert self.tm.is_my_task("qwe")
-        assert not self.tm.should_wait_for_node("qwe", "DEF", None, )
-        ctd = self.tm.get_next_subtask("DEF", "qwe", 1030, 10, b'')
+        assert not self.tm.should_wait_for_node("qwe", "DEF", 'oh')
+        ctd = self.tm.get_next_subtask("DEF", "qwe", 1030, 10, 'oh')
         assert ctd['subtask_id'] == "qqwwee"
         (handler, checker) = self._connect_signal_handler()
         self.tm.task_computation_failure("qqwwee", "something went wrong")
@@ -520,8 +519,8 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(t2)
         self.tm.start_task(t2.header.task_id)
         assert self.tm.is_my_task("task4")
-        assert not self.tm.should_wait_for_node("task4", "DEF", None, )
-        ctd = self.tm.get_next_subtask("DEF", "task4", 1000, 10, b'')
+        assert not self.tm.should_wait_for_node("task4", "DEF", 'oh')
+        ctd = self.tm.get_next_subtask("DEF", "task4", 1000, 10, 'oh')
         assert ctd['subtask_id'] == "ttt4"
         (handler, checker) = self._connect_signal_handler()
         self.tm.computed_task_received("ttt4", [],
@@ -533,8 +532,8 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
                                        self.tm.verification_finished)
         assert self.tm.verification_finished.call_count == 5
         assert self.tm.is_my_task("task4")
-        should_wait = self.tm.should_wait_for_node("task4", "DEF", None)
-        ctd = self.tm.get_next_subtask("DEF", "task4", 1000, 10, b'')
+        should_wait = self.tm.should_wait_for_node("task4", "DEF", 'oh')
+        ctd = self.tm.get_next_subtask("DEF", "task4", 1000, 10, 'oh')
         assert ctd['subtask_id'] == "sss4"
         self.tm.computed_task_received("sss4", [],
                                        self.tm.verification_finished)
@@ -635,7 +634,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(task_mock)
         self.tm.start_task(task_mock.header.task_id)
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "aabbcc"
-        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, b'')
+        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, 'oh')
         (handler, checker) = self._connect_signal_handler()
         assert self.tm.task_computation_failure("aabbcc",
                                                 "something went wrong")
@@ -658,7 +657,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(task_mock)
         self.tm.start_task(task_mock.header.task_id)
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "aabbcc"
-        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, b'')
+        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, 'oh')
         (handler, checker) = self._connect_signal_handler()
         reason = message.tasks.CannotComputeTask.REASON.WrongCTD
         assert self.tm.task_computation_cancelled("aabbcc",
@@ -685,7 +684,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(task_mock)
         self.tm.start_task(task_mock.header.task_id)
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "aabbcc"
-        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, b'')
+        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, 'oh')
         (handler, checker) = self._connect_signal_handler()
         reason = message.tasks.CannotComputeTask.REASON.WrongCTD
         assert self.tm.task_computation_cancelled("aabbcc",
@@ -711,7 +710,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(task_mock)
         self.tm.start_task(task_mock.header.task_id)
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = subtask_id
-        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, b'')
+        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, 'oh')
         self.tm.task_computation_cancelled(
             subtask_id,
             reason,
@@ -741,12 +740,12 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         assert self.tm.get_subtasks("xyz") == []
         assert self.tm.get_subtasks("TASK 1") == []
 
-        self.tm.get_next_subtask("NODEID", "xyz", 1000, 100, b'')
-        self.tm.get_next_subtask("NODEID", "TASK 1", 1000, 100, b'')
+        self.tm.get_next_subtask("NODEID", "xyz", 1000, 100, 'oh')
+        self.tm.get_next_subtask("NODEID", "TASK 1", 1000, 100, 'oh')
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "aabbcc"
-        self.tm.get_next_subtask("NODEID2", "xyz", 1000, 100, b'')
+        self.tm.get_next_subtask("NODEID2", "xyz", 1000, 100, 'oh')
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "ddeeff"
-        self.tm.get_next_subtask("NODEID3", "xyz", 1000, 100, b'')
+        self.tm.get_next_subtask("NODEID3", "xyz", 1000, 100, 'oh')
         self.assertEqual(set(self.tm.get_subtasks("xyz")),
                          {"xxyyzz", "aabbcc", "ddeeff"})
         assert self.tm.get_subtasks("TASK 1") == ["SUBTASK 1"]
@@ -816,7 +815,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
                                          timeout=10, subtask_timeout=1)
                 self.tm.add_new_task(t2)
                 self.tm.start_task(t2.header.task_id)
-                self.tm.get_next_subtask("ABC", "abc", 1000, 10, b'')
+                self.tm.get_next_subtask("ABC", "abc", 1000, 10, 'oh')
             with freeze_time(
                 start_time + datetime.timedelta(
                     seconds=t2.header.subtask_timeout + 1,
@@ -845,7 +844,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
                 )
                 self.tm.add_new_task(t3)
                 self.tm.start_task(t3.header.task_id)
-                self.tm.get_next_subtask("ABC", "qwe", 1000, 10, b'')
+                self.tm.get_next_subtask("ABC", "qwe", 1000, 10, 'oh')
             with freeze_time(
                 start_time + datetime.timedelta(
                     seconds=t3.header.subtask_timeout + 1,
@@ -1443,7 +1442,6 @@ class TestCopySubtaskResults(DatabaseFixture):
             self.assertEqual(new_subtask_state.stdout, 'stdout')
             self.assertEqual(new_subtask_state.stderr, 'stderr')
             self.assertEqual(new_subtask_state.results, ['result'])
-
 
         patch.object(self.tm, 'notice_task_updated').start()
         deferred = self.tm._copy_subtask_results(

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -266,8 +266,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
     def test_get_next_subtask_not_my_task(self, *_):
 
         wrong_task = not self.tm.is_my_task("xyz")
-        subtask = self.tm.get_next_subtask(
-            "DEF", "xyz", 1000, 10, b'')
+        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, 'oh')
         assert subtask is None
         assert wrong_task
 
@@ -280,8 +279,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.start_task(task_mock.header.task_id)
 
         assert self.tm.is_my_task("xyz")
-        subtask = self.tm.get_next_subtask(
-            "DEF", "xyz", 1000, 10, b'')
+        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, 'oh')
 
         assert subtask is None
 
@@ -295,8 +293,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.start_task(task_mock.header.task_id)
 
         assert self.tm.is_my_task("xyz")
-        subtask = self.tm.get_next_subtask(
-            "DEF", "xyz", 1000, 10, b'')
+        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, 'oh')
 
         assert subtask is None
 
@@ -315,7 +312,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         cached_node.save()
 
         subtask = self.tm.get_next_subtask(
-            cached_node.node, "xyz", 1000, 10, b'')
+            cached_node.node, "xyz", 1000, 10, 'oh')
         assert subtask is not None
         checker([("xyz", subtask['subtask_id'], SubtaskOp.ASSIGNED)])
         del handler
@@ -329,28 +326,28 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         task_state.status = self.tm.activeStatus[0]
 
         assert self.tm.is_my_task("xyz")
-        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 10, b'') is None
+        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 10, 'oh') is None
 
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "xyzxyz"
         assert self.tm.is_my_task("xyz")
-        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, b'')
+        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, 'oh')
         assert isinstance(subtask, ComputeTaskDef)
 
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "xyzxyz2"
         assert self.tm.is_my_task("xyz")
-        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 20000, b'') is None
+        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 20000, 'oh') is None
 
         assert self.tm.is_my_task("xyz")
-        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, b'')
+        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, 'oh')
         assert isinstance(subtask, ComputeTaskDef)
 
         del self.tm.subtask2task_mapping["xyzxyz2"]
         assert self.tm.is_my_task("xyz")
-        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 10, b'') is None
+        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 10, 'oh') is None
 
         del self.tm.tasks_states["xyz"].subtask_states["xyzxyz2"]
         assert self.tm.is_my_task("xyz")
-        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, b'')
+        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, 'oh')
         assert isinstance(subtask, ComputeTaskDef)
 
         self.tm.delete_task("xyz")

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -267,7 +267,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
 
         wrong_task = not self.tm.is_my_task("xyz")
         subtask = self.tm.get_next_subtask(
-            "DEF", "xyz", 1000, 10, None)
+            "DEF", "xyz", 1000, 10, b'')
         assert subtask is None
         assert wrong_task
 
@@ -281,7 +281,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
 
         assert self.tm.is_my_task("xyz")
         subtask = self.tm.get_next_subtask(
-            "DEF", "xyz", 1000, 10, None)
+            "DEF", "xyz", 1000, 10, b'')
 
         assert subtask is None
 
@@ -296,7 +296,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
 
         assert self.tm.is_my_task("xyz")
         subtask = self.tm.get_next_subtask(
-            "DEF", "xyz", 1000, 10, None)
+            "DEF", "xyz", 1000, 10, b'')
 
         assert subtask is None
 
@@ -315,7 +315,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         cached_node.save()
 
         subtask = self.tm.get_next_subtask(
-            cached_node.node, "xyz", 1000, 10, None)
+            cached_node.node, "xyz", 1000, 10, b'')
         assert subtask is not None
         checker([("xyz", subtask['subtask_id'], SubtaskOp.ASSIGNED)])
         del handler
@@ -329,28 +329,28 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         task_state.status = self.tm.activeStatus[0]
 
         assert self.tm.is_my_task("xyz")
-        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 10, None) is None
+        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 10, b'') is None
 
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "xyzxyz"
         assert self.tm.is_my_task("xyz")
-        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, None)
+        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, b'')
         assert isinstance(subtask, ComputeTaskDef)
 
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "xyzxyz2"
         assert self.tm.is_my_task("xyz")
-        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 20000, None) is None
+        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 20000, b'') is None
 
         assert self.tm.is_my_task("xyz")
-        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, None)
+        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, b'')
         assert isinstance(subtask, ComputeTaskDef)
 
         del self.tm.subtask2task_mapping["xyzxyz2"]
         assert self.tm.is_my_task("xyz")
-        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 10, None) is None
+        assert self.tm.get_next_subtask("DEF", "xyz", 1000, 10, b'') is None
 
         del self.tm.tasks_states["xyz"].subtask_states["xyzxyz2"]
         assert self.tm.is_my_task("xyz")
-        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, None)
+        subtask = self.tm.get_next_subtask("DEF", "xyz", 1000, 10, b'')
         assert isinstance(subtask, ComputeTaskDef)
 
         self.tm.delete_task("xyz")
@@ -442,8 +442,8 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(t)
         self.tm.start_task(t.header.task_id)
         assert self.tm.is_my_task("xyz")
-        should_wait = self.tm.should_wait_for_node("xyz", "DEF", None, )
-        ctd = self.tm.get_next_subtask("DEF", "xyz", 1030, 10, None, )
+        should_wait = self.tm.should_wait_for_node("xyz", "DEF", None)
+        ctd = self.tm.get_next_subtask("DEF", "xyz", 1030, 10, b'')
         assert ctd['subtask_id'] == "xxyyzz"
         assert not should_wait
         task_id = self.tm.subtask2task_mapping["xxyyzz"]
@@ -472,7 +472,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         assert progress != {}
         assert self.tm.is_my_task("abc")
         should_wait = self.tm.should_wait_for_node("abc", "DEF", None, )
-        ctd = self.tm.get_next_subtask("DEF", "abc", 1030, 10, None, )
+        ctd = self.tm.get_next_subtask("DEF", "abc", 1030, 10, b'')
         assert ctd['subtask_id'] == "aabbcc"
         assert not should_wait
         (handler, checker) = self._connect_signal_handler()
@@ -496,7 +496,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.start_task(t3.header.task_id)
         assert self.tm.is_my_task("qwe")
         assert not self.tm.should_wait_for_node("qwe", "DEF", None, )
-        ctd = self.tm.get_next_subtask("DEF", "qwe", 1030, 10, None, )
+        ctd = self.tm.get_next_subtask("DEF", "qwe", 1030, 10, b'')
         assert ctd['subtask_id'] == "qqwwee"
         (handler, checker) = self._connect_signal_handler()
         self.tm.task_computation_failure("qqwwee", "something went wrong")
@@ -521,7 +521,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.start_task(t2.header.task_id)
         assert self.tm.is_my_task("task4")
         assert not self.tm.should_wait_for_node("task4", "DEF", None, )
-        ctd = self.tm.get_next_subtask("DEF", "task4", 1000, 10, None, )
+        ctd = self.tm.get_next_subtask("DEF", "task4", 1000, 10, b'')
         assert ctd['subtask_id'] == "ttt4"
         (handler, checker) = self._connect_signal_handler()
         self.tm.computed_task_received("ttt4", [],
@@ -534,7 +534,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         assert self.tm.verification_finished.call_count == 5
         assert self.tm.is_my_task("task4")
         should_wait = self.tm.should_wait_for_node("task4", "DEF", None)
-        ctd = self.tm.get_next_subtask("DEF", "task4", 1000, 10, None, )
+        ctd = self.tm.get_next_subtask("DEF", "task4", 1000, 10, b'')
         assert ctd['subtask_id'] == "sss4"
         self.tm.computed_task_received("sss4", [],
                                        self.tm.verification_finished)
@@ -635,7 +635,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(task_mock)
         self.tm.start_task(task_mock.header.task_id)
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "aabbcc"
-        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, None,)
+        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, b'')
         (handler, checker) = self._connect_signal_handler()
         assert self.tm.task_computation_failure("aabbcc",
                                                 "something went wrong")
@@ -658,7 +658,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(task_mock)
         self.tm.start_task(task_mock.header.task_id)
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "aabbcc"
-        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, None,)
+        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, b'')
         (handler, checker) = self._connect_signal_handler()
         reason = message.tasks.CannotComputeTask.REASON.WrongCTD
         assert self.tm.task_computation_cancelled("aabbcc",
@@ -685,7 +685,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(task_mock)
         self.tm.start_task(task_mock.header.task_id)
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "aabbcc"
-        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, None,)
+        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, b'')
         (handler, checker) = self._connect_signal_handler()
         reason = message.tasks.CannotComputeTask.REASON.WrongCTD
         assert self.tm.task_computation_cancelled("aabbcc",
@@ -711,7 +711,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         self.tm.add_new_task(task_mock)
         self.tm.start_task(task_mock.header.task_id)
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = subtask_id
-        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, None,)
+        self.tm.get_next_subtask("NODE", "xyz", 1000, 100, b'')
         self.tm.task_computation_cancelled(
             subtask_id,
             reason,
@@ -741,12 +741,12 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
         assert self.tm.get_subtasks("xyz") == []
         assert self.tm.get_subtasks("TASK 1") == []
 
-        self.tm.get_next_subtask("NODEID", "xyz", 1000, 100, None,)
-        self.tm.get_next_subtask("NODEID", "TASK 1", 1000, 100, None,)
+        self.tm.get_next_subtask("NODEID", "xyz", 1000, 100, b'')
+        self.tm.get_next_subtask("NODEID", "TASK 1", 1000, 100, b'')
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "aabbcc"
-        self.tm.get_next_subtask("NODEID2", "xyz", 1000, 100, None,)
+        self.tm.get_next_subtask("NODEID2", "xyz", 1000, 100, b'')
         task_mock.query_extra_data_return_value.ctd['subtask_id'] = "ddeeff"
-        self.tm.get_next_subtask("NODEID3", "xyz", 1000, 100, None,)
+        self.tm.get_next_subtask("NODEID3", "xyz", 1000, 100, b'')
         self.assertEqual(set(self.tm.get_subtasks("xyz")),
                          {"xxyyzz", "aabbcc", "ddeeff"})
         assert self.tm.get_subtasks("TASK 1") == ["SUBTASK 1"]
@@ -816,7 +816,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
                                          timeout=10, subtask_timeout=1)
                 self.tm.add_new_task(t2)
                 self.tm.start_task(t2.header.task_id)
-                self.tm.get_next_subtask("ABC", "abc", 1000, 10, None,)
+                self.tm.get_next_subtask("ABC", "abc", 1000, 10, b'')
             with freeze_time(
                 start_time + datetime.timedelta(
                     seconds=t2.header.subtask_timeout + 1,
@@ -845,7 +845,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
                 )
                 self.tm.add_new_task(t3)
                 self.tm.start_task(t3.header.task_id)
-                self.tm.get_next_subtask("ABC", "qwe", 1000, 10, None,)
+                self.tm.get_next_subtask("ABC", "qwe", 1000, 10, b'')
             with freeze_time(
                 start_time + datetime.timedelta(
                     seconds=t3.header.subtask_timeout + 1,

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -430,10 +430,10 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
             def restart_subtask(self, subtask_id):
                 self.restarted[subtask_id] = True
 
-            def should_accept_client(self, node_id, wtct_hash=None):
+            def should_accept_client(self, node_id, offer_hash=None):
                 return AcceptClientVerdict.ACCEPTED
 
-            def accept_client(self, node_id, wtct_hash=None,
+            def accept_client(self, node_id, offer_hash=None,
                               num_subtasks: int = 1):
                 return AcceptClientVerdict.ACCEPTED
 

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -362,7 +362,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
 
         with self.assertLogs(logger, level='INFO') as cm:
             assert not ts.should_accept_provider(
-                node_id, "127.0.0.1", 'tid', 27.18, 1)
+                node_id, "127.0.0.1", 'tid', 27.18, 1, b'')
             _assert_log_msg(
                 cm,
                 f'INFO:{logger.name}:Cannot find task in my tasks: {ids}')
@@ -404,7 +404,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         with self.assertLogs(logger, level='INFO') as cm:
             # when
             accepted = ts.should_accept_provider(
-                node_id, "127.0.0.1", task_id, provider_perf, 1)
+                node_id, "127.0.0.1", task_id, provider_perf, 1, b'')
 
             # then
             assert not accepted
@@ -447,7 +447,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
             # when
             accepted = ts.should_accept_provider(
                 node_id, "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-                DEFAULT_MAX_MEMORY_SIZE_KB)
+                DEFAULT_MAX_MEMORY_SIZE_KB, b'')
 
             # then
             assert not accepted
@@ -495,7 +495,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         # when/then
         assert ts.should_accept_provider(
             node_id, "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-            DEFAULT_MAX_MEMORY_SIZE_KB)
+            DEFAULT_MAX_MEMORY_SIZE_KB, b'')
 
         # given
         self.client.get_computing_trust.return_value = \
@@ -503,7 +503,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         # when/then
         assert ts.should_accept_provider(
             node_id, "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-            DEFAULT_MAX_MEMORY_SIZE_KB)
+            DEFAULT_MAX_MEMORY_SIZE_KB, b'')
 
         # given
         trust = ts.config_desc.computing_trust - 0.2
@@ -512,7 +512,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
             # when
             accepted = ts.should_accept_provider(
                 node_id, "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-                DEFAULT_MAX_MEMORY_SIZE_KB)
+                DEFAULT_MAX_MEMORY_SIZE_KB, b'')
 
             # then
             assert not accepted
@@ -557,7 +557,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
             # when
             accepted = ts.should_accept_provider(
                 node_id, "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-                DEFAULT_MAX_MEMORY_SIZE_KB)
+                DEFAULT_MAX_MEMORY_SIZE_KB, b'')
 
             # then
             assert not accepted
@@ -594,7 +594,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         with self.assertLogs(logger, level='INFO') as cm:
             # when
             accepted = ts.should_accept_provider(node_id, "127.0.0.1",
-                                                 task_id, 99, 4)
+                                                 task_id, 99, 4, b'')
 
             # then
             assert not accepted
@@ -645,6 +645,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
                 task_id=task_id,
                 provider_perf=DEFAULT_PROVIDER_PERF,
                 max_memory_size=DEFAULT_MAX_MEMORY_SIZE_KB,
+                wtct_hash=b''
             )
             _assert_log_msg(
                 cm,
@@ -665,7 +666,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         # then
         assert not ts.should_accept_provider(
             "XYZ", "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-            DEFAULT_MAX_MEMORY_SIZE_KB)
+            DEFAULT_MAX_MEMORY_SIZE_KB, b'')
         listener.assert_called_once_with(
             sender=ANY,
             signal='golem.taskserver',
@@ -867,7 +868,7 @@ class TestTaskServer2(TaskServerBase):
         ts.task_manager.tasks_states[task_id].status = \
             ts.task_manager.activeStatus[0]
         subtask = ts.task_manager.get_next_subtask(
-            "DEF", task_id, 1000, 10, None)
+            "DEF", task_id, 1000, 10, b'')
         assert subtask is not None
         expected_value = ceil(1031 * 1010 / 3600)
         prev_calls = trust.COMPUTED.increase.call_count

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -646,7 +646,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
                 task_id=task_id,
                 provider_perf=DEFAULT_PROVIDER_PERF,
                 max_memory_size=DEFAULT_MAX_MEMORY_SIZE_KB,
-                wtct_hash=b''
+                offer_hash=b''
             )
             _assert_log_msg(
                 cm,

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -362,7 +362,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
 
         with self.assertLogs(logger, level='INFO') as cm:
             assert not ts.should_accept_provider(
-                node_id, "127.0.0.1", 'tid', 27.18, 1, 1)
+                node_id, "127.0.0.1", 'tid', 27.18, 1)
             _assert_log_msg(
                 cm,
                 f'INFO:{logger.name}:Cannot find task in my tasks: {ids}')
@@ -404,9 +404,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         with self.assertLogs(logger, level='INFO') as cm:
             # when
             accepted = ts.should_accept_provider(
-                node_id, "127.0.0.1", task_id,
-                provider_perf,
-                DEFAULT_MAX_MEMORY_SIZE_KB, 1)
+                node_id, "127.0.0.1", task_id, provider_perf, 1)
 
             # then
             assert not accepted
@@ -449,7 +447,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
             # when
             accepted = ts.should_accept_provider(
                 node_id, "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-                DEFAULT_MAX_RESOURCE_SIZE_KB, DEFAULT_MAX_MEMORY_SIZE_KB)
+                DEFAULT_MAX_MEMORY_SIZE_KB)
 
             # then
             assert not accepted
@@ -497,7 +495,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         # when/then
         assert ts.should_accept_provider(
             node_id, "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-            DEFAULT_MAX_RESOURCE_SIZE_KB, DEFAULT_MAX_MEMORY_SIZE_KB)
+            DEFAULT_MAX_MEMORY_SIZE_KB)
 
         # given
         self.client.get_computing_trust.return_value = \
@@ -505,7 +503,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         # when/then
         assert ts.should_accept_provider(
             node_id, "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-            DEFAULT_MAX_RESOURCE_SIZE_KB, DEFAULT_MAX_MEMORY_SIZE_KB)
+            DEFAULT_MAX_MEMORY_SIZE_KB)
 
         # given
         trust = ts.config_desc.computing_trust - 0.2
@@ -514,7 +512,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
             # when
             accepted = ts.should_accept_provider(
                 node_id, "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-                DEFAULT_MAX_RESOURCE_SIZE_KB, DEFAULT_MAX_MEMORY_SIZE_KB)
+                DEFAULT_MAX_MEMORY_SIZE_KB)
 
             # then
             assert not accepted
@@ -559,7 +557,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
             # when
             accepted = ts.should_accept_provider(
                 node_id, "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-                DEFAULT_MAX_RESOURCE_SIZE_KB, DEFAULT_MAX_MEMORY_SIZE_KB)
+                DEFAULT_MAX_MEMORY_SIZE_KB)
 
             # then
             assert not accepted
@@ -596,7 +594,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         with self.assertLogs(logger, level='INFO') as cm:
             # when
             accepted = ts.should_accept_provider(node_id, "127.0.0.1",
-                                                 task_id, 99, 3, 4)
+                                                 task_id, 99, 4)
 
             # then
             assert not accepted
@@ -643,10 +641,9 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         with self.assertLogs(logger, level='INFO') as cm:
             assert not ts.should_accept_provider(
                 node_id=node_id,
-                address="127.0.0.1",
+                ip_addr="127.0.0.1",
                 task_id=task_id,
                 provider_perf=DEFAULT_PROVIDER_PERF,
-                max_resource_size=DEFAULT_MAX_RESOURCE_SIZE_KB,
                 max_memory_size=DEFAULT_MAX_MEMORY_SIZE_KB,
             )
             _assert_log_msg(
@@ -668,7 +665,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         # then
         assert not ts.should_accept_provider(
             "XYZ", "127.0.0.1", task_id, DEFAULT_PROVIDER_PERF,
-            DEFAULT_MAX_RESOURCE_SIZE_KB, DEFAULT_MAX_MEMORY_SIZE_KB)
+            DEFAULT_MAX_MEMORY_SIZE_KB)
         listener.assert_called_once_with(
             sender=ANY,
             signal='golem.taskserver',

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -404,7 +404,8 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
         with self.assertLogs(logger, level='INFO') as cm:
             # when
             accepted = ts.should_accept_provider(
-                node_id, "127.0.0.1", task_id, provider_perf, 1, b'')
+                node_id, "127.0.0.1", task_id, provider_perf,
+                DEFAULT_MAX_MEMORY_SIZE_KB, b'')
 
             # then
             assert not accepted

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -791,64 +791,6 @@ class TestTaskSession(TaskSessionTestBase):
         tm.check_next_subtask.return_value = True
 
 
-class WaitingForResultsTestCase(
-        testutils.DatabaseFixture,
-        testutils.TempDirFixture,
-):
-    def setUp(self):
-        testutils.DatabaseFixture.setUp(self)
-        testutils.TempDirFixture.setUp(self)
-        history.MessageHistoryService()
-        self.ts = TaskSession(Mock())
-        self.ts.conn.send_message.side_effect = \
-            lambda msg: msg._fake_sign()
-        self.ts.task_server.get_node_name.return_value = "Zażółć gęślą jaźń"
-        requestor_keys = KeysAuth(
-            datadir=self.path,
-            difficulty=4,
-            private_key_name='prv',
-            password='',
-        )
-        self.ts.task_server.get_key_id.return_value = "key_id"
-        self.ts.key_id = requestor_keys.key_id
-        self.ts.task_server.get_share_options.return_value = \
-            hyperdrive_client.HyperdriveClientOptions('1', 1.0)
-
-        keys_auth = KeysAuth(
-            datadir=self.path,
-            difficulty=4,
-            private_key_name='prv',
-            password='',
-        )
-        self.ts.task_server.keys_auth = keys_auth
-        self.ts.concent_service.variant = variables.CONCENT_CHOICES['test']
-        ttc_prefix = 'task_to_compute'
-        hdr_prefix = f'{ttc_prefix}__want_to_compute_task__task_header'
-        self.msg = msg_factories.tasks.WaitingForResultsFactory(
-            sign__privkey=requestor_keys.ecc.raw_privkey,
-            **{
-                f'{ttc_prefix}__sign__privkey': requestor_keys.ecc.raw_privkey,
-                f'{ttc_prefix}__requestor_public_key':
-                    encode_hex(requestor_keys.ecc.raw_pubkey),
-                f'{ttc_prefix}__want_to_compute_task__sign__privkey':
-                    keys_auth.ecc.raw_privkey,
-                f'{ttc_prefix}__want_to_compute_task__provider_public_key':
-                    encode_hex(keys_auth.ecc.raw_pubkey),
-                f'{hdr_prefix}__sign__privkey':
-                    requestor_keys.ecc.raw_privkey,
-                f'{hdr_prefix}__requestor_public_key':
-                    encode_hex(requestor_keys.ecc.raw_pubkey),
-            },
-        )
-
-    def test_task_server_notification(self, *_):
-        self.ts._react_to_waiting_for_results(self.msg)
-        self.ts.task_server.subtask_waiting.assert_called_once_with(
-            task_id=self.msg.task_id,
-            subtask_id=self.msg.subtask_id,
-        )
-
-
 class ForceReportComputedTaskTestCase(testutils.DatabaseFixture,
                                       testutils.TempDirFixture):
     def setUp(self):

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -705,6 +705,7 @@ class TestTaskSession(TaskSessionTestBase):
     def test_react_to_want_to_compute_no_handshake(self, *_):
         mock_msg = Mock()
         mock_msg.concent_enabled = False
+        mock_msg.get_short_hash.return_value = b'wtct hash'
 
         self._prepare_handshake_test()
 
@@ -721,6 +722,7 @@ class TestTaskSession(TaskSessionTestBase):
     def test_react_to_want_to_compute_handshake_busy(self, *_):
         mock_msg = Mock()
         mock_msg.concent_enabled = False
+        mock_msg.get_short_hash.return_value = b'wtct hash'
 
         self._prepare_handshake_test()
 


### PR DESCRIPTION
I found those redundant checks when I was testing #4177 with a single requestor and three providers.
It is a waste of resources to check things twice, but what's more important, we are also wasting developer time to read and extend such a code.