### PR TITLE
[CLAY-399] hyperg: unify shared resource lifetimes

### DIFF
--- a/golem/network/hyperdrive/client.py
+++ b/golem/network/hyperdrive/client.py
@@ -8,9 +8,9 @@ import collections
 
 import requests
 from requests import HTTPError
-from twisted.internet.defer import inlineCallbacks
 
 from golem_messages import helpers as msg_helpers
+from twisted.internet.defer import inlineCallbacks
 from twisted.web.client import readBody
 from twisted.web.http_headers import Headers
 
@@ -243,17 +243,19 @@ class HyperdriveAsyncClient(HyperdriveClient):
             params: Optional[Dict] = None,
             parser: Optional[Callable[[Dict], Any]] = None,
     ):
+        body = None
+
         if endpoint and endpoint[0] == '/':
             endpoint = endpoint[1:]
         if params:
-            params = json.dumps(params).encode(self.ENCODING)
+            body = json.dumps(params).encode(self.ENCODING)
 
         uri = f'{self._url}/{endpoint}'.encode(self.ENCODING)
         response = yield AsyncHTTPRequest.run(
             method,
             uri=uri,
             headers=self.RAW_HEADERS,
-            body=params
+            body=body
         )
 
         try:

--- a/golem/network/hyperdrive/client.py
+++ b/golem/network/hyperdrive/client.py
@@ -24,12 +24,10 @@ def to_hyperg_peer(host: str, port: int) -> Dict[str, Tuple[str, int]]:
     return {'TCP': (host, port)}
 
 
-def round_timeout(value: Optional[Union[int, float]]) -> Optional[int]:
-    if not isinstance(value, (int, float)):
-        return None
-
-    value_int = int(math.ceil(value))
-    return value_int if value_int > 0 else None
+def round_timeout(value: Union[int, float]) -> int:
+    if not isinstance(value, (int, float)) or value <= 0:
+        raise ValueError(f"Invalid timeout: {value}")
+    return int(math.ceil(value))
 
 
 class HyperdriveClient(IClient):
@@ -70,22 +68,20 @@ class HyperdriveClient(IClient):
         return addresses
 
     def add(self, files, client_options=None, **kwargs):
-        timeout = client_options.timeout if client_options else None
         response = self._request(
             command='upload',
             id=kwargs.get('id'),
             files=files,
-            timeout=round_timeout(timeout)
+            timeout=round_timeout(client_options.timeout)
         )
         return response['hash']
 
     def restore(self, content_hash, client_options=None, **kwargs):
-        timeout = client_options.timeout if client_options else None
         response = self._request(
             command='upload',
             id=kwargs.get('id'),
             hash=content_hash,
-            timeout=round_timeout(timeout)
+            timeout=round_timeout(client_options.timeout)
         )
         return response['hash']
 
@@ -161,12 +157,11 @@ class HyperdriveAsyncClient(HyperdriveClient):
             client_options: ClientOptions,
             **kwargs
     ):
-        timeout = client_options.timeout if client_options else None
         params = dict(
             command='upload',
             id=kwargs.get('id'),
             files=files,
-            timeout=round_timeout(timeout))
+            timeout=round_timeout(client_options.timeout))
 
         return self._async_request(
             params=params,
@@ -178,12 +173,11 @@ class HyperdriveAsyncClient(HyperdriveClient):
             client_options: ClientOptions,
             **kwargs
     ):
