### PR TITLE
Make RequestedTaskManager tests use asyncio over Twisted

### DIFF
--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -176,3 +176,117 @@ def async_test(coro):
         loop = asyncio.new_event_loop()
         return loop.run_until_complete(coro(*args, **kwargs))
     return wrapper
+
+
+class AsyncTempDirFixture():
+    root_dir = None
+
+    @classmethod
+    def setup_class(cls):
+        logging.basicConfig(level=logging.DEBUG)
+        if cls.root_dir is None:
+            if is_osx():
+                # Use Golem's working directory in ~/Library/Application Support
+                # to avoid issues with mounting directories in Docker containers
+                cls.root_dir = os.path.join(get_local_datadir('tests'))
+                os.makedirs(cls.root_dir, exist_ok=True)
+            elif is_windows():
+                import win32api  # noqa pylint: disable=import-error
+                base_dir = get_local_datadir('default')
+                cls.root_dir = os.path.join(base_dir, 'ComputerRes', 'tests')
+                os.makedirs(cls.root_dir, exist_ok=True)
+                cls.root_dir = win32api.GetLongPathName(cls.root_dir)
+            else:
+                # Select nice root temp dir exactly once.
+                cls.root_dir = tempfile.mkdtemp(prefix='golem-tests-')
+
+    # Concurrent tests will fail
+    # @classmethod
+    # def tearDownClass(cls):
+    #     if os.path.exists(cls.root_dir):
+    #         shutil.rmtree(cls.root_dir)
+
+    def setup_method(self, method):
+
+        # KeysAuth uses it. Default val (250k+) slows down the tests terribly
+        ethereum.keys.PBKDF2_CONSTANTS['c'] = 1
+        prefix = method.__name__
+        self.tempdir = tempfile.mkdtemp(prefix=prefix, dir=self.root_dir)
+        self.path = self.tempdir  # Alias for legacy tests
+        if not is_windows():
+            os.chmod(self.tempdir, 0o770)
+        self.new_path = Path(self.path)
+
+    def teardown_method(self):
+        # Firstly kill Ethereum node to clean up after it later on.
+        try:
+            self.__remove_files()
+        except OSError as e:
+            logger.debug("%r", e, exc_info=True)
+            tree = ''
+            for path, _dirs, files in os.walk(self.path):
+                tree += path + '\n'
+                for f in files:
+                    tree += f + '\n'
+            logger.error("Failed to remove files %r", tree)
+            # Tie up loose ends.
+            import gc
+            gc.collect()
+            # On windows there's sometimes a problem with syncing all threads.
+            # Try again after 3 seconds
+            sleep(3)
+            self.__remove_files()
+
+    def temp_file_name(self, name: str) -> str:
+        return os.path.join(self.tempdir, name)
+
+    def additional_dir_content(self, file_num_list, dir_=None, results=None,
+                               sub_dir=None):
+        """
+        Create recursively additional temporary files in directories in given
+        directory.
+        For example file_num_list in format [5, [2], [4, []]] will create
+        5 files in self.tempdir directory, and 2 subdirectories - first one will
+        contain 2 tempfiles, second will contain 4 tempfiles and an empty
+        subdirectory.
+        :param file_num_list: list containing number of new files that should
+            be created in this directory or list describing file_num_list for
+            new inner directories
+        :param dir_: directory in which files should be created
+        :param results: list of created temporary files
+        :return:
+        """
+        if dir_ is None:
+            dir_ = self.tempdir
+        if sub_dir:
+            dir_ = os.path.join(dir_, sub_dir)
+            if not os.path.exists(dir_):
+                os.makedirs(dir_)
+        if results is None:
+            results = []
+        for el in file_num_list:
+            if isinstance(el, int):
+                for _ in range(el):
+                    t = tempfile.NamedTemporaryFile(dir=dir_, delete=False)
+                    results.append(t.name)
+            else:
+                new_dir = tempfile.mkdtemp(dir=dir_)
+                self.additional_dir_content(el, new_dir, results)
+        return results
+
+    def __remove_files(self):
+        if os.path.isdir(self.tempdir):
+            shutil.rmtree(self.tempdir)
+
+
+class AsyncDatabaseFixture(AsyncTempDirFixture):
+    """ Setups temporary database for tests."""
+
+    def setup_method(self, method):
+        super().setup_method(method)
+        self.database = Database(db, fields=DB_FIELDS, models=DB_MODELS,
+                                 db_dir=self.tempdir)
+
+    def teardown_method(self):
+        self.database.db.close()
+        super().teardown_method()

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -182,8 +182,12 @@ class AsyncDatabaseFixture():
     """ Setups temporary database for tests."""
 
     def setup_method(self, tmpdir):
