### PR TITLE
Improvements in Localhost environment

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,6 +4,7 @@ certifi==2018.1.18
 chardet==3.0.4
 codecov==2.0.15
 coverage==4.5.1
+dill==0.3.0
 factory-boy==2.9.2
 Faker==0.8.9
 flake8==3.7.7

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ certifi==2018.1.18
 chardet==3.0.4
 codecov==2.0.15
 coverage==4.5.1
+dill==0.3.0
 factory-boy==2.9.2
 Faker==0.8.9
 flake8==3.7.7

--- a/requirements-test_to-freeze.txt
+++ b/requirements-test_to-freeze.txt
@@ -1,5 +1,6 @@
 aenum
 codecov
+dill
 factory-boy==2.9.2
 Faker==0.8.9
 flake8

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ eventlet==0.24.1
 fs==2.4.4
 Golem-Messages==3.11.0
 Golem-Smart-Contracts-Interface==1.10.2
-golem_task_api==0.12.0
+golem_task_api==0.13.0
 greenlet==0.4.15
 h2==3.0.1
 hpack==3.0.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -19,7 +19,7 @@ eth-utils==1.0.3
 ethereum==1.6.1
 Golem-Messages==3.11.0
 Golem-Smart-Contracts-Interface==1.10.2
-golem_task_api==0.12.0
+golem_task_api==0.13.0
 html2text==2018.1.9
 humanize==0.5.1
 incremental==17.5.0

--- a/tests/golem/envs/localhost.py
+++ b/tests/golem/envs/localhost.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
+import signal
+from multiprocessing import Process
 from pathlib import Path
-from threading import Thread
 from typing import Optional, Dict, Any, Tuple, List, Awaitable, Callable
 
 from dataclasses import dataclass, asdict
@@ -142,8 +143,8 @@ class LocalhostRuntime(RuntimeBase):
         self._work_dir = payload.shared_dir
         self._app_handler = LocalhostAppHandler(payload.prerequisites)
 
-        self._server_loop = asyncio.new_event_loop()
-        self._server_thread = Thread(target=self._spawn_server, daemon=False)
+        self._server_process = Process(target=self._spawn_server, daemon=True)
+        self._shutdown_deferred: Optional[defer.Deferred] = None
 
     def prepare(self) -> defer.Deferred:
         self._prepared()
@@ -154,35 +155,45 @@ class LocalhostRuntime(RuntimeBase):
         return defer.succeed(None)
 
     def _spawn_server(self) -> None:
-        asyncio.set_event_loop(self._server_loop)
+        server_loop = asyncio.new_event_loop()
+        server_loop.add_signal_handler(signal.SIGTERM, server_loop.stop)
+        asyncio.set_event_loop(server_loop)
+        server_loop.run_until_complete(entrypoint(
+            work_dir=self._work_dir,
+            argv=self._command.split(),
+            requestor_handler=self._app_handler,
+            provider_handler=self._app_handler
+        ))
+
+    def _wait_for_server_shutdown(self):
         try:
-            self._server_loop.run_until_complete(entrypoint(
-                work_dir=self._work_dir,
-                argv=self._command.split(),
-                requestor_handler=self._app_handler,
-                provider_handler=self._app_handler
-            ))
+            self._server_process.join()
+            exit_code = self._server_process.exitcode
+            if exit_code != 0:
+                raise RuntimeError(
+                    f'Server process exited with exit code {exit_code}')
         except Exception as e:  # pylint: disable=broad-except
             self._error_occurred(e, str(e))
         else:
             self._stopped()
 
     def start(self) -> defer.Deferred:
-        self._server_thread.start()
+        self._server_process.start()
+        self._shutdown_deferred = threads.deferToThread(
+            self._wait_for_server_shutdown)
         self._started()
         return defer.succeed(None)
 
     def stop(self) -> defer.Deferred:
-        assert self._server_loop is not None
-        assert self._server_thread is not None
         try:
-            # FIXME: This raises 'Cannot close a running event loop'
-            self._server_loop.call_soon_threadsafe(self._server_loop.stop)
-            self._server_loop.call_soon_threadsafe(self._server_loop.close)
+            self._server_process.terminate()
         except Exception:  # pylint: disable=broad-except
             return defer.fail()
+        return defer.succeed(None)
 