-        timeout = client_options.timeout if client_options else None
         params = dict(
             command='upload',
             id=kwargs.get('id'),
             hash=content_hash,
-            timeout=round_timeout(timeout))
+            timeout=round_timeout(client_options.timeout))
 
         return self._async_request(
             params=params,

--- a/golem/network/hyperdrive/client.py
+++ b/golem/network/hyperdrive/client.py
@@ -46,7 +46,7 @@ class HyperdriveClient(IClient):
         super().__init__()
         # connection / read timeout
         self.timeout = timeout
-        # default POST request headers
+        # API destination address
         self._url = f'http://{host}:{port}'
 
     def __repr__(self):

--- a/golem/network/hyperdrive/client.py
+++ b/golem/network/hyperdrive/client.py
@@ -24,7 +24,7 @@ def to_hyperg_peer(host: str, port: int) -> Dict[str, Tuple[str, int]]:
     return {'TCP': (host, port)}
 
 
-def round_timeout(value: Union[int, float]) -> int:
+def round_timeout(value: Optional[Union[int, float]]) -> int:
     if not isinstance(value, (int, float)) or value <= 0:
         raise ValueError(f"Invalid timeout: {value}")
     return int(math.ceil(value))

--- a/golem/network/hyperdrive/client.py
+++ b/golem/network/hyperdrive/client.py
@@ -24,6 +24,8 @@ def to_hyperg_peer(host: str, port: int) -> Dict[str, Tuple[str, int]]:
     return {'TCP': (host, port)}
 
 
+# TODO: Change 'Optional[Union[int, float]]' hint to 'Union[int, float]' and
+#       remove the 'isinstance' check when HyperdriveResourceManager is removed
 def round_timeout(value: Optional[Union[int, float]]) -> int:
     if not isinstance(value, (int, float)) or value <= 0:
         raise ValueError(f"Invalid timeout: {value}")

--- a/golem/network/hyperdrive/daemon_manager.py
+++ b/golem/network/hyperdrive/daemon_manager.py
@@ -18,7 +18,7 @@ from golem.report import report_calls, Component
 logger = logging.getLogger('golem.resources')
 
 
-GOLEM_HYPERDRIVE_VERSION = '0.3.2'
+GOLEM_HYPERDRIVE_VERSION = '0.3.5'
 GOLEM_HYPERDRIVE_LOGFILE = 'hyperg.log'
 
 

--- a/golem/task/result/resultmanager.py
+++ b/golem/task/result/resultmanager.py
@@ -77,7 +77,7 @@ class EncryptedResultPackageManager(TaskResultPackageManager):
                                             error=error,
                                             async_=async_)
 
-    def create(self, task_result, key_or_secret=None):
+    def create(self, task_result, client_options, key_or_secret=None):
         if not key_or_secret:
             raise ValueError("Empty key / secret")
 
@@ -96,7 +96,11 @@ class EncryptedResultPackageManager(TaskResultPackageManager):
         package_path = packager.package_name(encrypted_package_path)
         package_size = os.path.getsize(package_path)
 
-        self.resource_manager.add_file(path, task_result.task_id)
+        self.resource_manager.add_file(
+            path,
+            task_result.task_id,
+            client_options=client_options)
+
         for resource in self.resource_manager.get_resources(
                 task_result.task_id):
             if file_name in resource.files:

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -311,8 +311,7 @@ def add_resources(client, resources, res_id, timeout):
     )
     package_path, package_sha1 = packager_result
     resource_size = os.path.getsize(package_path)
