### PR TITLE
Updated Docker images to use base image 1.7

### DIFF
--- a/apps/blender/blenderenvironment.py
+++ b/apps/blender/blenderenvironment.py
@@ -9,7 +9,7 @@ from golem.environments.environment import SupportStatus, UnsupportReason
 
 class BlenderEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/blender"
-    DOCKER_TAG = "1.11"
+    DOCKER_TAG = "1.12"
     ENV_ID = "BLENDER"
     SHORT_DESCRIPTION = "Blender (www.blender.org)"
 
@@ -17,7 +17,7 @@ class BlenderEnvironment(DockerEnvironment):
 class BlenderNVGPUEnvironment(BlenderEnvironment):
 
     DOCKER_IMAGE = "golemfactory/blender_nvgpu"
-    DOCKER_TAG = "1.5"
+    DOCKER_TAG = "1.6"
     ENV_ID = "BLENDER_NVGPU"
     SHORT_DESCRIPTION = "Blender + NVIDIA GPU (www.blender.org)"
 

--- a/apps/blender/resources/images/blender.Dockerfile
+++ b/apps/blender/resources/images/blender.Dockerfile
@@ -2,7 +2,7 @@
 # Blender setup is based on
 # https://github.com/ikester/blender-docker/blob/master/Dockerfile
 
-FROM golemfactory/base:1.6
+FROM golemfactory/base:1.7
 
 MAINTAINER Golem Tech <tech@golem.network>
 

--- a/apps/blender/resources/images/blender_nvgpu.Dockerfile
+++ b/apps/blender/resources/images/blender_nvgpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM golemfactory/nvgpu:1.5
+FROM golemfactory/nvgpu:1.6
 
 # Contents of blender.Dockerfile
 

--- a/apps/blender/resources/images/blender_verifier.Dockerfile
+++ b/apps/blender/resources/images/blender_verifier.Dockerfile
@@ -1,4 +1,4 @@
-FROM golemfactory/blender:1.11
+FROM golemfactory/blender:1.12
 
 # Install scripts requirements first, then add scripts.
 ADD entrypoints/scripts/verifier_tools/requirements.txt /golem/work/

--- a/apps/core/resources/images/base.Dockerfile
+++ b/apps/core/resources/images/base.Dockerfile
@@ -2,7 +2,7 @@
 # Installs python and sets up directories for Golem tasks.
 
 FROM golang:1.12.7 as stats-builder
-RUN git clone https://github.com/golemfactory/docker-cgroups-stats.git /build
+RUN git clone --depth 1 --branch 0.1 https://github.com/golemfactory/docker-cgroups-stats.git /build
 WORKDIR /build
 RUN go build -o docker-cgroups-stats main.go
 

--- a/apps/core/resources/images/nvgpu.Dockerfile
+++ b/apps/core/resources/images/nvgpu.Dockerfile
@@ -2,7 +2,7 @@
 # Installs python and sets up directories for Golem tasks.
 
 FROM golang:1.12.7 as stats-builder
-RUN git clone https://github.com/golemfactory/docker-cgroups-stats.git /build
+RUN git clone --depth 1 --branch 0.1 https://github.com/golemfactory/docker-cgroups-stats.git /build
 WORKDIR /build
 RUN go build -o docker-cgroups-stats main.go
 

--- a/apps/dummy/dummyenvironment.py
+++ b/apps/dummy/dummyenvironment.py
@@ -3,7 +3,7 @@ from golem.docker.environment import DockerEnvironment
 
 class DummyTaskEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/dummy"
-    DOCKER_TAG = "1.3"
+    DOCKER_TAG = "1.4"
     ENV_ID = "DUMMYPOW"
     SHORT_DESCRIPTION = "Dummy task (example app calculating proof-of-work " \
                         "hash)"

--- a/apps/dummy/resources/images/Dockerfile
+++ b/apps/dummy/resources/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM golemfactory/base:1.6
+FROM golemfactory/base:1.7
 
 MAINTAINER Golem Tech <tech@golem.network>
 

--- a/apps/glambda/glambdaenvironment.py
+++ b/apps/glambda/glambdaenvironment.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class GLambdaTaskEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/glambda"
-    DOCKER_TAG = "1.6"
+    DOCKER_TAG = "1.7"
     ENV_ID = "glambda"
     SHORT_DESCRIPTION = "GLambda PoC"
 

--- a/apps/glambda/resources/images/Dockerfile
+++ b/apps/glambda/resources/images/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     make install && \
     chmod -R 757 ${RASPA_DIR}/
 
-FROM golemfactory/base:1.6
+FROM golemfactory/base:1.7
 ENV RASPA_DIR=/opt/RASPA
 
 RUN set -x \