-        self.database = Database(db, fields=DB_FIELDS, models=DB_MODELS,
-                                 db_dir=tmpdir)
+        self.database = Database(
+            db,
+            fields=DB_FIELDS,
+            models=DB_MODELS,
+            db_dir=tmpdir
+        )
 
     def teardown_method(self):
         self.database.db.close()

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -10,6 +10,7 @@ from time import sleep
 
 import ethereum.keys
 import pycodestyle
+import pytest
 
 from golem.core.common import get_golem_path, is_windows, is_osx
 from golem.core.simpleenv import get_local_datadir
@@ -178,16 +179,13 @@ def async_test(coro):
     return wrapper
 
 
-class AsyncDatabaseFixture():
-    """ Setups temporary database for tests."""
-
-    def setup_method(self, tmpdir):
-        self.database = Database(
-            db,
-            fields=DB_FIELDS,
-            models=DB_MODELS,
-            db_dir=tmpdir
-        )
-
-    def teardown_method(self):
-        self.database.db.close()
+@pytest.fixture
+def pytest_database_fixture(tmpdir):
+    database = Database(
+        db,
+        fields=DB_FIELDS,
+        models=DB_MODELS,
+        db_dir=tmpdir
+    )
+    yield database
+    database.db.close()

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -178,115 +178,12 @@ def async_test(coro):
     return wrapper
 
 
-class AsyncTempDirFixture():
-    root_dir = None
-
-    @classmethod
-    def setup_class(cls):
-        logging.basicConfig(level=logging.DEBUG)
-        if cls.root_dir is None:
-            if is_osx():
-                # Use Golem's working directory in ~/Library/Application Support
-                # to avoid issues with mounting directories in Docker containers
-                cls.root_dir = os.path.join(get_local_datadir('tests'))
-                os.makedirs(cls.root_dir, exist_ok=True)
-            elif is_windows():
-                import win32api  # noqa pylint: disable=import-error
-                base_dir = get_local_datadir('default')
-                cls.root_dir = os.path.join(base_dir, 'ComputerRes', 'tests')
-                os.makedirs(cls.root_dir, exist_ok=True)
-                cls.root_dir = win32api.GetLongPathName(cls.root_dir)
-            else:
-                # Select nice root temp dir exactly once.
-                cls.root_dir = tempfile.mkdtemp(prefix='golem-tests-')
-
-    # Concurrent tests will fail
-    # @classmethod
-    # def tearDownClass(cls):
-    #     if os.path.exists(cls.root_dir):
-    #         shutil.rmtree(cls.root_dir)
-
-    def setup_method(self, method):
-
-        # KeysAuth uses it. Default val (250k+) slows down the tests terribly
-        ethereum.keys.PBKDF2_CONSTANTS['c'] = 1
-        prefix = method.__name__
-        self.tempdir = tempfile.mkdtemp(prefix=prefix, dir=self.root_dir)
-        self.path = self.tempdir  # Alias for legacy tests
-        if not is_windows():
-            os.chmod(self.tempdir, 0o770)
-        self.new_path = Path(self.path)
-
-    def teardown_method(self):
-        # Firstly kill Ethereum node to clean up after it later on.
-        try:
-            self.__remove_files()
-        except OSError as e:
-            logger.debug("%r", e, exc_info=True)
-            tree = ''
-            for path, _dirs, files in os.walk(self.path):
-                tree += path + '\n'
-                for f in files:
-                    tree += f + '\n'
-            logger.error("Failed to remove files %r", tree)
-            # Tie up loose ends.
-            import gc
-            gc.collect()
-            # On windows there's sometimes a problem with syncing all threads.
-            # Try again after 3 seconds
-            sleep(3)
-            self.__remove_files()
-
-    def temp_file_name(self, name: str) -> str:
-        return os.path.join(self.tempdir, name)
-
-    def additional_dir_content(self, file_num_list, dir_=None, results=None,
-                               sub_dir=None):
-        """
-        Create recursively additional temporary files in directories in given
-        directory.
-        For example file_num_list in format [5, [2], [4, []]] will create
-        5 files in self.tempdir directory, and 2 subdirectories - first one will
-        contain 2 tempfiles, second will contain 4 tempfiles and an empty
-        subdirectory.
-        :param file_num_list: list containing number of new files that should
-            be created in this directory or list describing file_num_list for
-            new inner directories
-        :param dir_: directory in which files should be created
-        :param results: list of created temporary files
-        :return:
-        """
-        if dir_ is None:
-            dir_ = self.tempdir
-        if sub_dir:
-            dir_ = os.path.join(dir_, sub_dir)
-            if not os.path.exists(dir_):
-                os.makedirs(dir_)
-        if results is None:
-            results = []
-        for el in file_num_list:
-            if isinstance(el, int):
-                for _ in range(el):
-                    t = tempfile.NamedTemporaryFile(dir=dir_, delete=False)
-                    results.append(t.name)
-            else:
-                new_dir = tempfile.mkdtemp(dir=dir_)
-                self.additional_dir_content(el, new_dir, results)
-        return results
-
-    def __remove_files(self):
-        if os.path.isdir(self.tempdir):
-            shutil.rmtree(self.tempdir)
-
-
-class AsyncDatabaseFixture(AsyncTempDirFixture):
+class AsyncDatabaseFixture():
     """ Setups temporary database for tests."""
 
