### PR TITLE
Use VideoCodec.can_convert() in transcoding tests

### DIFF
--- a/tests/apps/ffmpeg/task/test_ffmpegintegration_all_bundle_files.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegintegration_all_bundle_files.py
@@ -189,8 +189,7 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
         if not container.is_supported_video_codec(video_codec.value):
             pytest.skip("Target video codec not supported by the container")
 
-        supported_conversions = source_codec.get_supported_conversions()
-        if video_codec.value in supported_conversions:
+        if source_codec.can_convert(video_codec.value):
             (_input_report, _output_report, diff) = operation.run(
                 video["path"])
             self.assertEqual(diff, [])
@@ -243,8 +242,7 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
         if not video['container'].is_supported_video_codec(source_codec.value):
             pytest.skip("Target video codec not supported by the container")
 
-        supported_conversions = source_codec.get_supported_conversions()
-        if source_codec.value not in supported_conversions:
+        if source_codec.can_convert(source_codec.value):
             pytest.skip("Transcoding is not possible for this file without"
                         "also changing the video codec.")
 
@@ -297,8 +295,7 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
         if not video['container'].is_supported_video_codec(source_codec.value):
             pytest.skip("Target video codec not supported by the container")
 
-        supported_conversions = source_codec.get_supported_conversions()
-        if source_codec.value not in supported_conversions:
+        if source_codec.can_convert(source_codec.value):
             pytest.skip("Transcoding is not possible for this file without"
                         "also changing the video codec.")
 
@@ -351,8 +348,7 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
         if not video['container'].is_supported_video_codec(source_codec.value):
             pytest.skip("Target video codec not supported by the container")
 
-        supported_conversions = source_codec.get_supported_conversions()
-        if source_codec.value not in supported_conversions:
+        if source_codec.can_convert(source_codec.value):
             pytest.skip("Transcoding is not possible for this file without"
                         "also changing the video codec.")
 


### PR DESCRIPTION
A simple change requested in https://github.com/golemfactory/golem/pull/4515#discussion_r306383774. Makes transcoding tests use `VideoCodec.can_convert()` added in https://github.com/golemfactory/ffmpeg-tools/pull/16.

### Dependencies
This pull request is based on #4639 and should be merged after it. This is just for ease or development - It does not really depend on that base pull request and could be easily rebased on master.

For the code to work you also need a `golemfactory/ffmpeg-experimental` image built with https://github.com/golemfactory/ffmpeg-tools/pull/16. Tests in the CI won't pass until it's released on DockerHub.

**NOTE**: I have set the base branch of this pull request to `transcoding-task-p3-p4-skip-streams-which-are-not-supported-by-other-containers` (#4639) rather than `CGI/transcoding/master`. Please remember to change the base branch back to `CGI/transcoding/master` before you merge.