### PR TITLE
Create Task API directories before computing the task

### DIFF
--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -297,6 +297,7 @@ class NewTaskComputer:
             deadline=min(task_header.deadline, compute_task_def['deadline'])
         )
         ProviderTimer.start()
+        self.get_task_resources_dir().mkdir(parents=True, exist_ok=True)
 
     def compute(self) -> defer.Deferred:
         assigned_task = self._assigned_task

--- a/tests/golem/task/test_newtaskcomputer.py
+++ b/tests/golem/task/test_newtaskcomputer.py
@@ -17,15 +17,17 @@ from golem.envs import Runtime
 from golem.envs.docker.cpu import DockerCPUEnvironment, DockerCPUConfig
 from golem.task.envmanager import EnvironmentManager
 from golem.task.taskcomputer import NewTaskComputer
+from golem.testutils import TempDirFixture
 from golem.tools.testwithreactor import uninstall_reactor
 
 
-class NewTaskComputerTestBase(TwistedTestCase):
+class NewTaskComputerTestBase(TwistedTestCase, TempDirFixture):
 
     def setUp(self):
+        super().setUp()
         self.env_manager = mock.Mock(spec=EnvironmentManager)
         self.stats_keeper = mock.Mock(spec=IntStatsKeeper)
-        self.work_dir = Path('test')
+        self.work_dir = self.new_path
         self.task_computer = NewTaskComputer(
             env_manager=self.env_manager,
             work_dir=self.work_dir,
@@ -140,6 +142,7 @@ class TestTaskGiven(NewTaskComputerTestBase):
             self.task_computer.get_current_computing_env(),
             self.env_id)
         provider_timer.start.assert_called_once_with()
+        self.assertTrue(self.task_computer.get_task_resources_dir().exists())
 
     def test_has_assigned_task(self, provider_timer):
         task_header = self._get_task_header()


### PR DESCRIPTION
They should exist before we start computing the task.