### PR TITLE
sentry handler import moved into function not to install reactor too early

### DIFF
--- a/golem/tools/talkback.py
+++ b/golem/tools/talkback.py
@@ -1,6 +1,5 @@
 import logging
 from typing import Optional, Dict, cast
-from golem.tools.customloggers import SwitchedSentryHandler
 
 logger = logging.getLogger(__name__)
 
@@ -12,6 +11,7 @@ def user() -> Optional[Dict[str, str]]:
 
 
 def update_sentry_user(node_id: str, node_name: Optional[str] = None):
+    from golem.tools.customloggers import SwitchedSentryHandler
     logger_root = logging.getLogger()
     _sentry_user['id'] = node_id
     if node_name is not None:
@@ -26,6 +26,7 @@ def update_sentry_user(node_id: str, node_name: Optional[str] = None):
 
 
 def enable_sentry_logger(value):
+    from golem.tools.customloggers import SwitchedSentryHandler
     talkback_value = bool(value)
     logger_root = logging.getLogger()
     try:
@@ -39,9 +40,6 @@ def enable_sentry_logger(value):
 
             _sentry_user["env"] = env
             _sentry_user["golemVersion"] = golem.__version__
-        else:
-            del _sentry_user['env']
-            del _sentry_user['golemVersion']
 
         sentry_handler = [
             h for h in logger_root.handlers


### PR DESCRIPTION
this fixes 

```
Traceback (most recent call last):
  File "golemapp.py", line 313, in <module>
    start()  # pylint: disable=no-value-for-parameter
  File "C:\Users\magda.stasiewicz\Documents\sources\golem-venv\lib\site-packages\click\core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "C:\Users\magda.stasiewicz\Documents\sources\golem-venv\lib\site-packages\click\core.py", line 697, in main
    rv = self.invoke(ctx)
  File "C:\Users\magda.stasiewicz\Documents\sources\golem-venv\lib\site-packages\click\core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "C:\Users\magda.stasiewicz\Documents\sources\golem-venv\lib\site-packages\click\core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File "golemapp.py", line 225, in start
    _start()
  File "golemapp.py", line 184, in _start
    install_reactor()
  File "C:\Users\magda.stasiewicz\Documents\sources\golem\golem\core\common.py", line 323, in install_reactor
    iocpreactor.install()
  File "C:\Users\magda.stasiewicz\Documents\sources\golem-venv\lib\site-packages\twisted\internet\iocpreactor\reactor.py", line 270, in install
    main.installReactor(r)
  File "C:\Users\magda.stasiewicz\Documents\sources\golem-venv\lib\site-packages\twisted\internet\main.py", line 32, in installReactor
    raise error.ReactorAlreadyInstalledError("reactor already installed")
twisted.internet.error.ReactorAlreadyInstalledError: reactor already installed
```