### PR TITLE
Provide new envs performance in node's metadata

### DIFF
--- a/golem/task/envmanager.py
+++ b/golem/task/envmanager.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Dict, List, NamedTuple, Type
+from typing import Dict, List, NamedTuple, Type, Optional
 
 from twisted.internet.defer import Deferred, inlineCallbacks
 
@@ -83,11 +83,9 @@ class EnvironmentManager:
         if not self.enabled(env_id):
             raise Exception("Requested performance for disabled environment")
 
-        try:
-            perf = Performance.get(Performance.environment_id == env_id)
-            return perf.value
-        except Performance.DoesNotExist:
-            pass
+        result = self.get_cached_performance(env_id)
+        if result:
+            return result
 
         env = self._envs[env_id].instance
         self._running_benchmark = True
@@ -111,3 +109,10 @@ class EnvironmentManager:
             result
         )
         return result
+
+    @staticmethod
+    def get_cached_performance(env_id: EnvId) -> Optional[float]:
+        try:
+            return Performance.get(Performance.environment_id == env_id).value
+        except Performance.DoesNotExist:
+            return None

--- a/tests/golem/task/test_envmanager.py
+++ b/tests/golem/task/test_envmanager.py
@@ -160,3 +160,10 @@ class TestEnvironmentManagerDB(  # pylint: disable=too-many-ancestors
         # Then
         self.env.run_benchmark.assert_called_once()
         self.assertIsNone(result)
+
+    def test_cached_performance(self):
+        self.assertIsNone(self.manager.get_cached_performance(self.env_id))
+
+        perf = 123.4
+        Performance.update_or_create(self.env_id, perf)
+        self.assertEqual(perf, self.manager.get_cached_performance(self.env_id))


### PR DESCRIPTION
And that'll automatically make the netmasking use proper values for new envs.