### PR TITLE
Refactor DockerCPU[Config, Runtime, Environment] for easier inheritance

### DIFF
--- a/golem/core/simpleserializer.py
+++ b/golem/core/simpleserializer.py
@@ -5,6 +5,7 @@ import sys
 import types
 from abc import ABC, abstractmethod
 from enum import Enum
+from typing import Any, Dict
 
 from golem_messages import datastructures
 
@@ -175,6 +176,6 @@ class DictSerializable(ABC):
 
     @staticmethod
     @abstractmethod
-    def from_dict(data: dict) -> 'DictSerializable':
+    def from_dict(data: Dict[str, Any]) -> 'DictSerializable':
         """ Construct object from a dict containing only primitive types. """
         raise NotImplementedError

--- a/golem/envs/docker/cpu.py
+++ b/golem/envs/docker/cpu.py
@@ -1,12 +1,14 @@
 import logging
 import os
+from copy import deepcopy
 from pathlib import Path
 from socket import socket, SocketIO, SHUT_WR
 from threading import Thread, Lock
 from time import sleep
 from typing import Optional, Any, Dict, List, Type, ClassVar, \
-    NamedTuple, Tuple, Iterator, Union, Iterable
+    Tuple, Iterator, Union, Iterable
 
+from dataclasses import dataclass, field, asdict
 from docker.errors import APIError
 from twisted.internet.defer import Deferred, inlineCallbacks, succeed
 from twisted.internet.threads import deferToThread
@@ -36,26 +38,23 @@ mem = CONSTRAINT_KEYS['mem']
 cpu = CONSTRAINT_KEYS['cpu']
 
 
-class DockerCPUConfigData(NamedTuple):
+@dataclass
+class DockerCPUConfig(EnvConfig):
     # The directories this environment is allowed to work in
-    work_dirs: List[Path] = []
+    work_dirs: List[Path] = field(default_factory=list)
     memory_mb: int = 1024
     cpu_count: int = 1
 
-
-class DockerCPUConfig(DockerCPUConfigData, EnvConfig):
-    """ This exists because NamedTuple must be single superclass """
-
     def to_dict(self) -> Dict[str, Any]:
-        dict_ = self._asdict()
+        dict_ = asdict(self)
         dict_['work_dirs'] = [str(work_dir) for work_dir in dict_['work_dirs']]
         return dict_
 
-    @staticmethod
-    def from_dict(dict_: Dict[str, Any]) -> 'DockerCPUConfig':
-        _work_dirs = dict_.pop('work_dirs')
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> 'DockerCPUConfig':
+        _work_dirs = data.pop('work_dirs')
         work_dirs = [Path(work_dir) for work_dir in _work_dirs]
-        return DockerCPUConfig(work_dirs=work_dirs, **dict_)
+        return cls(work_dirs=work_dirs, **data)
 
 
 class DockerOutput(RuntimeOutput):
@@ -149,31 +148,21 @@ class DockerCPURuntime(RuntimeBase):
 
     def __init__(
             self,
-            payload: DockerRuntimePayload,
-            host_config: Dict[str, Any],
-            volumes: Optional[List[str]],
+            container_config: Dict[str, Any],
             port_mapper: ContainerPortMapper,
+            runtime_logger: Optional[logging.Logger] = None,
     ) -> None:
-        super().__init__(logger=logger)
+        super().__init__(logger=runtime_logger or logger)
 
-        image = f"{payload.image}:{payload.tag}"
         client = local_client()
 
         self._status_update_thread: Optional[Thread] = None
         self._container_id: Optional[str] = None
         self._stdin_socket: Optional[InputSocket] = None
-        self._container_config = client.create_container_config(
-            image=image,
-            volumes=volumes,
-            command=payload.command,
-            user=payload.user,
-            environment=payload.env,
-            working_dir=payload.work_dir,
-            ports=payload.ports,
-            host_config=host_config,
-            stdin_open=True
-        )
         self._port_mapper = port_mapper
