### PR TITLE
Clean up TaskServer::send_results

### DIFF
--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -143,7 +143,7 @@ class TaskComputerAdapter:
             self._task_server.send_results(
                 subtask_id=subtask_id,
                 task_id=task_id,
-                result={'data': [output_file]},
+                result=[output_file],
             )
         except Exception as e:  # pylint: disable=broad-except
             self._task_server.send_task_failed(
@@ -528,11 +528,12 @@ class TaskComputer:  # pylint: disable=too-many-instance-attributes
                         str(work_wall_clock_time))
             self.stats.increase_stat('computed_tasks')
 
+            assert isinstance(task_thread.result, dict)
             try:
                 self.task_server.send_results(
                     subtask_id,
                     subtask['task_id'],
-                    task_thread.result,
+                    task_thread.result['data'],
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 logger.error("Error sending the results: %r", exc)

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -476,17 +476,16 @@ class TaskServer(
             f'Error downloading resources: {reason}',
         )
 
-    def send_results(self, subtask_id, task_id, result):
-
-        if 'data' not in result:
-            raise AttributeError("Wrong result format")
+    def send_results(self, subtask_id: str, task_id: str, result: List[Path]):
+        if not result:
+            raise ValueError('Not results to send')
 
         if subtask_id in self.results_to_send:
             raise RuntimeError("Incorrect subtask_id: {}".format(subtask_id))
 
         # this is purely for tests
         if self.config_desc.overwrite_results:
-            for file_path in result['data']:
+            for file_path in result:
                 shutil.copyfile(
                     src=self.config_desc.overwrite_results,
                     dst=file_path)
@@ -499,7 +498,7 @@ class TaskServer(
         wtr = WaitingTaskResult(
             task_id=task_id,
             subtask_id=subtask_id,
-            result=result['data'],
+            result=result,
             last_sending_trial=last_sending_trial,
             delay_time=delay_time,
             owner=header.task_owner)

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -113,7 +113,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         args = task_server.send_results.call_args[0]
         self.assertEqual(args[0], "xxyyzz")
         self.assertEqual(args[1], "xyz")
-        self.assertEqual(args[2]["data"], 10000)
+        self.assertEqual(args[2], 10000)
         mock_finished.assert_called_once_with()
         mock_finished.reset_mock()
 

--- a/tests/golem/task/test_taskcomputeradapter.py
+++ b/tests/golem/task/test_taskcomputeradapter.py
@@ -196,7 +196,7 @@ class TestHandleComputationResults(TaskComputerAdapterTestBase):
         self.task_server.send_results.assert_called_once_with(
             task_id='test_task',
             subtask_id='test_subtask',
-            result={'data': [output_file]}
+            result=[output_file],
         )
 
     @defer.inlineCallbacks

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1057,14 +1057,14 @@ class TestRestoreResources(LogTestCase, testutils.DatabaseFixture,
 
 class TestSendResults(TaskServerTestBase):
 
-    def test_wrong_result_format(self):
-        with self.assertRaises(AttributeError):
-            self.ts.send_results('subtask_id', 'task_id', {'foo': 'bar'})
+    def test_no_results(self):
+        with self.assertRaises(ValueError):
+            self.ts.send_results('subtask_id', 'task_id', [])
 
     def test_subtask_already_sent(self):
         self.ts.results_to_send['subtask_id'] = Mock(spec=WaitingTaskResult)
         with self.assertRaises(RuntimeError):
-            self.ts.send_results('subtask_id', 'task_id', {'data': 'data'})
+            self.ts.send_results('subtask_id', 'task_id', ['data'])
 
     @patch('golem.task.taskserver.Trust')
     def test_ok(self, trust):
@@ -1091,13 +1091,13 @@ class TestSendResults(TaskServerTestBase):
         with patch.object(
             self.ts.task_manager, 'task_result_manager', result_manager
         ):
-            self.ts.send_results('subtask_id', 'task_id', {'data': 'data'})
+            self.ts.send_results('subtask_id', 'task_id', ['data'])
 
         result = self.ts.results_to_send.get('subtask_id')
         self.assertIsInstance(result, WaitingTaskResult)
         self.assertEqual(result.task_id, 'task_id')
         self.assertEqual(result.subtask_id, 'subtask_id')
-        self.assertEqual(result.result, 'data')
+        self.assertEqual(result.result, ['data'])
         self.assertEqual(result.last_sending_trial, 0)
         self.assertEqual(result.delay_time, 0)
         self.assertEqual(result.owner, header.task_owner)


### PR DESCRIPTION
Don't use single key dict.