-        return threads.deferToThread(self._server_thread.join, timeout=10)
+    def wait_until_stopped(self) -> defer.Deferred:
+        assert self._shutdown_deferred is not None
+        return self._shutdown_deferred
 
     def stdin(self, encoding: Optional[str] = None) -> RuntimeInput:
         raise NotImplementedError

--- a/tests/golem/envs/test_localhost_env.py
+++ b/tests/golem/envs/test_localhost_env.py
@@ -47,13 +47,38 @@ class TestLocalhostEnv(TwistedTestCase):
             shared_dir=Path('whatever')
         )
 
-    # FIXME: https://github.com/golemfactory/golem/issues/4643
-    @unittest.skip('To be fixed')
     @inlineCallbacks
-    def test_compute(self):
-        prereq = LocalhostPrerequisites(
-            compute_results={'test_subtask': 'test_result'}
-        )
+    def test_compute_ok(self):
+        subtask_id = 'test_subtask'
+        subtask_params = {'param': 'value'}
+        result_path = 'test_result'
+
+        async def compute(given_id, given_params):
+            assert given_id == subtask_id
+            assert given_params == subtask_params
+            return result_path
+
+        prereq = LocalhostPrerequisites(compute=compute)
+        service = self._get_service(prereq)
+        client_future = asyncio.ensure_future(ProviderAppClient.create(service))
+        client = yield deferred_from_future(client_future)
+        compute_future = asyncio.ensure_future(client.compute(
+            task_id='test_task',
+            subtask_id=subtask_id,
+            subtask_params=subtask_params
+        ))
+        result = yield deferred_from_future(compute_future)
+        self.assertEqual(result, Path(result_path))
+
+    @unittest.skip('LocalhostRuntime.stop is not working properly')  # FIXME
+    @inlineCallbacks
+    def test_compute_interrupted(self):
+
+        async def compute(_, __):
+            await asyncio.sleep(10)
+            return ''
+
+        prereq = LocalhostPrerequisites(compute=compute)
         service = self._get_service(prereq)
         client_future = asyncio.ensure_future(ProviderAppClient.create(service))
         client = yield deferred_from_future(client_future)
@@ -62,31 +87,44 @@ class TestLocalhostEnv(TwistedTestCase):
             subtask_id='test_subtask',
             subtask_params={'param': 'value'}
         ))
-        result = yield deferred_from_future(compute_future)
-        self.assertEqual(result, Path('test_result'))
+        yield service._runtime.stop()  # pylint: disable=protected-access
+        with self.assertRaises(OSError):
+            yield deferred_from_future(compute_future)
 
-    # FIXME: https://github.com/golemfactory/golem/issues/4643
-    @unittest.skip('To be fixed')
     @inlineCallbacks
     def test_benchmark(self):
-        prereq = LocalhostPrerequisites(benchmark_result=21.37)
+        benchmark_result = 21.37
+
+        async def run_benchmark():
+            return benchmark_result
+
+        prereq = LocalhostPrerequisites(run_benchmark=run_benchmark)
         service = self._get_service(prereq)
         client_future = asyncio.ensure_future(ProviderAppClient.create(service))
         client = yield deferred_from_future(client_future)
         benchmark_future = asyncio.ensure_future(client.run_benchmark())
         result = yield deferred_from_future(benchmark_future)
-        self.assertAlmostEqual(result, 21.37, places=5)
+        self.assertAlmostEqual(result, benchmark_result, places=5)
 
-    # FIXME: https://github.com/golemfactory/golem/issues/4643
-    @unittest.skip('To be fixed')
     @inlineCallbacks
     def test_subtasks(self):
