### PR TITLE
[P4] Transcoding: add option for stripping potentially problematic subtitle and data streams to transcoding task

### DIFF
--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
@@ -174,20 +174,27 @@ def do_replace(input_file,
                replacement_source,
                output_file,
                stream_type,
-               container=None):
+               container=None,
+               strip_unsupported_data_streams=False,
+               strip_unsupported_subtitle_streams=False):
 
     commands.replace_streams(
         input_file,
         replacement_source,
         output_file,
         stream_type,
-        container)
+        container,
+        strip_unsupported_data_streams,
+        strip_unsupported_subtitle_streams)
 
 
 def do_merge_and_replace(input_file,
                          chunks,
                          output_file,
-                         container=None):
+                         container=None,
+                         strip_unsupported_data_streams=False,
+                         strip_unsupported_subtitle_streams=False):
+
     output_basename = os.path.basename(output_file)
     [output_stem, output_extension] = os.path.splitext(output_basename)
 
@@ -201,7 +208,9 @@ def do_merge_and_replace(input_file,
         intermediate_file,
         output_file,
         'v',
-        container)
+        container,
+        strip_unsupported_data_streams,
+        strip_unsupported_subtitle_streams)
 
 
 def compute_metric(cmd, function):
@@ -264,13 +273,17 @@ def run_ffmpeg(params):
             params['replacement_source'],
             params['output_file'],
             params['stream_type'],
-            params.get('container'))
+            params.get('container'),
+            params.get('strip_unsupported_data_streams'),
+            params.get('strip_unsupported_subtitle_streams'))
     elif params['command'] == "merge-and-replace":
         do_merge_and_replace(
             params['input_file'],
             params['chunks'],
             params['output_file'],
-            params.get('container'))
+            params.get('container'),
+            params.get('strip_unsupported_data_streams'),
+            params.get('strip_unsupported_subtitle_streams'))
     elif params['command'] == "compute-metrics":
         compute_metrics(
             params["metrics_params"])

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -167,7 +167,10 @@ class StreamOperator:
                                         chunks_on_host,
                                         output_file_basename,
                                         task_dir,
-                                        container):
+                                        container,
+                                        strip_unsupported_data_streams=False,
+                                        strip_unsupported_subtitle_streams=
+                                        False):
 
         assert os.path.isdir(task_dir), \
             "Caller is responsible for ensuring that task dir exists."
@@ -192,6 +195,9 @@ class StreamOperator:
             'chunks': chunks_in_container,
             'output_file': container_files['out'],
             'container': container.value if container is not None else None,
+            'strip_unsupported_data_streams': strip_unsupported_data_streams,
+            'strip_unsupported_subtitle_streams':
+                strip_unsupported_subtitle_streams
         }
 
         logger.debug('Merge and replace params: %s', extra_data)

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -53,6 +53,8 @@ class TranscodingTaskOptions(Options):
         self.audio_params = TranscodingTaskOptions.AudioParams()
         self.input_stream_path = None
         self.output_container = None
+        self.strip_unsupported_data_streams = False
+        self.strip_unsupported_subtitle_streams = False
 
 
 class TranscodingTaskDefinition(TaskDefinition):
@@ -171,6 +173,8 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
             output_basename,
             self.task_dir,
             self.task_definition.options.output_container,
+            self.task_definition.options.strip_unsupported_data_streams,
+            self.task_definition.options.strip_unsupported_subtitle_streams,
         )
 
         # Move result to desired location.
@@ -291,6 +295,12 @@ class TranscodingTaskBuilder(CoreTaskBuilder):
             task_def.options.output_container = output_container
             task_def.options.audio_params = audio_params
             task_def.options.name = dictionary.get('name', '')
