### PR TITLE
Harden sweep_sessions

### DIFF
--- a/golem/task/server/queue_.py
+++ b/golem/task/server/queue_.py
@@ -17,6 +17,7 @@ if typing.TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
 class TaskMessagesQueueMixin:
     """Message Queue functionality for TaskServer"""
 
@@ -98,8 +99,14 @@ class TaskMessagesQueueMixin:
             self.initiate_session(node_id)
 
     def sweep_sessions(self):
-        for node_id in self.sessions:
-            session = self.sessions[node_id]
+        # Iterate over shallow copy to avoid problems with
+        # dict changing size during iteration.
+        for node_id in tuple(self.sessions.keys()):
+            try:
+                session = self.sessions[node_id]
+            except KeyError:
+                # Dict changed during iteration
+                continue
             if session is None:
                 continue
             if session.is_active:


### PR DESCRIPTION
Fix iteration error in `sweep_sessions()`

```python
2019-07-15 10:47:08 ERROR    golem.task.taskserver               TaskServer.sync_network job <bound method TaskMessagesQueueMixin.sweep_sessions of <golem.task.taskserver.TaskServer object at 0x0000018C5A180C18>> failed
Traceback (most recent call last):
  File "C:\BuildbotWorker\buildpackage_windows\build\golem\task\taskserver.py", line 208, in sync_network
  File "C:\BuildbotWorker\buildpackage_windows\build\golem\task\server\queue_.py", line 101, in sweep_sessions
RuntimeError: dictionary changed size during iteration
```