### PR TITLE
Use multiprocessing in LocalhostEnvironment

### DIFF
--- a/requirements-lint.txt
+++ b/requirements-lint.txt
@@ -4,6 +4,7 @@ certifi==2018.1.18
 chardet==3.0.4
 codecov==2.0.15
 coverage==4.5.1
+dill==0.3.0
 factory-boy==2.9.2
 Faker==0.8.9
 flake8==3.7.7

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -5,6 +5,7 @@ certifi==2018.1.18
 chardet==3.0.4
 codecov==2.0.15
 coverage==4.5.1
+dill==0.3.0
 factory-boy==2.9.2
 Faker==0.8.9
 flake8==3.7.7

--- a/requirements-test_to-freeze.txt
+++ b/requirements-test_to-freeze.txt
@@ -1,5 +1,6 @@
 aenum
 codecov
+dill
 factory-boy==2.9.2
 Faker==0.8.9
 flake8

--- a/tests/golem/envs/localhost.py
+++ b/tests/golem/envs/localhost.py
@@ -1,7 +1,8 @@
 import asyncio
 import logging
+import signal
+from multiprocessing import Process
 from pathlib import Path
-from threading import Thread
 from typing import Optional, Dict, Any, Tuple, List, Awaitable, Callable
 
 from dataclasses import dataclass, asdict
@@ -142,8 +143,8 @@ class LocalhostRuntime(RuntimeBase):
         self._work_dir = payload.shared_dir
         self._app_handler = LocalhostAppHandler(payload.prerequisites)
 
-        self._server_loop = asyncio.new_event_loop()
-        self._server_thread = Thread(target=self._spawn_server, daemon=False)
+        self._server_process = Process(target=self._spawn_server, daemon=True)
+        self._shutdown_deferred: Optional[defer.Deferred] = None
 
     def prepare(self) -> defer.Deferred:
         self._prepared()
@@ -154,35 +155,45 @@ class LocalhostRuntime(RuntimeBase):
         return defer.succeed(None)
 
     def _spawn_server(self) -> None:
-        asyncio.set_event_loop(self._server_loop)
+        server_loop = asyncio.new_event_loop()
+        server_loop.add_signal_handler(signal.SIGTERM, server_loop.stop)
+        asyncio.set_event_loop(server_loop)
+        server_loop.run_until_complete(entrypoint(
+            work_dir=self._work_dir,
+            argv=self._command.split(),
+            requestor_handler=self._app_handler,
+            provider_handler=self._app_handler
+        ))
+
+    def _wait_for_server_shutdown(self):
         try:
-            self._server_loop.run_until_complete(entrypoint(
-                work_dir=self._work_dir,
-                argv=self._command.split(),
-                requestor_handler=self._app_handler,
-                provider_handler=self._app_handler
-            ))
+            self._server_process.join()
+            exit_code = self._server_process.exitcode
+            if exit_code != 0:
+                raise RuntimeError(
+                    f'Server process exited with exit code {exit_code}')
         except Exception as e:  # pylint: disable=broad-except
             self._error_occurred(e, str(e))
         else:
             self._stopped()
 
     def start(self) -> defer.Deferred:
-        self._server_thread.start()
+        self._server_process.start()
+        self._shutdown_deferred = threads.deferToThread(
+            self._wait_for_server_shutdown)
         self._started()
         return defer.succeed(None)
 
     def stop(self) -> defer.Deferred:
-        assert self._server_loop is not None
-        assert self._server_thread is not None
         try:
-            # FIXME: This raises 'Cannot close a running event loop'
-            self._server_loop.call_soon_threadsafe(self._server_loop.stop)
-            self._server_loop.call_soon_threadsafe(self._server_loop.close)
+            self._server_process.terminate()
         except Exception:  # pylint: disable=broad-except
             return defer.fail()
+        return defer.succeed(None)
 
-        return threads.deferToThread(self._server_thread.join, timeout=10)
+    def wait_until_stopped(self) -> defer.Deferred:
+        assert self._shutdown_deferred is not None
+        return self._shutdown_deferred
 
     def stdin(self, encoding: Optional[str] = None) -> RuntimeInput:
         raise NotImplementedError

--- a/tests/golem/envs/test_localhost_env.py
+++ b/tests/golem/envs/test_localhost_env.py
@@ -1,5 +1,4 @@
 import asyncio
-import unittest
 from pathlib import Path
 
 from golem_task_api import (
@@ -8,6 +7,7 @@ from golem_task_api import (
     RequestorAppClient
 )
 from golem_task_api.structs import Subtask
+from grpclib.exceptions import StreamTerminatedError
 from twisted.internet.defer import inlineCallbacks
 from twisted.trial.unittest import TestCase as TwistedTestCase
 
@@ -70,12 +70,11 @@ class TestLocalhostEnv(TwistedTestCase):
         result = yield deferred_from_future(compute_future)
         self.assertEqual(result, Path(result_path))
 
-    @unittest.skip('LocalhostRuntime.stop is not working properly')  # FIXME
     @inlineCallbacks
     def test_compute_interrupted(self):
 
         async def compute(_, __):
-            await asyncio.sleep(10)
+            await asyncio.sleep(20)
             return ''
 
         prereq = LocalhostPrerequisites(compute=compute)
@@ -88,7 +87,7 @@ class TestLocalhostEnv(TwistedTestCase):
             subtask_params={'param': 'value'}
         ))
         yield service._runtime.stop()  # pylint: disable=protected-access
-        with self.assertRaises(OSError):
+        with self.assertRaises(StreamTerminatedError):
             yield deferred_from_future(compute_future)
 
     @inlineCallbacks

--- a/tests/golem/envs/test_localhost_env.py
+++ b/tests/golem/envs/test_localhost_env.py
@@ -87,7 +87,7 @@ class TestLocalhostEnv(TwistedTestCase):
             subtask_params={'param': 'value'}
         ))
         yield service._runtime.stop()  # pylint: disable=protected-access
-        with self.assertRaises(StreamTerminatedError):
+        with self.assertRaises((OSError, StreamTerminatedError)):
             yield deferred_from_future(compute_future)
 
     @inlineCallbacks


### PR DESCRIPTION
Running GRPC server in a subprocess instead of a thread provides a great speed up and allows to implement proper stop().