### PR TITLE
[P6a] Audio channel layout validations

### DIFF
--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -133,7 +133,11 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
             # matter which we choose.
             dst_params = self._get_extra_data(0)["targs"]
 
-            validation.validate_transcoding_params(src_params, dst_params)
+            validation.validate_transcoding_params(
+                src_params,
+                dst_params,
+                video_metadata
+            )
 
         except validation.InvalidVideo as e:
             logger.error(e.response_message)

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -121,20 +121,12 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
         try:
             validation.validate_video(video_metadata)
 
-            src_params = meta.create_params(
-                meta.get_format(video_metadata),
-                meta.get_resolution(video_metadata),
-                meta.get_video_codec(video_metadata),
-                meta.get_audio_codec(video_metadata),
-                meta.get_frame_rate(video_metadata))
-
             # Get parameters for example subtasks. All subtasks should have
             # the same conversion parameters which we check here, so it doesn't
             # matter which we choose.
             dst_params = self._get_extra_data(0)["targs"]
 
             validation.validate_transcoding_params(
-                src_params,
                 dst_params,
                 video_metadata
             )


### PR DESCRIPTION
A simple change required to make transcoding validations work after https://github.com/golemfactory/ffmpeg-tools/pull/12. `validate_transcoding_params()` now requires access to video metadata.

### Dependencies
This pull request is based on #4574 and should be merged after it. This is just for ease or development - It does not really depend on that base pull request and could be merged without it if rebased.

For the code to work you also need a `golemfactory/ffmpeg-experimental` image built with https://github.com/golemfactory/ffmpeg-tools/pull/12. Tests in the CI won't pass until it's released on DockerHub.

**NOTE**: I have set the base branch of this pull request to `transcoding-allow-transcoding-to-any-resolution-with-same-aspect-ratio` (#4574) rather than `CGI/transcoding/master`. Please remember to change the base branch back to `CGI/transcoding/master` before you merge.