### PR TITLE
Bump wasm-sandbox to 0.4.0

### DIFF
--- a/apps/images.ini
+++ b/apps/images.ini
@@ -4,5 +4,5 @@ golemfactory/blender blender/resources/images/blender.Dockerfile 1.10 blender/re
 golemfactory/blender_verifier blender/resources/images/blender_verifier.Dockerfile 1.5 blender/resources/images/
 golemfactory/blender_nvgpu blender/resources/images/blender_nvgpu.Dockerfile 1.4 . apps.core.nvgpu.is_supported
 golemfactory/dummy dummy/resources/images/Dockerfile 1.2 dummy/resources/images
-golemfactory/wasm wasm/resources/images/Dockerfile 0.3.0 wasm/resources/images
+golemfactory/wasm wasm/resources/images/Dockerfile 0.4.0 wasm/resources/images
 golemfactory/glambda glambda/resources/images/Dockerfile 1.5 .

--- a/apps/wasm/environment.py
+++ b/apps/wasm/environment.py
@@ -3,6 +3,6 @@ from golem.docker.environment import DockerEnvironment
 
 class WasmTaskEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/wasm"
-    DOCKER_TAG = "0.3.0"
+    DOCKER_TAG = "0.4.0"
     ENV_ID = "WASM"
     SHORT_DESCRIPTION = "WASM Sandbox"

--- a/apps/wasm/resources/images/Dockerfile
+++ b/apps/wasm/resources/images/Dockerfile
@@ -4,12 +4,12 @@ RUN apt -y update && apt -y install autoconf2.13 clang-6.0 --no-install-recommen
 
 RUN git clone https://github.com/golemfactory/sp-wasm.git
 WORKDIR /sp-wasm
-RUN git checkout tags/0.2.1
+RUN git checkout tags/0.4.0
 ENV SHELL=/bin/bash
 ENV CC=clang-6.0
 ENV CPP="clang-6.0 -E"
 ENV CXX=clang++-6.0
-RUN cargo install --path /sp-wasm/sp-wasm-cli --root /usr
+RUN cargo install --path . --root /usr
 RUN cargo clean
 
 FROM golemfactory/base:1.5


### PR DESCRIPTION
This PR bumps version of our wasm-sandbox to v0.4.0 which is now in agreement with [sp-wasm](https://github.com/golemfactory/sp-wasm) versioning.