### PR TITLE
Avoid storing resources_options in TaskCompKeeper

### DIFF
--- a/golem/task/server/resources.py
+++ b/golem/task/server/resources.py
@@ -101,15 +101,19 @@ class TaskResourcesMixin:
         logger.error("Cannot restore task '%s' resources: %r", task_id, error)
         self.task_manager.delete_task(task_id)
 
-    def request_resource(self, task_id, subtask_id, resources):
+    def request_resource(
+            self,
+            task_id,
+            subtask_id,
+            resources,
+            resources_options,
+    ):
         if not self.client.resource_server:
             logger.error("ResourceManager not ready")
             return False
         resources = self.resource_manager.from_wire(resources)
 
-        task_keeper = self.task_manager.comp_task_keeper
-        options = task_keeper.get_resources_options(subtask_id)
-        client_options = self.get_download_options(options)
+        client_options = self.get_download_options(resources_options)
         self.pull_resources(task_id, resources, client_options)
         return True
 

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -26,7 +26,6 @@ from golem.core.variables import NUM_OF_RES_TRANSFERS_NEEDED_FOR_VER
 from golem.environments.environment import SupportStatus, UnsupportReason
 from golem.environments.environmentsmanager import \
     EnvironmentsManager as OldEnvManager
-from golem.network.hyperdrive.client import HyperdriveClientOptions
 from golem.task.envmanager import EnvironmentManager as NewEnvManager
 from golem.task.taskproviderstats import ProviderStatsManager
 
@@ -114,10 +113,6 @@ class CompTaskKeeper:
         # information about tasks that this node wants to compute
         self.active_tasks: typing.Dict[str, CompTaskInfo] = {}
 
-        # information about resource options for subtask
-        self.resources_options: typing.Dict[str, typing.Optional[
-            HyperdriveClientOptions]] = {}
-
         # price information per last task request
         self.active_task_offers: typing.Dict[str, int] = {}
 
@@ -146,7 +141,7 @@ class CompTaskKeeper:
                 self.subtask_to_task,
                 self.task_package_paths,
                 self.active_task_offers,
-                self.resources_options
+                None,  # resources_options, leaving for backwards compatibility
             )
             pickle.dump(dump_data, f)
 
@@ -162,7 +157,8 @@ class CompTaskKeeper:
                 subtask_to_task = data[1]
                 task_package_paths = data[2] if len(data) > 2 else {}
                 active_task_offers = data[3] if len(data) > 3 else {}
-                resources_options = data[4] if len(data) > 4 else {}
+                # backwards compatibility, don't use slot 4
+                # resources_options = data[4] if len(data) > 4 else {}
         except (pickle.UnpicklingError, EOFError, AttributeError, KeyError):
             logger.exception(
                 'Problem restoring dumpfile: %s; deleting broken file',
@@ -175,7 +171,6 @@ class CompTaskKeeper:
         self.subtask_to_task.update(subtask_to_task)
         self.task_package_paths.update(task_package_paths)
         self.active_task_offers.update(active_task_offers)
-        self.resources_options.update(resources_options)
 
     def add_request(self, theader: dt_tasks.TaskHeader, price: int):
         # price is task_header.max_price
@@ -227,10 +222,6 @@ class CompTaskKeeper:
             header.subtask_timeout, task_to_compute.size)
 
         self.subtask_to_task[subtask_id] = task_id
-        if task_to_compute.resources_options:
-            task_to_compute.resources_options['options']['size'] = \
-                task_to_compute.size
-        self.resources_options[subtask_id] = task_to_compute.resources_options
         self.dump()
         return True
 
@@ -270,10 +261,6 @@ class CompTaskKeeper:
     def get_node_for_task_id(self, task_id) -> typing.Optional[str]:
         return self.active_tasks[task_id].header.task_owner.key
 
-    def get_resources_options(self, subtask_id: str) -> \
-            typing.Optional[HyperdriveClientOptions]:
-        return self.resources_options.get(subtask_id)
-
     def check_task_owner_by_subtask(self, task_owner_key_id, subtask_id):
         task_id = self.subtask_to_task.get(subtask_id)
         task = self.active_tasks.get(task_id)
@@ -295,7 +282,6 @@ class CompTaskKeeper:
             logger.info("Removing comp_task after deadline: %s", task_id)
 
             for subtask_id in self.active_tasks[task_id].subtasks:
