### PR TITLE
[O5] Modify decorator removing test files to remove them by default

### DIFF
--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -196,10 +196,11 @@ class PEP8MixIn(object):
 def keep_temporary_dirtree_if_test_failed(fun):
     @wraps(fun)
     def wrapper(self, *args, **kwargs):
-        fun(self, *args, **kwargs)
-        # If test fails, we won't reach this point, but tearDown
-        # will be called and directories won't be removed.
-        self.REMOVE_TMP_DIRS = True
+        try:
+            fun(self, *args, **kwargs)
+        except BaseException:
+            self.REMOVE_TMP_DIRS = False
+            raise
     return wrapper
 
 

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -218,7 +218,7 @@ class TestTaskIntegration(DatabaseFixture):
 
         # Assume that test failed. @dont_remove_dirs_on_failed_test decorator
         # will set this variable to True on the end of test.
-        self.REMOVE_TMP_DIRS = False
+        self.REMOVE_TMP_DIRS = True
 
         # build mock node
         self.node = dt_p2p_factory.Node()

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -193,7 +193,7 @@ class PEP8MixIn(object):
                          "Found code style errors (and warnings).")
 
 
-def remove_temporary_dirtree_if_test_passed(fun):
+def keep_temporary_dirtree_if_test_failed(fun):
     @wraps(fun)
     def wrapper(self, *args, **kwargs):
         fun(self, *args, **kwargs)

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -217,8 +217,9 @@ class TestTaskIntegration(DatabaseFixture):
     def setUp(self):
         super(TestTaskIntegration, self).setUp()
 
-        # Assume that test failed. @dont_remove_dirs_on_failed_test decorator
-        # will set this variable to True on the end of test.
+        # Assume that test passed and temporary files should be removed. If test
+        # fails @keep_temporary_dirtree_if_test_failed will set this variable to
+        # False after this test to keep temporary files.
         self.REMOVE_TMP_DIRS = True
 
         # build mock node

--- a/tests/apps/ffmpeg/task/test_ffmpegintegration.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegintegration.py
@@ -527,7 +527,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
             self.execute_task(task_def)
 
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_unsupported_target_video_codec(self):
         assert self.VIDEO_FILES[0]["container"] != Container.c_OGG
         with self.assertRaises(VideoCodecNotSupportedByContainer):
@@ -544,7 +544,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
             operation.run(self.VIDEO_FILES[0]["path"])
 
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_unsupported_target_container_if_exclusive_demuxer(self):
         with self.assertRaises(UnsupportedTargetVideoFormat):
             operation = SimulatedTranscodingOperation(
@@ -561,7 +561,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
             operation.run(self.VIDEO_FILES[0]["path"])
 
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_invalid_resolution_should_raise_proper_exception(self):
         dst_resolution = (100, 100)
         assert self.VIDEO_FILES[0]['resolution'][0] / dst_resolution[0] != \
@@ -581,7 +581,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
             operation.run(self.VIDEO_FILES[0]["path"])
 
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_invalid_frame_rate_should_raise_proper_exception(self):
         assert 55 not in list_supported_frame_rates()
         with self.assertRaises(InvalidFrameRate):
@@ -599,7 +599,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
             operation.run(self.VIDEO_FILES[0]["path"])
 
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_invalid_container_should_raise_proper_exception(self):
         with self.assertRaises(UnsupportedVideoFormat):
             operation = SimulatedTranscodingOperation(
@@ -615,7 +615,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
             operation.run(self.VIDEO_FILES[0]["path"])
 
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_unsupported_audio_codec_should_raise_proper_exception(self):
         with self.assertRaises(AudioCodecNotSupportedByContainer):
             operation = SimulatedTranscodingOperation(
@@ -630,7 +630,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
             operation.run("big_buck_bunny_stereo.mp4")
 
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_task_invalid_audio_params(self):
         resource_stream = os.path.join(self.RESOURCES,
                                        'big_buck_bunny_stereo.mp4')

--- a/tests/apps/ffmpeg/task/test_ffmpegintegration.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegintegration.py
@@ -16,7 +16,7 @@ from apps.transcoding.common import TranscodingTaskBuilderException, \
     AudioCodecNotSupportedByContainer
 from apps.transcoding.ffmpeg.task import ffmpegTaskTypeInfo
 from golem.testutils import TestTaskIntegration, \
-    remove_temporary_dirtree_if_test_passed
+    keep_temporary_dirtree_if_test_failed
 from golem.tools.ci import ci_skip
 from tests.apps.ffmpeg.task.utils.ffprobe_report_set import FfprobeReportSet
 from tests.apps.ffmpeg.task.utils.ffprobe_report import FuzzyDuration, \
@@ -209,7 +209,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
         ),
     )
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_split_and_merge_with_codec_change(self,
                                                video,
                                                video_codec,
@@ -272,7 +272,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
         ),
     )
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_split_and_merge_with_resolution_change(self, video, resolution):
         # FIXME: These tests should be re-enabled once all the fixes needed
         # to make them pass are done and merged.
@@ -331,7 +331,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
         ),
     )
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_split_and_merge_with_frame_rate_change(self, video, frame_rate):
         # FIXME: These tests should be re-enabled once all the fixes needed
         # to make them pass are done and merged.
@@ -391,7 +391,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
         ),
     )
     @pytest.mark.slow
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_split_and_merge_with_different_subtask_counts(self,
                                                            video,
                                                            subtasks_count):
@@ -429,7 +429,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
         (_input_report, _output_report, diff) = operation.run(video["path"])
         self.assertEqual(diff, [])
 
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_simple_case(self):
         resource_stream = os.path.join(self.RESOURCES, 'test_video2')
         result_file = os.path.join(self.root_dir, 'test_simple_case.mp4')
@@ -447,7 +447,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
         result = task.task_definition.output_file
         self.assertTrue(TestTaskIntegration.check_file_existence(result))
 
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_nonexistent_output_dir(self):
         resource_stream = os.path.join(self.RESOURCES, 'test_video2')
         result_file = os.path.join(self.root_dir, 'nonexistent', 'path',
@@ -469,7 +469,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
         self.assertTrue(TestTaskIntegration.check_dir_existence(
             os.path.dirname(result_file)))
 
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_nonexistent_resource(self):
         resource_stream = os.path.join(self.RESOURCES,
                                        'test_nonexistent_video.mp4')
@@ -488,7 +488,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
         with self.assertRaises(TranscodingTaskBuilderException):
             self.execute_task(task_def)
 
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_invalid_resource_stream(self):
         resource_stream = os.path.join(
             self.RESOURCES,
@@ -509,7 +509,7 @@ class TestFfmpegIntegration(TestTaskIntegration):
         with self.assertRaises(ffmpegException):
             self.execute_task(task_def)
 
-    @remove_temporary_dirtree_if_test_passed
+    @keep_temporary_dirtree_if_test_failed
     def test_task_invalid_params(self):
         resource_stream = os.path.join(self.RESOURCES, 'test_video2')
         result_file = os.path.join(self.root_dir, 'test_invalid_params.mp4')


### PR DESCRIPTION
This is a simple change that flips the meaning of the `@remove_temporary_dirtree_if_test_passed` decorator (now called `@keep_temporary_dirtree_if_test_failed`). Now temporary files are automatically deleted unless you use the decorator. And even then we only keep them if the test fails.

### Dependencies
This pull request is based on #4515 and should be merged after it.

**NOTE**: I have set the base branch of this pull request to `transcoding-all-files-codecs-framerates-resolutions` (#4515) rather than `CGI/transcoding/master`. Please remember to change the base branch back to `CGI/transcoding/master` before you merge.