-    def setup_method(self, method):
-        super().setup_method(method)
+    def setup_method(self, tmp_path):
         self.database = Database(db, fields=DB_FIELDS, models=DB_MODELS,
-                                 db_dir=self.tempdir)
+                                 db_dir=str(tmp_path))
 
     def teardown_method(self):
         self.database.db.close()
-        super().teardown_method()

--- a/golem/testutils.py
+++ b/golem/testutils.py
@@ -181,9 +181,9 @@ def async_test(coro):
 class AsyncDatabaseFixture():
     """ Setups temporary database for tests."""
 
-    def setup_method(self, tmp_path):
+    def setup_method(self, tmpdir):
         self.database = Database(db, fields=DB_FIELDS, models=DB_MODELS,
-                                 db_dir=str(tmp_path))
+                                 db_dir=tmpdir)
 
     def teardown_method(self):
         self.database.db.close()

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -22,7 +22,7 @@ pylint==1.9.2
 pytest-asyncio==0.10.0
 pytest-cov==2.5.1
 pytest-timeout==1.2.1
-pytest==5.1.2
+pytest==3.6.3
 python-dateutil==2.7.2
 requests==2.21.0
 six==1.12.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -22,7 +22,7 @@ pylint==1.9.2
 pytest-asyncio==0.10.0
 pytest-cov==2.5.1
 pytest-timeout==1.2.1
-pytest==3.6.3
+pytest==5.1.2
 python-dateutil==2.7.2
 requests==2.21.0
 six==1.12.0

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -19,6 +19,7 @@ py==1.5.3
 pycodestyle==2.5.0
 pyflakes==2.1.1
 pylint==1.9.2
+pytest-asyncio==0.10.0
 pytest-cov==2.5.1
 pytest-timeout==1.2.1
 pytest==3.6.3

--- a/requirements-test_to-freeze.txt
+++ b/requirements-test_to-freeze.txt
@@ -9,6 +9,6 @@ pylint==1.9.2
 pytest-asyncio
 pytest-cov
 pytest-timeout==1.2.1
-pytest==3.6.3
+pytest==5.1.2
 requests==2.21.0
 urllib3==1.24.3

--- a/requirements-test_to-freeze.txt
+++ b/requirements-test_to-freeze.txt
@@ -9,6 +9,6 @@ pylint==1.9.2
 pytest-asyncio
 pytest-cov
 pytest-timeout==1.2.1
-pytest==5.1.2
+pytest==3.6.3
 requests==2.21.0
 urllib3==1.24.3

--- a/requirements-test_to-freeze.txt
+++ b/requirements-test_to-freeze.txt
@@ -6,6 +6,7 @@ Faker==0.8.9
 flake8
 freezegun==0.3.11
 pylint==1.9.2
+pytest-asyncio
 pytest-cov
 pytest-timeout==1.2.1
 pytest==3.6.3

--- a/tests/golem/task/test_requestedtaskmanager.py
+++ b/tests/golem/task/test_requestedtaskmanager.py
@@ -3,7 +3,7 @@ import asyncio
 from freezegun import freeze_time
 from golem_task_api.client import RequestorAppClient
 from golem_task_api.structs import Subtask
-from mock import Mock, patch, MagicMock
+from mock import Mock, MagicMock
 import pytest
 
 from golem.app_manager import AppManager
@@ -26,16 +26,21 @@ class AsyncMock(MagicMock):
 
 class TestRequestedTaskManager(AsyncDatabaseFixture):
 
-    def setup_method(self, method):
-        super().setup_method(method)
+    @pytest.fixture(autouse=True)
+    def setup_method(self, tmp_path):
+        super().setup_method(tmp_path)
+        self.tmp_path = tmp_path
+
         self.env_manager = Mock(spec=EnvironmentManager)
         self.app_manager = Mock(spec=AppManager)
         self.public_key = str.encode('0xdeadbeef')
+        self.rtm_path = self.tmp_path / 'rtm'
+        self.rtm_path.mkdir()
         self.rtm = RequestedTaskManager(
             env_manager=self.env_manager,
             app_manager=self.app_manager,
             public_key=self.public_key,
-            root_path=self.new_path
+            root_path=self.rtm_path
         )
 
     def test_create_task(self):
@@ -50,7 +55,7 @@ class TestRequestedTaskManager(AsyncDatabaseFixture):
             row = RequestedTask.get(RequestedTask.task_id == task_id)
             assert row.status == TaskStatus.creating
             assert row.start_time < default_now()