-    client_options = client.task_server.get_share_options(res_id, None)
-    client_options.timeout = timeout
+    client_options = client.task_server.get_share_options(timeout=timeout)
     resource_server_result = yield client.resource_server.add_resources(
         package_path,
         res_id,

--- a/golem/task/server/helpers.py
+++ b/golem/task/server/helpers.py
@@ -127,8 +127,7 @@ def send_report_computed_task(task_server, waiting_task_result) -> None:
 
     my_node: LocalNode = task_server.node
     client_options = task_server.get_share_options(
-        waiting_task_result.task_id,
-        waiting_task_result.owner.prv_addr,
+        address=waiting_task_result.owner.prv_addr,
     )
 
     report_computed_task = message.tasks.ReportComputedTask(

--- a/golem/task/server/resources.py
+++ b/golem/task/server/resources.py
@@ -77,8 +77,7 @@ class TaskResourcesMixin:
                            resource_hash: Optional[str] = None,
                            timeout: Optional[int] = None):
 
-        options = self.get_share_options(task_id, None)
-        options.timeout = timeout
+        options = self.get_share_options(timeout=timeout)
 
         try:
             resource_hash, _ = self.resource_manager.add_resources(
@@ -154,15 +153,18 @@ class TaskResourcesMixin:
             options.set(size=size)
         return options
 
-    def get_share_options(self, task_id: str,  # noqa # pylint: disable=unused-argument
-                          address: Optional[str]) -> HyperdriveClientOptions:
+    def get_share_options(
+            self,
+            address: Optional[str] = None,
+            timeout: Optional[int] = None,
+    ) -> HyperdriveClientOptions:
         """
         Builds share options with a list of peers in HyperG format.
         If the given address is a private one, put the list of private addresses
         before own public address.
 
-        :param _task_id: Task id (unused)
         :param address: IP address of the node we're currently connected to
+        :param timeout: Share timeout in seconds
         """
 
         node = getattr(self, 'node')
@@ -180,7 +182,8 @@ class TaskResourcesMixin:
 
         peers.insert(-1 if prefer_prv else 0, pub_peer)
 
-        return self.resource_manager.build_client_options(peers=peers)
+        return self.resource_manager.build_client_options(
+            peers=peers, timeout=timeout)
 
     def _verify_peer(self, ip_address, _port):
         is_accessible = self.is_address_in_network  # noqa # pylint: disable=no-member
@@ -276,11 +279,10 @@ class TaskResourcesMixin:
 
     def _share_handshake_nonce(self, key_id):
         handshake = self.resource_handshakes.get(key_id)
-        options = self.get_share_options(handshake.nonce, None)
-        options.timeout = self.HANDSHAKE_TIMEOUT
+        options = self.get_share_options(timeout=self.HANDSHAKE_TIMEOUT)
 
         deferred = self.resource_manager.add_file(handshake.file,
-                                                  self.NONCE_TASK,
+                                                  res_id=key_id,
                                                   client_options=options,
                                                   async_=True)
 

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -106,6 +106,7 @@ class TaskServer(
 ):
 
     BENCHMARK_TIMEOUT = 60  # s
+    RESULT_SHARE_TIMEOUT = 3600 * 24 * 7 * 2  # s
 
     def __init__(self,
                  node,
@@ -507,17 +508,22 @@ class TaskServer(
 
     def _create_and_set_result_package(self, wtr):
         task_result_manager = self.task_manager.task_result_manager
+        client_options = self.get_share_options(
+            timeout=self.RESULT_SHARE_TIMEOUT)
 
         wtr.result_secret = task_result_manager.gen_secret()
-        result = task_result_manager.create(wtr, wtr.result_secret)
+        result = task_result_manager.create(
+            wtr,
+            client_options,
+            wtr.result_secret)
+
         (
             wtr.result_hash,
             wtr.result_path,
             wtr.package_sha1,
             wtr.result_size,
             wtr.package_path,
-        ) = \
-            result
+        ) = result
 
     def send_task_failed(
             self, subtask_id: str, task_id: str, err_msg: str) -> None:

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -413,7 +413,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 price=price,
                 size=package_size,
                 resources_options=self.task_server.get_share_options(
-                    ctd['subtask_id'], self.address).__dict__
+                    address=self.address).__dict__
             )
             ttc.generate_ethsig(self.my_private_key)
             if ttc.concent_enabled:

--- a/tests/golem/resource/base/common.py
+++ b/tests/golem/resource/base/common.py
@@ -32,6 +32,7 @@ class AddGetResources(TempDirFixture, LogTestCase):
 
         self.task_id = str(uuid.uuid4())
 
+        client_options = mock.Mock(timeout=10.)
         client_1, dir_1, session_1 = self._create_client(self.task_id, '_1')
         client_2, dir_2, session_2 = self._create_client(self.task_id, '_2')
 
@@ -45,7 +46,10 @@ class AddGetResources(TempDirFixture, LogTestCase):
         self.resources_relative, resources = self._create_resources(
             self.resource_dir_1)
         client_1.resource_server.resource_manager.add_resources(
-            resources, self.task_id, async_=False)
+            resources,
+            self.task_id,
+            client_options=client_options,
+            async_=False)
 
     def tearDown(self):
         self.client_1.quit()

