### PR TITLE
Blender inconsistent subtask sizes

### DIFF
--- a/apps/blender/task/blenderrendertask.py
+++ b/apps/blender/task/blenderrendertask.py
@@ -115,7 +115,7 @@ class PreviewUpdater(object):
         self.perfectly_placed_subtasks = 0
         if os.path.exists(self.preview_file_path):
             with handle_opencv_image_error(logger):
-                OpenCVImgRepr.empty(self.preview_res_x, self.preview_res_y)\
+                OpenCVImgRepr.empty(self.preview_res_x, self.preview_res_y) \
                     .save_with_extension(self.preview_file_path, PREVIEW_EXT)
 
     def _get_height(self, subtask_number):
@@ -441,10 +441,8 @@ class BlenderRenderTask(FrameRenderingTask):
         if self.use_frames:
             if total_tasks <= len(self.frames):
                 return 1
-            else:
-                return max(1, int(total_tasks / len(self.frames)))
-        else:
-            return total_tasks
+            return max(1, int(total_tasks / len(self.frames)))
+        return total_tasks
 
     def get_subtask_y_border(self, start_task):
         parts_in_frame = self.get_parts_in_frame(self.total_tasks)
@@ -693,7 +691,8 @@ def get_min_max_y(part, parts_in_frame, res_y):
         max_y = (parts_in_frame - part + 1) * (1.0 / parts_in_frame)
     else:
         ceiling_height = int(math.ceil(res_y / parts_in_frame))
-        ceiling_subtasks = parts_in_frame - (ceiling_height * parts_in_frame - res_y)
+        ceiling_subtasks = parts_in_frame - \
+            (ceiling_height * parts_in_frame - res_y)
         if part > ceiling_subtasks:
             min_y = (parts_in_frame - part) * (ceiling_height - 1) / res_y
             max_y = (parts_in_frame - part + 1) * (ceiling_height - 1) / res_y

--- a/apps/blender/task/blenderrendertask.py
+++ b/apps/blender/task/blenderrendertask.py
@@ -369,7 +369,7 @@ class BlenderRenderTask(FrameRenderingTask):
             frames = self.frames or [1]
             parts = 1
 
