### PR TITLE
Gracefully handle [deposit]payment migration problems

### DIFF
--- a/golem/database/database.py
+++ b/golem/database/database.py
@@ -40,8 +40,10 @@ class GolemSqliteDatabase(peewee.SqliteDatabase):
                 elif datetime.datetime.now() > deadline:
                     logger.warning(
                         "execute_sql() retry timeout after %d iterations."
-                        " Giving up.",
+                        " Giving up. sql=%r, params=%r",
                         iterations,
+                        sql,
+                        params,
                     )
                     raise
                 logger.debug(

--- a/golem/database/schemas/031_migrate_payment_to_task_payment.py
+++ b/golem/database/schemas/031_migrate_payment_to_task_payment.py
@@ -17,6 +17,18 @@ STATUS_MAPPING = {
 
 def migrate_payment(database, db_row):
     details = json.loads(db_row['details'])
+    if details['node_info'] is None:
+        logger.info(
+            "Won't migrate payment without node_info. Skipping. db_row=%s",
+            db_row,
+        )
+        return
+    if details['node_info']['key'] is None:
+        logger.info(
+            "Won't migrate payment without node id. Skipping. db_row=%s",
+            db_row,
+        )
+        return
     status = STATUS_MAPPING[db_row['status']]
     cursor = database.execute_sql(
         "INSERT INTO walletoperation"

--- a/golem/database/schemas/033_deposit_payment_to_wallet_operation.py
+++ b/golem/database/schemas/033_deposit_payment_to_wallet_operation.py
@@ -37,6 +37,16 @@ def migrate_dp(database, db_row):
 
 
 def migrate(migrator, database, fake=False, **kwargs):
+    try:
+        database.execute_sql('SELECT 1 from depositpayment')
+    except pw.OperationalError as e:
+        if str(e) == 'no such table: depositpayment':
+            logger.info(
+                "depositpayment table missing in DB. Skipping this migration.",
+            )
+            return
+        # Raise unexpected exceptions
+        raise
     cursor = database.execute_sql(
         'SELECT tx, value, status, fee,'
         '       created_date'

--- a/tests/golem/database/test_migration.py
+++ b/tests/golem/database/test_migration.py
@@ -1,4 +1,5 @@
 # pylint: disable=protected-access
+import datetime
 import functools
 from contextlib import contextmanager
 from unittest import TestCase
@@ -437,6 +438,41 @@ class TestSavedMigrations(TempDirFixture):
             self.assertEqual(tp_count, 1)
 
     @patch('golem.database.Database._create_tables')
+    def test_31_payments_migration_invalid_node_info(self, *_args):
+        with self.database_context() as database:
+            database._migrate_schema(6, 30)
+
+            details_null_key = '{"node_info": {"key": null}}'
+            details_null_node = '{"node_info": null}'
+            for cnt, details in enumerate(
+                    (details_null_key, details_null_node),
+            ):
+                database.db.execute_sql(
+                    "INSERT INTO payment ("
+                    "    subtask, created_date, modified_date, status,"
+                    "    payee, value, details)"
+                    " VALUES (?, datetime('now'), datetime('now'), 1,"
+                    "         '0x0eeA941c1244ADC31F53525D0eC1397ff6951C9C', 10,"
+                    "         ?)",
+                    (f"0xdead{cnt}", details, ),
+                )
+            database._migrate_schema(30, 31)
+
+            # UNIONS don't work here. Do it manually
+            cursor = database.db.execute_sql("SELECT count(*) FROM payment")
+            payment_count = cursor.fetchone()[0]
+            cursor = database.db.execute_sql(
+                "SELECT count(*) FROM walletoperation",
+            )
+            wo_count = cursor.fetchone()[0]
+            cursor = database.db.execute_sql("SELECT count(*) FROM taskpayment")
+            tp_count = cursor.fetchone()[0]
+            # Migrated payments shouldn't be removed
+            self.assertEqual(payment_count, 2)
+            self.assertEqual(wo_count, 0)
+            self.assertEqual(tp_count, 0)
+
+    @patch('golem.database.Database._create_tables')
     def test_32_incomes_migration(self, *_args):
         with self.database_context() as database:
             database._migrate_schema(6, 31)
@@ -509,6 +545,23 @@ class TestSavedMigrations(TempDirFixture):
                     fee,
                 ],
             )
+
+    @patch('golem.database.Database._create_tables')
+    def test_33_deposit_payments_migration_table_missing(self, *_args):
+        with self.database_context() as database:
+            database._migrate_schema(6, 32)
+
+            database.db.RETRY_TIMEOUT = datetime.timedelta(seconds=0)
+            database.db.execute_sql(
+                "DROP TABLE depositpayment"
+            )
+            database._migrate_schema(32, 33)
+
+            cursor = database.db.execute_sql(
+                "SELECT count(*) FROM walletoperation",
+            )
+            wo_count = cursor.fetchone()[0]
+            self.assertEqual(wo_count, 0)
 
 
 def generate(start, stop):


### PR DESCRIPTION
Fixes: #4499 (Write more friendly log msg)
Fixes: #4500 (as above)

Also handles missing `depositpayment` table. This probably happens when migration 33 isn't properly rollbacked.