### PR TITLE
Cleanup subtasks count

### DIFF
--- a/apps/appsmanager.py
+++ b/apps/appsmanager.py
@@ -2,32 +2,45 @@ import os
 from configparser import ConfigParser
 from collections import OrderedDict
 from importlib import import_module
+from typing import (
+    Dict,
+    List,
+    TYPE_CHECKING,
+    Tuple,
+    Type,
+)
 
 from golem.config.active import APP_MANAGER_CONFIG_FILES
 from golem.core.common import get_golem_path
 from golem.environments.environment import SupportStatus
 
+if TYPE_CHECKING:
+    # pylint:disable=unused-import, ungrouped-imports
+    from golem.environments.environment import Environment  # noqa: F401
+    from golem.task.taskbase import TaskBuilder, TaskTypeInfo  # noqa: F401
+    from apps.core.benchmark.benchmarkrunner import CoreBenchmark  # noqa: F401
+
 
 class App(object):
     """ Basic Golem App Representation """
     def __init__(self):
-        self.env = None  # inherit from Environment
-        self.builder = None  # inherit from TaskBuilder
-        self.task_type_info = None  # inherit from TaskTypeInfo
-        self.benchmark = None  # inherit from Benchmark
-        self.benchmark_builder = None  # inherit from TaskBuilder
+        self.env: Type['Environment'] = None
+        self.builder: Type['TaskBuilder'] = None
+        self.task_type_info: Type['TaskTypeInfo'] = None
+        self.benchmark: Type['CoreBenchmark'] = None
+        self.benchmark_builder: Type['TaskBuilder'] = None
 
 
 class AppsManager(object):
     """ Temporary solution for apps detection and management. """
-    def __init__(self):
-        self.apps = OrderedDict()
+    def __init__(self) -> None:
+        self.apps: Dict[str, App] = OrderedDict()
 
-    def load_all_apps(self):
+    def load_all_apps(self) -> None:
         for config_file in APP_MANAGER_CONFIG_FILES:
             self._load_apps(config_file)
 
-    def _load_apps(self, apps_config_file):
+    def _load_apps(self, apps_config_file) -> None:
 
         parser = ConfigParser()
         config_path = os.path.join(get_golem_path(), apps_config_file)
@@ -47,10 +60,11 @@ class AppsManager(object):
 
             self.apps[section] = app
 
-    def get_env_list(self):
+    def get_env_list(self) -> List['Environment']:
         return [app.env() for app in self.apps.values()]
 