--- a/tests/golem/resource/test_resourcemanager.py
+++ b/tests/golem/resource/test_resourcemanager.py
@@ -1,8 +1,15 @@
+import datetime
 from unittest import mock
+
+from freezegun import freeze_time
 
 from golem.resource.client import ClientOptions
 from golem.resource.resourcemanager import ResourceManager, ResourceId
 from golem.testutils import TempDirFixture
+
+NOW = 500
+TIMEOUT = 10
+VALID_TO = 1000
 
 
 class TestResourceManager(TempDirFixture):
@@ -11,10 +18,16 @@ class TestResourceManager(TempDirFixture):
     def setUp(self):
         super().setUp()
 
+        self.client_options = ClientOptions(
+            client_id="mocked",
+            version=1.0,
+            options={'timeout': TIMEOUT})
+
         client = mock.Mock()
-        client.build_options.return_value = ClientOptions("mocked", 1.0)
         client.add_async.return_value = ResourceId("0x0")
         client.get_async.return_value = ["0x0", ["mocked.file"]]
+        client.resource_async.return_value = {'validTo': VALID_TO}
+        client.build_options.return_value = self.client_options
 
         self.resource_manager = ResourceManager(client)  # noqa
         self.client = client
@@ -30,33 +43,54 @@ class TestResourceManager(TempDirFixture):
     def test_share(self):
         sample_path = self.new_path / "sample.txt"
 
-        result = self.resource_manager.share(sample_path).result
-        assert isinstance(result, str)
-        assert self.resource_manager._cache[sample_path] == result
+        response = self.resource_manager.share(sample_path, self.client_options)
+        assert isinstance(response.result, str)
+        assert self.resource_manager._cache[sample_path] == response.result
 
+    @freeze_time(datetime.datetime.utcfromtimestamp(NOW))
     def test_share_cached(self):
         sample_path = self.new_path / "sample.txt"
 
         # First upload
-        self.resource_manager.share(sample_path)
+        self.resource_manager.share(sample_path, self.client_options)
         assert self.client.add_async.call_count == 1
         # Second upload (cache lookup)
-        self.resource_manager.share(sample_path)
+        self.resource_manager.share(sample_path, self.client_options)
         assert self.client.add_async.call_count == 1
+
+    @freeze_time(datetime.datetime.utcfromtimestamp(NOW))
+    def test_share_cache_timed_out(self):
+        sample_path = self.new_path / "sample.txt"
+
+        self.client.resource_async.return_value = {'validTo': NOW + TIMEOUT - 1}
+
+        # First upload
+        self.resource_manager.share(sample_path, self.client_options)
+        assert self.client.cancel_async.call_count == 0
+        assert self.client.add_async.call_count == 1
+
+        # Second upload (cache lookup)
+        self.resource_manager.share(sample_path, self.client_options)
+        assert self.client.cancel_async.call_count == 1
+        assert self.client.add_async.call_count == 2
 
     def test_download(self):
         resource_id = ResourceId("0x0")
         sample_dir = self.new_path / "directory"
         sample_dir.mkdir(parents=True)
 
-        self.resource_manager.download(resource_id, sample_dir)
+        self.resource_manager.download(
+            resource_id,
+            sample_dir,
+            self.client_options)
         assert self.client.get_async.called
 
     def test_drop(self):
         sample_path = self.new_path / "sample.txt"
 
-        resource_id = self.resource_manager.share(sample_path).result
+        response = self.resource_manager.share(
+            sample_path, self.client_options)
         assert sample_path in self.resource_manager._cache
 
