### PR TITLE
Decrease severity of task not active log msg

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -373,7 +373,7 @@ class TaskManager(TaskEventListener):
     def task_needs_computation(self, task_id: str) -> bool:
         if self.task_finished(task_id):
             task_status = self.tasks_states[task_id].status
-            logger.info(
+            logger.debug(
                 'task is not active: %(task_id)s, status: %(task_status)s',
                 {
                     'task_id': task_id,


### PR DESCRIPTION
It was spamming logs during cyclic mask updating
<img width="1026" alt="wp_task_not_active" src="https://user-images.githubusercontent.com/293058/61200843-0ac54c00-a6e3-11e9-9de5-9376aaa5c146.png">
