### PR TITLE
package hash/size cleanup

### DIFF
--- a/golem/resource/base/resourceserver.py
+++ b/golem/resource/base/resourceserver.py
@@ -46,13 +46,12 @@ class BaseResourceServer:
     def sync_network(self):
         self._download_resources()
 
-    def add_resources(self, pkg_path, pkg_sha1, res_id, pkg_size,  # noqa pylint:disable=too-many-arguments
-                 client_options=None) -> Deferred:
+    def add_resources(self, pkg_path, res_id, client_options=None) -> Deferred:
         _result = Deferred()
         _result.addErrback(self._add_res_error)
 
         def callback(r):
-            value = r, pkg_path, pkg_sha1, pkg_size
+            value = r, pkg_path
             _result.callback(value)
 
         _deferred = self.resource_manager.add_resources(

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -308,14 +308,12 @@ def add_resources(client, resources, res_id, timeout):
     client_options.timeout = timeout
     resource_server_result = yield client.resource_server.add_resources(
         package_path,
-        package_sha1,
         res_id,
-        resource_size,
         client_options=client_options,
     )
 
     logger.info("Resource package created. res_id=%r", res_id)
-    return resource_server_result
+    return resource_server_result + (package_sha1, resource_size)
 
 
 @defer.inlineCallbacks

--- a/tests/golem/resource/base/test_base_resourceserver.py
+++ b/tests/golem/resource/base/test_base_resourceserver.py
@@ -102,9 +102,7 @@ class TestResourceServer(testwithreactor.TestDirFixtureWithReactor):
 
         _deferred = rs.create_resource_package(existing_paths, self.task_id)
         pkg_path, pkg_sha1 = sync_wait(_deferred)
-        resource_size = os.path.getsize(pkg_path)
-        return rm, rs.add_resources(pkg_path, pkg_sha1, self.task_id,
-                                    resource_size)
+        return rm, rs.add_resources(pkg_path, self.task_id)
 
     def testAddResources(self):
         rm, deferred = self._add_task()

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -90,7 +90,7 @@ class ProviderBase(test_client.TestClientBase):
 
         def add_resources(*_args, **_kwargs):
             resource_manager_result = 'res_hash', ['res_file_1']
-            result = resource_manager_result, 'res_file_1', 'package_hash', 42
+            result = resource_manager_result, 'res_file_1'
             return test_client.done_deferred(result)
 
         self.client.resource_server.create_resource_package = mock.Mock(
@@ -227,7 +227,7 @@ class TestRestartTask(ProviderBase):
 
         def add_resources(*_args, **_kwargs):
             resource_manager_result = 'res_hash', ['res_file_1']
-            result = resource_manager_result, 'res_file_1', 'package_hash', 0
+            result = resource_manager_result, 'res_file_1'
             return test_client.done_deferred(result)
 
         self.client.resource_server = mock.Mock(
@@ -356,7 +356,7 @@ class TestGetMaskForTask(test_client.TestClientBase):
             exp_potential_workers=8)
 
 
-@mock.patch('os.path.getsize')
+@mock.patch('os.path.getsize', return_value=123)
 class TestEnqueueNewTask(ProviderBase):
     def test_enqueue_new_task(self, *_):
         c = self.client
@@ -548,13 +548,13 @@ class TestValidateTaskDict(ProviderBase):
             rpc._validate_task_dict(self.client, self.t_dict)
 
 
-@mock.patch('os.path.getsize')
+@mock.patch('os.path.getsize', return_value=123)
 @mock.patch('golem.task.taskmanager.TaskManager.dump_task')
 class TestRestartSubtasks(ProviderBase):
     def setUp(self):
         super().setUp()
         self.task = self.client.task_manager.create_task(self.t_dict)
-        with mock.patch('os.path.getsize'):
+        with mock.patch('os.path.getsize', return_value=123):
             golem_deferred.sync_wait(
                 rpc.enqueue_new_task(self.client, self.task),
             )
@@ -706,7 +706,7 @@ class TestRestartFrameSubtasks(ProviderBase):
     def setUp(self):
         super().setUp()
         self.task = self.client.task_manager.create_task(self.t_dict)
-        with mock.patch('os.path.getsize'):
+        with mock.patch('os.path.getsize', return_value=123):
             golem_deferred.sync_wait(
                 rpc.enqueue_new_task(self.client, self.task),
             )
@@ -745,12 +745,12 @@ class TestRestartFrameSubtasks(ProviderBase):
         self.assertEqual(error, f'Task not found: {task_id!r}')
 
 
-@mock.patch('os.path.getsize')
+@mock.patch('os.path.getsize', return_value=123)
 class TestExceptionPropagation(ProviderBase):
     def setUp(self):
         super().setUp()
         self.task = self.client.task_manager.create_task(self.t_dict)
-        with mock.patch('os.path.getsize'):
+        with mock.patch('os.path.getsize', return_value=123):
             golem_deferred.sync_wait(
                 rpc.enqueue_new_task(self.client, self.task),
             )
@@ -1024,7 +1024,7 @@ class TestGetFragments(ProviderBase):
         deferred = rpc._prepare_task(self.client, task, force=False)
         return golem_deferred.sync_wait(deferred)
 
-    @mock.patch('os.path.getsize')
+    @mock.patch('os.path.getsize', return_value=123)
     @mock.patch('golem.task.taskmanager.TaskManager._get_task_output_dir')
     def test_get_fragments(self, *_):
         tm = self.client.task_manager


### PR DESCRIPTION
ResourceServer::add_resources takes hash and size just in order to return them. This is unnecessary.