### PR TITLE
Auto-setup wrapper for environments

### DIFF
--- a/golem/envs/__init__.py
+++ b/golem/envs/__init__.py
@@ -226,11 +226,6 @@ class Runtime(ABC):
         """ Register a listener for a given type of Runtime events. """
         raise NotImplementedError
 
-    @abstractmethod
-    def call(self, alias: str, *args, **kwargs) -> Deferred:
-        """ Send RPC call to the Runtime. """
-        raise NotImplementedError
-
 
 class RuntimeBase(Runtime, ABC):
 

--- a/golem/envs/auto_setup.py
+++ b/golem/envs/auto_setup.py
@@ -1,0 +1,195 @@
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Optional,
+    Tuple,
+    Type
+)
+
+from twisted.internet.defer import (
+    Deferred,
+    DeferredLock,
+    inlineCallbacks
+)
+
+from golem.envs import (
+    CounterId,
+    CounterUsage,
+    EnvConfig,
+    EnvEventListener,
+    EnvEventType,
+    Environment,
+    EnvMetadata,
+    EnvStatus,
+    EnvSupportStatus,
+    Prerequisites,
+    Runtime,
+    RuntimeEventListener,
+    RuntimeEventType,
+    RuntimeInput,
+    RuntimeOutput,
+    RuntimePayload,
+    RuntimeStatus
+)
+
+
+class RuntimeSetupWrapper(Runtime):
+
+    def __init__(
+            self,
+            runtime: Runtime,
+            start_usage: Callable[[], Deferred],
+            end_usage: Callable[[], Deferred]
+    ) -> None:
+        self._runtime = runtime
+        self._start_usage = start_usage
+        self._end_usage = end_usage
+
+    @inlineCallbacks
+    def prepare(self) -> Deferred:
+        yield self._start_usage()
+        yield self._runtime.prepare()
+
+    @inlineCallbacks
+    def clean_up(self) -> Deferred:
+        yield self._runtime.clean_up()
+        yield self._end_usage()
+
+    def start(self) -> Deferred:
+        return self._runtime.start()
+
+    def wait_until_stopped(self) -> Deferred:
+        return self._runtime.wait_until_stopped()
+
+    def stop(self) -> Deferred:
+        return self._runtime.stop()
+
+    def status(self) -> RuntimeStatus:
+        return self._runtime.status()
+
+    def stdin(self, encoding: Optional[str] = None) -> RuntimeInput:
+        return self._runtime.stdin(encoding)
+
+    def stdout(self, encoding: Optional[str] = None) -> RuntimeOutput:
+        return self._runtime.stdout(encoding)
+
+    def stderr(self, encoding: Optional[str] = None) -> RuntimeOutput:
+        return self._runtime.stderr(encoding)
+
+    def get_port_mapping(self, port: int) -> Tuple[str, int]:
+        return self._runtime.get_port_mapping(port)
+
+    def usage_counters(self) -> Dict[CounterId, CounterUsage]:
+        return self._runtime.usage_counters()
+
+    def listen(
+            self,
+            event_type: RuntimeEventType,
+            listener: RuntimeEventListener
+    ) -> None:
+        self._runtime.listen(event_type, listener)
+
+
+def auto_setup(wrapped: Type[Environment]) -> Type[Environment]:
+
+    class EnvSetupWrapper(Environment):
+
+        def __init__(self, *args, **kwargs) -> None:
+            self._env = wrapped(*args, **kwargs)  # type: ignore
+            self._num_users = 0
+            self._lock = DeferredLock()
+
+        @inlineCallbacks
+        def _start_usage(self) -> Deferred:
+            yield self._lock.acquire()
+            try:
+                if self._num_users == 0:
+                    yield self._env.prepare()
+                self._num_users += 1
+            finally:
+                self._lock.release()
+
+        @inlineCallbacks
+        def _end_usage(self) -> Deferred:
+            yield self._lock.acquire()
+            try:
+                self._num_users -= 1
+                if self._num_users == 0:
+                    yield self._env.clean_up()
+            finally:
+                self._lock.release()
+
+        @classmethod
+        def supported(cls) -> EnvSupportStatus:
+            return wrapped.supported()
+
+        def status(self) -> EnvStatus:
+            return self._env.status()
+
+        def prepare(self) -> Deferred:
+            raise AttributeError('prepare and clean_up not supported')
+
+        def clean_up(self) -> Deferred:
+            raise AttributeError('prepare and clean_up not supported')
+
+        @inlineCallbacks
+        def run_benchmark(self) -> Deferred:
+            yield self._start_usage()
+            try:
+                return (yield self._env.run_benchmark())
+            finally:
+                yield self._end_usage()
+
+        @classmethod
+        def metadata(cls) -> EnvMetadata:
+            return wrapped.metadata()
+
+        @classmethod
+        def parse_prerequisites(
+                cls,
+                prerequisites_dict: Dict[str, Any]
+        ) -> Prerequisites:
+            return wrapped.parse_prerequisites(prerequisites_dict)
+
+        @inlineCallbacks
+        def install_prerequisites(
+                self,
+                prerequisites: Prerequisites
+        ) -> Deferred:
+            yield self._start_usage()
+            try:
+                return (yield self._env.install_prerequisites(prerequisites))
+            finally:
+                yield self._end_usage()
+
+        @classmethod
+        def parse_config(cls, config_dict: Dict[str, Any]) -> EnvConfig:
+            return wrapped.parse_config(config_dict)
+
+        def config(self) -> EnvConfig:
+            return self._env.config()
+
+        def update_config(self, config: EnvConfig) -> None:
+            self._env.update_config(config)
+
+        def listen(
+                self,
+                event_type: EnvEventType,
+                listener: EnvEventListener
+        ) -> None:
+            self._env.listen(event_type, listener)
+
+        def runtime(
+                self,
+                payload: RuntimePayload,
+                config: Optional[EnvConfig] = None
+        ) -> Runtime:
+            runtime = self._env.runtime(payload, config)
+            return RuntimeSetupWrapper(
+                runtime=runtime,
+                start_usage=self._start_usage,
+                end_usage=self._end_usage
+            )
+
+    return EnvSetupWrapper