-        min_y, max_y = self.get_subtask_y_border(start_task, parts)
+        min_y, max_y = self.get_subtask_y_border(start_task)
 
         crops = [
             {"outfilebasename": "{}_{}".format(
@@ -437,7 +437,17 @@ class BlenderRenderTask(FrameRenderingTask):
         self.subtasks_given[subtask_id]['ctd'] = ctd
         return self.ExtraData(ctd=ctd)
 
-    def get_subtask_y_border(self, start_task, parts_in_frame):
+    def get_parts_in_frame(self, total_tasks):
+        if self.use_frames:
+            if total_tasks <= len(self.frames):
+                return 1
+            else:
+                return max(1, int(total_tasks / len(self.frames)))
+        else:
+            return total_tasks
+
+    def get_subtask_y_border(self, start_task):
+        parts_in_frame = self.get_parts_in_frame(self.total_tasks)
         if not self.use_frames:
             return get_min_max_y(start_task, parts_in_frame, self.res_y)
         elif parts_in_frame > 1:

--- a/apps/blender/task/blenderrendertask.py
+++ b/apps/blender/task/blenderrendertask.py
@@ -369,16 +369,7 @@ class BlenderRenderTask(FrameRenderingTask):
             frames = self.frames or [1]
             parts = 1
 
-        if not self.use_frames:
-            min_y, max_y = self._get_min_max_y(start_task)
-        elif parts > 1:
-            min_y = (parts - self._count_part(start_task, parts)) \
-                    * (1.0 / parts)
-            max_y = (parts - self._count_part(start_task, parts) + 1) \
-                * (1.0 / parts)
-        else:
-            min_y = 0.0
-            max_y = 1.0
+        min_y, max_y = self.get_subtask_y_border(start_task, parts)
 
         crops = [
             {"outfilebasename": "{}_{}".format(
@@ -446,6 +437,15 @@ class BlenderRenderTask(FrameRenderingTask):
         self.subtasks_given[subtask_id]['ctd'] = ctd
         return self.ExtraData(ctd=ctd)
 
+    def get_subtask_y_border(self, start_task, parts_in_frame):
+        if not self.use_frames:
+            return get_min_max_y(start_task, parts_in_frame, self.res_y)
+        elif parts_in_frame > 1:
+            part = self._count_part(start_task, parts_in_frame)
+            return get_min_max_y(part, parts_in_frame, self.res_y)
+
+        return 0.0, 1.0
+
     def restart(self):
         super(BlenderRenderTask, self).restart()
         if self.use_frames:
@@ -494,13 +494,6 @@ class BlenderRenderTask(FrameRenderingTask):
             os.makedirs(self.test_task_res_path)
 
         return self._new_compute_task_def(hash, extra_data, 0)
-
-    def _get_min_max_y(self, start_task):
-        if self.use_frames:
-            parts = int(self.total_tasks / len(self.frames))
-        else:
-            parts = self.total_tasks
-        return get_min_max_y(start_task, parts, self.res_y)
 
     def after_test(self, results, tmp_dir):
         return_data = dict()
@@ -684,22 +677,22 @@ def generate_expected_offsets(parts, res_x, res_y):
     return expected_offsets
 
 
-def get_min_max_y(task_num, parts, res_y):
-    if res_y % parts == 0:
-        min_y = (parts - task_num) * (1.0 / parts)
-        max_y = (parts - task_num + 1) * (1.0 / parts)
+def get_min_max_y(part, parts_in_frame, res_y):
+    if res_y % parts_in_frame == 0:
+        min_y = (parts_in_frame - part) * (1.0 / parts_in_frame)
+        max_y = (parts_in_frame - part + 1) * (1.0 / parts_in_frame)
     else:
-        ceiling_height = int(math.ceil(res_y / parts))
-        ceiling_subtasks = parts - (ceiling_height * parts - res_y)
-        if task_num > ceiling_subtasks:
-            min_y = (parts - task_num) * (ceiling_height - 1) / res_y
-            max_y = (parts - task_num + 1) * (ceiling_height - 1) / res_y
+        ceiling_height = int(math.ceil(res_y / parts_in_frame))
+        ceiling_subtasks = parts_in_frame - (ceiling_height * parts_in_frame - res_y)
+        if part > ceiling_subtasks:
+            min_y = (parts_in_frame - part) * (ceiling_height - 1) / res_y
+            max_y = (parts_in_frame - part + 1) * (ceiling_height - 1) / res_y
         else:
-            min_y = (parts - ceiling_subtasks) * (ceiling_height - 1)
-            min_y += (ceiling_subtasks - task_num) * ceiling_height
+            min_y = (parts_in_frame - ceiling_subtasks) * (ceiling_height - 1)
+            min_y += (ceiling_subtasks - part) * ceiling_height
             min_y = min_y / res_y
 
-            max_y = (parts - ceiling_subtasks) * (ceiling_height - 1)
-            max_y += (ceiling_subtasks - task_num + 1) * ceiling_height
+            max_y = (parts_in_frame - ceiling_subtasks) * (ceiling_height - 1)
+            max_y += (ceiling_subtasks - part + 1) * ceiling_height
             max_y = max_y / res_y
     return min_y, max_y

--- a/tests/apps/blender/task/test_blenderrendertask.py
+++ b/tests/apps/blender/task/test_blenderrendertask.py
@@ -364,7 +364,7 @@ class TestBlenderTask(TempDirFixture, LogTestCase):
                 self.bt.res_y = yres
                 cur_max_y = self.bt.res_y
                 for i in range(1, self.bt.total_tasks + 1):
-                    min_y, max_y = self.bt._get_min_max_y(i)
+                    min_y, max_y = self.bt.get_subtask_y_border(i)
                     min_y = int(float(self.bt.res_y) * min_y)
                     max_y = int(float(self.bt.res_y) * max_y)
                     self.assertTrue(max_y == cur_max_y)
@@ -375,7 +375,7 @@ class TestBlenderTask(TempDirFixture, LogTestCase):
         self.bt.frames = [4, 5, 10, 11, 12]
         self.bt.total_tasks = 20
         self.bt.res_y = 300
-        assert self.bt._get_min_max_y(2) == (0.5, 0.75)
+        assert self.bt.get_subtask_y_border(2) == (0.5, 0.75)
 
     def test_put_img_together_exr(self):
         for chunks in [1, 5, 7, 11, 13, 31, 57, 100]:


### PR DESCRIPTION
Fix for problem with blender tasks being negatively verified for uneven divisions (400x400 pixels, 3 subtasks) and multiple frames