### PR TITLE
Implement new env performance before sending WTCT

### DIFF
--- a/golem/task/envmanager.py
+++ b/golem/task/envmanager.py
@@ -83,7 +83,6 @@ class EnvironmentManager:
         if not self.enabled(env_id):
             raise Exception("Requested performance for disabled environment")
 
-        perf = None
         try:
             perf = Performance.get(Performance.environment_id == env_id)
             return perf.value

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -59,8 +59,9 @@ class WrongOwnerException(Exception):
 
 
 class CompTaskInfo:
-    def __init__(self, header: dt_tasks.TaskHeader) -> None:
+    def __init__(self, header: dt_tasks.TaskHeader, performance: float) -> None:
         self.header = header
+        self.performance = performance
         self.requests = 1
         self.subtasks: typing.Dict[str, message.tasks.ComputeTaskDef] = {}
         # TODO Add concent communication timeout. Issue #2406
@@ -177,7 +178,12 @@ class CompTaskKeeper:
         self.active_task_offers.update(active_task_offers)
         self.resources_options.update(resources_options)
 
-    def add_request(self, theader: dt_tasks.TaskHeader, price: int):
+    def add_request(
+            self,
+            theader: dt_tasks.TaskHeader,
+            price: int,
+            performance: float
+    ):
         # price is task_header.max_price
         logger.debug('CT.add_request(%r, %s)', theader, price)
         if price < 0:
@@ -186,7 +192,7 @@ class CompTaskKeeper:
         if task_id in self.active_tasks:
             self.active_tasks[task_id].requests += 1
         else:
-            self.active_tasks[task_id] = CompTaskInfo(theader)
+            self.active_tasks[task_id] = CompTaskInfo(theader, performance)
         self.active_task_offers[task_id] = compute_subtask_value(
             price, self.active_tasks[task_id].header.subtask_timeout
         )

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -1139,9 +1139,9 @@ class TaskManager(TaskEventListener):
         task_type = self.task_types[task_type_name]
         return task_type.get_preview(task, single=single)
 
-    def add_comp_task_request(self, theader, price):
+    def add_comp_task_request(self, theader, price, performance):
         """ Add a header of a task which this node may try to compute """