-                self.resources_options.pop(subtask_id, None)
                 self.subtask_to_task.pop(subtask_id, None)
 
             self.active_tasks.pop(task_id, None)

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -388,27 +388,26 @@ class TaskServer(
 
     def task_given(
             self,
-            node_id: str,
-            ctd: message.ComputeTaskDef,
-            price: int
+            msg: message.tasks.TaskToCompute,
     ) -> bool:
         if self.task_computer.has_assigned_task():
             logger.error("Trying to assign a task, when it's already assigned")
             return False
 
-        self.task_computer.task_given(ctd)
+        self.task_computer.task_given(msg.compute_task_def)
         self.request_resource(
-            ctd['task_id'],
-            ctd['subtask_id'],
-            ctd['resources'],
+            msg.task_id,
+            msg.subtask_id,
+            msg.compute_task_def['resources'],
+            msg.resources_options,
         )
         self.requested_tasks.clear()
-        update_requestor_assigned_sum(node_id, price)
+        update_requestor_assigned_sum(msg.requestor_id, msg.price)
         dispatcher.send(
             signal='golem.subtask',
             event='started',
-            subtask_id=ctd['subtask_id'],
-            price=price,
+            subtask_id=msg.subtask_id,
+            price=msg.price,
         )
         return True
 

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -597,7 +597,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             return
 
         self.task_manager.comp_task_keeper.receive_subtask(msg)
-        if not self.task_server.task_given(self.key_id, ctd, msg.price):
+        if not self.task_server.task_given(msg):
             _cannot_compute(None)
             return
 

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -721,18 +721,6 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         ctk.restore()
         self.assertEqual(ctk.get_package_paths(task_id), package_paths)
 
-    @mock.patch('golem.core.golem_async.async_run', async_run)
-    def test_resources_options(self):
-        task_path = Path(self.path)
-        self._dump_some_tasks(task_path)
-        ctk = CompTaskKeeper(task_path)
-
-        assert ctk.get_resources_options("unknown") is None
-        subtask_id = random.choice(list(ctk.subtask_to_task.keys()))
-        res = ctk.get_resources_options(subtask_id)
-        assert isinstance(res, dict)
-        assert res['client_id'] == HyperdriveClient.CLIENT_ID
-
 
 class TestTaskHeaderKeeperBase(TwistedTestCase):
 

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1124,28 +1124,27 @@ class TestTaskGiven(TaskServerTestBase):
             request_resource, task_given, has_assigned_task):
 
         has_assigned_task.return_value = False
-        node_id = 'test_node'
-        task_id = 'test_task'
-        subtask_id = 'test_subtask'
-        resources = ['test_resource']
-        ctd = ComputeTaskDef(
-            task_id=task_id,
-            subtask_id=subtask_id,
-            resources=resources
-        )
-        price = 123
+        ttc = msg_factories.tasks.TaskToComputeFactory()
 
-        result = self.ts.task_given(node_id, ctd, price)
+        result = self.ts.task_given(ttc)
         self.assertEqual(result, True)
 
-        task_given.assert_called_once_with(ctd)
-        request_resource.assert_called_once_with(task_id, subtask_id, resources)
-        update_requestor_assigned_sum.assert_called_once_with(node_id, price)
+        task_given.assert_called_once_with(ttc.compute_task_def)
+        request_resource.assert_called_once_with(
+            ttc.task_id,
+            ttc.subtask_id,
+            ttc.compute_task_def['resources'],  # noqa pylint: disable=unsubscriptable-object
+            ttc.resources_options,
+        )
+        update_requestor_assigned_sum.assert_called_once_with(
+            ttc.requestor_id,
+            ttc.price,
+        )
         dispatcher_mock.send.assert_called_once_with(
             signal='golem.subtask',
             event='started',
-            subtask_id=subtask_id,
-            price=price
+            subtask_id=ttc.subtask_id,
+            price=ttc.price,
         )
         logger_mock.error.assert_not_called()
 
@@ -1154,7 +1153,7 @@ class TestTaskGiven(TaskServerTestBase):
             request_resource, task_given, has_assigned_task):
 
         has_assigned_task.return_value = True
-        result = self.ts.task_given('', Mock(), 0)
+        result = self.ts.task_given(Mock())
         self.assertEqual(result, False)
 
         task_given.assert_not_called()

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -458,11 +458,7 @@ class TaskSessionReactToTaskToComputeTest(TaskSessionTestBase):
         ttc = self.ttc_prepare_and_react(ctd)
         self.task_session.task_manager.\
             comp_task_keeper.receive_subtask.assert_called_with(ttc)
-        self.task_session.task_server.task_given.assert_called_with(
-            self.header.task_owner.key,
-            ctd,
-            ttc.price,
-        )
+        self.task_session.task_server.task_given.assert_called_with(ttc)
         self.conn.close.assert_not_called()
 
     def test_no_ctd(self, *_):
@@ -496,17 +492,6 @@ class TaskSessionReactToTaskToComputeTest(TaskSessionTestBase):
         # Wrong data size -> failure
         self.ttc_prepare_and_react(resource_size=1024)
         self.assertCannotComputeTask(self.reasons.ResourcesTooBig)
-
-    def test_ctd_custom_code(self):
-        # Allow custom code / code in ComputerTaskDef -> proper execution
-        ctd = self.ctd(extra_data__src_code="print 'Hello world!'")
-        ttc = self.ttc_prepare_and_react(ctd)
-        self.task_session.task_server.task_given.assert_called_with(
-            self.header.task_owner.key,
-            ctd,
-            ttc.price,
-        )
-        self.conn.close.assert_not_called()
 
     def test_fail_no_environment_available(self):
         # No environment available -> failure


### PR DESCRIPTION
It's completely unnecessary since we can just pass TTC and grab it from there.