-    def get_benchmarks(self):
+    def get_benchmarks(self) \
+            -> Dict[str, Tuple['CoreBenchmark', Type['TaskBuilder']]]:
         """ Returns list of data representing benchmark for registered app
         :return dict: dictionary, where environment ids are the keys and values
         are defined as pairs of instance of Benchmark and class of task builder
@@ -66,5 +80,5 @@ class AppsManager(object):
         return benchmarks
 
     @staticmethod
-    def _benchmark_enabled(env):
+    def _benchmark_enabled(env) -> bool:
         return env.check_support() == SupportStatus.ok()

--- a/apps/blender/task/blenderrendertask.py
+++ b/apps/blender/task/blenderrendertask.py
@@ -322,9 +322,9 @@ class BlenderRenderTask(FrameRenderingTask):
         super(BlenderRenderTask, self).initialize(dir_manager)
 
         if self.use_frames:
-            parts = int(self.total_tasks / len(self.frames))
+            parts = int(self.get_total_tasks() / len(self.frames))
         else:
-            parts = self.total_tasks
+            parts = self.get_total_tasks()
         expected_offsets = generate_expected_offsets(parts, self.res_x,
                                                      self.res_y)
         preview_y = expected_offsets[parts + 1]
@@ -364,7 +364,7 @@ class BlenderRenderTask(FrameRenderingTask):
 
         if self.use_frames:
             frames, parts = self._choose_frames(self.frames, start_task,
-                                                self.total_tasks)
+                                                self.get_total_tasks())
         else:
             frames = self.frames or [1]
             parts = 1
@@ -385,7 +385,7 @@ class BlenderRenderTask(FrameRenderingTask):
                       "output_format": self.output_format,
                       "path_root": self.main_scene_dir,
                       "start_task": start_task,
-                      "total_tasks": self.total_tasks,
+                      "total_tasks": self.get_total_tasks(),
                       "crops": crops,
                       "entrypoint":
                           "python3 /golem/entrypoints/render_entrypoint.py",
@@ -445,7 +445,7 @@ class BlenderRenderTask(FrameRenderingTask):
         return total_tasks
 
     def get_subtask_y_border(self, start_task):
-        parts_in_frame = self.get_parts_in_frame(self.total_tasks)
+        parts_in_frame = self.get_parts_in_frame(self.get_total_tasks())
         if not self.use_frames:
             return get_min_max_y(start_task, parts_in_frame, self.res_y)
         elif parts_in_frame > 1:
@@ -574,13 +574,13 @@ class BlenderRenderTask(FrameRenderingTask):
         if not self.use_frames:
             self.mark_part_on_preview(subtask['start_task'], img_task, color,
                                       self.preview_updater)
-        elif self.total_tasks <= len(self.frames):
+        elif self.get_total_tasks() <= len(self.frames):
             for i in range(0, int(math.floor(self.res_x * self.scale_factor))):
                 for j in range(0,
                                int(math.floor(self.res_y * self.scale_factor))):
                     img_task.set_pixel((i, j), color)
         else:
-            parts = int(self.total_tasks / len(self.frames))
+            parts = int(self.get_total_tasks() / len(self.frames))
             pu = self.preview_updaters[frame_index]
             part = (subtask['start_task'] - 1) % parts + 1
             self.mark_part_on_preview(part, img_task, color, pu)

--- a/apps/core/task/coretask.py
+++ b/apps/core/task/coretask.py
@@ -7,9 +7,9 @@ from typing import (
     Any,
     Dict,
     List,
-    Optional,
     Type,
-    TYPE_CHECKING)
+    TYPE_CHECKING,
+)
 
 from ethereum.utils import denoms
 from golem_messages import idgenerator
@@ -22,6 +22,8 @@ from golem.core.common import HandleKeyError, timeout_to_deadline, to_unicode, \
     string_to_timeout
 from golem.core.fileshelper import outer_dir_path
 from golem.docker.environment import DockerEnvironment
+# importing DirManager could be under "if TYPE_CHECKING", but it's needed here
+# for validation by 'enforce'
 from golem.resource.dirmanager import DirManager
 from golem.task.taskbase import Task, TaskBuilder, \
     TaskTypeInfo, AcceptClientVerdict

--- a/apps/dummy/task/dummytask.py
+++ b/apps/dummy/task/dummytask.py
@@ -39,7 +39,6 @@ class DummyTask(CoreTask):
     TESTING_CHAR = "a"
 
     def __init__(self,
-                 total_tasks: int,
                  task_definition: DummyTaskDefinition,
                  root_path=None,
                  owner=None):
@@ -47,7 +46,6 @@ class DummyTask(CoreTask):
             owner=owner,
             task_definition=task_definition,
             root_path=root_path,
-            total_tasks=total_tasks
         )
 
     def _extra_data(self, perf_index=0.0) -> ComputeTaskDef:

--- a/apps/glambda/task/glambdatask.py
+++ b/apps/glambda/task/glambdatask.py
@@ -70,13 +70,11 @@ class GLambdaTask(CoreTask):
                  owner: dt_p2p.Node,
                  dir_manager: DirManager,
                  resource_size=None,
-                 root_path: Optional[str] = None,
-                 total_tasks=1) -> None:
+                 root_path: Optional[str] = None) -> None:
         super().__init__(task_definition,
                          owner,
                          resource_size,
-                         root_path,
-                         total_tasks)
+                         root_path)
         self.method = task_definition.options.method
         self.args = task_definition.options.args
         self.verification_metadata = task_definition.options.verification

--- a/apps/rendering/benchmark/renderingbenchmark.py
+++ b/apps/rendering/benchmark/renderingbenchmark.py
@@ -21,7 +21,6 @@ class RenderingBenchmark(CoreBenchmark):
         self._task_definition.subtask_timeout = 10000
         self._task_definition.optimize_total = False
         self._task_definition.resources = set()
-        self._task_definition.total_tasks = 1
         self._task_definition.subtasks_count = 1
         self._task_definition.start_task = 1
         self._task_definition.task_id = str(uuid.uuid4())

--- a/apps/rendering/task/framerenderingtask.py
+++ b/apps/rendering/task/framerenderingtask.py
@@ -49,7 +49,6 @@ def calculate_subtasks_count_with_frames(
     return est
 
 
-@rpc_utils.expose('comp.task.subtasks.count')
 def calculate_subtasks_count(
         subtasks_count: int,
         optimize_total: bool,

--- a/apps/rendering/task/framerenderingtask.py
+++ b/apps/rendering/task/framerenderingtask.py
@@ -106,7 +106,7 @@ class FrameRenderingTask(RenderingTask):
         self.use_frames = task_definition.options.use_frames
         self.frames = task_definition.options.frames
 
-        parts = max(1, int(self.total_tasks / len(self.frames)))
+        parts = max(1, int(self.get_total_tasks() / len(self.frames)))
 
         self.frames_given = {}
         self.frames_state = {}
@@ -189,14 +189,15 @@ class FrameRenderingTask(RenderingTask):
         for result_file in result_files:
             if not self.use_frames:
                 self._collect_image_part(num_start, result_file)
-            elif self.total_tasks <= len(self.frames):
+            elif self.get_total_tasks() <= len(self.frames):
                 frames = self._collect_frames(num_start, result_file, frames)
             else:
                 self._collect_frame_part(num_start, result_file, parts)
 
         self.num_tasks_received += 1
 
-        if self.num_tasks_received == self.total_tasks and not self.use_frames:
+        if self.num_tasks_received == \
+                self.get_total_tasks() and not self.use_frames:
             self._put_image_together()
 
     def get_frames_to_subtasks(self):
@@ -249,7 +250,7 @@ class FrameRenderingTask(RenderingTask):
             if not final:
                 img_pasted = self._paste_new_chunk(
                     img, self._get_preview_file_path(num), part,
-                    int(self.total_tasks / len(self.frames))
+                    int(self.get_total_tasks() / len(self.frames))
                 )
                 resize_and_save(img_pasted)
             else:
@@ -268,7 +269,7 @@ class FrameRenderingTask(RenderingTask):
         state = self.frames_state[frame_key]
         subtask_ids = self.frames_subtasks[frame_key]
 
-        parts = max(1, int(self.total_tasks / len(self.frames)))
+        parts = max(1, int(self.get_total_tasks() / len(self.frames)))
         counters = defaultdict(lambda: 0, dict())
 
         # Count the number of occurrences of each subtask state
@@ -352,7 +353,7 @@ class FrameRenderingTask(RenderingTask):
             upper_y = 0
             lower_y = int(round(self.res_y * self.scale_factor))
         else:
-            parts = max(1, int(self.total_tasks / len(self.frames)))
+            parts = max(1, int(self.get_total_tasks() / len(self.frames)))
             part_height = self.res_y / parts * self.scale_factor
             upper_y = int(math.ceil(part_height) * ((subtask['start_task'] - 1) % parts))
             lower_y = int(math.floor(part_height) * ((subtask['start_task'] - 1) % parts + 1))
@@ -434,7 +435,7 @@ class FrameRenderingTask(RenderingTask):
         return ((start_num - 1) % parts) + 1
 
     def __full_frames(self):
-        return self.total_tasks <= len(self.frames)
+        return self.get_total_tasks() <= len(self.frames)
 
     def __mark_sub_frame(self, sub, frame, color):
         idx = self.frames.index(frame)

--- a/apps/rendering/task/framerenderingtask.py
+++ b/apps/rendering/task/framerenderingtask.py
@@ -16,13 +16,11 @@ from apps.rendering.resources.utils import handle_opencv_image_error
 from apps.rendering.task.renderingtask import (RenderingTask,
                                                RenderingTaskBuilder,
                                                PREVIEW_EXT)
+from apps.rendering.task.renderingtaskstate import RendererDefaults
 from golem.verifier.rendering_verifier import FrameRenderingVerifier
 from golem.core.common import update_dict, to_unicode
+from golem.rpc import utils as rpc_utils
 from golem.task.taskstate import SubtaskStatus, TaskStatus
-
-if typing.TYPE_CHECKING:
-    # pylint:disable=unused-import, ungrouped-imports
-    from apps.rendering.task.renderingtaskstate import RendererDefaults
 
 
 logger = logging.getLogger("apps.rendering")
@@ -73,6 +71,23 @@ def _calculate_subtasks_count(
     if defaults.min_subtasks <= total <= defaults.max_subtasks:
         return total
     return defaults.default_subtasks
+
+
+@rpc_utils.expose('comp.task.subtasks.count')
+def legacy_calculate_subtasks_count(
+        subtasks_count: int,
+        optimize_total: bool,
+        use_frames: bool,
+        frames: list) -> int:
+    """
+    TODO: remove this before 0.21
+    """
+    return _calculate_subtasks_count(
+        subtasks_count,
+        optimize_total,
+        use_frames,
+        frames,
+        RendererDefaults())
 
 
 class FrameRendererOptions(Options):

--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -49,14 +49,14 @@ class RenderingTask(CoreTask):
     # Task methods #
     ################
 
-    def __init__(self, task_definition, total_tasks, root_path, owner):
+    def __init__(self, task_definition: 'RenderingTaskDefinition', root_path,
+                 owner):
 
         CoreTask.__init__(
             self,
             task_definition=task_definition,
             owner=owner,
-            root_path=root_path,
-            total_tasks=total_tasks)
+            root_path=root_path)
 
         if task_definition.docker_images is None:
             task_definition.docker_images = self.environment.docker_images
@@ -169,10 +169,11 @@ class RenderingTask(CoreTask):
         x = int(round(self.res_x * self.scale_factor))
         y = int(round(self.res_y * self.scale_factor))
         upper = max(0,
-                    int(math.floor(y / self.total_tasks
+                    int(math.floor(y / self.get_total_tasks()
                                    * (subtask['start_task'] - 1))))
         lower = min(
-            int(math.floor(y / self.total_tasks * (subtask['start_task']))),
+            int(math.floor(y / self.get_total_tasks()
+                           * (subtask['start_task']))),
             y,
         )
         for i in range(0, x):
@@ -191,9 +192,9 @@ class RenderingTask(CoreTask):
 
     def _get_next_task(self):
         logger.debug(f"_get_next_task. last_task={self.last_task}, "
-                     f"total_tasks={self.total_tasks}, "
+                     f"total_tasks={self.get_total_tasks()}, "
                      f"num_failed_subtasks={self.num_failed_subtasks}")
-        if self.last_task != self.total_tasks:
+        if self.last_task != self.get_total_tasks():
             self.last_task += 1
             start_task = self.last_task
             return start_task

--- a/apps/rendering/task/renderingtask.py
+++ b/apps/rendering/task/renderingtask.py
@@ -299,10 +299,6 @@ class RenderingTaskBuilder(CoreTaskBuilder):
         kwargs['total_tasks'] = self._calculate_total(self.DEFAULTS())
         return kwargs
 
-    def build(self):
-        task = super(RenderingTaskBuilder, self).build()
-        return task
-
     @classmethod
     def build_dictionary(cls, definition):
         parent = super(RenderingTaskBuilder, cls)

--- a/apps/wasm/task.py
+++ b/apps/wasm/task.py
@@ -161,10 +161,10 @@ class WasmTask(CoreTask):
     REDUNDANCY_FACTOR = 1
     CALLBACKS: Dict[str, Callable] = {}
 
-    def __init__(self, total_tasks: int, task_definition: WasmTaskDefinition,
+    def __init__(self, task_definition: WasmTaskDefinition,
                  root_path: Optional[str] = None, owner: Node = None) -> None:
         super().__init__(
-            total_tasks=total_tasks, task_definition=task_definition,
+            task_definition=task_definition,
             root_path=root_path, owner=owner
         )
         self.options: WasmTaskOptions = task_definition.options

--- a/golem/environments/environment.py
+++ b/golem/environments/environment.py
@@ -67,10 +67,8 @@ class UnsupportReason(enum.Enum):
 class Environment():
 
     @classmethod
-    def get_id(cls):
-        """ Get Environment unique id
-        :return str:
-        """
+    def get_id(cls) -> str:
+        """ Get Environment unique id """
         return "DEFAULT"
 
     def __init__(self):
@@ -85,17 +83,14 @@ class Environment():
         """
         return SupportStatus.ok()
 