-        self.resource_manager.drop(resource_id)
+        self.resource_manager.drop(response.result)
         assert sample_path not in self.resource_manager._cache

--- a/tests/golem/task/result/test_resultmanager.py
+++ b/tests/golem/task/result/test_resultmanager.py
@@ -45,12 +45,14 @@ def create_package(result_manager, node_name, task_id):
     files = [out_file, out_dir_file]
     rm.add_files(files, task_id)
 
+    client_options = Mock(size=1024, timeout=10.)
     secret = result_manager.gen_secret()
     result = result_manager.create(
         task_result=MockTaskResult(
             task_id,
             [rm.storage.relative_path(f, task_id) for f in files]
         ),
+        client_options=client_options,
         key_or_secret=secret
     )
 

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -685,7 +685,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
                                           HyperdriveClient.VERSION)
 
         client_options = ts.get_download_options(options)
-        assert client_options.peers is None
+        assert not client_options.peers
 
         peers = [
             to_hyperg_peer('127.0.0.1', 3282),

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -108,6 +108,7 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
         self.task_manager = Mock(tasks_states={}, tasks={})
         self.task_manager.task_finished.return_value = False
         server = Mock(task_manager=self.task_manager)
+        server.client.task_server = server
         server.get_key_id = lambda: self.provider_key
         server.get_share_options.return_value = None
         self.conn = Mock(server=server)
@@ -179,7 +180,8 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
                 key=self.requestor_key,
             ),
             subtask_timeout=1,
-            max_price=1, )
+            max_price=1,
+            deadline=int(time.time() + 3600))
         task_header.sign(self.requestor_keys.raw_privkey)  # noqa pylint: disable=no-value-for-parameter
         return task_header
 
@@ -277,6 +279,9 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
         wtct = self._get_wtct()
         ts = self._get_requestor_tasksession(accept_provider=True)
         ts.task_server.config_desc.offer_pooling_interval = 0
+        options = HyperdriveClientOptions(
+            "CLI1", 0.3, options=dict(timeout=10., size=1024))
+        ts.task_server.get_share_options.return_value = options
         ts.task_server.get_resources.return_value = \
             self.additional_dir_content([5, [2], [4]])
         self._fake_add_task()
@@ -290,13 +295,13 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
         ts.task_manager.should_wait_for_node.return_value = False
         ts.conn.send_message.side_effect = \
             lambda msg: msg.sign_message(self.requestor_keys.raw_privkey)
-        options = HyperdriveClientOptions("CLI1", 0.3)
-        ts.task_server.get_share_options.return_value = options
+
         new_path = os.path.join(self.path, "tempzip")
         zp = ZipPackager()
         _, hash_ = zp.create(new_path, ctd["resources"])
         ts.interpret(wtct)
         started = time.time()
+
         while ts.conn.send_message.call_args is None:
             if time.time() - started > 10:
                 self.fail("Test timed out")
@@ -325,7 +330,7 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
             ['size', os.path.getsize(new_path)],
             ['ethsig', ttc.ethsig],
             ['resources_options', {'client_id': 'CLI1', 'version': 0.3,
-                                   'options': {}}],
+                                   'options': dict(timeout=10., size=1024)}],
             ['promissory_note_sig',
              ttc._get_promissory_note().sign(self.requestor_keys.raw_privkey)],
             ['concent_promissory_note_sig',


### PR DESCRIPTION
~**Do not merge**~
**Requires `simple-transfer` v0.3.5+ ~(not released)~**

Adds support for the 2 new API calls:
- GET `/resources`
    Response:
    ```
    {
        "hash": hash,
        "files": n_files,
        "totalSize": size,
        "validTo": valid_to
    }
    ```
- GET `/resources/{resource_id}`
    Response:
    ```
    {
        "hash": hash,
        "files": files,
        "totalSize": size,
        "validTo": valid_to
    }
    ```

The latter will be used for validating the lifetimes of cache entries in the new `ResourceManager`.