### PR TITLE
Sending resource usage stats in ReportComputedTask

### DIFF
--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -251,7 +251,7 @@ class DockerTaskThread(TaskThread):
                 return json.load(f)
         except json.JSONDecodeError as e:
             logger.warning(
-                    f'Failed to parse stats file: {stats_file}.', exc_info=e)
+                f'Failed to parse stats file: {stats_file}.', exc_info=e)
             return {}
 
     def end_comp(self):

--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -2,7 +2,7 @@ import json
 import logging
 from pathlib import Path
 from typing import ClassVar, Optional, TYPE_CHECKING, Tuple, Dict, Union, \
-    List, NamedTuple
+    List
 
 import requests
 
@@ -250,8 +250,8 @@ class DockerTaskThread(TaskThread):
             with stats_file.open() as f:
                 return json.load(f)
         except json.JSONDecodeError as e:
-            logger.warning(f'Failed to parse stats file: {stats_file}.',
-                    exc_info=e)
+            logger.warning(
+                    f'Failed to parse stats file: {stats_file}.', exc_info=e)
             return {}
 
     def end_comp(self):

--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -1,3 +1,4 @@
+import json
 import logging
 from pathlib import Path
 from typing import ClassVar, Optional, TYPE_CHECKING, Tuple, Dict, Union, \
@@ -224,12 +225,13 @@ class DockerTaskThread(TaskThread):
         return estm_mem
 
     def _task_computed(self, estm_mem: Optional[int]) -> None:
-        out_files = [
-            str(path) for path in self.dir_mapping.output.glob("*")
-        ]
+        out_files = [str(path) for path in self.dir_mapping.output.glob("*")]
+
         self.result = {
             "data": out_files,
+            "stats": self.get_stats(),
         }
+
         if estm_mem is not None:
             self.result = (self.result, estm_mem)
         self._deferred.callback(self)
@@ -237,6 +239,19 @@ class DockerTaskThread(TaskThread):
     def get_progress(self):
         # TODO: make the container update some status file? Issue #56
         return 0.0
+
+    def get_stats(self) -> Dict:
+        stats_file: Path = self.dir_mapping.stats / DockerJob.STATS_FILE
+
+        if not stats_file.exists():
+            return {}
+
+        try:
+            with stats_file.open() as f:
+                return json.load(f)
+        except json.JSONDecodeError as e:
+            logger.warning(f'Failed to parse stats file: {stats_file}. {e}')
+            return {}
 
     def end_comp(self):
         try:

--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -250,7 +250,8 @@ class DockerTaskThread(TaskThread):
             with stats_file.open() as f:
                 return json.load(f)
         except json.JSONDecodeError as e:
-            logger.warning(f'Failed to parse stats file: {stats_file}.', exc_info=e)
+            logger.warning(f'Failed to parse stats file: {stats_file}.',
+                    exc_info=e)
             return {}
 
     def end_comp(self):

--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -250,7 +250,7 @@ class DockerTaskThread(TaskThread):
             with stats_file.open() as f:
                 return json.load(f)
         except json.JSONDecodeError as e:
-            logger.warning(f'Failed to parse stats file: {stats_file}. {e}')
+            logger.warning(f'Failed to parse stats file: {stats_file}.', exc_info=e)
             return {}
 
     def end_comp(self):

--- a/golem/task/server/helpers.py
+++ b/golem/task/server/helpers.py
@@ -13,6 +13,7 @@ from golem.network.transport import msg_queue
 if typing.TYPE_CHECKING:
     # pylint: disable=unused-import
     from golem.network.p2p.local_node import LocalNode
+    from golem.task.taskserver import TaskServer, WaitingTaskResult
 
 logger = logging.getLogger(__name__)
 
@@ -102,9 +103,11 @@ def computed_task_reported(
         )
 
 