-            assert (self.new_path / golem_params.app_id / task_id).exists()
+            assert (self.rtm_path / golem_params.app_id / task_id).exists()
 
     @pytest.mark.asyncio
     async def test_init_task(self, monkeypatch):
@@ -237,7 +242,7 @@ class TestRequestedTaskManager(AsyncDatabaseFixture):
             name='a',
             task_timeout=1,
             subtask_timeout=1,
-            output_directory=self.new_path / 'output',
+            output_directory=self.tmp_path / 'output',
             resources=[],
             max_subtasks=1,
             max_price_per_hour=1,

--- a/tests/golem/task/test_requestedtaskmanager.py
+++ b/tests/golem/task/test_requestedtaskmanager.py
@@ -1,4 +1,5 @@
 import asyncio
+from pathlib import Path
 
 from freezegun import freeze_time
 from golem_task_api.client import RequestorAppClient
@@ -27,9 +28,10 @@ class AsyncMock(MagicMock):
 class TestRequestedTaskManager(AsyncDatabaseFixture):
 
     @pytest.fixture(autouse=True)
-    def setup_method(self, tmp_path):
-        super().setup_method(tmp_path)
-        self.tmp_path = tmp_path
+    def setup_method(self, tmpdir):
+        super().setup_method(tmpdir)
+        # TODO: Replace with tmp_path when pytest is updated to 5.x
+        self.tmp_path = Path(tmpdir)
 
         self.env_manager = Mock(spec=EnvironmentManager)
         self.app_manager = Mock(spec=AppManager)

--- a/tests/golem/task/test_requestedtaskmanager.py
+++ b/tests/golem/task/test_requestedtaskmanager.py
@@ -264,7 +264,7 @@ class TestRequestedTaskManager():
         return task_id
 
     @staticmethod
-    def _add_next_subtask_to_client_mock(_mock_client):
+    def _add_next_subtask_to_client_mock(client_mock):
         result = Subtask(subtask_id='', params={}, resources=[])
-        _mock_client.next_subtask.return_value = result
-        _mock_client.has_pending_subtasks.return_value = True
+        client_mock.next_subtask.return_value = result
+        client_mock.has_pending_subtasks.return_value = True

--- a/tests/golem/task/test_requestedtaskmanager.py
+++ b/tests/golem/task/test_requestedtaskmanager.py
@@ -20,7 +20,7 @@ from golem.task.requestedtaskmanager import (
     ComputingNodeDefinition,
 )
 from golem.task.taskstate import TaskStatus, SubtaskStatus
-from golem.testutils import AsyncDatabaseFixture
+from golem.testutils import pytest_database_fixture  # noqa pylint: disable=unused-import
 
 
 class AsyncMock(MagicMock):
@@ -40,11 +40,11 @@ def mock_client(monkeypatch):
     return _mock_client
 
 
-class TestRequestedTaskManager(AsyncDatabaseFixture):
+@pytest.mark.usefixtures('pytest_database_fixture')
+class TestRequestedTaskManager():
 
     @pytest.fixture(autouse=True)
     def setup_method(self, tmpdir):
-        super().setup_method(tmpdir)
         # TODO: Replace with tmp_path when pytest is updated to 5.x
         self.tmp_path = Path(tmpdir)
 
@@ -77,8 +77,6 @@ class TestRequestedTaskManager(AsyncDatabaseFixture):
     @pytest.mark.asyncio
     async def test_init_task(self, mock_client):
         # given
-        # mock_client = self._mock_client_create()
-
         task_id = self._create_task()
         # when
         await self.rtm.init_task(task_id)
@@ -96,7 +94,6 @@ class TestRequestedTaskManager(AsyncDatabaseFixture):
     @pytest.mark.asyncio
     async def test_init_task_wrong_status(self):
         # given
-
         task_id = self._create_task()
         # when
         await self.rtm.init_task(task_id)


### PR DESCRIPTION
This cleanup PR is from all leftover comments from #4632

~in progress~

~Change base to develop after the other PR is merged~

- [x] Make `DatabaseFixture` independent of `unittest.TestCase`
- [x] Remove all Twisted logic from `test_requestedtaskmanager.py`
- [x] Remove all TestCase logic from `test_requestedtaskmanager.py`
  - [x] `assert`
  - [x] `addCleanup(`
- [x] Bonus: use `pytest`'s `tmpdir` fixture for the temporary directory
- [x] Bonus: Use mocks like: https://github.com/golemfactory/golem/pull/4632#discussion_r318147420 or https://stackoverflow.com/questions/32480108/mocking-async-call-in-python-3-5
 - [x] Bonus: try to just use async_test decorator like https://github.com/golemfactory/golem/blob/develop/tests/golem/task/task_api/test_task_api_service.py#L39