### PR TITLE
Upgrade to Task API v 0.13.0

### DIFF
--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -118,12 +118,12 @@ class TaskComputerAdapter:
     def support_direct_computation(self, value: bool) -> None:
         self._old_computer.support_direct_computation = value
 
-    def get_task_resources_dir(self) -> Path:
+    def get_subtask_inputs_dir(self) -> Path:
         if not self._new_computer.has_assigned_task():
             raise ValueError(
                 'Task resources directory only available when a task-api task '
                 'is assigned')
-        return self._new_computer.get_task_resources_dir()
+        return self._new_computer.get_subtask_inputs_dir()
 
     def start_computation(self) -> None:
         if self._new_computer.has_assigned_task():
@@ -260,8 +260,8 @@ class NewTaskComputer:
             return None
         return self._assigned_task.subtask_id
 
-    def get_task_resources_dir(self) -> Path:
-        return self._get_task_dir() / task_api_constants.NETWORK_RESOURCES_DIR
+    def get_subtask_inputs_dir(self) -> Path:
+        return self._get_task_dir() / task_api_constants.SUBTASK_INPUTS_DIR
 
     def _is_computing(self) -> bool:
         return self._computation is not None
@@ -283,7 +283,7 @@ class NewTaskComputer:
             deadline=min(task_header.deadline, compute_task_def['deadline'])
         )
         ProviderTimer.start()
-        self.get_task_resources_dir().mkdir(parents=True, exist_ok=True)
+        self.get_subtask_inputs_dir().mkdir(parents=True, exist_ok=True)
 
     def compute(self) -> defer.Deferred:
         assigned_task = self._assigned_task

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -465,7 +465,7 @@ class TaskServer(
             for resource_id in msg.compute_task_def['resources']:
                 deferreds.append(self.new_resource_manager.download(
                     resource_id,
-                    self.task_computer.get_task_resources_dir(),
+                    self.task_computer.get_subtask_inputs_dir(),
                     msg.resources_options,
                 ))
             defer.gatherResults(deferreds, consumeErrors=True)\

--- a/tests/golem/task/test_newtaskcomputer.py
+++ b/tests/golem/task/test_newtaskcomputer.py
@@ -126,7 +126,7 @@ class TestTaskGiven(NewTaskComputerTestBase):
             self.task_computer.get_current_computing_env(),
             self.env_id)
         provider_timer.start.assert_called_once_with()
-        self.assertTrue(self.task_computer.get_task_resources_dir().exists())
+        self.assertTrue(self.task_computer.get_subtask_inputs_dir().exists())
 
     def test_has_assigned_task(self, provider_timer):
         task_header = self._get_task_header()

--- a/tests/golem/task/test_taskcomputeradapter.py
+++ b/tests/golem/task/test_taskcomputeradapter.py
@@ -373,14 +373,14 @@ class TestTaskResourcesDir(TaskComputerAdapterTestBase):
             ValueError,
             'Task resources directory only available when a task-api task'
                 ' is assigned'):  # pylint: disable=bad-continuation
-            self.adapter.get_task_resources_dir()
+            self.adapter.get_subtask_inputs_dir()
 
     def test_new_assigned(self):
         self.new_computer.has_assigned_task.return_value = True
         self.old_computer.has_assigned_task.return_value = False
         self.assertEqual(
-            self.new_computer.get_task_resources_dir.return_value,
-            self.adapter.get_task_resources_dir(),
+            self.new_computer.get_subtask_inputs_dir.return_value,
+            self.adapter.get_subtask_inputs_dir(),
         )
 
 

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1316,7 +1316,7 @@ class TestTaskGiven(TaskServerTestBase):
         for resource in ttc.compute_task_def['resources']:  # noqa pylint: disable=unsubscriptable-object
             self.ts.new_resource_manager.download.assert_any_call(
                 resource,
-                self.ts.task_computer.get_task_resources_dir.return_value,
+                self.ts.task_computer.get_subtask_inputs_dir.return_value,
                 ttc.resources_options,
             )
         self.assertEqual(


### PR DESCRIPTION
Renamed some methods to use the 'subtask inputs' term consistently.