--- a/golem/envs/docker/cpu.py
+++ b/golem/envs/docker/cpu.py
@@ -416,9 +416,6 @@ class DockerCPURuntime(RuntimeBase):
     def usage_counters(self) -> Dict[CounterId, CounterUsage]:
         raise NotImplementedError
 
-    def call(self, alias: str, *args, **kwargs) -> Deferred:
-        raise NotImplementedError
-
 
 class DockerCPUEnvironment(EnvironmentBase):
 

--- a/tests/golem/envs/test_auto_setup.py
+++ b/tests/golem/envs/test_auto_setup.py
@@ -1,0 +1,211 @@
+from unittest.mock import Mock, call
+
+from twisted.internet import defer
+from twisted.trial.unittest import TestCase as TwistedTestCase
+
+from golem.envs import (
+    EnvConfig,
+    EnvEventType,
+    Environment,
+    Prerequisites,
+    Runtime,
+    RuntimeEventType,
+    RuntimePayload
+)
+from golem.envs.auto_setup import auto_setup
+
+
+class TestAutoSetup(TwistedTestCase):
+    # pylint: disable=too-many-public-methods
+
+    def setUp(self):
+        self.env_cls = Mock(spec_set=Environment)
+        self.runtime = Mock(spec_set=Runtime)
+        self.env = self.env_cls()
+        self.env.runtime.return_value = self.runtime
+        self.wrapped_cls = auto_setup(self.env_cls)
+        self.wrapped_env = self.wrapped_cls()
+
+    def test_supported(self):
+        self.assertEqual(self.wrapped_cls.supported(), self.env_cls.supported())
+
+    def test_metadata(self):
+        self.assertEqual(self.wrapped_cls.metadata(), self.env_cls.metadata())
+
+    def test_parse_prerequisites(self):
+        prereq_dict = {'key': 'value'}
+        prereq = self.wrapped_cls.parse_prerequisites(prereq_dict)
+        self.assertEqual(prereq, self.env_cls.parse_prerequisites.return_value)
+        self.env_cls.parse_prerequisites.assert_called_once_with(prereq_dict)
+
+    def test_parse_config(self):
+        config_dict = {'key': 'value'}
+        config = self.wrapped_cls.parse_config(config_dict)
+        self.assertEqual(config, self.env_cls.parse_config.return_value)
+        self.env_cls.parse_config.assert_called_once_with(config_dict)
+
+    def test_status(self):
+        self.assertEqual(self.wrapped_env.status(), self.env.status())
+
+    @defer.inlineCallbacks
+    def test_prepare(self):
+        with self.assertRaises(AttributeError):
+            yield self.wrapped_env.prepare()
+
+    @defer.inlineCallbacks
+    def test_clean_up(self):
+        with self.assertRaises(AttributeError):
+            yield self.wrapped_env.prepare()
+
+    def test_update_config(self):
+        config = Mock(spec_set=EnvConfig)
+        self.wrapped_env.update_config(config)
+        self.env.update_config.assert_called_once_with(config)
+
+    def test_listen(self):
+        event_type = EnvEventType.ENABLED
+        listener = lambda _: None  # noqa: E731
+        self.wrapped_env.listen(event_type, listener)
+        self.env.listen.assert_called_once_with(event_type, listener)
+
+    @defer.inlineCallbacks
+    def test_run_benchmark(self):
+        self.env.run_benchmark.return_value = defer.succeed(21.37)
+        result = yield self.wrapped_env.run_benchmark()
+        self.assertEqual(result, 21.37)
+        self.env.assert_has_calls((
+            call.prepare(),
+            call.run_benchmark(),
+            call.clean_up()
+        ))
+
+    @defer.inlineCallbacks
+    def test_install_prerequisites(self):
+        prereq = Mock(spec_set=Prerequisites)
+        self.env.install_prerequisites.return_value = True
+        result = yield self.wrapped_env.install_prerequisites(prereq)
+        self.assertEqual(result, True)
+        self.env.assert_has_calls((
+            call.prepare(),
+            call.install_prerequisites(prereq),
+            call.clean_up()
+        ))
+
+    @defer.inlineCallbacks
+    def test_install_prerequisites_during_benchmark(self):
+
+        @defer.inlineCallbacks
+        def _benchmark():
+            self.env.prepare.assert_called_once()
+            self.env.reset_mock()
+            prereq = Mock(spec_set=Prerequisites)
+            yield self.wrapped_env.install_prerequisites(prereq)
+            self.env.prepare.assert_not_called()
+            self.env.clean_up.assert_not_called()
+
+        self.env.run_benchmark.side_effect = _benchmark
+        yield self.wrapped_env.run_benchmark()
+        self.env.clean_up.assert_called_once()
+
+    @defer.inlineCallbacks
+    def test_runtime_flow(self):
+        master_mock = Mock()  # To assert call order between two mocks
+        master_mock.attach_mock(self.env.prepare, 'env_prepare')
+        master_mock.attach_mock(self.env.clean_up, 'env_clean_up')
+        master_mock.attach_mock(self.runtime.prepare, 'runtime_prepare')
+        master_mock.attach_mock(self.runtime.start, 'runtime_start')
+        master_mock.attach_mock(self.runtime.stop, 'runtime_stop')
+        master_mock.attach_mock(self.runtime.clean_up, 'runtime_clean_up')
+
+        payload = Mock(spec_set=RuntimePayload)
+        config = Mock(spec_set=EnvConfig)
+        runtime = self.wrapped_env.runtime(payload, config)
+        self.env.runtime.assert_called_once_with(payload, config)
+
+        yield runtime.prepare()
+        master_mock.assert_has_calls((
+            call.env_prepare(),
+            call.runtime_prepare()
+        ))
+
+        master_mock.reset_mock()
+        yield runtime.start()
+        master_mock.assert_has_calls((
+            call.runtime_start(),
+        ))
+
+        master_mock.reset_mock()
+        yield runtime.stop()
+        master_mock.assert_has_calls((
+            call.runtime_stop(),
+        ))
+
+        master_mock.reset_mock()
+        yield runtime.clean_up()
+        master_mock.assert_has_calls((
+            call.runtime_clean_up(),
+            call.env_clean_up()
+        ))
+
+    @defer.inlineCallbacks
+    def test_runtime_wait_until_stopped(self):
+        payload = Mock(spec_set=RuntimePayload)
+        config = Mock(spec_set=EnvConfig)
+        runtime = self.wrapped_env.runtime(payload, config)
+        yield runtime.wait_until_stopped()
+        self.runtime.wait_until_stopped.assert_called_once_with()
+
+    def test_runtime_status(self):
+        payload = Mock(spec_set=RuntimePayload)
+        config = Mock(spec_set=EnvConfig)
+        runtime = self.wrapped_env.runtime(payload, config)
+        self.assertEqual(runtime.status(), self.runtime.status())
+
+    def test_runtime_stdin(self):
+        payload = Mock(spec_set=RuntimePayload)
+        config = Mock(spec_set=EnvConfig)
+        runtime = self.wrapped_env.runtime(payload, config)
+        stdin = runtime.stdin('utf-7')
+        self.runtime.stdin.assert_called_once_with('utf-7')
+        self.assertEqual(stdin, self.runtime.stdin())
+
+    def test_runtime_stdout(self):
+        payload = Mock(spec_set=RuntimePayload)
+        config = Mock(spec_set=EnvConfig)
+        runtime = self.wrapped_env.runtime(payload, config)
+        stdout = runtime.stdout('utf-7')
+        self.runtime.stdout.assert_called_once_with('utf-7')
+        self.assertEqual(stdout, self.runtime.stdout())
+
+    def test_runtime_stderr(self):
+        payload = Mock(spec_set=RuntimePayload)
+        config = Mock(spec_set=EnvConfig)
+        runtime = self.wrapped_env.runtime(payload, config)
+        stderr = runtime.stderr('utf-7')
+        self.runtime.stderr.assert_called_once_with('utf-7')
+        self.assertEqual(stderr, self.runtime.stderr())
+
+    def test_runtime_port_mapping(self):
+        self.runtime.get_port_mapping.return_value = '127.0.0.1', 666
+        payload = Mock(spec_set=RuntimePayload)
+        config = Mock(spec_set=EnvConfig)
+        runtime = self.wrapped_env.runtime(payload, config)
+        mapping = runtime.get_port_mapping(1234)
+        self.assertEqual(mapping, ('127.0.0.1', 666))
+        self.runtime.get_port_mapping.assert_called_once_with(1234)
+
+    def test_runtime_usage_counters(self):
+        payload = Mock(spec_set=RuntimePayload)
+        config = Mock(spec_set=EnvConfig)
+        runtime = self.wrapped_env.runtime(payload, config)
+        counters = runtime.usage_counters()
+        self.assertEqual(counters, self.runtime.usage_counters())
+
+    def test_runtime_listen(self):
+        payload = Mock(spec_set=RuntimePayload)
+        config = Mock(spec_set=EnvConfig)
+        runtime = self.wrapped_env.runtime(payload, config)
+        event_type = RuntimeEventType.PREPARED
+        listener = lambda _: None  # noqa: E731
+        runtime.listen(event_type, listener)
+        self.runtime.listen.assert_called_once_with(event_type, listener)


### PR DESCRIPTION
A decorator that automagically prepares and cleans up environment when it's necessary. That means in particular:
  * Running benchmarks
  * Installing prerequisites
  * Using runtimes (runtime usage starts with calling `prepare()` and ends with calling `clean_up()`, creation is not included)

Some comments:
  * `DockerCPUEnvironment` is not ready to use this decorator because runtime creation assumes the environment is enabled. This however could be quite easily refactored.
  * The wrapper currently assumes 'infinite parallel factor' which means it can handle running benchmark, installing prerequisites, and running arbitrary number of runtimes, all at once. However, with small adjustment we could make the wrapper enforce exclusion between these (if needed).