### PR TITLE
Fix saved ports in the KnownHosts table

### DIFF
--- a/golem/network/p2p/peersession.py
+++ b/golem/network/p2p/peersession.py
@@ -529,7 +529,7 @@ class PeerSession(BasicSafeSession):
         self.p2p_service.add_known_peer(
             self.node_info,
             self.address,
-            self.port,
+            self.listen_port,
             self.metadata
         )
         self.p2p_service.set_suggested_address(


### PR DESCRIPTION
Noticed that while inspecting my local `KnownHosts` table - all of the entries have had invalid ports.
`self.port` is the port used by the other side to connect to us, `self.listen_port` is the one that we wanna save, because that's where the other side listens.