### PR TITLE
bump messages to 3.11 (always require contract address in the sig has…

### DIFF
--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -434,8 +434,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                     f"Signing promissory notes for GNTDeposit at: "
                     f"{self.deposit_contract_address}"
                 )
-                ttc.sign_promissory_note(private_key=self.my_private_key)
-                ttc.sign_concent_promissory_note(
+                ttc.sign_all_promissory_notes(
                     deposit_contract_address=self.deposit_contract_address,
                     private_key=self.my_private_key
                 )
@@ -618,10 +617,8 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 _cannot_compute(reasons.TooShortDeposit)
                 return
 
-            if not (msg.verify_promissory_note() and
-                    msg.verify_concent_promissory_note(
-                        deposit_contract_address=self.deposit_contract_address
-                    )):
+            if not msg.verify_all_promissory_notes(
+                    deposit_contract_address=self.deposit_contract_address):
                 _cannot_compute(reasons.PromissoryNoteMissing)
                 logger.debug(
                     f"Requestor failed to provide correct promissory"

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ eth-utils==1.0.3
 ethereum==1.6.1
 eventlet==0.24.1
 fs==2.4.4
-Golem-Messages==3.10.0
+Golem-Messages==3.11.0
 Golem-Smart-Contracts-Interface==1.10.2
 golem_task_api==0.12.0
 greenlet==0.4.15

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -17,7 +17,7 @@ docker==3.5.0
 enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
-Golem-Messages==3.10.0
+Golem-Messages==3.11.0
 Golem-Smart-Contracts-Interface==1.10.2
 golem_task_api==0.12.0
 html2text==2018.1.9

--- a/scripts/concent_acceptance_tests/base.py
+++ b/scripts/concent_acceptance_tests/base.py
@@ -94,8 +94,7 @@ class ConcentBaseTest(unittest.TestCase):
 
     def ttc_add_promissory_and_sign(self, ttc, priv_key=None) -> None:
         priv_key = priv_key or self.requestor_priv_key
-        ttc.sign_promissory_note(private_key=priv_key)
-        ttc.sign_concent_promissory_note(
+        ttc.sign_all_promissory_notes(
             deposit_contract_address=
             self.ethereum_config.deposit_contract_address,
             private_key=priv_key,

--- a/tests/golem/task/test_concent_logic.py
+++ b/tests/golem/task/test_concent_logic.py
@@ -62,8 +62,8 @@ class TaskToComputeConcentTestCase(testutils.TempDirFixture):
         self.msg.generate_ethsig(self.requestor_keys.raw_privkey)
         self.ethereum_config = EthereumConfig()
         self.msg.sign_all_promissory_notes(
-            deposit_contract_address=getattr(
-                self.ethereum_config, 'deposit_contract_address'),
+            deposit_contract_address=self.ethereum_config.
+            deposit_contract_address,
             private_key=self.requestor_keys.raw_privkey
         )
         self.msg.sign_message(self.requestor_keys.raw_privkey)  # noqa go home pylint, you're drunk pylint: disable=no-value-for-parameter
@@ -225,8 +225,8 @@ class TaskToComputeConcentTestCase(testutils.TempDirFixture):
 
     def test_bad_promissory_note_sig(self, send_mock, *_):
         self.msg.sign_promissory_note(
-            deposit_contract_address=getattr(
-                self.ethereum_config, 'deposit_contract_address'),
+            deposit_contract_address=self.ethereum_config.
+            deposit_contract_address,
             private_key=self.different_keys.raw_privkey
         )
         self.task_session._react_to_task_to_compute(self.msg)
@@ -237,8 +237,8 @@ class TaskToComputeConcentTestCase(testutils.TempDirFixture):
 
     def test_bad_concent_promissory_note_sig(self, send_mock, *_):
         self.msg.sign_concent_promissory_note(
-            deposit_contract_address=getattr(
-                self.ethereum_config, 'deposit_contract_address'),
+            deposit_contract_address=self.ethereum_config.
+            deposit_contract_address,
             private_key=self.different_keys.raw_privkey
         )
         self.task_session._react_to_task_to_compute(self.msg)

--- a/tests/golem/task/test_concent_logic.py
+++ b/tests/golem/task/test_concent_logic.py
@@ -60,9 +60,8 @@ class TaskToComputeConcentTestCase(testutils.TempDirFixture):
         self.msg.concent_enabled = True
         self.msg.want_to_compute_task.sign_message(self.keys.raw_privkey)  # noqa pylint: disable=no-member
         self.msg.generate_ethsig(self.requestor_keys.raw_privkey)
-        self.msg.sign_promissory_note(self.requestor_keys.raw_privkey)
         self.ethereum_config = EthereumConfig()
-        self.msg.sign_concent_promissory_note(
+        self.msg.sign_all_promissory_notes(
             deposit_contract_address=getattr(
                 self.ethereum_config, 'deposit_contract_address'),
             private_key=self.requestor_keys.raw_privkey
@@ -225,7 +224,11 @@ class TaskToComputeConcentTestCase(testutils.TempDirFixture):
         )
 
     def test_bad_promissory_note_sig(self, send_mock, *_):
-        self.msg.sign_promissory_note(self.different_keys.raw_privkey)
+        self.msg.sign_promissory_note(
+            deposit_contract_address=getattr(
+                self.ethereum_config, 'deposit_contract_address'),
+            private_key=self.different_keys.raw_privkey
+        )
         self.task_session._react_to_task_to_compute(self.msg)
         self.assert_rejected(
             send_mock,

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -330,12 +330,13 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
             ['resources_options', {'client_id': 'CLI1', 'version': 0.3,
                                    'options': {}}],
             ['promissory_note_sig',
-             ttc._get_promissory_note().sign(self.requestor_keys.raw_privkey)],
+             ttc._get_promissory_note(
+                 getattr(self.ethereum_config, 'deposit_contract_address')
+             ).sign(self.requestor_keys.raw_privkey)],
             ['concent_promissory_note_sig',
              ttc._get_concent_promissory_note(
                  getattr(self.ethereum_config, 'deposit_contract_address')
-             ).sign(
-                 self.requestor_keys.raw_privkey)],
+             ).sign(self.requestor_keys.raw_privkey)],
         ]
         self.assertCountEqual(ttc.slots(), expected)
 
@@ -346,7 +347,9 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
 
     def test_task_to_compute_promissory_notes(self):
         ttc, _, __, ___, ____ = self._fake_send_ttc()
-        self.assertTrue(ttc.verify_promissory_note())
+        self.assertTrue(ttc.verify_promissory_note(
+            getattr(self.ethereum_config, 'deposit_contract_address')
+        ))
         self.assertTrue(ttc.verify_concent_promissory_note(
             getattr(self.ethereum_config, 'deposit_contract_address')
         ))

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -331,11 +331,11 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
                                    'options': {}}],
             ['promissory_note_sig',
              ttc._get_promissory_note(
-                 getattr(self.ethereum_config, 'deposit_contract_address')
+                 self.ethereum_config.deposit_contract_address
              ).sign(self.requestor_keys.raw_privkey)],
             ['concent_promissory_note_sig',
              ttc._get_concent_promissory_note(
-                 getattr(self.ethereum_config, 'deposit_contract_address')
+                 self.ethereum_config.deposit_contract_address
              ).sign(self.requestor_keys.raw_privkey)],
         ]
         self.assertCountEqual(ttc.slots(), expected)
@@ -348,10 +348,10 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
     def test_task_to_compute_promissory_notes(self):
         ttc, _, __, ___, ____ = self._fake_send_ttc()
         self.assertTrue(ttc.verify_promissory_note(
-            getattr(self.ethereum_config, 'deposit_contract_address')
+            self.ethereum_config.deposit_contract_address
         ))
         self.assertTrue(ttc.verify_concent_promissory_note(
-            getattr(self.ethereum_config, 'deposit_contract_address')
+            self.ethereum_config.deposit_contract_address
         ))
 
 
@@ -606,7 +606,7 @@ class TestTaskSession(TaskSessionTestBase):
         self.assertIsInstance(srv, message.concents.SubtaskResultsVerify)
         self.assertEqual(srv.subtask_results_rejected, srr)
         self.assertTrue(srv.verify_concent_promissory_note(
-            getattr(self.ethereum_config, 'deposit_contract_address')
+            self.ethereum_config.deposit_contract_address
         ))
 
     @patch('golem.task.taskkeeper.ProviderStatsManager', Mock())


### PR DESCRIPTION
…h data)