### PR TITLE
Make the Concent Service optional from Provider's POV

### DIFF
--- a/golem/network/concent/client.py
+++ b/golem/network/concent/client.py
@@ -216,7 +216,16 @@ class ConcentClientService(threading.Thread):
     @property
     def enabled(self) -> bool:
         """Indicates whether this client is available and user turned it on"""
-        return self.available and soft_switch.is_on()
+        return self.available and soft_switch.concent_is_on()
+
+    @property
+    def required_as_provider(self) -> bool:
+        """
+        Indicates whether concent is required for any tasks
+        considered for computation as a provider
+        (assuming it's enabled)
+        """
+        return soft_switch.is_required_as_provider()
 
     def run(self) -> None:
         last_receive = 0.0

--- a/golem/network/concent/soft_switch.py
+++ b/golem/network/concent/soft_switch.py
@@ -9,24 +9,55 @@ class SoftSwitch(enum.Enum):
     OFF: str = 'off'
 
 
-KEY = "concent_soft_switch"
-DEFAULT = SoftSwitch.OFF
+SOFT_SWITCH_KEY = "concent_soft_switch"
+REQUIRED_KEY = "concent_required"
 
 
-@rpc_utils.expose('golem.concent.switch')
-def is_on() -> bool:
+def _is_on(key: str, default: SoftSwitch) -> bool:
     query = GenericKeyValue.select().where(
-        GenericKeyValue.key == KEY,
+        GenericKeyValue.key == key,
     ).limit(1)
     try:
         value = SoftSwitch(query[0].value)
     except IndexError:
-        value = DEFAULT
+        value = default
     return value == SoftSwitch.ON
 
 
-@rpc_utils.expose('golem.concent.switch.turn')
-def turn(on: bool) -> None:
-    entry, _ = GenericKeyValue.get_or_create(key=KEY)
+def _turn(key: str, on: bool) -> None:
+    entry, _ = GenericKeyValue.get_or_create(key=key)
     entry.value = SoftSwitch.ON.value if on else SoftSwitch.OFF.value
     entry.save()