-    def is_accepted(self):
-        """ Check if user wants to compute tasks from this environment
-        :return bool:
-        """
+    def is_accepted(self) -> bool:
+        """ Check if user wants to compute tasks from this environment """
         return self.accept_tasks
 
     @classmethod
-    def get_performance(cls):
+    def get_performance(cls) -> float:
         """ Return performance index associated with the environment. Return
         0.0 if performance is unknown
-        :return float:
         """
         try:
             perf = Performance.get(Performance.environment_id == cls.get_id())

--- a/golem/task/benchmarkmanager.py
+++ b/golem/task/benchmarkmanager.py
@@ -1,6 +1,5 @@
 from copy import copy
 import logging
-import os
 from threading import Thread
 from typing import Union
 

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -13,7 +13,6 @@ from golem_messages.datastructures import masking
 from twisted.internet import defer
 
 from apps.core.task import coretask
-from apps.rendering.task import framerenderingtask
 from apps.rendering.task.renderingtask import RenderingTask
 from golem.core import golem_async
 from golem.core import common
@@ -66,25 +65,6 @@ def _validate_task_dict(client, task_dict) -> None:
     if 'id' in task_dict:
         logger.warning("discarding the UUID from the preset")
         del task_dict['id']
-
-    subtasks_count = task_dict.get('subtasks_count', 0)
-    options = task_dict.get('options', {})
-    optimize_total = bool(options.get('optimize_total', False))
-    if subtasks_count and not optimize_total:
-        computed_subtasks = framerenderingtask.calculate_subtasks_count(
-            subtasks_count=subtasks_count,
-            optimize_total=False,
-            use_frames=options.get('frame_count', 1) > 1,
-            frames=[None] * options.get('frame_count', 1),
-        )
-        if computed_subtasks != subtasks_count:
-            raise ValueError(
-                "Subtasks count {:d} is invalid."
-                " Maybe use {:d} instead?".format(
-                    subtasks_count,
-                    computed_subtasks,
-                )
-            )
 
     if task_dict['concent_enabled']:
         if not client.concent_service.enabled:  # `enabled` implies `available`

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -915,7 +915,7 @@ class ClientProvider:
 
         fragments: typing.Dict[int, typing.List[typing.Dict]] = {}
 
