### PR TITLE
Implement ProviderAppClient.shutdown in NewTaskComputer

### DIFF
--- a/golem/task/task_api/__init__.py
+++ b/golem/task/task_api/__init__.py
@@ -54,6 +54,9 @@ class EnvironmentTaskApiService(TaskApiService):
         return self._runtime.get_port_mapping(port)
 
     def running(self) -> bool:
+        """
+        Checks if the service is 'closable' thus needs to be shutdown on errors
+        """
         return self._runtime is not None and self._runtime.status() in [
             RuntimeStatus.CREATED,
             RuntimeStatus.PREPARING,

--- a/golem/task/task_api/__init__.py
+++ b/golem/task/task_api/__init__.py
@@ -5,7 +5,13 @@ from typing import Optional, Tuple, Type
 from golem_task_api import TaskApiService
 
 from golem.core.deferred import sync_wait
-from golem.envs import Environment, Prerequisites, Runtime, RuntimePayload
+from golem.envs import (
+    Environment,
+    Prerequisites,
+    Runtime,
+    RuntimePayload,
+    RuntimeStatus,
+)
 
 
 class TaskApiPayloadBuilder(abc.ABC):
@@ -46,6 +52,15 @@ class EnvironmentTaskApiService(TaskApiService):
         sync_wait(self._runtime.prepare())
         sync_wait(self._runtime.start())
         return self._runtime.get_port_mapping(port)
+
+    def running(self) -> bool:
+        return self._runtime is not None and self._runtime.status() in [
+            RuntimeStatus.CREATED,
+            RuntimeStatus.PREPARING,
+            RuntimeStatus.PREPARED,
+            RuntimeStatus.STARTING,
+            RuntimeStatus.RUNNING,
+        ]
 
     async def wait_until_shutdown_complete(self) -> None:
         assert self._runtime is not None

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -10,10 +10,7 @@ from threading import Lock
 
 from dataclasses import dataclass
 from golem_messages.message.tasks import ComputeTaskDef, TaskHeader
-from golem_task_api import (
-    ProviderAppClient,
-	constants as task_api_constants
-)
+from golem_task_api import ProviderAppClient, constants as task_api_constants
 from pydispatch import dispatcher
 from twisted.internet import defer
 

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -371,10 +371,12 @@ class NewTaskComputer:
             ProviderTimer.finish()
             self._computation = None
             self._assigned_task = None
-            if not success:
-                # Ensure the app_client is shutdown before dropping the var
-                yield self._app_client.shutdown()
-            self._app_client = None
+            # This check should not be needed but is there to please the linter
+            if self._app_client is not None:
+                if not success:
+                    # Ensure the app_client is shutdown before dropping the var
+                    yield self._app_client.shutdown()
+                self._app_client = None
             self._task_finished_callback()
 
     def _get_task_dir(self) -> Path:

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -369,9 +369,10 @@ class NewTaskComputer:
             ProviderTimer.finish()
             self._computation = None
             self._assigned_task = None
-            if not success:
-                yield app_client.shutdown()
             self._task_finished_callback()
+            if not success:
+                # Cleanup can throw errors, do this last
+                yield app_client.shutdown()
 
     def _get_task_dir(self) -> Path:
         assert self._assigned_task is not None

--- a/requirements.txt
+++ b/requirements.txt
@@ -39,7 +39,7 @@ eth-utils==1.0.3
 ethereum==1.6.1
 eventlet==0.24.1
 fs==2.4.4
-git+https://github.com/golemfactory/task-api@mwu/provider-shutdown&subdirectory=python#egg=golem_task_api
+git+https://github.com/golemfactory/task-api@mwu/provider-shutdown#egg=golem_task_api&subdirectory=python
 Golem-Messages==3.9.0
 Golem-Smart-Contracts-Interface==1.10.2
 greenlet==0.4.15

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
 #git+https://github.com/golemfactory/golem-messages@<branchname>#egg=golem-messages
-#golem_task_api==0.9.0
 --extra-index-url https://builds.golem.network --trusted-host build.golem.network
 appdirs==1.4.3
 argh==0.26.2
@@ -39,9 +38,9 @@ eth-utils==1.0.3
 ethereum==1.6.1
 eventlet==0.24.1
 fs==2.4.4
-git+https://github.com/golemfactory/task-api@mwu/provider-shutdown#egg=golem_task_api&subdirectory=python
 Golem-Messages==3.9.0
 Golem-Smart-Contracts-Interface==1.10.2
+golem_task_api==0.11.0
 greenlet==0.4.15
 h2==3.0.1
 hpack==3.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 #git+https://github.com/golemfactory/golem-messages@<branchname>#egg=golem-messages
+#golem_task_api==0.9.0
 --extra-index-url https://builds.golem.network --trusted-host build.golem.network
 appdirs==1.4.3
 argh==0.26.2
@@ -38,9 +39,9 @@ eth-utils==1.0.3
 ethereum==1.6.1
 eventlet==0.24.1
 fs==2.4.4
+git+https://github.com/golemfactory/task-api@mwu/provider-shutdown&subdirectory=python#egg=golem_task_api
 Golem-Messages==3.9.0
 Golem-Smart-Contracts-Interface==1.10.2
-golem_task_api==0.9.0
 greenlet==0.4.15
 h2==3.0.1
 hpack==3.0.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -1,4 +1,5 @@
 #git+https://github.com/golemfactory/golem-messages@<branchname>#egg=golem-messages
+#golem_task_api==0.9.0
 --extra-index-url https://builds.golem.network
 appdirs>=1.4
 asn1crypto==0.22.0
@@ -17,9 +18,9 @@ docker==3.5.0
 enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
+git+https://github.com/golemfactory/task-api@mwu/provider-shutdown&subdirectory=python#egg=golem_task_api
 Golem-Messages==3.9.0
 Golem-Smart-Contracts-Interface==1.10.2
-golem_task_api==0.9.0
 html2text==2018.1.9
 humanize==0.5.1
 incremental==17.5.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -1,5 +1,4 @@
 #git+https://github.com/golemfactory/golem-messages@<branchname>#egg=golem-messages
-#golem_task_api==0.9.0
 --extra-index-url https://builds.golem.network
 appdirs>=1.4
 asn1crypto==0.22.0
@@ -18,9 +17,9 @@ docker==3.5.0
 enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
-git+https://github.com/golemfactory/task-api@mwu/provider-shutdown#egg=golem_task_api&subdirectory=python
 Golem-Messages==3.9.0
 Golem-Smart-Contracts-Interface==1.10.2
+golem_task_api==0.11.0
 html2text==2018.1.9
 humanize==0.5.1
 incremental==17.5.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -18,7 +18,7 @@ docker==3.5.0
 enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
-git+https://github.com/golemfactory/task-api@mwu/provider-shutdown&subdirectory=python#egg=golem_task_api
+git+https://github.com/golemfactory/task-api@mwu/provider-shutdown#egg=golem_task_api&subdirectory=python
 Golem-Messages==3.9.0
 Golem-Smart-Contracts-Interface==1.10.2
 html2text==2018.1.9

--- a/setup_util/setup_commons.py
+++ b/setup_util/setup_commons.py
@@ -215,7 +215,7 @@ def parse_requirements(my_path):
         if line.startswith('-') or line.startswith('#'):
             continue
 
-        m = re.match('.+#egg=(?P<package>.+)$', line)
+        m = re.match('.+#egg=(?P<package>.+?)(?:&.+)?$', line)
         if m:
             requirements.append(m.group('package'))
             dependency_links.append(line)

--- a/tests/golem/task/test_newtaskcomputer.py
+++ b/tests/golem/task/test_newtaskcomputer.py
@@ -20,12 +20,10 @@ from golem.tools.testwithreactor import uninstall_reactor
 
 class NewTaskComputerTestBase(TwistedTestCase):
 
-    @mock.patch('golem.task.taskcomputer.ProviderAppClient')
-    def setUp(self, provider_client):  # pylint: disable=arguments-differ
+    def setUp(self):
         self.env_manager = mock.Mock(spec=EnvironmentManager)
         self.task_finished_callback = mock.Mock()
         self.stats_keeper = mock.Mock(spec=IntStatsKeeper)
-        self.provider_client = provider_client()
         self.work_dir = Path('test')
         self.task_computer = NewTaskComputer(
             env_manager=self.env_manager,
@@ -183,6 +181,8 @@ class TestCompute(NewTaskComputerTestBase):
             'NewTaskComputer._get_task_dir',
             return_value=self.task_dir
         )
+        provider_client_cls = self._patch_async('ProviderAppClient')
+        self.provider_client = provider_client_cls()
         self.provider_timer = self._patch_async('ProviderTimer')
         self.dispatcher = self._patch_async('dispatcher')
         self.logger = self._patch_async('logger')


### PR DESCRIPTION
Depends on https://github.com/golemfactory/task-api/pull/20

Replace the `NewTaskComputer._runtime` hack with a proper implementation of shutdown.

- Only store the running `ProviderAppClient` in `self._app_client`
- Call `ProviderAppClient.shutdown()` on any form of error, to ensure it is shut(ting) down
- ~use `self.has_assigned_task()` where possible over `is None` check~