### PR TITLE
Extract event loop from twisted.reactor

### DIFF
--- a/golem/decorators.py
+++ b/golem/decorators.py
@@ -6,20 +6,6 @@ from golem import model
 log = logging.getLogger('golem.decorators')
 
 
-def log_error(reraise=False):
-    def _curry(f):
-        @functools.wraps(f)
-        def _wrapper(*args, **kwargs):
-            try:
-                return f(*args, **kwargs)
-            except Exception:  # pylint: disable=broad-except
-                log.exception('Error in %r', f)
-                if reraise:
-                    raise
-        return _wrapper
-    return _curry
-
-
 def run_with_db():
     """Run only when DB is active"""
     def wrapped(f):

--- a/golem/monitor/monitor.py
+++ b/golem/monitor/monitor.py
@@ -12,7 +12,6 @@ from pydispatch import dispatcher
 
 from golem.core import golem_async
 from golem.core import variables
-from golem.decorators import log_error
 from golem.task.taskproviderstats import ProviderStats
 from golem.task.taskrequestorstats import CurrentStats, FinishedTasksStats, \
     AggregateTaskStats
@@ -90,7 +89,6 @@ class SystemMonitor(object):
 
     # pylint: disable=unused-argument
     @golem_async.taskify()
-    @log_error()
     async def dispatch_listener(
             self,
             sender,


### PR DESCRIPTION
AsyncIO event loop is created in `common.install_reactor()`
and can be extracted from `twisted.internet.reactor` when
needed (in threads).