### PR TITLE
Don't upload resources unnecessarily

### DIFF
--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -359,7 +359,6 @@ class CoreTask(Task):
             int(timeout_to_deadline(self.header.subtask_timeout)),
             self.header.deadline,
         )
-        ctd['resources'] = self.get_resources()
 
         return ctd
 

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -436,6 +436,8 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             resources = self.task_server.get_resources(ctd['subtask_id'])
             ctd["resources"] = resources
             logger.info("resources_result: %r", resources_result)
+        else:
+            ctd["resources"] = self.task_server.get_resources(ctd['task_id'])
 
         logger.info(
             "Subtask assigned. task_id=%r, node=%s, subtask_id=%r",

--- a/tests/golem/task/test_concent_logic.py
+++ b/tests/golem/task/test_concent_logic.py
@@ -477,6 +477,7 @@ class ReactToWantToComputeTaskTestCase(TestWithReactor):
             pass
 
         task_session.task_server.get_share_options.return_value = X()
+        task_session.task_server.get_resources.return_value = []
 
         with mock.patch(
             'golem.task.tasksession.taskkeeper.compute_subtask_value',


### PR DESCRIPTION
Because currently we re-upload the same resources for each subtask. Effectively wasting requestor's disk space.

https://github.com/golemfactory/golem/pull/3744/files#r253069796