+
+
+@rpc_utils.expose('golem.concent.switch')
+def concent_is_on() -> bool:
+    """
+    Verify if the Concent is marked as enabled within the Golem Node
+    """
+    return _is_on(SOFT_SWITCH_KEY, default=SoftSwitch.OFF)
+
+
+@rpc_utils.expose('golem.concent.switch.turn')
+def concent_turn(on: bool) -> None:
+    """
+    Mark Concent as enabled/disabled within the Golem Node
+    """
+    _turn(SOFT_SWITCH_KEY, on)
+
+
+@rpc_utils.expose('golem.concent.required_as_provider')
+def is_required_as_provider() -> bool:
+    """
+    Verify if the Concent is required for tasks accepted for computation
+    as a Provider
+    """
+    return _is_on(REQUIRED_KEY, default=SoftSwitch.ON)
+
+
+@rpc_utils.expose('golem.concent.required_as_provider.turn')
+def required_as_provider_turn(on: bool) -> None:
+    """
+    Mark Concent as required/not-required for tasks accepted for computation
+    """
+    _turn(REQUIRED_KEY, on)

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -303,13 +303,16 @@ class TaskServer(
                 supported = supported.join(SupportStatus.err({
                     UnsupportReason.MAX_PRICE: theader.max_price}))
 
-            if self.client.concent_service.enabled:
-                if not theader.concent_enabled:
-                    supported = supported.join(
-                        SupportStatus.err({
-                            UnsupportReason.CONCENT_REQUIRED: True,
-                        }),
-                    )
+            if (
+                    self.client.concent_service.enabled
+                    and self.client.concent_service.required_as_provider
+                    and not theader.concent_enabled
+            ):
+                supported = supported.join(
+                    SupportStatus.err({
+                        UnsupportReason.CONCENT_REQUIRED: True,
+                    }),
+                )
 
             if not supported.is_ok():
                 logger.debug(
@@ -359,7 +362,11 @@ class TaskServer(
                 price=price,
                 max_resource_size=self.config_desc.max_resource_size,
                 max_memory_size=self.config_desc.max_memory_size,
-                concent_enabled=self.client.concent_service.enabled,
+
+                concent_enabled=
+                self.client.concent_service.enabled
+                if theader.concent_enabled else False,
+
                 provider_public_key=self.keys_auth.key_id,
                 provider_ethereum_address=self.keys_auth.eth_addr,
                 task_header=theader,

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -363,8 +363,7 @@ class TaskServer(
                 max_resource_size=self.config_desc.max_resource_size,
                 max_memory_size=self.config_desc.max_memory_size,
 
-                concent_enabled=
-                self.client.concent_service.enabled
+                concent_enabled=self.client.concent_service.enabled
                 if theader.concent_enabled else False,
 
                 provider_public_key=self.keys_auth.key_id,

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -471,7 +471,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 and not msg.concent_enabled
         ):
             # Provider requires concent
-            # if it's enabed locally and marked as required
+            # if it's enabled locally and marked as required
             _cannot_compute(reasons.ConcentRequired)
             return
         if not self.concent_service.enabled and msg.concent_enabled:

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -43,6 +43,7 @@ if TYPE_CHECKING:
     from .taskcomputer import TaskComputer  # noqa pylint:disable=unused-import
     from .taskmanager import TaskManager  # noqa pylint:disable=unused-import
     from .taskserver import TaskServer  # noqa pylint:disable=unused-import
+    from golem.network.concent.client import ConcentClientService  # noqa pylint:disable=unused-import
 
 logger = logging.getLogger(__name__)
 
@@ -132,7 +133,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
         return self.task_server.task_computer
 
     @property
-    def concent_service(self):
+    def concent_service(self) -> 'ConcentClientService':
         return self.task_server.client.concent_service
 
     @property
@@ -464,8 +465,13 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             _cannot_compute(reasons.OfferCancelled)
             return
 
-        if self.concent_service.enabled and not msg.concent_enabled:
-            # Provider requires concent if it's enabed locally
+        if (
+                self.concent_service.enabled
+                and self.concent_service.required_as_provider
+                and not msg.concent_enabled
+        ):
+            # Provider requires concent
+            # if it's enabed locally and marked as required
             _cannot_compute(reasons.ConcentRequired)
             return
         if not self.concent_service.enabled and msg.concent_enabled:

--- a/scripts/node_integration_tests/playbooks/base.py
+++ b/scripts/node_integration_tests/playbooks/base.py
@@ -89,6 +89,7 @@ class NodeTestPlaybook:
         self.current_step = 0
         self.known_tasks: typing.Optional[typing.Set[str]] = None
         self.task_id: typing.Optional[str] = None
+        self.previous_task_id: typing.Optional[str] = None
         self.nodes_started = False
         self.task_in_creation = False
         self.subtasks: typing.Dict[NodeId, typing.Set[str]] = {}
@@ -425,6 +426,75 @@ class NodeTestPlaybook:
         self.start_nodes()
         print("Nodes restarted")
         self.next()
+
+    def step_wait_task_timeout(self):
+        def on_success(result):
+            if result['status'] == 'Timeout':
+                print("Task timed out as expected.")
+                self.previous_task_id = self.task_id
+                self.task_id = None
+                self.next()
+            elif result['status'] == 'Finished':
+                print("Task finished unexpectedly, failing test :(")
+                self.fail()
+            else:
+                print("Task status: {} ... ".format(result['status']))
+                time.sleep(10)
+
+        return self.call(NodeId.requestor, 'comp.task', self.task_id,
+                         on_success=on_success)
+
+    def step_enable_concent(self, node_id: NodeId):
+        def on_success(_):
+            self.next()
+
+        def on_error(_):
+            print(f"Error enabling Concent for {node_id.value}")
+            self.fail()
+
+        return self.call(
+            node_id,
+            'golem.concent.switch.turn', 1,
+            on_success=on_success, on_error=on_error,
+        )
+
+    def step_disable_concent(self, node_id: NodeId):
+        def on_success(_):
+            self.next()
+
+        def on_error(_):
+            print(f"Error disabling Concent for {node_id.value}")
+            self.fail()
+
+        return self.call(
+            node_id,
+            'golem.concent.switch.turn', 0,
+            on_success=on_success, on_error=on_error,
+        )
+
+    def step_ensure_concent_on(self, node_id: NodeId):
+        def on_success(result):
+            if result is True:
+                print(f"Concent is enabled for {node_id.value}.")
+                self.next()
+            else:
+                self.fail(
+                    "Concent unexpectedly disabled for %s... (result=%r)" % (
+                        node_id.value, result
+                    )
+                )
+
+        return self.call(node_id, 'golem.concent.switch', on_success=on_success)
+
+    def step_ensure_concent_off(self, node_id: NodeId):
+        def on_success(result):
+            if result is True:
+                self.fail(f"Concent unexpectedly enabled for {node_id.value}.")
+            else:
+                print(f"Concent is disabled for {node_id.value} as expected.")
+                self.next()
+
+        return self.call(node_id, 'golem.concent.switch', on_success=on_success)
 
     initial_steps: typing.Tuple = (
         partial(step_get_key, node_id=NodeId.provider),

--- a/scripts/node_integration_tests/playbooks/concent/concent_base.py
+++ b/scripts/node_integration_tests/playbooks/concent/concent_base.py
@@ -19,44 +19,6 @@ class ConcentTestPlaybook(NodeTestPlaybook):
         helpers.clear_output(self.output_queues[node_id])
         self.next()
 
-    def step_check_is_concent_off(self, node_id: NodeId):
-        def on_success(result):
-            if result is True:
-                print(f"Concent unexpectedly already enabled for"
-                      " {node_id.value}...")
-            self.next()
-
-        return self.call(node_id, 'golem.concent.switch', on_success=on_success)
-
-    def step_enable_concent(self, node_id: NodeId):
-        def on_success(_):
-            self.next()
-
-        def on_error(result):
-            print(f"Error enabling Concent for {node_id.value}")
-            self.fail()
-
-        return self.call(
-            node_id,
-            'golem.concent.switch.turn', 1,
-            on_success=on_success, on_error=on_error,
-        )
-
-    def step_ensure_concent_on(self, node_id: NodeId):
-        def on_success(result):
-            if result is True:
-                print(f"Enabled Concent for {node_id.value}.")
-                self.next()
-            else:
-                self.fail(
-                    "Failed to enable Concent for %s... (result=%r)" % (
-                        node_id.value, result
-                    )
-                )
-            self.next()
-
-        return self.call(node_id, 'golem.concent.switch', on_success=on_success)
-
     @staticmethod
     def check_concent_logs(
             output_queue: 'queue.Queue',
@@ -116,13 +78,19 @@ class ConcentTestPlaybook(NodeTestPlaybook):
         return None, None
 
     initial_steps = NodeTestPlaybook.initial_steps + (
-        partial(step_check_is_concent_off, node_id=NodeId.provider),
-        partial(step_enable_concent, node_id=NodeId.provider),
-        partial(step_ensure_concent_on, node_id=NodeId.provider),
+        partial(NodeTestPlaybook.step_ensure_concent_off,
+                node_id=NodeId.provider),
+        partial(NodeTestPlaybook.step_enable_concent,
+                node_id=NodeId.provider),
+        partial(NodeTestPlaybook.step_ensure_concent_on,
+                node_id=NodeId.provider),
 
-        partial(step_check_is_concent_off, node_id=NodeId.requestor),
-        partial(step_enable_concent, node_id=NodeId.requestor),
-        partial(step_ensure_concent_on, node_id=NodeId.requestor),
+        partial(NodeTestPlaybook.step_ensure_concent_off,
+                node_id=NodeId.requestor),
+        partial(NodeTestPlaybook.step_enable_concent,
+                node_id=NodeId.requestor),
+        partial(NodeTestPlaybook.step_ensure_concent_on,
+                node_id=NodeId.requestor),
 
         partial(step_clear_output, node_id=NodeId.requestor),
         partial(step_clear_output, node_id=NodeId.provider),

--- a/scripts/node_integration_tests/playbooks/concent/concent_config_base.py
+++ b/scripts/node_integration_tests/playbooks/concent/concent_config_base.py
@@ -1,8 +1,8 @@
-from ..test_config_base import TestConfigBase
+from ..test_config_base import TestConfigBase, CONCENT_STAGING
 
 
 class ConcentTestConfigBase(TestConfigBase):
     def __init__(self):
         super().__init__()
         for node_config in self.nodes.values():
-            node_config.concent = 'staging'
+            node_config.concent = CONCENT_STAGING

--- a/scripts/node_integration_tests/playbooks/golem/concent/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/concent/playbook.py
@@ -1,0 +1,32 @@
+from functools import partial
+import typing
+
+from ...base import NodeTestPlaybook
+from ...test_config_base import NodeId
+
+
+class Playbook(NodeTestPlaybook):
+
+    steps: typing.Tuple = NodeTestPlaybook.initial_steps + (
+        partial(NodeTestPlaybook.step_ensure_concent_off,
+                node_id=NodeId.provider),
+        partial(NodeTestPlaybook.step_enable_concent,
+                node_id=NodeId.provider),
+        partial(NodeTestPlaybook.step_ensure_concent_on,
+                node_id=NodeId.provider),
+
+        partial(NodeTestPlaybook.step_ensure_concent_off,
+                node_id=NodeId.requestor),
+        partial(NodeTestPlaybook.step_enable_concent,
+                node_id=NodeId.requestor),
+        partial(NodeTestPlaybook.step_ensure_concent_on,
+                node_id=NodeId.requestor),
+
+        NodeTestPlaybook.step_create_task,
+        NodeTestPlaybook.step_get_task_id,
+        NodeTestPlaybook.step_get_task_status,
+        NodeTestPlaybook.step_wait_task_finished,
+        NodeTestPlaybook.step_verify_output,
+        NodeTestPlaybook.step_get_subtasks,
+        NodeTestPlaybook.step_verify_income,
+    )

--- a/scripts/node_integration_tests/playbooks/golem/concent/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/concent/test_config.py
@@ -1,8 +1,8 @@
-from ..test_config_base import TestConfigBase
+from ...test_config_base import TestConfigBase, CONCENT_STAGING
 
 
 class TestConfig(TestConfigBase):
     def __init__(self):
         super().__init__()
         for node_config in self.nodes.values():
-            node_config.concent = 'staging'
+            node_config.concent = CONCENT_STAGING

--- a/scripts/node_integration_tests/playbooks/golem/concent_provider/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/concent_provider/playbook.py
@@ -7,6 +7,36 @@ from ...test_config_base import NodeId
 
 
 class Playbook(NodeTestPlaybook):
+    def step_ensure_concent_required(self, node_id: NodeId, is_on: bool):
+        def on_success(result):
+            if result is is_on:
+                print(f"Concent is {'' if is_on else 'not '}required "
+                      f"for {node_id.value} as expected.")
+                self.next()
+            else:
+                self.fail(f"Concent unexpectedly "
+                          f"{'not ' if is_on else ''}required "
+                          f"for {node_id.value}... (result={result})")
+
+        return self.call(
+            node_id,
+            'golem.concent.required_as_provider', on_success=on_success
+        )
+
+    def step_turn_concent_required(self, node_id: NodeId, on: bool):
+        def on_success(_):
+            self.next()
+
+        def on_error(_):
+            print(f"Error {'enabling' if on else 'disabling'} "
+                  f"Concent for {node_id.value}")
+            self.fail()
+
+        return self.call(
+            node_id,
+            'golem.concent.required_as_provider.turn', on,
+            on_success=on_success, on_error=on_error,
+        )
 
     steps: typing.Tuple = NodeTestPlaybook.initial_steps + (
         # enable Concent for the provider
@@ -17,6 +47,8 @@ class Playbook(NodeTestPlaybook):
                 node_id=NodeId.provider),
         partial(NodeTestPlaybook.step_ensure_concent_on,
                 node_id=NodeId.provider),
+        partial(step_ensure_concent_required,
+                node_id=NodeId.provider, is_on=True),
 
         # ensure Concent is disabled for the requestor
 
@@ -30,7 +62,10 @@ class Playbook(NodeTestPlaybook):
         NodeTestPlaybook.step_get_task_status,
         NodeTestPlaybook.step_wait_task_timeout,
 
-        # todo: make concent optional for a provider
+        partial(step_turn_concent_required,
+                node_id=NodeId.provider, on=False),
+        partial(step_ensure_concent_required,
+                node_id=NodeId.provider, is_on=False),
 
         # the second task should now finish correctly
 

--- a/scripts/node_integration_tests/playbooks/golem/concent_provider/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/concent_provider/playbook.py
@@ -1,0 +1,43 @@
+from functools import partial
+import time
+import typing
+
+from ...base import NodeTestPlaybook
+from ...test_config_base import NodeId
+
+
+class Playbook(NodeTestPlaybook):
+
+    steps: typing.Tuple = NodeTestPlaybook.initial_steps + (
+        # enable Concent for the provider
+
+        partial(NodeTestPlaybook.step_ensure_concent_off,
+                node_id=NodeId.provider),
+        partial(NodeTestPlaybook.step_enable_concent,
+                node_id=NodeId.provider),
+        partial(NodeTestPlaybook.step_ensure_concent_on,
+                node_id=NodeId.provider),
+
+        # ensure Concent is disabled for the requestor
+
+        partial(NodeTestPlaybook.step_ensure_concent_off,
+                node_id=NodeId.requestor),
+
+        # the task should time out
+
+        NodeTestPlaybook.step_create_task,
+        NodeTestPlaybook.step_get_task_id,
+        NodeTestPlaybook.step_get_task_status,
+        NodeTestPlaybook.step_wait_task_timeout,
+
+        # todo: make concent optional for a provider
+
+        # the second task should now finish correctly
+
+        NodeTestPlaybook.step_get_known_tasks,
+        NodeTestPlaybook.step_create_task,
+        NodeTestPlaybook.step_get_task_id,
+        NodeTestPlaybook.step_get_task_status,
+        NodeTestPlaybook.step_wait_task_finished,
+        NodeTestPlaybook.step_verify_output,
+    )

--- a/scripts/node_integration_tests/playbooks/golem/concent_provider/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/concent_provider/playbook.py
@@ -1,5 +1,4 @@
 from functools import partial
-import time
 import typing
 
 from ...base import NodeTestPlaybook

--- a/scripts/node_integration_tests/playbooks/golem/concent_provider/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/concent_provider/test_config.py
@@ -1,0 +1,10 @@
+from ...test_config_base import (
+    TestConfigBase, NodeId, CONCENT_STAGING, CONCENT_DISABLED
+)
+
+
+class TestConfig(TestConfigBase):
+    def __init__(self):
+        super().__init__(task_settings='2_short')
+        self.nodes[NodeId.provider].concent = CONCENT_STAGING
+        self.nodes[NodeId.requestor].concent = CONCENT_DISABLED

--- a/scripts/node_integration_tests/playbooks/golem/jpg/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/jpg/test_config.py
@@ -1,13 +1,7 @@
-from scripts.node_integration_tests import helpers
-
-
 from ...test_config_base import TestConfigBase
 
 
 class TestConfig(TestConfigBase):
-    def __init__(self):
-        super().__init__(task_settings='jpg')
-
     def update_task_dict(self):
-        self.task_package = 'test_task_1'
         super().update_task_dict()
+        self.task_dict['options']['format'] = 'JPG'

--- a/scripts/node_integration_tests/playbooks/golem/jpg/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/jpg/test_config.py
@@ -11,7 +11,3 @@ class TestConfig(TestConfigBase):
     def update_task_dict(self):
         self.task_package = 'test_task_1'
         super().update_task_dict()
-        self.task_dict['main_scene_file'] = helpers.scene_file_path(
-            task_package_name='test_task_1',
-            file_path='wlochaty3.blend',
-        )

--- a/scripts/node_integration_tests/playbooks/golem/rpc_test/concent/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/rpc_test/concent/test_config.py
@@ -1,9 +1,10 @@
-from scripts.node_integration_tests.playbooks.test_config_base import \
-    TestConfigBase
+from scripts.node_integration_tests.playbooks.test_config_base import (
+    TestConfigBase, CONCENT_STAGING,
+)
 
 
 class TestConfig(TestConfigBase):
     def __init__(self):
         super().__init__()
         for node_config in self.nodes.values():
-            node_config.concent = 'staging'
+            node_config.concent = CONCENT_STAGING

--- a/scripts/node_integration_tests/playbooks/golem/task_timeout/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/task_timeout/playbook.py
@@ -24,7 +24,6 @@ class Playbook(NodeTestPlaybook):
       allowing the task as a whole to finish successfully this time.
 
     """
-    previous_task_id = None
 
     def step_wait_subtask_completed(self):
         def on_success(result):
@@ -44,23 +43,6 @@ class Playbook(NodeTestPlaybook):
         return self.call(NodeId.requestor, 'comp.task.subtasks', self.task_id,
                          on_success=on_success)
 
-    def step_wait_task_timeout(self):
-        def on_success(result):
-            if result['status'] == 'Timeout':
-                print("Task timed out as expected.")
-                self.previous_task_id = self.task_id
-                self.task_id = None
-                self.next()
-            elif result['status'] == 'Finished':
-                print("Task finished unexpectedly, failing test :(")
-                self.fail()
-            else:
-                print("Task status: {} ... ".format(result['status']))
-                time.sleep(10)
-
-        return self.call(NodeId.requestor, 'comp.task', self.task_id,
-                         on_success=on_success)
-
     def step_restart_task(self):
         def on_success(result):
             print("Restarted task. {}".format(result))
@@ -78,7 +60,7 @@ class Playbook(NodeTestPlaybook):
         NodeTestPlaybook.step_get_task_id,
         NodeTestPlaybook.step_get_task_status,
         step_wait_subtask_completed,
-        step_wait_task_timeout,
+        NodeTestPlaybook.step_wait_task_timeout,
         NodeTestPlaybook.step_stop_nodes,
         NodeTestPlaybook.step_restart_nodes,
     ) + NodeTestPlaybook.initial_steps + (

--- a/scripts/node_integration_tests/playbooks/test_config_base.py
+++ b/scripts/node_integration_tests/playbooks/test_config_base.py
@@ -17,11 +17,14 @@ if TYPE_CHECKING:
     requestor = None
     provider = None
 
+CONCENT_STAGING = 'staging'
+CONCENT_DISABLED = 'disabled'
+
 
 class NodeConfig:
     def __init__(self) -> None:
         self.additional_args: Dict[str, Any] = {}
-        self.concent = 'disabled'
+        self.concent = CONCENT_DISABLED
         # if datadir is None it will be automatically created
         self.datadir: Optional[str] = None
         self.log_level: Optional[str] = None

--- a/scripts/node_integration_tests/run_test.py
+++ b/scripts/node_integration_tests/run_test.py
@@ -7,7 +7,11 @@ from golem.config.environments import set_environment
 from scripts.node_integration_tests.playbook_loader import \
     get_config_and_playbook_class
 from scripts.node_integration_tests.playbooks import run_playbook
-from scripts.node_integration_tests.playbooks.test_config_base import NodeId
+from scripts.node_integration_tests.playbooks.test_config_base import (
+    NodeId,
+    CONCENT_DISABLED,
+)
+
 
 if TYPE_CHECKING:
     from scripts.node_integration_tests.playbooks.test_config_base \
@@ -118,7 +122,7 @@ def main():
     args = parse_args()
 
     if args.mainnet:
-        set_environment('mainnet', 'disabled')
+        set_environment('mainnet', CONCENT_DISABLED)
 
     config, playbook_class = get_config_and_playbook_class(args.test_path)
 

--- a/scripts/node_integration_tests/tasks/__init__.py
+++ b/scripts/node_integration_tests/tasks/__init__.py
@@ -37,23 +37,6 @@ _TASK_SETTINGS = {
             ]
         }
     },
-    'jpg': {
-        'type': "Blender",
-        'name': 'test task',
-        'timeout': "0:10:00",
-        "subtask_timeout": "0:09:50",
-        "subtasks_count": 1,
-        "bid": 1.0,
-        "resources": [],
-        "options": {
-            "output_path": '',
-            "format": "JPG",
-            "resolution": [
-                320,
-                240
-            ]
-        }
-    },
     'jpeg': {
         'type': "Blender",
         'name': 'test task',

--- a/scripts/node_integration_tests/tests/test_golem.py
+++ b/scripts/node_integration_tests/tests/test_golem.py
@@ -104,3 +104,7 @@ class GolemNodeTest(NodeTestBase):
             'golem.regular_run_stop_on_reject',
             **{'task-settings': '4-by-3'}
         )
+
+    def test_concent_provider(self):
+        self._run_test('golem.concent_provider')
+

--- a/scripts/node_integration_tests/tests/test_golem.py
+++ b/scripts/node_integration_tests/tests/test_golem.py
@@ -107,4 +107,3 @@ class GolemNodeTest(NodeTestBase):
 
     def test_concent_provider(self):
         self._run_test('golem.concent_provider')
-

--- a/scripts/node_integration_tests/tests/test_golem.py
+++ b/scripts/node_integration_tests/tests/test_golem.py
@@ -8,9 +8,17 @@ from .base import NodeTestBase, disable_key_reuse
 class GolemNodeTest(NodeTestBase):
 
     def test_regular_task_run(self):
+        """
+        runs a normal, successful task run between a single provider
+        and a single requestor.
+        """
         self._run_test('golem.regular_run')
 
     def test_concent(self):
+        """
+        runs a normal task between a provider and a requestor
+        with Concent enabled
+        """
         self._run_test('golem.concent')
 
     def test_rpc(self):
@@ -29,14 +37,29 @@ class GolemNodeTest(NodeTestBase):
     def test_frame_restart(self):
         self._run_test('golem.restart_frame')
 
-    @unittest.skipIf(PROTOCOL_CONST.ID <= '29', "Known issue in 0.18.x")
     def test_exr(self):
+        """
+        verifies if Golem - when supplied with `EXR` as the format - will
+        render the output as EXR with the proper extension.
+        """
         self._run_test('golem.exr')
 
     def test_jpeg(self):
+        """
+        verifies if Golem - when supplied with `JPEG` as the format - will
+        render the output as JPEG with the proper extension.
+        """
         self._run_test('golem.jpeg')
 
     def test_jpg(self):
+        """
+        verifies if Golem - when supplied with `JPG` as the format - will
+        still execute a task.
+
+        as the proper name of the format in Golem's internals is `JPEG`
+        the format is treated as an _unknown_ and thus, the default `PNG`
+        is used.
+        """
         self._run_test('golem.jpg')
 
     def test_nested(self):

--- a/tests/golem/network/concent/test_soft_switch.py
+++ b/tests/golem/network/concent/test_soft_switch.py
@@ -2,7 +2,7 @@ from golem.network.concent import soft_switch
 from golem.tools.testwithdatabase import TestWithDatabase
 
 
-class ContentSwitchTestMixin:
+class ConcentSwitchTestMixin:
     @property
     def _default(self):
         raise NotImplementedError()
@@ -27,7 +27,7 @@ class ContentSwitchTestMixin:
         self.assertFalse(self._is_on())
 
 
-class TestContentSoftSwitch(ContentSwitchTestMixin, TestWithDatabase):
+class TestConcentSoftSwitch(ConcentSwitchTestMixin, TestWithDatabase):
     @property
     def _default(self):
         return False
@@ -39,7 +39,7 @@ class TestContentSoftSwitch(ContentSwitchTestMixin, TestWithDatabase):
         return soft_switch.concent_is_on()
 
 
-class TestContentRequiredAsProvider(ContentSwitchTestMixin, TestWithDatabase):
+class TestConcentRequiredAsProvider(ConcentSwitchTestMixin, TestWithDatabase):
     @property
     def _default(self):
         return True

--- a/tests/golem/network/concent/test_soft_switch.py
+++ b/tests/golem/network/concent/test_soft_switch.py
@@ -2,15 +2,50 @@ from golem.network.concent import soft_switch
 from golem.tools.testwithdatabase import TestWithDatabase
 
 
-class TestContentSoftSwitch(TestWithDatabase):
+class ContentSwitchTestMixin:
+    @property
+    def _default(self):
+        raise NotImplementedError()
+
+    def _turn(self, on: bool):
+        raise NotImplementedError()
+
+    def _is_on(self):
+        raise NotImplementedError()
+
     def test_default_value(self):
-        self.assertFalse(soft_switch.is_on())
+        self.assertEqual(self._is_on(), self._default)
 
     def test_turn_on(self):
-        soft_switch.turn(True)
-        self.assertTrue(soft_switch.is_on())
+        self._turn(False)
+        self._turn(True)
+        self.assertTrue(self._is_on())
 
     def test_turn_off(self):
-        soft_switch.turn(True)
-        soft_switch.turn(False)
-        self.assertFalse(soft_switch.is_on())
+        self._turn(True)
+        self._turn(False)
+        self.assertFalse(self._is_on())
+
+
+class TestContentSoftSwitch(ContentSwitchTestMixin, TestWithDatabase):
+    @property
+    def _default(self):
+        return False
+
+    def _turn(self, on: bool):
+        return soft_switch.concent_turn(on)
+
+    def _is_on(self):
+        return soft_switch.concent_is_on()
+
+
+class TestContentRequiredAsProvider(ContentSwitchTestMixin, TestWithDatabase):
+    @property
+    def _default(self):
+        return True
+
+    def _turn(self, on: bool):
+        return soft_switch.required_as_provider_turn(on)
+
+    def _is_on(self):
+        return soft_switch.is_required_as_provider()

--- a/tests/golem/task/test_concent_logic.py
+++ b/tests/golem/task/test_concent_logic.py
@@ -64,6 +64,7 @@ class TaskToComputeConcentTestCase(testutils.TempDirFixture):
             self.ethereum_config.deposit_contract_address
 
         self.task_session.concent_service.enabled = True
+        self.task_session.concent_service.required_as_provider = True
         self.task_session.task_computer.has_assigned_task.return_value = False
         self.task_session.task_server.keys_auth.ecc.raw_pubkey = \
             self.keys.raw_pubkey
@@ -103,6 +104,12 @@ class TaskToComputeConcentTestCase(testutils.TempDirFixture):
         self.msg.concent_enabled = False
         self.task_session._react_to_task_to_compute(self.msg)
         self.assert_rejected(send_mock)
+
+    def test_requestor_concent_disabled_but_not_required(self, send_mock, *_):
+        self.msg.concent_enabled = False
+        self.task_session.concent_service.required_as_provider = False
+        self.task_session._react_to_task_to_compute(self.msg)
+        self.assert_accepted(send_mock)
 
     def test_provider_doesnt_want_concent(self, send_mock, *_):
         self.task_session.concent_service.enabled = False

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -168,9 +168,9 @@ class TestTaskServerConcent(TaskServerTestBase):
         keys_auth = KeysAuth(self.path, 'prv_key', '')
         self.task_header = get_example_task_header(keys_auth.public_key)
         self.task_header.concent_enabled = False
-        self.task_header.sign(private_key=keys_auth._private_key)
+        self.task_header.sign(private_key=keys_auth._private_key)  # noqa pylint:disable=no-value-for-parameter
         self._prepare_handshake(
-            self.task_header.task_owner.key,
+            self.task_header.task_owner.key,  # noqa pylint:disable=no-member
             self.task_header.task_id
         )
         self.ts.add_task_header(self.task_header)


### PR DESCRIPTION
adds two RPC endpoints:

`golem.concent.required_as_provider`
and
`golem.concent.required_as_provider.turn`

(analogous to `golem.concent.switch`)

that can be used to make the Concent Service either required (default) or optional from Provider's POV 

if required is on, Provider won't accept any tasks that have `concent_enabled=False`
if required is off on the other hand, Provider will accept both the tasks that have `concent_enabled=True` and those where `concent_enabled` is `False`