-        for subtask_index in range(1, task.total_tasks + 1):
+        for subtask_index in range(1, task.get_total_tasks() + 1):
             fragments[subtask_index] = []
 
         for subtask in self.task_manager.get_subtasks_dict(task_id) or []:

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -4,13 +4,18 @@ from enum import Enum
 from typing import (
     List,
     Optional,
-    Type)
+    Type,
+    TYPE_CHECKING
+)
 
-import golem_messages
-from golem_messages.datastructures import tasks as dt_tasks
+if TYPE_CHECKING:
+    # pylint:disable=unused-import, ungrouped-imports
+    import golem_messages
+    from golem_messages.datastructures.tasks import TaskHeader
 
-from apps.core.task.coretaskstate import TaskDefinition, Options
-from golem.task.taskstate import TaskState
+    from apps.core.task.coretaskstate import TaskDefinition, Options
+    from golem.task.taskstate import TaskState
+
 
 logger = logging.getLogger("golem.task")
 
@@ -31,8 +36,8 @@ class TaskTypeInfo(object):
 
     def __init__(self,
                  name: str,
-                 definition: Type[TaskDefinition],
-                 options: Type[Options],
+                 definition: 'Type[TaskDefinition]',
+                 options: 'Type[Options]',
                  task_builder_type: 'Type[TaskBuilder]') -> None:
         self.name = name
         self.options = options