-def send_report_computed_task(task_server, waiting_task_result) -> None:
-    """ Send task results after finished computations
-    """
+def send_report_computed_task(
+        task_server: 'TaskServer',
+        waiting_task_result: 'WaitingTaskResult') -> None:
+    """ Send task results after finished computations """
+
     task_to_compute = history.get(
         message_class_name='TaskToCompute',
         node_id=waiting_task_result.owner.key,
@@ -143,6 +146,7 @@ def send_report_computed_task(task_server, waiting_task_result) -> None:
         multihash=waiting_task_result.result_hash,
         secret=waiting_task_result.result_secret,
         options=client_options.__dict__,
+        stats=waiting_task_result.stats,
     )
 
     signed_report_computed_task = msg_utils.copy_and_sign(

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -1080,7 +1080,7 @@ class WaitingTaskResult:
     result_secret: Optional[str] = None
     result_sha1: Optional[str] = None
     result_size: int = 0
-    stats: Dict = field(default_factory=lambda: {})
+    stats: Dict = field(default_factory=dict)
 
 
 @dataclass

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -6,6 +6,7 @@ import os
 import shutil
 import time
 import weakref
+from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
 from typing import (
@@ -15,6 +16,8 @@ from typing import (
     Optional,
     Union,
     Set,
+    Tuple,
+    TYPE_CHECKING,
 )
 
 from golem_messages import exceptions as msg_exceptions
@@ -77,6 +80,9 @@ from .taskcomputer import TaskComputerAdapter
 from .taskkeeper import TaskHeaderKeeper
 from .taskmanager import TaskManager
 from .tasksession import TaskSession
+
+if TYPE_CHECKING:
+    from golem_messages.datastructures import p2p as dt_p2p
 
 logger = logging.getLogger(__name__)
 
@@ -1057,38 +1063,29 @@ class TaskServer(
         return os.path.join(datadir, "ComputerRes")
 
 
-# TODO: https://github.com/golemfactory/golem/issues/2633
-#       and remove linter switch offs
-# pylint: disable=too-many-arguments, too-many-locals
-class WaitingTaskResult(object):
-    def __init__(self, task_id, subtask_id, result,
-                 last_sending_trial, delay_time, owner, stats, result_path=None,
-                 result_hash=None, result_secret=None, package_sha1=None,
-                 result_size=None, package_path=None):
+@dataclass
+class WaitingTaskResult:
+    delay_time: float
+    last_sending_trial: int
+    owner: 'dt_p2p.Node'
+    result: Tuple
+    stats: Dict
+    subtask_id: str
+    task_id: str
 
-        self.task_id = task_id
-        self.subtask_id = subtask_id
-        self.last_sending_trial = last_sending_trial
-        self.delay_time = delay_time
-        self.owner = owner
-
-        self.result = result
-        self.result_path = result_path
-        self.result_hash = result_hash
-        self.result_secret = result_secret
-        self.package_sha1 = package_sha1
-        self.package_path = package_path
-        self.result_size = result_size
-
-        self.stats = stats
-
-        self.already_sending = False
-# pylint: enable=too-many-arguments, too-many-locals
+    already_sending: bool = False
+    package_path: str = None
+    package_sha1: str = None
+    result_hash: str = None
+    result_path: str = None
+    result_secret: str = None
+    result_sha1: str = None
+    result_size: int = None
 
 
-class WaitingTaskFailure(object):
-    def __init__(self, task_id, subtask_id, err_msg, owner):
-        self.task_id = task_id
-        self.subtask_id = subtask_id
-        self.owner = owner
-        self.err_msg = err_msg
+@dataclass
+class WaitingTaskFailure:
+    err_msg: str
+    owner: 'dt_p2p.Node'
+    subtask_id: str
+    task_id: str

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -82,7 +82,7 @@ from .taskmanager import TaskManager
 from .tasksession import TaskSession
 
 if TYPE_CHECKING:
-    from golem_messages.datastructures import p2p as dt_p2p
+    from golem_messages.datastructures import p2p as dt_p2p # noqa pylint:disable=unused-import
 
 logger = logging.getLogger(__name__)
 
@@ -1069,18 +1069,18 @@ class WaitingTaskResult:
     last_sending_trial: int
     owner: 'dt_p2p.Node'
     result: Tuple
-    stats: Dict
     subtask_id: str
     task_id: str
 
     already_sending: bool = False
-    package_path: str = None
-    package_sha1: str = None
-    result_hash: str = None
-    result_path: str = None
-    result_secret: str = None
-    result_sha1: str = None
-    result_size: int = None
+    package_path: Optional[str] = None
+    package_sha1: Optional[str] = None
+    result_hash: Optional[str] = None
+    result_path: Optional[str] = None
+    result_secret: Optional[str] = None
+    result_sha1: Optional[str] = None
+    result_size: int = 0
+    stats: Dict = field(default_factory=lambda: {})
 
 
 @dataclass

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -82,7 +82,7 @@ from .taskmanager import TaskManager
 from .tasksession import TaskSession
 
 if TYPE_CHECKING:
-    from golem_messages.datastructures import p2p as dt_p2p # noqa pylint:disable=unused-import
+    from golem_messages.datastructures import p2p as dt_p2p # noqa pylint: disable=unused-import,ungrouped-imports
 
 logger = logging.getLogger(__name__)
 

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -1062,7 +1062,7 @@ class TaskServer(
 # pylint: disable=too-many-arguments, too-many-locals
 class WaitingTaskResult(object):
     def __init__(self, task_id, subtask_id, result,
-                 last_sending_trial, delay_time, owner, result_path=None,
+                 last_sending_trial, delay_time, owner, stats, result_path=None,
                  result_hash=None, result_secret=None, package_sha1=None,
                  result_size=None, package_path=None):
 
@@ -1079,6 +1079,8 @@ class WaitingTaskResult(object):
         self.package_sha1 = package_sha1
         self.package_path = package_path
         self.result_size = result_size
+
+        self.stats = stats
 
         self.already_sending = False
 # pylint: enable=too-many-arguments, too-many-locals

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ eth-utils==1.0.3
 ethereum==1.6.1
 eventlet==0.24.1
 fs==2.4.4
-Golem-Messages==3.9.0
+Golem-Messages==3.10.0
 Golem-Smart-Contracts-Interface==1.10.2
 golem_task_api==0.9.0
 greenlet==0.4.15

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -17,7 +17,7 @@ docker==3.5.0
 enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
-Golem-Messages==3.9.0
+Golem-Messages==3.10.0
 Golem-Smart-Contracts-Interface==1.10.2
 golem_task_api==0.9.0
 html2text==2018.1.9

--- a/tests/golem/docker/test_dummy_job.py
+++ b/tests/golem/docker/test_dummy_job.py
@@ -15,7 +15,7 @@ class TestDummyTaskDockerJob(TestDockerJob):
         return "golemfactory/dummy"
 
     def _get_test_tag(self):
-        return "1.2"
+        return "1.3"
 
     def test_dummytask_job(self):
         os.mkdir(os.path.join(self.resources_dir, "data"))


### PR DESCRIPTION
Resolves: #4526

Adds the logic for extracting usage statistics and including them in the
ReportComputedTask message. The stats are extracted from a file created
by Docker jobs in a mounted volume.