### PR TITLE
manifest cleanup

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,4 @@ include requirements.txt
 include README.md
 include LICENSE.txt
 include loggingconfig.py
-recursive-include apps *.blend
+recursive-include apps *.blend *.txt

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,4 @@ include requirements.txt
 include README.md
 include LICENSE.txt
 include loggingconfig.py
-include golem/ethereum/genesis_golem.json
-include golem/ethereum/mine_pending_transactions.js
-recursive-include apps *.blend *.jpg *.lxs *.ply *.lxo *.lxm *.lxv *.txt
+recursive-include apps *.blend


### PR DESCRIPTION
I've noticed `MANIFEST.in` file, which has two suspicious lines
```
include golem/ethereum/genesis_golem.json
include golem/ethereum/mine_pending_transactions.js
```

while we do not have those files in repo (there is even Issue #439 by @chfast on that).
furthermore it's last line is also strange
```
recursive-include apps *.blend *.jpg *.lxs *.ply *.lxo *.lxm *.lxv *.txt
```

because there is no files with jpg,lxs,ply,lxo,lxm nor lxv extension within `apps` folder
can be checked by
```
find -E apps -regex ".*\.(jpg|lxs|ply|lxo|lxm|lxv)$" 
```

and only textfiles are from `wasm` usecase which I'm kinda sure are not intended to be included...
so this line should be
```
recursive-include apps *.blend
```

maybe it is a good time to clean it up...