@@ -60,7 +65,7 @@ class TaskBuilder(abc.ABC):
     @classmethod
     @abc.abstractmethod
     def build_definition(cls, task_type: TaskTypeInfo, dictionary,
-                         minimal=False):
+                         minimal=False) -> 'TaskDefinition':
         """ Build task defintion from dictionary with described options.
         :param dict dictionary: described all options need to build a task
         :param bool minimal: if this option is set too True, then only minimal
@@ -73,7 +78,7 @@ class TaskBuilder(abc.ABC):
     # move to overriding their own TaskDefinitions instead of
     # overriding `build_dictionary. Issue #2424`
     @staticmethod
-    def build_dictionary(definition: TaskDefinition) -> dict:
+    def build_dictionary(definition: 'TaskDefinition') -> dict:
         return definition.to_dict()
 
 
@@ -95,8 +100,8 @@ class Task(abc.ABC):
                 setattr(self, key, value)
 
     def __init__(self,
-                 header: dt_tasks.TaskHeader,
-                 task_definition: TaskDefinition) -> None:
+                 header: 'TaskHeader',
+                 task_definition: 'TaskDefinition') -> None:
         self.header = header
         self.task_definition = task_definition
 
@@ -162,7 +167,8 @@ class Task(abc.ABC):
         pass  # Implement in derived class
 
     @abc.abstractmethod
-    def query_extra_data_for_test_task(self) -> golem_messages.message.ComputeTaskDef:  # noqa pylint:disable=line-too-long
+    def query_extra_data_for_test_task(self) \
+            -> 'golem_messages.message.ComputeTaskDef':
         pass  # Implement in derived methods
 
     @abc.abstractmethod
@@ -259,10 +265,8 @@ class Task(abc.ABC):
         return []
 
     @abc.abstractmethod
-    def update_task_state(self, task_state: TaskState):
-        """Update some task information taking into account new state.
-        :param TaskState task_state:
-        """
+    def update_task_state(self, task_state: 'TaskState'):
+        """ Update some task information taking into account new state. """
         return  # Implement in derived class
 
     @abc.abstractmethod

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -12,6 +12,7 @@ from typing import (
     Iterable,
     List,
     Optional,
+    Tuple,
     Type,
     TYPE_CHECKING,
 )
@@ -161,7 +162,8 @@ class TaskManager(TaskEventListener):
     def get_task_manager_root(self):
         return self.root_path
 
-    def create_task(self, dictionary, minimal=False):
+    def create_task_definition(self, dictionary, minimal=False) \
+            -> 'Tuple[TaskDefinition, Type[TaskBuilder]]':
         purpose = TaskPurpose.TESTING if minimal else TaskPurpose.REQUESTING
         type_name = dictionary['type'].lower()
         compute_on = dictionary.get('compute_on', 'cpu').lower()
@@ -178,6 +180,11 @@ class TaskManager(TaskEventListener):
             builder_type.build_definition(task_type, dictionary, minimal)
         definition.task_id = CoreTask.create_task_id(self.keys_auth.public_key)
         definition.concent_enabled = dictionary.get('concent_enabled', False)
+        return definition, builder_type
+
+    def create_task(self, dictionary, minimal=False):
+        definition, builder_type = \
+            self.create_task_definition(dictionary, minimal)
         return builder_type(self.node, definition, self.dir_manager).build()
 
     def get_task_definition_dict(self, task: Task):

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -598,7 +598,7 @@ class TaskManager(TaskEventListener):
                 = SubtaskStatus.failure
 
         new_task.num_failed_subtasks = \
-            new_task.total_tasks - len(subtasks_to_copy)
+            new_task.get_total_tasks() - len(subtasks_to_copy)
 
         def handle_copy_error(subtask_id, error):
             logger.error(

--- a/tests/apps/blender/task/test_blenderrendertask.py
+++ b/tests/apps/blender/task/test_blenderrendertask.py
@@ -34,53 +34,54 @@ from apps.rendering.task.renderingtaskstate import (
     RenderingTaskDefinition)
 from golem.resource.dirmanager import DirManager
 from golem.task.taskbase import AcceptClientVerdict
-from golem.task.taskstate import SubtaskStatus, SubtaskState
+from golem.task.taskstate import SubtaskStatus
 from golem.testutils import TempDirFixture
 from golem.tools.assertlogs import LogTestCase
 
 
 class BlenderTaskInitTest(TempDirFixture, LogTestCase):
-
-    def test_compositing(self):
+    def _get_blender_task(self,
+                          *,
+                          subtasks_count=6,
+                          compositing=True,
+                          use_frames=True) \
+                          -> BlenderRenderTask:
         task_definition = RenderingTaskDefinition()
         task_definition.options = BlenderRendererOptions()
-        task_definition.options.use_frames = True
+        task_definition.options.use_frames = use_frames
         task_definition.options.frames = [7, 8, 10]
+        task_definition.options.compositing = compositing
         task_definition.main_scene_file = self.temp_file_name("example.blend")
         task_definition.output_file = self.temp_file_name('output')
         task_definition.output_format = 'PNG'
         task_definition.resolution = [2, 300]
+        task_definition.subtasks_count = subtasks_count
         task_definition.task_id = "ABC"
 
-        def _get_blender_task(task_definition, total_tasks=6):
-            return BlenderRenderTask(
-                owner=dt_p2p_factory.Node(),
-                task_definition=task_definition,
-                total_tasks=total_tasks,
-                root_path=self.tempdir,
-            )
+        return BlenderRenderTask(
+            owner=dt_p2p_factory.Node(),
+            task_definition=task_definition,
+            root_path=self.tempdir,
+        )
 
-        # Compostiting set to False
-        task_definition.options.compositing = False
-        bt = _get_blender_task(task_definition)
+    def test_compositing_false(self):
+        bt = self._get_blender_task(compositing=False)
         assert not bt.compositing
 
-        # Compositing True, use frames, more subtasks than frames
-        task_definition.options.compositing = True
-        bt = _get_blender_task(task_definition)
+    def test_more_subtasks_than_frames(self):
+        bt = self._get_blender_task()
         assert not bt.compositing
 
-        # Compositing True, use frames, as many subtasks as frames
-        bt = _get_blender_task(task_definition, 3)
+    def test_as_many_subtasks_as_frames(self):
+        bt = self._get_blender_task(subtasks_count=3)
         assert not bt.compositing
 
-        # Compositing True, use frames, less subtasks than frames
-        bt = _get_blender_task(task_definition, 1)
+    def test_less_subtasks_than_frames(self):
+        bt = self._get_blender_task(subtasks_count=1)
         assert not bt.compositing
 
-        # Compositing True, use frames is False, as many extra_data as frames
-        task_definition.options.use_frames = False
-        bt = _get_blender_task(task_definition, 3)
+    def test_no_frames_as_many_subtasks_as_frames(self):
+        bt = self._get_blender_task(subtasks_count=3, use_frames=False)
         assert not bt.compositing
 
 
@@ -98,11 +99,11 @@ class TestBlenderFrameTask(TempDirFixture):
         task_definition.output_format = 'PNG'
         task_definition.resolution = [200, 300]
         task_definition.task_id = str(uuid.uuid4())
+        task_definition.subtasks_count = 6
         BlenderRenderTask.VERIFICATION_QUEUE._reset()
         self.bt = BlenderRenderTask(
             owner=dt_p2p_factory.Node(),
             task_definition=task_definition,
-            total_tasks=6,
             root_path=self.tempdir,
         )
 
@@ -118,7 +119,7 @@ class TestBlenderFrameTask(TempDirFixture):
     @mock.patch('apps.core.verification_task.deadline_to_timeout')
     def test_computation_failed_or_finished(self, mock_dtt):
         mock_dtt.return_value = 1.0
-        assert self.bt.total_tasks == 6
+        assert self.bt.get_total_tasks() == 6
 
         # Failed compuation stays failed
         extra_data1 = self.bt.query_extra_data(1000, "ABC", "abc")
@@ -205,7 +206,7 @@ class TestBlenderFrameTask(TempDirFixture):
 
         # If num frames == num subtask, make sure that
         # blender script describe whole frame
-        self.bt.total_tasks = 3
+        self.bt.task_definition.subtasks_count = 3
         extra_data = self.bt.query_extra_data(100, node_id="node1",
                                               node_name="node11")
         assert extra_data.ctd is not None
@@ -249,10 +250,10 @@ class TestBlenderTask(TempDirFixture, LogTestCase):
         task_definition.resolution = [res_x, res_y]
         task_definition.main_scene_file = path.join(self.path, "example.blend")
         task_definition.task_id = str(uuid.uuid4())
+        task_definition.subtasks_count = total_tasks
         bt = BlenderRenderTask(
             owner=dt_p2p_factory.Node(),
             task_definition=task_definition,
-            total_tasks=total_tasks,
             root_path=self.tempdir)
         bt.initialize(DirManager(self.tempdir))
         return bt
@@ -349,7 +350,7 @@ class TestBlenderTask(TempDirFixture, LogTestCase):
         self.bt.accept_client("ABC", 'offer hash')
         ctd = extra_data.ctd
         assert ctd['extra_data']['start_task'] == 1
-        self.bt.last_task = self.bt.total_tasks
+        self.bt.last_task = self.bt.get_total_tasks()
         self.bt.subtasks_given[1] = {'status': SubtaskStatus.finished}
         assert self.bt.should_accept_client("ABC", 'offer hash') != \
             AcceptClientVerdict.ACCEPTED
@@ -357,13 +358,13 @@ class TestBlenderTask(TempDirFixture, LogTestCase):
     def test_get_min_max_y(self):
         self.assertEqual(self.bt.res_x, 2)
         self.assertEqual(self.bt.res_y, 300)
-        self.assertEqual(self.bt.total_tasks, 7)
+        self.assertEqual(self.bt.get_total_tasks(), 7)
         for tasks in [1, 6, 7, 20, 60]:
-            self.bt.total_tasks = tasks
+            self.bt.task_definition.subtasks_count = tasks
             for yres in range(1, 100):
                 self.bt.res_y = yres
                 cur_max_y = self.bt.res_y
-                for i in range(1, self.bt.total_tasks + 1):
+                for i in range(1, self.bt.get_total_tasks() + 1):
                     min_y, max_y = self.bt.get_subtask_y_border(i)
                     min_y = int(float(self.bt.res_y) * min_y)
                     max_y = int(float(self.bt.res_y) * max_y)
@@ -373,7 +374,7 @@ class TestBlenderTask(TempDirFixture, LogTestCase):
 
         self.bt.use_frames = True
         self.bt.frames = [4, 5, 10, 11, 12]
-        self.bt.total_tasks = 20
+        self.bt.task_definition.subtasks_count = 20
         self.bt.res_y = 300
         assert self.bt.get_subtask_y_border(2) == (0.5, 0.75)
 

--- a/tests/apps/core/task/test_coretask.py
+++ b/tests/apps/core/task/test_coretask.py
@@ -43,13 +43,14 @@ class TestCoreTask(LogTestCase, TestDirFixture):
             pass
 
     @staticmethod
-    def _get_core_task_definition():
+    def _get_core_task_definition(subtasks_count=1):
         task_definition = TaskDefinition()
         task_definition.max_price = 100
         task_definition.task_id = "deadbeef"
         task_definition.estimated_memory = 1024
         task_definition.timeout = 3000
         task_definition.subtask_timeout = 30
+        task_definition.subtasks_count = subtasks_count
         return task_definition
 
     def test_instantiation(self):
@@ -82,8 +83,8 @@ class TestCoreTask(LogTestCase, TestDirFixture):
         task = CoreTaskDeabstractedEnv(task_def, node)
         self.assertIsInstance(task, CoreTask)
 
-    def _get_core_task(self):
-        task_def = TestCoreTask._get_core_task_definition()
+    def _get_core_task(self, *, subtasks_count=1):
+        task_def = TestCoreTask._get_core_task_definition(subtasks_count)
         task = self.CoreTaskDeabstracted(
             task_definition=task_def,
             owner=dt_p2p_factory.Node(),
@@ -344,8 +345,7 @@ class TestCoreTask(LogTestCase, TestDirFixture):
             os.chmod(files[1], 0o700)
 
     def test_needs_computation(self):
-        c = self._get_core_task()
-        c.total_tasks = 13
+        c = self._get_core_task(subtasks_count=13)
         assert c.needs_computation()
         c.last_task = 4
         assert c.needs_computation()
@@ -365,8 +365,7 @@ class TestCoreTask(LogTestCase, TestDirFixture):
         assert c.get_active_tasks() == 27
 
     def test_get_tasks_left(self):
-        c = self._get_core_task()
-        c.total_tasks = 13
+        c = self._get_core_task(subtasks_count=13)
         assert c.get_tasks_left() == 13
         c.last_task = 3
         assert c.get_tasks_left() == 10
@@ -384,9 +383,7 @@ class TestCoreTask(LogTestCase, TestDirFixture):
         c.abort()
 
     def test_get_progress(self):
-        c = self._get_core_task()
-        assert c.get_progress() == 0
-        c.total_tasks = 13
+        c = self._get_core_task(subtasks_count=13)
         assert c.get_progress() == 0
         c.num_tasks_received = 1
         assert abs(c.get_progress() - 0.0769) < 0.01

--- a/tests/apps/dummy/task/test_dummytask.py
+++ b/tests/apps/dummy/task/test_dummytask.py
@@ -26,7 +26,8 @@ class TestDummyTask(TempDirFixture, LogTestCase, PEP8MixIn):
     def _get_new_dummy(self):
         td = DummyTaskDefinition(DummyTaskDefaults())
         td.task_id = str(uuid.uuid4())
-        dt = DummyTask(5, td, "root/path", dt_p2p_factory.Node())
+        td.subtasks_count = 5
+        dt = DummyTask(td, "root/path", dt_p2p_factory.Node())
         return dt, td
 
     def test_constants(self):

--- a/tests/apps/glambda/test_task.py
+++ b/tests/apps/glambda/test_task.py
@@ -83,7 +83,7 @@ class GLambdaBenchmarkTaskTestCase(TestCase):
         dir_manager.get_task_output_dir.return_value = ''
 
         task = GLambdaBenchmarkTask(
-            total_tasks=1, task_definition=task_def,
+            task_definition=task_def,
             root_path='/', owner=p2p.Node(), dir_manager=dir_manager
         )
 
@@ -108,7 +108,7 @@ class GLambdaTaskTestCase(TempDirFixture):
         )
         task_def.task_id = str(uuid4())
         self.task = GLambdaTask(
-            total_tasks=1, task_definition=task_def,
+            task_definition=task_def,
             root_path='/', owner=p2p.Node(),
             dir_manager=DirManager(root_path=self.tempdir)
         )

--- a/tests/apps/rendering/task/test_renderingtask.py
+++ b/tests/apps/rendering/task/test_renderingtask.py
@@ -11,10 +11,8 @@ from apps.rendering.resources.imgrepr import load_img, OpenCVImgRepr, \
     OpenCVError
 from apps.rendering.task.renderingtask import (MIN_TIMEOUT, PREVIEW_EXT,
                                                RenderingTask,
-                                               RenderingTaskBuilderError,
                                                RenderingTaskBuilder,
                                                SUBTASK_MIN_TIMEOUT)
-from apps.core.task.coretask import logger as logger_core
 from apps.rendering.task.renderingtask import logger as logger_render
 
 from apps.rendering.task.renderingtaskstate import RenderingTaskDefinition
@@ -23,7 +21,6 @@ from golem.resource.dirmanager import DirManager
 from golem.task.taskstate import SubtaskStatus
 from golem.tools.assertlogs import LogTestCase
 from golem.tools.testdirfixture import TestDirFixture
-
 
 
 def _get_test_exr(alt=False):
@@ -341,30 +338,8 @@ class TestRenderingTaskBuilder(TestDirFixture, LogTestCase):
         with self.assertNoLogs(logger_render, level="WARNING"):
             assert builder._calculate_total(defaults) == 33
 
-    def test_build_definition_minimal(self):
-        # given
-        tti = CoreTaskTypeInfo("TESTTASK", RenderingTaskDefinition,
-                               Options, RenderingTaskBuilder)
-        tti.output_file_ext = 'txt'
-        task_dict = {
-            'resources': {"file1.png", "file2.txt", 'file3.jpg', 'file4.txt'},
-            'compute_on': 'cpu',
-            'task_type': 'TESTTASK',
-            'subtasks_count': 1
-        }
 
-        # when
-        definition = RenderingTaskBuilder.build_definition(
-            tti, task_dict, minimal=True)
-
-        # then
-        assert definition.main_scene_file in ['file2.txt', 'file4.txt']
-        assert definition.task_type == "TESTTASK"
-        assert definition.resources == {'file1.png', 'file2.txt',
-                                        'file3.jpg', 'file4.txt'}
-
-
-class TestBuildDefinition(TestDirFixture, LogTestCase):
+class TestBuildDefinition(LogTestCase):
     def setUp(self):
         super().setUp()
         self.tti = CoreTaskTypeInfo("TESTTASK", RenderingTaskDefinition,
@@ -376,7 +351,7 @@ class TestBuildDefinition(TestDirFixture, LogTestCase):
             'compute_on': 'cpu',
             'task_type': 'TESTTASK',
             'subtasks_count': 1,
-            'options': {'output_path': self.path,
+            'options': {'output_path': "/foo/bar",
                         'format': 'PNG',
                         'resolution': [800, 600]},
             'name': "NAME OF THE TASK",
@@ -455,3 +430,25 @@ class TestBuildDefinition(TestDirFixture, LogTestCase):
             # and it modifies it on windows
             path.normpath("/path/to/file5.txt"),
         }
+
+    def test_build_definition_minimal(self):
+        # given
+        tti = CoreTaskTypeInfo("TESTTASK", RenderingTaskDefinition,
+                               Options, RenderingTaskBuilder)
+        tti.output_file_ext = 'txt'
+        task_dict = {
+            'resources': {"file1.png", "file2.txt", 'file3.jpg', 'file4.txt'},
+            'compute_on': 'cpu',
+            'task_type': 'TESTTASK',
+            'subtasks_count': 1
+        }
+
+        # when
+        definition = RenderingTaskBuilder.build_definition(
+            tti, task_dict, minimal=True)
+
+        # then
+        assert definition.main_scene_file in ['file2.txt', 'file4.txt']
+        assert definition.task_type == "TESTTASK"
+        assert definition.resources == {'file1.png', 'file2.txt',
+                                        'file3.jpg', 'file4.txt'}

--- a/tests/apps/wasm/test_task.py
+++ b/tests/apps/wasm/test_task.py
@@ -130,7 +130,7 @@ class WasmTaskTestCase(TempDirFixture):
         )
         task_def.task_id = str(uuid4())
         self.task = WasmTask(
-            total_tasks=2, task_definition=task_def,
+            task_definition=task_def,
             root_path='/', owner=p2p.Node(),
         )
 

--- a/tests/golem/docker/test_docker_blender_task.py
+++ b/tests/golem/docker/test_docker_blender_task.py
@@ -116,7 +116,7 @@ class TestDockerBlenderCyclesTask(TestDockerBlenderTaskBase):
         assert len(task.task_resources) == 1
         assert task.task_resources[0].endswith(
             'scene-Helicopter-27-cycles.blend')
-        assert task.total_tasks == 6
+        assert task.get_total_tasks() == 6
         assert task.last_task == 0
         assert task.num_tasks_received == 0
         assert task.subtasks_given == {}

--- a/tests/golem/resource/test_resource.py
+++ b/tests/golem/resource/test_resource.py
@@ -22,6 +22,7 @@ class TestGetTaskResources(TempDirFixture):
         task_definition.estimated_memory = 1024
         task_definition.timeout = 3000
         task_definition.subtask_timeout = 30
+        task_definition.subtasks_count = 1
         return task_definition
 
     def _get_core_task(self):

--- a/tests/golem/task/dummy/task.py
+++ b/tests/golem/task/dummy/task.py
@@ -110,8 +110,6 @@ class DummyTask(Task):
         self.resource_parts = {}
 
         self.shared_data_file = None
-        self.subtasks_count = num_subtasks
-        self.total_tasks = self.subtasks_count
         self.subtask_ids = []
         self.subtask_data = {}
         self.subtask_results = {}
@@ -155,17 +153,17 @@ class DummyTask(Task):
         return 0.
 
     def get_total_tasks(self):
-        return self.subtasks_count
+        return self.task_definition.subtasks_count
 
     def get_tasks_left(self):
-        return self.subtasks_count - len(self.subtask_results)
+        return self.get_total_tasks() - len(self.subtask_results)
 
     @property
     def price(self) -> int:
-        return self.subtask_price * self.total_tasks
+        return self.subtask_price * self.get_total_tasks()
 
     def needs_computation(self):
-        return len(self.subtask_data) < self.subtasks_count
+        return len(self.subtask_data) < self.get_total_tasks()
 
     def finished_computation(self):
         return self.get_tasks_left() == 0
@@ -211,10 +209,10 @@ class DummyTask(Task):
     def verify_task(self):
         # Check if self.subtask_results contains a non None result
         # for each subtack.
-        if not len(self.subtask_results) == self.subtasks_count:
+        if not len(self.subtask_results) == self.get_total_tasks():
             print(
                 "Results vs Count: "
-                f"{len(self.subtask_results)} != {self.subtasks_count}",
+                f"{len(self.subtask_results)} != {self.get_total_tasks()}",
             )
             return False
         print(f"subtask results: {self.subtask_results}")

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -1056,9 +1056,9 @@ class TestGetFragments(ProviderBase):
 
     def test_no_subtasks(self, *_):
         task_id = str(uuid.uuid4())
-        subtask_count = 5
+        subtasks_count = 5
         mock_task = Mock(spec=RenderingTask)
-        mock_task.total_tasks = subtask_count
+        mock_task.get_total_tasks.return_value = subtasks_count
         mock_task_state = Mock()
         mock_task_state.subtask_states = None
         tm = self.provider.task_manager
@@ -1067,6 +1067,6 @@ class TestGetFragments(ProviderBase):
 
         task_fragments, error = self.provider.get_fragments(task_id)
 
-        self.assertEqual(len(task_fragments), subtask_count)
+        self.assertEqual(len(task_fragments), subtasks_count)
         subtasks = list(itertools.chain.from_iterable(task_fragments.values()))
         self.assertFalse(subtasks)

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -527,19 +527,6 @@ class TestValidateTaskDict(ProviderBase):
         with self.assertRaisesRegex(rpc.CreateTaskError, msg):
             rpc._validate_task_dict(self.client, self.t_dict)
 
-    @mock.patch(
-        "apps.rendering.task.framerenderingtask.calculate_subtasks_count",
-    )
-    def test_computed_subtasks(self, calculate_mock, *_):
-        computed_subtasks = self.t_dict['subtasks_count'] - 1
-        calculate_mock.return_value = computed_subtasks
-        msg = "Subtasks count {:d} is invalid. Maybe use {:d} instead?".format(
-            self.t_dict['subtasks_count'],
-            computed_subtasks,
-        )
-        with self.assertRaisesRegex(ValueError, msg):
-            rpc._validate_task_dict(self.client, self.t_dict)
-
 
 @mock.patch('os.path.getsize')
 @mock.patch('golem.task.taskmanager.TaskManager.dump_task')

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -174,6 +174,31 @@ class TestCreateTask(ProviderBase, TestClientBase):
                                              '0.166667, available: 0.000000\n')
 
 
+class TestCreateTaskDryRun(ProviderBase):
+    def test_success(self):
+        # given
+        self.t_dict['subtasks_count'] = 0
+
+        # when
+        new_dict, error = self.provider.create_task_dry_run(self.t_dict)
+
+        # then
+        assert error is None
+        assert new_dict['id'] is not None
+        assert new_dict['subtasks_count'] == 10
+
+    def test_failure(self):
+        # given
+        self.t_dict['type'] = "unknown"
+
+        # when
+        new_dict, error = self.provider.create_task_dry_run(self.t_dict)
+
+        # then
+        assert new_dict is None
+        assert error is not None
+
+
 class ConcentDepositLockPossibilityTest(unittest.TestCase):
 
     def test_validate_lock_funds_possibility_raises_if_not_enough_funds(self):


### PR DESCRIPTION
This PR is required for #4003. It cleans up how `subtasks_count` is validated and corrected during task creation.

Most of the noise comes from removing `CoreTask.total_tasks` field. It's redundant with `CoreTask.task_definition.subtasks_count`. The main reason for removing it was to remove calculation from `RenderingTaskBuilder.get_task_kwargs` (see also #4595). There is a method `CoreTask.get_total_tasks()`, which should be used and could be overridden by deriving classes (like `WasmTask` does).

This also affects golemfactory/golem-electron#253. ~~The existing `comp.task.subtasks.count` RPC method is removed.~~ (EDIT: it's restored for now, but should be removed soon) Instead a new one is created `comp.task.create.dry_run`, so that client might check not only `subtasks_count` but all other parameters as well.