-        self.comp_task_keeper.add_request(theader, price)
+        self.comp_task_keeper.add_request(theader, price, performance)
 
     def __add_subtask_to_tasks_states(self, node_id,
                                       ctd, price: int):

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -309,7 +309,16 @@ class TaskServer(
 
         self._last_task_request_time = time.time()
         self.task_computer.stats.increase_stat('tasks_requested')
-        self._request_task(task_header)
+
+        def _request_task_error(e):
+            logger.error(
+                "Failed to request task: task_id=%r, exception=%r",
+                task_header.task_id,
+                e
+            )
+        # Unyielded deferred, fire and forget requesting a new task
+        deferred = self._request_task(task_header)
+        deferred.addErrback(_request_task_error)  # pylint: disable=no-member
 
     @inlineCallbacks
     def _request_task(self, theader: dt_tasks.TaskHeader) -> Deferred:

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -39,7 +39,7 @@ from golem.envs import Environment as NewEnv
 from golem.envs.docker.cpu import DockerCPUConfig
 from golem.envs.docker.non_hypervised import NonHypervisedDockerCPUEnvironment
 from golem.marketplace import OfferPool
-from golem.model import Performance, TaskPayment
+from golem.model import TaskPayment
 from golem.network.hyperdrive.client import HyperdriveAsyncClient
 from golem.network.transport import msg_queue
 from golem.network.transport.network import ProtocolFactory, SessionFactory
@@ -353,10 +353,10 @@ class TaskServer(
             # Check performance
             performance = None
             if isinstance(env, OldEnv):
-                performance = yield env.get_performance()
+                performance = env.get_performance()
             else:  # NewEnv
                 env_mgr = self.task_keeper.new_env_manager
-                performance = env_mgr.get_performance(env_id)
+                performance = yield env_mgr.get_performance(env_id)
             if performance is None:
                 return None
 

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -289,7 +289,7 @@ class TaskServer(
             return
         self._request_task(task_header)
 
-    def _request_random_task(self):
+    def _request_random_task(self) -> None:
         """ If there is no task currently computing and time elapsed from last
             request exceeds the configured request interval, choose a random
             task from the network to compute on our machine. """

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -269,7 +269,10 @@ class TaskServer(
         super().resume()
         CoreTask.VERIFICATION_QUEUE.resume()
 
-    def get_environment_by_id(self, env_id: str) -> Union[OldEnv, NewEnv]:
+    def get_environment_by_id(
+            self,
+            env_id: str
+    ) -> Optional[Union[OldEnv, NewEnv]]:
         """ Looks for the requested env_id in the new, then the old env_manager.
             Returns None when the environment is not found. """
         keeper = self.task_keeper
@@ -293,16 +296,16 @@ class TaskServer(
 
         if time.time() - self._last_task_request_time \
                 < self.config_desc.task_request_interval:
-            return None
+            return
 
         if self.task_computer.has_assigned_task() \
                 or (not self.task_computer.compute_tasks) \
                 or (not self.task_computer.runnable):
-            return None
+            return
 
         task_header = self.task_keeper.get_task(self.requested_tasks)
         if task_header is None:
-            return None
+            return
 
         self._last_task_request_time = time.time()
         self.task_computer.stats.increase_stat('tasks_requested')

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -358,6 +358,7 @@ class TaskServer(
                 env_mgr = self.task_keeper.new_env_manager
                 performance = yield env_mgr.get_performance(env_id)
             if performance is None:
+                logger.debug("Not requesting task, benchmark is in progress.")
                 return None
 
             # Check handshake
@@ -412,7 +413,7 @@ class TaskServer(
             return theader.task_id
         except Exception as err:  # pylint: disable=broad-except
             logger.warning("Cannot send request for task: %s", err)
-            logger.info("Detailed traceback", exc_info=True)
+            logger.debug("Detailed traceback", exc_info=True)
             self.remove_task_header(theader.task_id)
 
         return None

--- a/tests/golem/task/test_envmanager.py
+++ b/tests/golem/task/test_envmanager.py
@@ -75,7 +75,7 @@ class TestEnvironmentManager(TestCase):
         # Then
         self.assertFalse(self.manager.enabled("env1"))
         self.assertTrue(self.manager.enabled("env2"))
-        self.assertRaises(KeyError, self.manager.enabled, "bogus_env")
+        self.assertFalse(self.manager.enabled("bogus_env"))
 
     def test_payload_builder(self):
         _, pb = self.register_env("env1")

--- a/tests/golem/task/test_envmanager.py
+++ b/tests/golem/task/test_envmanager.py
@@ -90,7 +90,7 @@ class TestEnvironmentManager(EnvManagerBaseTest):
         self.assertEqual(pb, self.manager.payload_builder("env1"))
 
 
-class TestEnvironmentManagerDB(
+class TestEnvironmentManagerDB(  # pylint: disable=too-many-ancestors
         EnvManagerBaseTest,
         DatabaseFixture,
         TwistedTestCase

--- a/tests/golem/task/test_envmanager.py
+++ b/tests/golem/task/test_envmanager.py
@@ -1,14 +1,19 @@
 from unittest import TestCase
 from unittest.mock import MagicMock
 
+from twisted.internet.defer import inlineCallbacks
+from twisted.trial.unittest import TestCase as TwistedTestCase
+
 from golem.envs import Environment
+from golem.model import Performance
 from golem.task.task_api import TaskApiPayloadBuilder
 from golem.task.envmanager import EnvironmentManager
+from golem.testutils import DatabaseFixture
 
 
-class TestEnvironmentManager(TestCase):
-
+class EnvManagerBaseTest(TestCase):
     def setUp(self):
+        super().setUp()
         self.manager = EnvironmentManager()
 
     def register_env(self, env_id):
@@ -17,6 +22,9 @@ class TestEnvironmentManager(TestCase):
         payload_builder = MagicMock(sepc_set=TaskApiPayloadBuilder)
         self.manager.register_env(env, payload_builder)
         return env, payload_builder
+
+
+class TestEnvironmentManager(EnvManagerBaseTest):
 
     def test_register_env(self):
         # Given
@@ -80,3 +88,72 @@ class TestEnvironmentManager(TestCase):
     def test_payload_builder(self):
         _, pb = self.register_env("env1")
         self.assertEqual(pb, self.manager.payload_builder("env1"))
+
+
+class TestEnvironmentManagerDB(
+        EnvManagerBaseTest,
+        DatabaseFixture,
+        TwistedTestCase
+):
+    @inlineCallbacks
+    def test_get_performance_running(self):
+        # Given
+        env_id = "env1"
+        self.register_env(env_id)
+        env = self.manager._envs[env_id]
+        self.manager._running_benchmark = True
+
+        # When
+        result = yield self.manager.get_performance(env_id)
+
+        # Then
+        env.instance.run_benchmark.assert_not_called()
+        self.assertTrue(result is None)
+
+    @inlineCallbacks
+    def test_get_performance_disabled_env(self):
+        # Given
+        env_id = "env1"
+        self.register_env(env_id)
+        env = self.manager._envs[env_id]
+        self.manager.set_enabled(env_id, False)
+
+        # When
+
+        with self.assertRaises(Exception):
+            yield self.manager.get_performance(env_id)
+
+        # Then
+        env.instance.run_benchmark.assert_not_called()
+
+    @inlineCallbacks
+    def test_get_performance_in_db(self):
+        # Given
+        env_id = "env1"
+        self.register_env(env_id)
+        env = self.manager._envs[env_id]
+        self.manager.set_enabled(env_id, True)
+
+        Performance.update_or_create(env_id, 300.0)
+
+        # When
+        yield self.manager.get_performance(env_id)
+
+        # Then
+        env.instance.run_benchmark.assert_not_called()
+
+    @inlineCallbacks
+    def test_get_performance_benchmark_error(self):
+        # Given
+        env_id = "env1"
+        self.register_env(env_id)
+        env = self.manager._envs[env_id]
+        env.instance.get_benchmark = MagicMock(side_effect=Exception)
+
+        self.manager.set_enabled(env_id, True)
+
+        # When
+        yield self.manager.get_performance(env_id)
+
+        # Then
+        env.instance.run_benchmark.assert_called_once()

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -506,7 +506,7 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
 
             test_headers.append(header)
             price_bid = int(random.random() * 100)
-            ctk.add_request(header, price_bid)
+            ctk.add_request(header, price_bid, 0.0)
 
             ctd = ComputeTaskDef()
             ctd['task_id'] = header.task_id
@@ -571,28 +571,28 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         header.task_id = "xyz"
         header.subtask_timeout = 1
         with self.assertRaises(TypeError):
-            ctk.add_request(header, "not a number")
+            ctk.add_request(header, "not a number", 0.0)
         with self.assertRaises(ValueError):
-            ctk.add_request(header, -2)
-        ctk.add_request(header, 5 * 10 ** 18)
+            ctk.add_request(header, -2, 0.0)
+        ctk.add_request(header, 5 * 10 ** 18, 0.0)
         self.assertEqual(ctk.active_tasks["xyz"].requests, 1)
         self.assertEqual(ctk.active_task_offers["xyz"], 1388888888888889)
         self.assertEqual(ctk.active_tasks["xyz"].header, header)
-        ctk.add_request(header, 1 * 10 ** 17)
+        ctk.add_request(header, 1 * 10 ** 17, 0.0)
         self.assertEqual(ctk.active_tasks["xyz"].requests, 2)
         self.assertEqual(ctk.active_task_offers["xyz"], 27777777777778)
         self.assertEqual(ctk.active_tasks["xyz"].header, header)
         header.task_id = "xyz2"
-        ctk.add_request(header, 314 * 10 ** 15)
+        ctk.add_request(header, 314 * 10 ** 15, 0.0)
         self.assertEqual(ctk.active_task_offers["xyz2"], 87222222222223)
         header.task_id = "xyz"
         thread = get_task_header()
         thread.task_id = "qaz123WSX"
         with self.assertRaises(ValueError):
-            ctk.add_request(thread, -1)
+            ctk.add_request(thread, -1, 0.0)
         with self.assertRaises(TypeError):
-            ctk.add_request(thread, '1')
-        ctk.add_request(thread, 12)
+            ctk.add_request(thread, '1', 0.0)
+        ctk.add_request(thread, 12, 0.0)
 
         ctd = ComputeTaskDef()
         ttc = msg_factories.tasks.TaskToComputeFactory(price=0)
@@ -612,7 +612,7 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         th = get_task_header()
         task_id = th.task_id
         price_bid = 5
-        ctk.add_request(th, price_bid)
+        ctk.add_request(th, price_bid, 0.0)
         subtask_id = idgenerator.generate_new_id_from_id(task_id)
         ctd = ComputeTaskDef()
         ctd['task_id'] = task_id
@@ -648,7 +648,7 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         ctk = CompTaskKeeper(self.new_path)
         header = get_task_header()
         task_id = header.task_id
-        ctk.add_request(header, 40003)
+        ctk.add_request(header, 40003, 0.0)
         ctk.active_tasks[task_id].requests = 0
         subtask_id = idgenerator.generate_new_id_from_id(task_id)
         comp_task_def = {

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1444,7 +1444,8 @@ class TestEnvManager(TaskServerAsyncTestBase):
     @defer.inlineCallbacks
     def test_request_task(self):
         # Given
-        task_header = get_example_task_header("abc")
+
+        task_header = get_example_task_header('abc')
 
         self.ts.should_accept_requestor = Mock(return_value=SupportStatus.ok())
         self.ts.client.concent_service.enabled = False
@@ -1458,7 +1459,9 @@ class TestEnvManager(TaskServerAsyncTestBase):
 
         mock_handshake = Mock()
         mock_handshake.success = Mock(return_value=True)
-        self.ts.resource_handshakes[task_header.task_owner.key] = mock_handshake
+        self.ts.resource_handshakes[
+            task_header.task_owner.key  # pylint: disable=no-member
+        ] = mock_handshake
 
         # When
         yield self.ts._request_task(task_header)
@@ -1470,7 +1473,7 @@ class TestEnvManager(TaskServerAsyncTestBase):
     def test_request_task_running_benchmark(self):
         # Given
         performance = None
-        task_header = get_example_task_header("abc")
+        task_header = get_example_task_header('abc')
 
         self.ts.should_accept_requestor = Mock(return_value=SupportStatus.ok())
         self.ts.client.concent_service.enabled = False
@@ -1484,7 +1487,9 @@ class TestEnvManager(TaskServerAsyncTestBase):
 
         mock_handshake = Mock()
         mock_handshake.success = Mock(return_value=True)
-        self.ts.resource_handshakes[task_header.task_owner.key] = mock_handshake
+        self.ts.resource_handshakes[
+            task_header.task_owner.key  # pylint: disable=no-member
+        ] = mock_handshake
 
         # When
         result = yield self.ts._request_task(task_header)

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -698,6 +698,7 @@ class TestTaskSession(TaskSessionTestBase):
                 max_price=1,
             ),
             20,
+            0.0,
         )
         assert task_keeper.active_tasks["abc"].requests == 1
         self.task_session.task_manager.comp_task_keeper = task_keeper


### PR DESCRIPTION
Compute the new app benchmark if needed. Send the new app benchmark score in WTCT so that it can be used in the new subtask creation flow.

Steps taken:
- Added new env as return value to `TaskServer.get_environment_by_id()`
- Added (new) `EnvironmentManager.get_performance()`
  - Stores performance scores in the same table as old EnvironmentManager
  - returns Deferred -> float if benchmark is cached or started, None when benchmark is running
- Added performance to `CompTaskInfo` so it does not have to be calculated after the task is completed 
- Made a task on the clay board for the minimum env performance

Steps left:
- [x] TODO: Decide on `deferToThread` or `sync_wait` for running the benchmark
- [x] Run unit and integration tests for old code
- [x] Add unit tests for new code