+
+        self._container_config = client.create_container_config(
+            **container_config)
 
     def _inspect_container(self) -> Tuple[str, int]:
         """ Inspect Docker container associated with this runtime. Returns
@@ -193,7 +182,7 @@ class DockerCPURuntime(RuntimeBase):
             if self._status != RuntimeStatus.RUNNING:
                 return
 
-            logger.debug("Updating runtime status...")
+            self._logger.debug("Updating runtime status...")
 
             try:
                 container_status, exit_code = self._inspect_container()
@@ -202,7 +191,7 @@ class DockerCPURuntime(RuntimeBase):
                 return
 
             if container_status in self.CONTAINER_RUNNING:
-                logger.debug("Container still running, no status update.")
+                self._logger.debug("Container still running, no status update.")
 
             elif container_status in self.CONTAINER_STOPPED:
                 if exit_code == 0:
@@ -222,14 +211,14 @@ class DockerCPURuntime(RuntimeBase):
             self._update_status()
             sleep(self.STATUS_UPDATE_INTERVAL)
 
-        logger.info("Runtime is no longer running. "
-                    "Stopping status update thread.")
+        self._logger.info("Runtime is no longer running. "
+                          "Stopping status update thread.")
 
     def prepare(self) -> Deferred:
         self._change_status(
             from_status=RuntimeStatus.CREATED,
             to_status=RuntimeStatus.PREPARING)
-        logger.info("Preparing runtime...")
+        self._logger.info("Preparing runtime...")
 
         def _prepare():
             client = local_client()
@@ -240,7 +229,7 @@ class DockerCPURuntime(RuntimeBase):
             self._container_id = container_id
 
             for warning in result.get("Warnings") or []:
-                logger.warning("Container creation warning: %s", warning)
+                self._logger.warning("Container creation warning: %s", warning)
 
             sock = client.attach_socket(
                 container_id, params={'stdin': True, 'stream': True}
@@ -257,7 +246,7 @@ class DockerCPURuntime(RuntimeBase):
         self._change_status(
             from_status=[RuntimeStatus.FAILURE, RuntimeStatus.STOPPED],
             to_status=RuntimeStatus.CLEANING_UP)
-        logger.info("Cleaning up runtime...")
+        self._logger.info("Cleaning up runtime...")
 
         def _clean_up():
             client = local_client()
@@ -280,17 +269,17 @@ class DockerCPURuntime(RuntimeBase):
         self._change_status(
             from_status=RuntimeStatus.PREPARED,
             to_status=RuntimeStatus.STARTING)
-        logger.info("Starting container '%s'...", self._container_id)
+        self._logger.info("Starting container '%s'...", self._container_id)
 
         def _start():
             client = local_client()
             client.start(self._container_id)
 
         def _spawn_status_update_thread(_):
-            logger.debug("Spawning status update thread...")
+            self._logger.debug("Spawning status update thread...")
             self._status_update_thread = Thread(target=self._update_status_loop)
             self._status_update_thread.start()
-            logger.debug("Status update thread spawned.")
+            self._logger.debug("Status update thread spawned.")
 
         deferred_start = deferToThread(_start)
         deferred_start.addCallback(self._started)
@@ -308,19 +297,19 @@ class DockerCPURuntime(RuntimeBase):
     def stop(self) -> Deferred:
         with self._status_lock:
             self._assert_status(self._status, RuntimeStatus.RUNNING)
-        logger.info("Stopping container '%s'...", self._container_id)
+        self._logger.info("Stopping container '%s'...", self._container_id)
 
         def _stop():
             client = local_client()
             client.stop(self._container_id)
 
         def _join_status_update_thread(res):
-            logger.debug("Joining status update thread...")
+            self._logger.debug("Joining status update thread...")
             self._status_update_thread.join(self.STATUS_UPDATE_INTERVAL * 2)
             if self._status_update_thread.is_alive():
-                logger.warning("Failed to join status update thread.")
+                self._logger.warning("Failed to join status update thread.")
             else:
-                logger.debug("Status update thread joined.")
+                self._logger.debug("Status update thread joined.")
             return res
 
         def _close_stdin(res):
@@ -356,7 +345,7 @@ class DockerCPURuntime(RuntimeBase):
 
         assert stdout or stderr
         assert self._container_id is not None
-        logger.debug(
+        self._logger.debug(
             "Attaching to output of container '%s'...", self._container_id)
         client = local_client()
 
@@ -364,7 +353,7 @@ class DockerCPURuntime(RuntimeBase):
             raw_output = client.attach(
                 container=self._container_id,
                 stdout=stdout, stderr=stderr, logs=True, stream=stream)
-            logger.debug("Successfully attached to output.")
+            self._logger.debug("Successfully attached to output.")
             # If not using stream the output is a single `bytes` object
             return raw_output if stream else [raw_output]
         except APIError as e:
@@ -398,7 +387,8 @@ class DockerCPURuntime(RuntimeBase):
         # between checking and attaching to the output.
         self._update_status()
         if self.status() not in stream_available:
-            logger.debug("Container no longer running. Getting offline output.")
+            self._logger.debug("Container no longer running. "
+                               "Getting offline output.")
             raw_output = self._get_raw_output(stream=False, **kwargs)
 
         return DockerOutput(raw_output, encoding=encoding)
@@ -457,10 +447,8 @@ class DockerCPUEnvironment(EnvironmentBase):
 
     @classmethod
     def supported(cls) -> EnvSupportStatus:
-        logger.info('Checking environment support status...')
         if cls._get_hypervisor_class() is None:
             return EnvSupportStatus(False, "No supported hypervisor found")
-        logger.info('Environment supported.')
         return EnvSupportStatus(True)
 
     @classmethod
@@ -477,8 +465,12 @@ class DockerCPUEnvironment(EnvironmentBase):
                 return DockerForMac
         return None
 
-    def __init__(self, config: DockerCPUConfig) -> None:
-        super().__init__(logger=logger)
+    def __init__(
+            self,
+            config: DockerCPUConfig,
+            env_logger: Optional[logging.Logger] = None,
+    ) -> None:
+        super().__init__(logger=env_logger or logger)
         self._validate_config(config)
         self._config = config
 
@@ -501,7 +493,7 @@ class DockerCPUEnvironment(EnvironmentBase):
             raise ValueError(f"Cannot prepare because environment is in "
                              f"invalid state: '{self._status}'")
         self._status = EnvStatus.PREPARING
-        logger.info("Preparing environment...")
+        self._logger.info("Preparing environment...")
 
         def _prepare():
             try:
@@ -518,7 +510,7 @@ class DockerCPUEnvironment(EnvironmentBase):
             raise ValueError(f"Cannot clean up because environment is in "
                              f"invalid state: '{self._status}'")
         self._status = EnvStatus.CLEANING_UP
-        logger.info("Cleaning up environment...")
+        self._logger.info("Cleaning up environment...")
 
         def _clean_up():
             try:
@@ -577,10 +569,10 @@ class DockerCPUEnvironment(EnvironmentBase):
         if self._status != EnvStatus.ENABLED:
             raise ValueError(f"Cannot prepare prerequisites because environment"
                              f"is in invalid state: '{self._status}'")
-        logger.info("Preparing prerequisites...")
+        self._logger.info("Preparing prerequisites...")
 
         if not Whitelist.is_whitelisted(prerequisites.image):
-            logger.info(
+            self._logger.info(
                 "Docker image '%s' is not whitelisted.",
                 prerequisites.image,
             )
@@ -607,25 +599,27 @@ class DockerCPUEnvironment(EnvironmentBase):
         return DockerCPUConfig(**config_dict)
 
     def config(self) -> DockerCPUConfig:
-        return DockerCPUConfig(*self._config)
+        return deepcopy(self._config)
 
     def update_config(self, config: EnvConfig) -> None:
         assert isinstance(config, DockerCPUConfig)
         if self._status != EnvStatus.DISABLED:
             raise ValueError(
                 "Config can be updated only when the environment is disabled")
-        logger.info("Updating environment configuration...")
+        self._logger.info("Updating environment configuration...")
 
+        self._logger.info("Validating configuration...")
         self._validate_config(config)
+        self._logger.info("Configuration positively validated.")
+
         if config.work_dirs != self._config.work_dirs:
             self._update_work_dirs(config.work_dirs)
         self._constrain_hypervisor(config)
-        self._config = DockerCPUConfig(*config)
+        self._config = self.parse_config(asdict(config))
         self._config_updated(config)
 
     @classmethod
     def _validate_config(cls, config: DockerCPUConfig) -> None:
-        logger.info("Validating configuration...")
         for work_dir in config.work_dirs:
             if not work_dir.is_dir():
                 raise ValueError(f"Invalid working directory: '{work_dir}'")
@@ -646,16 +640,15 @@ class DockerCPUEnvironment(EnvironmentBase):
             raise ValueError(f"Not enough memory: {config.memory_mb} MB")
         if config.cpu_count < cls.MIN_CPU_COUNT:
             raise ValueError(f"Not enough CPUs: {config.cpu_count}")
-        logger.info("Configuration positively validated.")
 
     def _update_work_dirs(self, work_dirs: List[Path]) -> None:
-        logger.info("Updating hypervisor's working directory...")
+        self._logger.info("Updating hypervisor's working directory...")
         try:
             self._hypervisor.update_work_dirs(work_dirs)
         except Exception as e:
             self._error_occurred(e, "Updating working directory failed.")
             raise
-        logger.info("Working directory successfully updated.")
+        self._logger.info("Working directory successfully updated.")
 
     def _constrain_hypervisor(self, config: DockerCPUConfig) -> None:
         current = self._hypervisor.constraints()
@@ -665,18 +658,18 @@ class DockerCPUEnvironment(EnvironmentBase):
         }
 
         if target == current:
-            logger.info("No need to reconfigure hypervisor.")
+            self._logger.info("No need to reconfigure hypervisor.")
             return
 
-        logger.info("Hypervisor configuration differs. "
-                    "Reconfiguring hypervisor...")
+        self._logger.info("Hypervisor configuration differs. "
+                          "Reconfiguring hypervisor...")
         try:
             with self._hypervisor.reconfig_ctx():
                 self._hypervisor.constrain(**target)
         except Exception as e:
             self._error_occurred(e, "Reconfiguring hypervisor failed.")
             raise
-        logger.info("Hypervisor successfully reconfigured.")
+        self._logger.info("Hypervisor successfully reconfigured.")
 
     def runtime(
             self,
@@ -692,14 +685,7 @@ class DockerCPUEnvironment(EnvironmentBase):
         else:
             config = self.config()
 
-        host_config = self._create_host_config(config, payload)
-        volumes = [b.target for b in payload.binds] if payload.binds else None
-        return DockerCPURuntime(
-            payload,
-            host_config,
-            volumes,
-            self._port_mapper,
-        )
+        return self._create_runtime(config, payload)
 
     def _create_host_config(
             self,
@@ -730,3 +716,36 @@ class DockerCPUEnvironment(EnvironmentBase):
             dns_search=self.DNS_SEARCH_DOMAINS,
             cap_drop=self.DROPPED_KERNEL_CAPABILITIES
         )
+
+    def _create_container_config(
+            self,
+            config: DockerCPUConfig,
+            payload: DockerRuntimePayload,
+    ) -> Dict[str, Any]:
+        image = f"{payload.image}:{payload.tag}"
+        volumes = [b.target for b in payload.binds] if payload.binds else None
+        host_config = self._create_host_config(config, payload)
+
+        return dict(
+            image=image,
+            volumes=volumes,
+            command=payload.command,
+            user=payload.user,
+            environment=payload.env,
+            working_dir=payload.work_dir,
+            ports=payload.ports,
+            host_config=host_config,
+            stdin_open=True
+        )
+
+    def _create_runtime(
+            self,
+            config: DockerCPUConfig,
+            payload: DockerRuntimePayload,
+    ) -> DockerCPURuntime:
+        container_config = self._create_container_config(config, payload)
+
+        return DockerCPURuntime(
+            container_config,
+            self._port_mapper,
+            runtime_logger=self._logger)

--- a/tests/golem/envs/docker/cpu/test_env.py
+++ b/tests/golem/envs/docker/cpu/test_env.py
@@ -13,7 +13,10 @@ from golem.docker.hypervisor.virtualbox import VirtualBoxHypervisor
 from golem.docker.task_thread import DockerBind
 from golem.envs import EnvStatus
 from golem.envs.docker import DockerPrerequisites, DockerRuntimePayload
-from golem.envs.docker.cpu import DockerCPUEnvironment, DockerCPUConfig
+from golem.envs.docker.cpu import (
+    DockerCPUEnvironment,
+    DockerCPUConfig,
+)
 
 cpu = CONSTRAINT_KEYS['cpu']
 mem = CONSTRAINT_KEYS['mem']
@@ -153,7 +156,7 @@ class TestDockerCPUEnv(TestCase):
     @patch_env('_get_hypervisor_class')
     def setUp(self, get_hypervisor, *_):  # pylint: disable=arguments-differ
         self.hypervisor = Mock(spec=Hypervisor)
-        self.config = DockerCPUConfig(work_dirs=[Mock()])
+        self.config = DockerCPUConfig(work_dirs=[Path('test')])
         get_hypervisor.return_value.instance.return_value = self.hypervisor
         self.logger = Mock(spec=Logger)
         with patch_cpu('logger', self.logger):
@@ -369,7 +372,7 @@ class TestUpdateConfig(TestDockerCPUEnv):
     def test_config_changed(
             self, constrain, validate, config_updated, update_work_dirs):
         config = DockerCPUConfig(
-            work_dirs=[Mock()],
+            work_dirs=[Path('test_2')],
             memory_mb=2137,
             cpu_count=12
         )
@@ -528,60 +531,17 @@ class TestRuntime(TestDockerCPUEnv):
         is_whitelisted.assert_called_once_with(payload.image)
 
     @patch_cpu('Whitelist.is_whitelisted', return_value=True)
-    @patch_cpu('DockerCPURuntime')
-    @patch_env('_create_host_config')
-    def test_default_config(self, create_host_config, runtime_mock, _):
-        payload = mock_docker_runtime_payload()
-        runtime = self.env.runtime(payload)
+    @patch_cpu('local_client')
+    def test_container_config_passed(self, local_client, _):
+        local_client.return_value = local_client
+        method = '_create_container_config'
+        return_value = {'custom_key': 'custom_value'}
 
-        create_host_config.assert_called_once_with(self.config, payload)
-        runtime_mock.assert_called_once_with(
-            payload, create_host_config(), None, ANY)
-        self.assertEqual(runtime, runtime_mock())
+        with patch.object(self.env, method, return_value=return_value):
+            self.env._create_runtime(Mock(), Mock())
 
-    @patch_cpu('Whitelist.is_whitelisted', return_value=True)
-    @patch_cpu('DockerCPURuntime')
-    @patch_env('_create_host_config')
-    def test_custom_config(self, create_host_config, runtime_mock, _):
-        payload = mock_docker_runtime_payload()
-        config = Mock(spec=DockerCPUConfig)
-        runtime = self.env.runtime(payload, config=config)
-
-        create_host_config.assert_called_once_with(config, payload)
-        runtime_mock.assert_called_once_with(
-            payload, create_host_config(), None, ANY)
-        self.assertEqual(runtime, runtime_mock())
-
-    @patch_cpu('Whitelist.is_whitelisted', return_value=True)
-    @patch_cpu('DockerCPURuntime')
-    @patch_env('_create_host_config')
-    def test_shared_dir(self, create_host_config, runtime_mock, _):
-        target_dir = '/foo'
-        docker_bind = Mock(spec=DockerBind, target=target_dir)
-        payload = mock_docker_runtime_payload(binds=[docker_bind])
-        runtime = self.env.runtime(payload)
-
-        create_host_config.assert_called_once_with(self.config, payload)
-        runtime_mock.assert_called_once_with(
-            payload,
-            create_host_config(),
-            [target_dir],
-            ANY)
-        self.assertEqual(runtime, runtime_mock())
-
-    @patch_cpu('Whitelist.is_whitelisted', return_value=True)
-    @patch_cpu('DockerCPURuntime')
-    def test_port_mapping(self, runtime_mock, _):
-        port = 4444
-        payload = mock_docker_runtime_payload(ports=[port])
-        runtime = self.env.runtime(payload)
-        runtime_mock.assert_called_once_with(
-            payload,
-            ANY,
-            ANY,
-            self.env._port_mapper,
-        )
-        self.assertEqual(runtime, runtime_mock())
+        local_client.create_container_config.assert_called_once_with(
+            **return_value)
 
 
 class TestCreateHostConfig(TestDockerCPUEnv):
@@ -679,3 +639,38 @@ class TestCreateHostConfig(TestDockerCPUEnv):
             cap_drop=ANY,
         )
         self.assertEqual(host_config, local_client().create_host_config())
+
+
+class TestCreateContainerConfig(TestDockerCPUEnv):
+
+    @patch_cpu('local_client')
+    @patch_cpu('DockerCPURuntime')
+    def test_custom_config(self, runtime, _):
+        payload = DockerRuntimePayload(
+            image='repo/img',
+            tag='1.0',
+            command='cmd',
+            env={'key': 'val'},
+            user='user',
+            work_dir='/test',
+            binds=[DockerBind(source=Path('/test'), target='/test')],
+        )
+
+        with patch.object(self.env, '_create_host_config', return_value={}):
+            self.env._create_runtime(self.config, payload)
+
+        container_config = dict(
+            image='repo/img:1.0',
+            command='cmd',
+            volumes=['/test'],
+            environment={'key': 'val'},
+            ports=None,
+            user='user',
+            working_dir='/test',
+            host_config={},
+            stdin_open=True)
+
+        runtime.assert_called_once_with(
+            container_config,
+            ANY,
+            runtime_logger=ANY)

--- a/tests/golem/envs/docker/cpu/test_integration.py
+++ b/tests/golem/envs/docker/cpu/test_integration.py
@@ -15,6 +15,23 @@ from golem.tools.ci import ci_skip
 @ci_skip
 class TestIntegration(TestCase, DatabaseFixture):
 
+    @classmethod
+    def setUpClass(cls) -> None:
+        super().setUpClass()
+
+        # pylint: disable=protected-access
+        hypervisor_cls = DockerCPUEnvironment._get_hypervisor_class()
+        assert hypervisor_cls is not None, "No supported hypervisor found"
+
+        cls.hypervisor = hypervisor_cls(get_config=lambda: {})
+        cls.vm_was_running = cls.hypervisor.vm_running
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.vm_was_running:
+            cls.hypervisor.start_vm()
+        super().tearDownClass()
+
     @inlineCallbacks
     def setUp(self):
         DatabaseFixture.setUp(self)

--- a/tests/golem/envs/docker/cpu/test_runtime.py
+++ b/tests/golem/envs/docker/cpu/test_runtime.py
@@ -23,35 +23,28 @@ class TestInit(TestCase):
 
     @patch('local_client')
     def test_init(self, local_client):
-        payload = DockerRuntimePayload(
-            image='repo/img',
-            tag='1.0',
-            command='cmd',
-            env={'key': 'value'},
-            user='user',
-            work_dir='/test'
-        )
-        host_config = {'memory': '1234m'}
         volumes = ['/test']
-        runtime = DockerCPURuntime(payload, host_config, volumes, Mock())
-
-        local_client().create_container_config.assert_called_once_with(
+        host_config = {'memory': '1234m'}
+        container_config = dict(
             image='repo/img:1.0',
             command='cmd',
             volumes=volumes,
-            environment={'key': 'value'},
+            environment={'key': 'val', 'key2': 'val2'},
             ports=None,
             user='user',
             working_dir='/test',
             host_config=host_config,
             stdin_open=True,
+            runtime='test',
         )
+
+        runtime = DockerCPURuntime(container_config, Mock())
+
+        local_client().create_container_config.assert_called_once_with(
+            **container_config)
         self.assertEqual(runtime.status(), RuntimeStatus.CREATED)
         self.assertIsNone(runtime._container_id)
         self.assertIsNone(runtime._stdin_socket)
-        self.assertEqual(
-            runtime._container_config,
-            local_client().create_container_config())
 
 
 class TestDockerCPURuntime(TestCase):
@@ -62,15 +55,7 @@ class TestDockerCPURuntime(TestCase):
         self.logger = self._patch_async('logger')
         self.client = self._patch_async('local_client').return_value
         self.container_config = self.client.create_container_config()
-
-        payload = DockerRuntimePayload(
-            image='repo/img',
-            tag='1.0',
-            env={}
-        )
-
-        self.runtime = DockerCPURuntime(payload, {}, None, Mock())
-        self.container_config = self.client.create_container_config()
+        self.runtime = DockerCPURuntime(self.container_config, Mock())
 
         # We want to make sure that status is being set and read using lock.
 

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -598,6 +598,7 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
             )
         self.client.monitor = Mock()
         self.client._update_hw_preset = Mock()
+        self.client.task_server.change_config = Mock()
 
     def test_node(self, *_):
         c = self.client


### PR DESCRIPTION
Deriving `DockerCPU*` is now a bit more flexible. Changes were picked from the DockerGPUEnvironment branch and will now serve as a base branch for that PR (https://github.com/golemfactory/golem/pull/4618).

List of changes:
- `DockerCPUConfig` is now a `dataclass`
- uses container instead of host config arg in `DockerCPURuntime.__init__`
- it is possible to provide a custom logger for `DockerCPU[Environment|Runtime]`
- uses self._logger instead of logger in `DockerCPURuntime`
- uses self._logger instead of logger in `DockerCPUEnvironment`
- splits `DockerCPUEnvironment.runtime` into separate methods