### PR TITLE
Remove deadline param from funds locker

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -187,7 +187,6 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         self.transaction_system.start()
 
         self.funds_locker = FundsLocker(self.transaction_system)
-        self._services.append(self.funds_locker)
 
         self.use_docker_manager = use_docker_manager
         self.connect_to_known_hosts = connect_to_known_hosts
@@ -543,7 +542,6 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
                         task_id,
                         task.subtask_price,
                         unfinished_subtasks,
-                        task.header.deadline,
                     )
                 except eth_exceptions.NotEnoughFunds as e:
                     # May happen when gas prices increase, not much we can do

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -372,7 +372,6 @@ def enqueue_new_task(client, task, force=False) \
         task_id,
         task.subtask_price,
         task.get_total_tasks(),
-        task.header.deadline,
     )
     logger.debug('Enqueue new task. task_id=%r', task)
 

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -350,11 +350,9 @@ class TestClient(TestClientBase):
             ),
         }
         subtask_price = 123
-        deadline = 23
         tm.tasks = {
             "t2": Mock(
                 subtask_price=subtask_price,
-                header=Mock(deadline=deadline),
                 get_total_tasks=Mock(return_value=3)
             ),
         }
@@ -363,7 +361,6 @@ class TestClient(TestClientBase):
             "t2",
             subtask_price,
             2,
-            deadline,
         )
 
 
@@ -380,7 +377,6 @@ class TestClientRestartSubtasks(TestClientBase):
             self.task_id,
             self.subtask_price,
             10,
-            time.time(),
         )
 
         self.client.task_server = Mock()


### PR DESCRIPTION
Tasks are removed by `remove_task` after they time out so no need for doing that asynchronously as well.