### PR TITLE
Minor refactor of TaskSession::check_ctd_params

### DIFF
--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -533,7 +533,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 return
 
         try:
-            self._check_ctd_params(ctd)
+            self._check_task_header(msg.want_to_compute_task.task_header)
             self._set_env_params(
                 env_id=msg.want_to_compute_task.task_header.environment,
                 ctd=ctd,
@@ -930,9 +930,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             return RequestorCheckResult.NOT_FOUND
         return self.check_requestor_for_task(task_id, "Subtask %r" % subtask_id)
 
-    def _check_ctd_params(self, ctd: message.ComputeTaskDef) -> None:
-        header = self.task_manager.comp_task_keeper.get_task_header(
-            ctd['task_id'])
+    def _check_task_header(self, header: message.tasks.TaskHeader) -> None:
         owner = header.task_owner
 
         reasons = message.tasks.CannotComputeTask.REASON

--- a/tests/golem/task/test_concent_logic.py
+++ b/tests/golem/task/test_concent_logic.py
@@ -32,7 +32,7 @@ cannot_reasons = message.tasks.CannotComputeTask.REASON
 # pylint: disable=protected-access
 
 
-@mock.patch("golem.task.tasksession.TaskSession._check_ctd_params",
+@mock.patch("golem.task.tasksession.TaskSession._check_task_header",
             return_value=True)
 @mock.patch("golem.task.tasksession.TaskSession.send")
 class TaskToComputeConcentTestCase(testutils.TempDirFixture):

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -387,11 +387,12 @@ class TaskSessionReactToTaskToComputeTest(TaskSessionTestBase):
         self.task_session.task_server.get_environment_by_id.return_value = \
             self.env
 
-        self.header = self.task_session.task_manager.\
-            comp_task_keeper.get_task_header()
+        self.header = msg_factories.tasks.TaskHeaderFactory()
         self.header.task_owner.key = self.task_session.key_id
         self.header.task_owner.pub_addr = '10.10.10.10'
         self.header.task_owner.pub_port = 1112
+        self.task_session.task_manager.\
+            comp_task_keeper.get_task_header.return_value = self.header
 
         self.reasons = message.tasks.CannotComputeTask.REASON
 
@@ -421,6 +422,7 @@ class TaskSessionReactToTaskToComputeTest(TaskSessionTestBase):
             compute_task_def=ctd,
             **kwargs,
         )
+        ttc.want_to_compute_task.task_header = self.header
         ttc.want_to_compute_task.provider_public_key = encode_hex(
             self.keys.ecc.raw_pubkey)
         ttc.want_to_compute_task.sign_message(self.keys.ecc.raw_privkey)  # noqa pylint: disable=no-member


### PR DESCRIPTION
Use the task header from the message instead of the local one.