### PR TITLE
Stop Golem from crashing on benchmark failure

### DIFF
--- a/apps/glambda/glambdaenvironment.py
+++ b/apps/glambda/glambdaenvironment.py
@@ -1,9 +1,13 @@
+import filecmp
+import logging
 import shutil
 from typing import Dict
 
 from golem.core.common import is_linux
 from golem.docker.environment import DockerEnvironment
 from golem.environments.environment import SupportStatus, UnsupportReason
+
+logger = logging.getLogger(__name__)
 
 
 class GLambdaTaskEnvironment(DockerEnvironment):
@@ -14,10 +18,20 @@ class GLambdaTaskEnvironment(DockerEnvironment):
 
     def check_support(self) -> SupportStatus:
         GVISOR_SECURE_RUNTIME = 'runsc'
-        if is_linux() and not shutil.which(GVISOR_SECURE_RUNTIME):
-            return SupportStatus.err({
-                UnsupportReason.ENVIRONMENT_NOT_SECURE: self.ENV_ID
-            })
+        if is_linux():
+            if not shutil.which(GVISOR_SECURE_RUNTIME):
+                return SupportStatus.err({
+                    UnsupportReason.ENVIRONMENT_NOT_SECURE: self.ENV_ID
+                })
+            if not filecmp.cmp('/sys/fs/cgroup/cpuset/cpuset.cpus',
+                       '/sys/fs/cgroup/cpuset/docker/cpuset.cpus'):
+                logger.info('Unable to start GLambda app. Setting '
+                '`cgroup.cpuset.cpus` does not match `docker.cpuset.cpus`.
+                'Potential fix: `cat /sys/fs/cgroup/cpuset/cpuset.cpus '
+                '> /sys/fs/cgroup/cpuset/docker/cpuset.cpus`.')
+                return SupportStatus.err({
+                    UnsupportReason.ENVIRONMENT_MISCONFIGURED: self.ENV_ID
+                })
         return super().check_support()
 
     def get_container_config(self) -> Dict:

--- a/apps/glambda/glambdaenvironment.py
+++ b/apps/glambda/glambdaenvironment.py
@@ -23,17 +23,19 @@ class GLambdaTaskEnvironment(DockerEnvironment):
                 return SupportStatus.err({
                     UnsupportReason.ENVIRONMENT_NOT_SECURE: self.ENV_ID
                 })
-            if not self._is_cgroup_cpuset_cfg_correct():
-                logger.warn('Unable to start GLambda app. Setting '
-                '`cgroup.cpuset.cpus` does not match `docker.cpuset.cpus`.'
-                'Potential fix: `cat /sys/fs/cgroup/cpuset/cpuset.cpus '
-                '> /sys/fs/cgroup/cpuset/docker/cpuset.cpus`.')
+            if not GLambdaTaskEnvironment._is_cgroup_cpuset_cfg_correct():
+                logger.warning('Unable to start GLambda app. Setting '
+                               '`cgroup.cpuset.cpus` does not match `docker.'
+                               'cpuset.cpus`. Potential fix: `cat /sys/fs/'
+                               'cgroup/cpuset/cpuset.cpus > /sys/fs/cgroup/'
+                               'cpuset/docker/cpuset.cpus`.')
                 return SupportStatus.err({
                     UnsupportReason.ENVIRONMENT_MISCONFIGURED: self.ENV_ID
                 })
         return super().check_support()
 
-    def _is_cgroup_cpuset_cfg_correct(self):
+    @staticmethod
+    def _is_cgroup_cpuset_cfg_correct():
         try:
             res = filecmp.cmp('/sys/fs/cgroup/cpuset/cpuset.cpus',
                               '/sys/fs/cgroup/cpuset/docker/cpuset.cpus')

--- a/golem/environments/environment.py
+++ b/golem/environments/environment.py
@@ -54,6 +54,7 @@ class UnsupportReason(enum.Enum):
     ENVIRONMENT_UNSUPPORTED = 'environment_unsupported'
     ENVIRONMENT_NOT_ACCEPTING_TASKS = 'environment_not_accepting_tasks'
     ENVIRONMENT_NOT_SECURE = 'environment_not_secure'
+    ENVIRONMENT_MISCONFIGURED = 'environment_misconfigured'
     MAX_PRICE = 'max_price'
     APP_VERSION = 'app_version'
     DENY_LIST = 'deny_list'

--- a/golem/task/benchmarkmanager.py
+++ b/golem/task/benchmarkmanager.py
@@ -51,9 +51,8 @@ class BenchmarkManager(object):
         def error_callback(err: Union[str, Exception]):
             logger.error("Unable to run %s benchmark: %s", env_id, str(err))
             if error:
-                if isinstance(err, str):
-                    err = Exception(err)
-                error(err)
+                logger.info('%s performance is %.2f', env_id, 0)
+                success(0)
 
         task_state = TaskDesc()
         task_state.status = TaskStatus.notStarted

--- a/golem/task/benchmarkmanager.py
+++ b/golem/task/benchmarkmanager.py
@@ -51,8 +51,9 @@ class BenchmarkManager(object):
         def error_callback(err: Union[str, Exception]):
             logger.error("Unable to run %s benchmark: %s", env_id, str(err))
             if error:
-                logger.info('%s performance is %.2f', env_id, 0)
-                success(0)
+                if isinstance(err, str):
+                    err = Exception(err)
+                error(err)
 
         task_state = TaskDesc()
         task_state.status = TaskStatus.notStarted


### PR DESCRIPTION
A rationale is that Golem should not crash on a failed benchmark. Ideally it should disable the app for this particular run. Since this is not straightforward to add I propose this PR which sets app's performance to 0. It will at least stabilize startup behavior. 

The context is GLambda's secure runtime for docker - gVisor, randomly crashing due to problems with permissions on `/sys/fs/cgroup/cpuset/docker/cpuset.cpu`. We are probably hitting issue described [here](https://bugzilla.redhat.com/show_bug.cgi?id=1609785#c1). From my trials one such cpuset mask refresh is e.g. running `docker run -it --cpuset-cpus=0 some_image`, although I'm not sure if it always works.

