### PR TITLE
Docker environment integration tests cleanup

### DIFF
--- a/tests/golem/envs/docker/cpu/test_integration.py
+++ b/tests/golem/envs/docker/cpu/test_integration.py
@@ -1,12 +1,10 @@
 import socket
-import tempfile
-from pathlib import Path
 
 import pytest
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase
 
-from golem.envs import EnvStatus, RuntimeStatus
+from golem.envs import RuntimeStatus
 from golem.envs.docker import DockerPrerequisites, DockerRuntimePayload
 from golem.envs.docker.cpu import DockerCPUConfig, DockerCPUEnvironment
 from golem.envs.docker.whitelist import Whitelist
@@ -17,31 +15,35 @@ from golem.tools.ci import ci_skip
 @ci_skip
 class TestIntegration(TestCase, DatabaseFixture):
 
-    @pytest.mark.timeout(60)  # 60 sec should be well enough for this test
+    @inlineCallbacks
+    def setUp(self):
+        DatabaseFixture.setUp(self)
+        # Not using simply self.new_path as work_dir because this path changes
+        # with every test case. On Windows the working directory has to be
+        # shared so using self.new_path would result with a pop-up window
+        # appearing during every test.
+        config = DockerCPUConfig(work_dirs=[self.new_path.parent.parent])
+        self.env = DockerCPUEnvironment(config)
+        yield self.env.prepare()
+
+    @inlineCallbacks
+    def tearDown(self):
+        yield self.env.clean_up()
+        DatabaseFixture.tearDown(self)
+
+    @pytest.mark.timeout(120)  # 120 sec should be well enough for this test
     @inlineCallbacks
     def test_io(self):
-        # Set up environment
-        config = DockerCPUConfig(work_dirs=[Path(tempfile.gettempdir())])
-        env = DockerCPUEnvironment(config)
-        yield env.prepare()
-        self.assertEqual(env.status(), EnvStatus.ENABLED)
-
-        # Add environment cleanup to clean it if test goes wrong
-        def _clean_up_env():
-            if env.status() != EnvStatus.DISABLED:
-                env.clean_up()
-        self.addCleanup(_clean_up_env)
-
         # Download image
         Whitelist.add("busybox")
-        installed = yield env.install_prerequisites(DockerPrerequisites(
+        installed = yield self.env.install_prerequisites(DockerPrerequisites(
             image="busybox",
             tag="latest"
         ))
         self.assertTrue(installed)
 
         # Create runtime
-        runtime = env.runtime(DockerRuntimePayload(
+        runtime = self.env.runtime(DockerRuntimePayload(
             image="busybox",
             tag="latest",
             env={},
@@ -77,37 +79,23 @@ class TestIntegration(TestCase, DatabaseFixture):
         yield runtime.clean_up()
         self.assertEqual(runtime.status(), RuntimeStatus.TORN_DOWN)
 
-        # Clean up the environment
-        yield env.clean_up()
-        self.assertEqual(env.status(), EnvStatus.DISABLED)
-
     @inlineCallbacks
     def test_benchmark(self):
-        config = DockerCPUConfig(work_dirs=[Path(tempfile.gettempdir())])
-        env = DockerCPUEnvironment(config)
-        yield env.prepare()
-
-        Whitelist.add(env.BENCHMARK_IMAGE.split('/')[0])
-        score = yield env.run_benchmark()
+        Whitelist.add(self.env.BENCHMARK_IMAGE.split('/')[0])
+        score = yield self.env.run_benchmark()
         self.assertGreater(score, 0)
-
-        yield env.clean_up()
 
     @inlineCallbacks
     def test_ports(self):
-        config = DockerCPUConfig(work_dirs=[Path(tempfile.gettempdir())])
-        env = DockerCPUEnvironment(config)
-        yield env.prepare()
-
         Whitelist.add("busybox")
-        installed = yield env.install_prerequisites(DockerPrerequisites(
+        installed = yield self.env.install_prerequisites(DockerPrerequisites(
             image="busybox",
             tag="latest"
         ))
         self.assertTrue(installed)
 
         port = 4444
-        runtime = env.runtime(DockerRuntimePayload(
+        runtime = self.env.runtime(DockerRuntimePayload(
             image="busybox",
             tag="latest",
             command=f"nc -l -k -p {port}",
@@ -126,5 +114,3 @@ class TestIntegration(TestCase, DatabaseFixture):
         finally:
             yield runtime.stop()
             yield runtime.clean_up()
-
-            yield env.clean_up()


### PR DESCRIPTION
* Moved common common code to `setUp()`/`tearDown()`
* Extended timeout for test_io because DockerToolbox is slow