-        exp_subtask = Subtask(
+        subtask = Subtask(
             subtask_id='test_subtask',
             params={'param': 'value'},
             resources=['test_resource']
         )
-        prereq = LocalhostPrerequisites(subtasks=[exp_subtask])
+        subtasks = [subtask]
+
+        async def next_subtask():
+            return subtasks.pop(0)
+
+        async def has_pending_subtasks():
+            return bool(subtasks)
+
+        prereq = LocalhostPrerequisites(
+            next_subtask=next_subtask,
+            has_pending_subtasks=has_pending_subtasks
+        )
         service = self._get_service(prereq)
         client_future = asyncio.ensure_future(
             RequestorAppClient.create(service))
@@ -99,8 +137,8 @@ class TestLocalhostEnv(TwistedTestCase):
         self.assertTrue(pending_subtasks)
 
         subtask_future = asyncio.ensure_future(client.next_subtask('whatever'))
-        subtask = yield deferred_from_future(subtask_future)
-        self.assertEqual(subtask, exp_subtask)
+        result = yield deferred_from_future(subtask_future)
+        self.assertEqual(result, subtask)
 
         pending_subtasks_future = asyncio.ensure_future(
             client.has_pending_subtasks('whatever')
@@ -111,26 +149,30 @@ class TestLocalhostEnv(TwistedTestCase):
         shutdown_future = asyncio.ensure_future(client.shutdown())
         yield deferred_from_future(shutdown_future)
 
-    # FIXME: https://github.com/golemfactory/golem/issues/4643
-    @unittest.skip('To be fixed')
     @inlineCallbacks
     def test_verify(self):
-        prereq = LocalhostPrerequisites(verify_results={
-            'good_subtask': (True, None),
-            'bad_subtask': (False, 'test_error')
-        })
+        good_subtask_id = 'good_subtask'
+        bad_subtask_id = 'bad_subtask'
+
+        async def verify(subtask_id):
+            if subtask_id == good_subtask_id:
+                return True, None
+            elif subtask_id == bad_subtask_id:
+                return False, 'test_error'
+
+        prereq = LocalhostPrerequisites(verify=verify)
         service = self._get_service(prereq)
         client_future = asyncio.ensure_future(
             RequestorAppClient.create(service))
         client = yield deferred_from_future(client_future)
 
         good_verify_future = asyncio.ensure_future(
-            client.verify('test_task', 'good_subtask'))
+            client.verify('test_task', good_subtask_id))
         good_verify_result = yield deferred_from_future(good_verify_future)
         self.assertTrue(good_verify_result)
 
         bad_verify_future = asyncio.ensure_future(
-            client.verify('test_task', 'bad_subtask'))
+            client.verify('test_task', bad_subtask_id))
         bad_verify_result = yield deferred_from_future(bad_verify_future)
         self.assertFalse(bad_verify_result)
 

--- a/tests/golem/envs/test_localhost_env.py
+++ b/tests/golem/envs/test_localhost_env.py
@@ -1,5 +1,4 @@
 import asyncio
-import unittest
 from pathlib import Path
 
 from golem_task_api import (
@@ -8,6 +7,7 @@ from golem_task_api import (
     RequestorAppClient
 )
 from golem_task_api.structs import Subtask
+from grpclib.exceptions import StreamTerminatedError
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase as TwistedTestCase
 
@@ -70,12 +70,11 @@ class TestLocalhostEnv(TwistedTestCase):
         result = yield deferred_from_future(compute_future)
         self.assertEqual(result, Path(result_path))
 
-    @unittest.skip('LocalhostRuntime.stop is not working properly')  # FIXME
     @inlineCallbacks
     def test_compute_interrupted(self):
 
         async def compute(_, __):
-            await asyncio.sleep(10)
+            await asyncio.sleep(20)
             return ''
 
         prereq = LocalhostPrerequisites(compute=compute)
@@ -88,7 +87,7 @@ class TestLocalhostEnv(TwistedTestCase):
             subtask_params={'param': 'value'}
         ))
         yield service._runtime.stop()  # pylint: disable=protected-access
-        with self.assertRaises(OSError):
+        with self.assertRaises(StreamTerminatedError):
             yield deferred_from_future(compute_future)
 
     @inlineCallbacks

--- a/tests/golem/envs/test_localhost_env.py
+++ b/tests/golem/envs/test_localhost_env.py
@@ -87,7 +87,7 @@ class TestLocalhostEnv(TwistedTestCase):
             subtask_params={'param': 'value'}
         ))
         yield service._runtime.stop()  # pylint: disable=protected-access
-        with self.assertRaises(StreamTerminatedError):
+        with self.assertRaises((OSError, StreamTerminatedError)):
             yield deferred_from_future(compute_future)
 
     @inlineCallbacks


### PR DESCRIPTION
* `LocalhostPrerequisites` contain functions instead of return values because those were not flexible enough for more complicated test scenarios (e.g. timeouts, errors).
* Running GRPC server in a subprocess instead of a thread provides a great speed up and allows to implement proper `stop()`.