--- a/apps/images.ini
+++ b/apps/images.ini
@@ -1,8 +1,8 @@
-golemfactory/base core/resources/images/base.Dockerfile 1.6 .
-golemfactory/nvgpu core/resources/images/nvgpu.Dockerfile 1.5 . apps.core.nvgpu.is_supported
-golemfactory/blender blender/resources/images/blender.Dockerfile 1.11 blender/resources/images/
-golemfactory/blender_verifier blender/resources/images/blender_verifier.Dockerfile 1.7 blender/resources/images/
-golemfactory/blender_nvgpu blender/resources/images/blender_nvgpu.Dockerfile 1.5 . apps.core.nvgpu.is_supported
-golemfactory/dummy dummy/resources/images/Dockerfile 1.3 dummy/resources/images
-golemfactory/wasm wasm/resources/images/Dockerfile 0.4.1 wasm/resources/images
-golemfactory/glambda glambda/resources/images/Dockerfile 1.6 .
+golemfactory/base core/resources/images/base.Dockerfile 1.7 .
+golemfactory/nvgpu core/resources/images/nvgpu.Dockerfile 1.6 . apps.core.nvgpu.is_supported
+golemfactory/blender blender/resources/images/blender.Dockerfile 1.12 blender/resources/images/
+golemfactory/blender_verifier blender/resources/images/blender_verifier.Dockerfile 1.8 blender/resources/images/
+golemfactory/blender_nvgpu blender/resources/images/blender_nvgpu.Dockerfile 1.6 . apps.core.nvgpu.is_supported
+golemfactory/dummy dummy/resources/images/Dockerfile 1.4 dummy/resources/images
+golemfactory/wasm wasm/resources/images/Dockerfile 0.5 wasm/resources/images
+golemfactory/glambda glambda/resources/images/Dockerfile 1.7 .

--- a/apps/wasm/environment.py
+++ b/apps/wasm/environment.py
@@ -3,6 +3,6 @@ from golem.docker.environment import DockerEnvironment
 
 class WasmTaskEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/wasm"
-    DOCKER_TAG = "0.4.1"
+    DOCKER_TAG = "0.5"
     ENV_ID = "WASM"
     SHORT_DESCRIPTION = "WASM Sandbox"

--- a/apps/wasm/resources/images/Dockerfile
+++ b/apps/wasm/resources/images/Dockerfile
@@ -12,7 +12,7 @@ ENV CXX=clang++-6.0
 RUN cargo install --path . --root /usr
 RUN cargo clean
 
-FROM golemfactory/base:1.6
+FROM golemfactory/base:1.7
 WORKDIR /
 COPY --from=builder /usr/bin/wasm-sandbox /
 COPY scripts/ /golem/scripts/

--- a/golem/verifier/blender_verifier.py
+++ b/golem/verifier/blender_verifier.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 # pylint: disable=R0902
 class BlenderVerifier(FrameRenderingVerifier):
     DOCKER_NAME = 'golemfactory/blender_verifier'
-    DOCKER_TAG = '1.7'
+    DOCKER_TAG = '1.8'
 
     def __init__(self, verification_data, docker_task_cls: Type) -> None:
         super().__init__(verification_data)

--- a/scripts/docker_integrity/image_integrity.ini
+++ b/scripts/docker_integrity/image_integrity.ini
@@ -3,11 +3,11 @@
 #
 # Hash is a result of docker inspect --format='{{index .Id}}' $IMAGE
 # repository                    tag                 hash
-golemfactory/base               1.6                 99fe698fea9b9e611b8e341d28923a6a2b9539289746dc2783c6491b6c3b0155
-golemfactory/blender            1.11                4b8f94b46569cbf85f9cd597626217709ff68685ddf3924564bf4374cec8803a
-golemfactory/blender_nvgpu      1.5                 6fbd8938f3bd567718905c196d33936629b4f5dc05ca0c9d664ea7b7cc6705b4
-golemfactory/blender_verifier   1.7                 e6ca9ec9ffc4230a0ffeae8d11c5a9b425f530000d22a9b044c247fd0b07ca75
-golemfactory/dummy              1.3                 a80a9769931c78896e5c4469ffc356cdfa121f10a7d7e9c5f46db4970b3654cd
-golemfactory/glambda            1.6                 3dc716953133ce136fea40b742cdf6598b7915f1366bdf6bed44bf324f711789
-golemfactory/nvgpu              1.5                 9570a8a2d5e3d45110e535bcd1e13206af73f902351555e52a7fc05ee82ff743
-golemfactory/wasm               0.4.1               340f748617f0d442a0b6d0ef18ef101478bef9c4b9cef256ce703c0cdcd9ced9
+golemfactory/base               1.7                 3dab93cb88094fdfc441399cf43767babcb7c0b36fc83490ee3561fbcc98b81c
+golemfactory/blender            1.12                9654677d197fd3fb2b4b344fad7b70775c3c4819fb8b50e42eaee261dda70aa4
+golemfactory/blender_nvgpu      1.6                 9b120257c9fa5f8736ad482f6bd42db7a5fadb04bbdf483521ed6b392d8178ba
+golemfactory/blender_verifier   1.8                 54c533b4d543d580e2d78f5725718434c03bad9ed4c8d9913f61b8da13b7fdba
+golemfactory/dummy              1.4                 70e9289a1abec564ce382eed328f385a75afbee549a376ece80e073a023e3138
+golemfactory/glambda            1.7                 8bde6311defcd5fab4a1f1eafa7496d5ca73a6f2a8cf26512412f19c5b6f09a7
+golemfactory/nvgpu              1.6                 820c20605d03bbe14b79048395ce23d6be3b150807f28a646ce1b26490e177c2
+golemfactory/wasm               0.5                 e4e6b8d2a51aa7ab3048d8dd0cd9e495438b97ca69a1a77e316746f59fbe2e1c


### PR DESCRIPTION
This was necessary to include changes made to the provider usage collection script. More specifically, the script now handles errors when cgroups are not available (relevant commit is [here](https://github.com/golemfactory/docker-cgroups-stats/commit/1b9ad42513c24355699198340ad62472f279663c)).