### PR TITLE
Fix typehints of conftest files

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,12 +1,15 @@
+from typing import List
+import _pytest
 import pytest
 
 
-def pytest_addoption(parser) -> None:
+def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
     parser.addoption("--runslow", action="store_true",
                      default=False, help="run slow tests")
 
 
-def pytest_collection_modifyitems(config, items) -> None:
+def pytest_collection_modifyitems(config: _pytest.config.Config,
+                                  items: List[pytest.Item]) -> None:
     if config.getoption("--runslow"):
         # --runslow given in cli: do not skip slow tests
         return

--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -19,7 +19,7 @@ pycodestyle==2.5.0
 pyflakes==2.1.1
 pylint==1.9.2
 pytest-cov==2.5.1
-pytest==3.3.1
+pytest==3.6.3
 python-dateutil==2.7.2
 requests==2.21.0
 six==1.11.0

--- a/scripts/node_integration_tests/conftest.py
+++ b/scripts/node_integration_tests/conftest.py
@@ -1,10 +1,12 @@
 from typing import List
 import _pytest
+import pytest
 
 from .key_reuse import NodeKeyReuseConfig
 
 DUMP_OUTPUT_ON_CRASH = False
 DUMP_OUTPUT_ON_FAIL = False
+
 
 class DumpOutput:
     @staticmethod
@@ -26,7 +28,7 @@ class DumpOutput:
         DUMP_OUTPUT_ON_FAIL = True
 
 
-def pytest_addoption(parser: _pytest.config.Parser) -> None:
+def pytest_addoption(parser: _pytest.config.argparsing.Parser) -> None:
 
     parser.addoption(
         "--disable-key-reuse", action="store_true",
@@ -48,7 +50,7 @@ def pytest_addoption(parser: _pytest.config.Parser) -> None:
 
 
 def pytest_collection_modifyitems(config: _pytest.config.Config,
-                                  items: List[_pytest.main.Item]) -> None:
+                                  items: List[pytest.Item]) -> None:
     if config.getoption("--disable-key-reuse"):
         NodeKeyReuseConfig.disable()
     hostname = config.getoption("--granary-hostname")


### PR DESCRIPTION
Needed after recent pytest upgrade.
Smoke fails currently because of that.