### PR TITLE
Reproduction of bug in reputation system - database LocalRank creation

### DIFF
--- a/golem/model.py
+++ b/golem/model.py
@@ -397,6 +397,14 @@ class TaskPayment(BaseModel):
 ##################
 
 
+def provider_efficacy_producer():
+    def producer():
+        return ProviderEfficacy(0., 0., 0., 0.)
+    # peewee-migrate expects a '__self__' attribute
+    producer.__self__ = ProviderEfficacy
+    return producer
+
+
 class LocalRank(BaseModel):
     """ Represent nodes experience with other nodes, number of positive and
     negative interactions.
@@ -416,7 +424,7 @@ class LocalRank(BaseModel):
     requestor_paid_sum = HexIntegerField(default=0)
     provider_efficiency = FloatField(default=1.0)
     provider_efficacy = ProviderEfficacyField(
-        default=ProviderEfficacy(0., 0., 0., 0.))
+        default=provider_efficacy_producer())
 
     class Meta:
         database = db

--- a/tests/golem/test_model.py
+++ b/tests/golem/test_model.py
@@ -6,6 +6,7 @@ from datetime import (
 from peewee import IntegrityError
 
 import golem.model as m
+from golem.task.taskstate import SubtaskOp
 from golem.testutils import DatabaseFixture
 
 from tests.factories import model as m_factory
@@ -54,6 +55,19 @@ class TestLocalRank(DatabaseFixture):
         self.assertEqual(0, r.positive_resource)
         self.assertEqual(0, r.negative_resource)
         self.assertEqual((0, 0, 0, 0), r.provider_efficacy.vector)
+
+    def test_modify_efficacy(self):
+        # Create new LocalRank database entry with default values.
+        rank, _ = m.LocalRank.get_or_create(node_id="blaa_node")
+        efficacy = rank.provider_efficacy
+
+        # Update efficacy in created entry.
+        efficacy.update(SubtaskOp.FINISHED)
+
+        # Create new LocalRank database entry. It should have default values.
+        rank, _ = m.LocalRank.get_or_create(node_id="blaa_node2")
+        self.assertEqual((0, 0, 0, 0), rank.provider_efficacy.vector)
+
 
 
 class TestGlobalRank(DatabaseFixture):


### PR DESCRIPTION
This PR adds test that reproduces bug related to LocalRank database entry creation.

# Description:
Creation of LocalRank database object should fill it with default value for provider_efficacy. But this default value changes if someone calls update_provider_efficacy function in database_manager.py. All new database entries are created with updated value.

It seems that all new objects are referencing the same provider_efficacy object. Probably this is caused by database that makes only shallow copy of default value (peewee.py line 4764).

# Workaround:
This bug was originally discovered in https://github.com/golemfactory/golem/pull/4584. There were dependencies between tests that caused tests/golem/test_model.py:TestLocalRank:test_default_fields test fails. TestBlenderIntegration tested whole workflow of blender task and called provider reputation updates functions. Because these test cases were executed before test_model.py module, database default value was already changed.

To avoid this issue, I changed update_provider_efficacy function in database_manager.py (line 233), to make deepcopy of provider_efficacy field.
But real solution to this problem probably requires changes in database itself.