### PR TITLE
Correct linter name in summary

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -108,7 +108,7 @@ main() {
     local names=(
         "pylint main"
         "pylint tests"
-        "pycodestyle"
+        "flake8"
         "mypy"
     )
 

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -722,7 +722,8 @@ class TestRestartSubtasks(ProviderBase):
         self.provider.restart_subtasks(
             task_id=task_id,
             subtask_ids=self.subtask_ids,
-            disable_concent=True
+            disable_concent=True,
+            ignore_gas_price=ignore_gas_price,
         )
 
         validate_funds_mock.assert_called_once_with(


### PR DESCRIPTION
In linter summary, flake8 is wrongly labelled as pycodestyle.