### PR TITLE
Start UPnP discovery and mapping in a separate thread

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -16,6 +16,7 @@ from twisted.internet.defer import (
     inlineCallbacks,
     gatherResults,
     Deferred)
+from twisted.internet.threads import deferToThread
 
 from apps.appsmanager import AppsManager
 import golem
@@ -466,6 +467,7 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             task_cleaner_service.start()
             self._services.append(task_cleaner_service)
 
+        @inlineCallbacks
         def connect(ports):
             logger.info(
                 'Golem is listening on addr: %s'
@@ -476,10 +478,11 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
                 self.node.hyperdrive_prv_port
             )
 
+            ports = ports + list(hyperdrive_ports)
             if self.config_desc.use_upnp:
-                self.start_upnp(ports + list(hyperdrive_ports))
-            self.node.update_public_info()
+                yield deferToThread(self.start_upnp, ports)
 
+            self.node.update_public_info()
             public_ports = [
                 self.node.p2p_pub_port,
                 self.node.pub_port,


### PR DESCRIPTION
UPnP port mapping process will no longer block the main thread.

This should improve the situation with sporadic RPC's websocket ping timeouts during startup.