+            if 'strip_unsupported_data_streams' in options:
+                task_def.options.strip_unsupported_data_streams = options[
+                    'strip_unsupported_data_streams']
+            if 'strip_unsupported_subtitle_streams' in options:
+                task_def.options.strip_unsupported_subtitle_streams = options[
+                    'strip_unsupported_subtitle_streams']
 
             logger.debug(
                 'Transcoding task definition has been built [definition=%s]',

--- a/tests/apps/ffmpeg/task/test_ffmpegintegration.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegintegration.py
@@ -53,6 +53,8 @@ class TestFfmpegIntegration(FfmpegIntegrationBase):
             video_options=None,
             audio_options=None,
             subtasks_count=2,
+            strip_unsupported_data_streams=False,
+            strip_unsupported_subtitle_streams=False,
     ):
         task_def_for_transcoding = {
             'type': 'FFMPEG',
@@ -67,6 +69,10 @@ class TestFfmpegIntegration(FfmpegIntegrationBase):
                 'video': video_options if video_options is not None else {},
                 'audio': audio_options if audio_options is not None else {},
                 'container': container,
+                'strip_unsupported_data_streams':
+                    strip_unsupported_data_streams,
+                'strip_unsupported_subtitle_streams':
+                    strip_unsupported_subtitle_streams,
             }
         }
 

--- a/tests/apps/ffmpeg/task/test_ffmpegtask.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegtask.py
@@ -76,7 +76,9 @@ class TestffmpegTask(TempDirFixture):
                     'bit_rate': 18,
                     'codec': 'mp3'
                 },
-                'container': 'mp4'
+                'container': 'mp4',
+                'strip_unsupported_data_streams': False,
+                'strip_unsupported_subtitle_streams': False,
             }
         }
 

--- a/tests/apps/ffmpeg/task/utils/simulated_transcoding_operation.py
+++ b/tests/apps/ffmpeg/task/utils/simulated_transcoding_operation.py
@@ -42,6 +42,8 @@ class SimulatedTranscodingOperation:
         self._task_options: Dict[str, Any] = {
             'output_container': None,
             'subtasks_count': 2,
+            'strip_unsupported_data_streams': False,
+            'strip_unsupported_subtitle_streams': False,
         }
         self._ffprobe_report_set: Optional[FfprobeReportSet] = None
 
@@ -152,13 +154,14 @@ class SimulatedTranscodingOperation:
                         container: Union[Container, str],
                         video_options: Dict[str, str],
                         audio_options: Dict[str, str],
-                        subtasks_count: int) -> dict:
+                        subtasks_count: int,
+                        strip_unsupported_data_streams: bool,
+                        strip_unsupported_subtitle_streams: bool) -> dict:
 
         if isinstance(container, Container):
             container_str = container.value
         else:
             container_str = container
-
         return {
             'type': 'FFMPEG',
             'name': os.path.splitext(os.path.basename(result_file))[0],
@@ -172,6 +175,9 @@ class SimulatedTranscodingOperation:
                 'audio': audio_options if audio_options is not None else {},
                 'video': video_options if video_options is not None else {},
                 'container': container_str,
+                'strip_unsupported_subtitle_streams':
+                    strip_unsupported_subtitle_streams,
+                'strip_unsupported_data_streams': strip_unsupported_data_streams
             }
         }
 
@@ -235,6 +241,8 @@ class SimulatedTranscodingOperation:
                 self._video_options,
                 self._audio_options,
                 self._task_options['subtasks_count'],
+                self._task_options['strip_unsupported_data_streams'],
+                self._task_options['strip_unsupported_subtitle_streams'],
             )
 
             self._task_executor.execute_task(task_def)


### PR DESCRIPTION
This pull request adds two new prameters to the transcoding task. The parameters allow stripping `data`/`subtitle` streams not present on our whitelist from the video (https://github.com/golemfactory/ffmpeg-tools/pull/15).

The feature is disabled by default in the task because we're essentially stripping information that can be important to the user. In many cases, however, this information is not really critical and user most likely prefers it to be removed than his transcoding to fail so we're now giving him that option. 

### Dependencies
This pull request is based on #4638 and should be merged after it. This is just for ease or development - It does not really depend on that base pull request and could be merged without it if rebased.

The feature depends on changes added in https://github.com/golemfactory/ffmpeg-tools/pull/15. Tests won't pass until that pull request is merged.

**NOTE**: I have set the base branch of this pull request to `transcoding-task-p1-move-integration-tests-to-a-separate-file` (#4638) rather than `CGI/transcoding/master`. Please remember to change the base branch back to `CGI/transcoding/master` before you merge.