### PR TITLE
Allow users to enable / disable discovered docker images

### DIFF
--- a/golem/envs/docker/whitelist.py
+++ b/golem/envs/docker/whitelist.py
@@ -4,7 +4,7 @@ import golem.model
 
 
 def repository_from_image_name(image_name: str) -> str:
-    return image_name.split('/')[0]
+    return image_name.rsplit('/', maxsplit=1)[0]
 
 
 class Whitelist:

--- a/golem/envs/docker/whitelist.py
+++ b/golem/envs/docker/whitelist.py
@@ -1,7 +1,21 @@
+from typing import List
+
 import golem.model
 
 
+def repository_from_image_name(image_name: str) -> str:
+    return image_name.split('/')[0]
+
+
 class Whitelist:
+
+    @staticmethod
+    def get() -> List[str]:
+        return [
+            whitelisted.repository for whitelisted in
+            golem.model.DockerWhitelist.select().execute()
+        ]
+
     @classmethod
     def add(cls, repository: str) -> bool:
         """
@@ -26,7 +40,7 @@ class Whitelist:
 
     @staticmethod
     def is_whitelisted(image_name: str) -> bool:
-        repository = image_name.split('/')[0]
+        repository = repository_from_image_name(image_name)
         query = \
             golem.model.DockerWhitelist.select().where(
                 golem.model.DockerWhitelist.repository == repository,

--- a/golem/envs/docker/whitelist.py
+++ b/golem/envs/docker/whitelist.py
@@ -10,7 +10,7 @@ def repository_from_image_name(image_name: str) -> str:
 class Whitelist:
 
     @staticmethod
-    def get() -> List[str]:
+    def get_all() -> List[str]:
         return [
             whitelisted.repository for whitelisted in
             golem.model.DockerWhitelist.select().execute()

--- a/golem/node.py
+++ b/golem/node.py
@@ -38,8 +38,13 @@ from golem.docker.manager import DockerManager
 from golem.ethereum.transactionsystem import TransactionSystem
 from golem.model import DB_MODELS, db, DB_FIELDS
 from golem.network.transport.tcpnetwork_helpers import SocketAddress
-from golem.report import StatusPublisher, Component, Stage, report_calls, \
-    EventPublisher
+from golem.report import (
+    Component,
+    EventPublisher,
+    Stage,
+    StatusPublisher,
+    report_calls,
+)
 from golem.rpc import utils as rpc_utils
 from golem.rpc.mapping import rpceventnames
 from golem.rpc.router import CrossbarRouter

--- a/golem/node.py
+++ b/golem/node.py
@@ -38,7 +38,8 @@ from golem.docker.manager import DockerManager
 from golem.ethereum.transactionsystem import TransactionSystem
 from golem.model import DB_MODELS, db, DB_FIELDS
 from golem.network.transport.tcpnetwork_helpers import SocketAddress
-from golem.report import StatusPublisher, Component, Stage, report_calls
+from golem.report import StatusPublisher, Component, Stage, report_calls, \
+    EventPublisher
 from golem.rpc import utils as rpc_utils
 from golem.rpc.mapping import rpceventnames
 from golem.rpc.router import CrossbarRouter
@@ -316,6 +317,7 @@ class Node(HardwarePresetsMixin):
             methods = self.get_rpc_mapping()
             self.rpc_session.add_procedures(methods)
             self._rpc_publisher = Publisher(self.rpc_session)
+            EventPublisher.initialize(self._rpc_publisher)
             StatusPublisher.initialize(self._rpc_publisher)
 
         return deferred.addCallbacks(on_connect, self._error('rpc session'))

--- a/golem/report.py
+++ b/golem/report.py
@@ -30,12 +30,43 @@ class Component(object):
     hyperdrive = 'hyperdrive'
 
 
-class StatusPublisher(object):
+class EventPublisher:
+    _initialized: ClassVar[bool] = False
+    _rpc_publisher: ClassVar[Optional[Publisher]] = None
+
+    @classmethod
+    def initialize(cls, rpc_publisher: Publisher) -> bool:
+        if cls._initialized:
+            return False
+        cls._rpc_publisher = rpc_publisher
+        cls._initialized = True
+        return True
+
+    @classmethod
+    def publish(cls, alias: str, *args, **kwargs) -> Optional[Deferred]:
+        if not cls._initialized:
+            return None
+
+        from twisted.internet import reactor
+        deferred = Deferred()
+
+        def _publish():
+            maybeDeferred(
+                cls._rpc_publisher.publish,
+                alias,
+                *args,
+                **kwargs
+            ).chainDeferred(deferred)
+
+        reactor.callFromThread(_publish)
+        return deferred
+
+
+class StatusPublisher:
     """
     Publishes method execution stages via RPC.
     """
-    _initialized: ClassVar[bool] = False
-    _rpc_publisher: ClassVar[Optional[Publisher]] = None
+    _event_publisher: ClassVar[EventPublisher] = EventPublisher()
     _last_status: ClassVar[Dict[str, Tuple[str, str, Any]]] = dict()
 
     @classmethod
@@ -54,21 +85,8 @@ class StatusPublisher(object):
                  session is closing or there was an error
         """
         cls._update_status(component, method, stage, data)
-
-        if cls._rpc_publisher:
-            from twisted.internet import reactor
-            deferred = Deferred()
-
-            def _publish():
-                maybeDeferred(
-                    cls._rpc_publisher.publish,
-                    Golem.evt_golem_status,
-                    cls._last_status
-                ).chainDeferred(deferred)
-
-            reactor.callFromThread(_publish)
-            return deferred
-        return None
+        return cls._event_publisher.publish(
+            Golem.evt_golem_status, cls._last_status)
 
     @classmethod
     def last_status(cls):
@@ -76,15 +94,12 @@ class StatusPublisher(object):
 
     @classmethod
     def initialize(cls, rpc_publisher):
-        if cls._initialized:
+        if not cls._event_publisher.initialize(rpc_publisher):
             return
 
         from pydispatch import dispatcher
         dispatcher.connect(cls._publish_listener,
                            signal=Golem.evt_golem_status)
-
-        cls._rpc_publisher = rpc_publisher
-        cls._initialized = True
 
     @classmethod
     def _publish_listener(cls, event: str = 'default', **kwargs) -> None:

--- a/golem/rpc/mapping/rpceventnames.py
+++ b/golem/rpc/mapping/rpceventnames.py
@@ -5,6 +5,7 @@ class Golem:
 
 class Environment:
     evt_opts_changed = 'evt.env.opts'
+    evt_prereq_discovered = 'evt.env.prereq.discovered'
 
 
 class Network:

--- a/golem/task/server/whitelist.py
+++ b/golem/task/server/whitelist.py
@@ -3,7 +3,7 @@ from typing import Any, Dict, List
 from dataclasses import dataclass, field, asdict
 
 from golem.core.common import get_timestamp_utc
-from golem.envs.docker.whitelist import Whitelist, repository_from_image_name
+from golem.envs.docker.whitelist import Whitelist
 from golem.report import EventPublisher
 from golem.rpc import utils as rpc_utils
 from golem.rpc.mapping.rpceventnames import Environment

--- a/golem/task/server/whitelist.py
+++ b/golem/task/server/whitelist.py
@@ -1,0 +1,76 @@
+from typing import Any, Dict, List
+
+from dataclasses import dataclass, field, asdict
+
+from golem.core.common import get_timestamp_utc
+from golem.envs.docker.whitelist import Whitelist, repository_from_image_name
+from golem.report import EventPublisher
+from golem.rpc import utils as rpc_utils
+from golem.rpc.mapping.rpceventnames import Environment
+
+MAX_DISCOVERED_IMAGES: int = 50
+
+
+@dataclass
+class DiscoveredDockerImage:
+    name: str
+    discovery_ts: float = field(default_factory=get_timestamp_utc)
+
+
+class DockerWhitelistRPC:
+    def __init__(self) -> None:
+        self._discovered: List[DiscoveredDockerImage] = list()
+
+    def _docker_image_discovered(
+            self,
+            name: str
+    ) -> None:
+        if Whitelist.is_whitelisted(name):
+            return
+        for discovered in self._discovered:
+            if discovered.name == name:
+                discovered.discovery_ts = get_timestamp_utc()
+                return
+
+        discovered_image = DiscoveredDockerImage(name)
+        self._discovered.append(discovered_image)
+        self._docker_refresh_discovered()
+
+        EventPublisher.publish(
+            Environment.evt_prereq_discovered,
+            asdict(discovered_image),
+            'docker')
+
+    def _docker_refresh_discovered(self) -> None:
+        """ Update the internal discovered Docker image collection based on
+            Whitelist status and the number of MAX_DISCOVERED_IMAGES stored """
+        self._discovered = [
+            discovered for discovered in self._discovered
+            if not Whitelist.is_whitelisted(
+                repository_from_image_name(discovered.name))
+        ]
+        self._discovered = self._discovered[-MAX_DISCOVERED_IMAGES:]
+
+    @rpc_utils.expose('env.docker.repository.discovered')
+    def _docker_discovered_get(self) -> Dict[str, Dict[str, Any]]:
+        return {
+            discovered.name: asdict(discovered)
+            for discovered in self._discovered
+        }
+
+    @staticmethod
+    @rpc_utils.expose('env.docker.repository.whitelist')
+    def _docker_whitelist_get() -> List[str]:
+        return Whitelist.get()
+
+    @rpc_utils.expose('env.docker.repository.whitelist.add')
+    def _docker_whitelist_add(self, image_name: str) -> None:
+        repository = repository_from_image_name(image_name)
+        Whitelist.add(repository)
+        self._docker_refresh_discovered()
+
+    @staticmethod
+    @rpc_utils.expose('env.docker.repository.whitelist.remove')
+    def _docker_whitelist_remove(image_name: str) -> None:
+        repository = repository_from_image_name(image_name)
+        Whitelist.remove(repository)

--- a/golem/task/server/whitelist.py
+++ b/golem/task/server/whitelist.py
@@ -15,6 +15,12 @@ MAX_DISCOVERED_IMAGES: int = 50
 class DiscoveredDockerImage:
     name: str
     discovery_ts: float = field(default_factory=get_timestamp_utc)
+    last_seen_ts: float = field(default_factory=get_timestamp_utc)
+    times_seen: int = 1
+
+    def appeared(self) -> None:
+        self.last_seen_ts = get_timestamp_utc()
+        self.times_seen += 1
 
 
 class DockerWhitelistRPC:
@@ -29,19 +35,19 @@ class DockerWhitelistRPC:
             return
         for discovered in self._discovered:
             if discovered.name == name:
-                discovered.discovery_ts = get_timestamp_utc()
+                discovered.appeared()
                 return
 
         discovered_image = DiscoveredDockerImage(name)
         self._discovered.append(discovered_image)
-        self._docker_refresh_discovered()
+        self._docker_refresh_discovered_images()
 
         EventPublisher.publish(
             Environment.evt_prereq_discovered,
             asdict(discovered_image),
             'docker')
 
-    def _docker_refresh_discovered(self) -> None:
+    def _docker_refresh_discovered_images(self) -> None:
         """ Update the internal discovered Docker image collection based on
             Whitelist status and the number of MAX_DISCOVERED_IMAGES stored """
         self._discovered = [
@@ -51,7 +57,7 @@ class DockerWhitelistRPC:
         ]
         self._discovered = self._discovered[-MAX_DISCOVERED_IMAGES:]
 
-    @rpc_utils.expose('env.docker.repository.discovered')
+    @rpc_utils.expose('env.docker.images.discovered')
     def _docker_discovered_get(self) -> Dict[str, Dict[str, Any]]:
         return {
             discovered.name: asdict(discovered)
@@ -59,18 +65,18 @@ class DockerWhitelistRPC:
         }
 
     @staticmethod
-    @rpc_utils.expose('env.docker.repository.whitelist')
+    @rpc_utils.expose('env.docker.images.whitelist')
     def _docker_whitelist_get() -> List[str]:
         return Whitelist.get()
 
-    @rpc_utils.expose('env.docker.repository.whitelist.add')
+    @rpc_utils.expose('env.docker.images.whitelist.add')
     def _docker_whitelist_add(self, image_name: str) -> None:
         repository = repository_from_image_name(image_name)
         Whitelist.add(repository)
-        self._docker_refresh_discovered()
+        self._docker_refresh_discovered_images()
 
     @staticmethod
-    @rpc_utils.expose('env.docker.repository.whitelist.remove')
+    @rpc_utils.expose('env.docker.images.whitelist.remove')
     def _docker_whitelist_remove(image_name: str) -> None:
         repository = repository_from_image_name(image_name)
         Whitelist.remove(repository)

--- a/tests/golem/envs/docker/test_whitelist.py
+++ b/tests/golem/envs/docker/test_whitelist.py
@@ -11,9 +11,11 @@ class TestWhitelist(DatabaseFixture):
 
         Whitelist.add(repo)
         assert Whitelist.is_whitelisted(image)
+        assert Whitelist.get() == [repo]
 
         Whitelist.remove(repo)
         assert not Whitelist.is_whitelisted(image)
+        assert not Whitelist.get()
 
     def test_double_add_remove(self):
         repo = 'test_repo'

--- a/tests/golem/envs/docker/test_whitelist.py
+++ b/tests/golem/envs/docker/test_whitelist.py
@@ -11,11 +11,11 @@ class TestWhitelist(DatabaseFixture):
 
         Whitelist.add(repo)
         assert Whitelist.is_whitelisted(image)
-        assert Whitelist.get() == [repo]
+        assert Whitelist.get_all() == [repo]
 
         Whitelist.remove(repo)
         assert not Whitelist.is_whitelisted(image)
-        assert not Whitelist.get()
+        assert not Whitelist.get_all()
 
     def test_double_add_remove(self):
         repo = 'test_repo'

--- a/tests/golem/task/server/test_whitelist.py
+++ b/tests/golem/task/server/test_whitelist.py
@@ -1,0 +1,120 @@
+import unittest
+from unittest import mock
+
+from freezegun import freeze_time
+
+from golem.core.common import get_timestamp_utc
+from golem.task.server.whitelist import DiscoveredDockerImage, \
+    DockerWhitelistRPC
+from golem.tools.testwithdatabase import TestWithDatabase
+
+ROOT_PATH = 'golem.task.server.whitelist'
+MAX_IMAGES = 5
+
+
+class TestDiscoveredDockerImage(unittest.TestCase):
+
+    @freeze_time("1000")
+    def test_new(self):
+        discovered_img = DiscoveredDockerImage(name='golemfactory/test')
+        self.assertEqual(discovered_img.name, 'golemfactory/test')
+        self.assertEqual(discovered_img.discovery_ts, get_timestamp_utc())
+
+
+@mock.patch(f'{ROOT_PATH}.MAX_DISCOVERED_IMAGES', MAX_IMAGES)
+@mock.patch(f'{ROOT_PATH}.EventPublisher')
+class TestDiscoveryStorage(TestWithDatabase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.whitelist_rpc = DockerWhitelistRPC()
+
+    def test_discovery_storage_limit(self, event_publisher):
+        for i in range(MAX_IMAGES * 2):
+            self.whitelist_rpc._docker_image_discovered(name=f'repo/{i}')
+
+        assert event_publisher.publish.call_count == MAX_IMAGES * 2
+        assert len(self.whitelist_rpc._discovered) == MAX_IMAGES
+
+        for i in range(MAX_IMAGES):
+            discovered_app = self.whitelist_rpc._discovered[i]
+            assert discovered_app.name == f'repo/{MAX_IMAGES + i}'
+
+    def test_discovered_twice(self, event_publisher):
+
+        with freeze_time("1000"):
+            initial_time = get_timestamp_utc()
+            self.whitelist_rpc._docker_image_discovered(name=f'repo/0')
+
+        assert len(self.whitelist_rpc._discovered) == 1
+        assert self.whitelist_rpc._discovered[0].discovery_ts == initial_time
+        assert event_publisher.publish.call_count == 1
+
+        with freeze_time("2000"):
+            update_time = get_timestamp_utc()
+            self.whitelist_rpc._docker_image_discovered(name=f'repo/0')
+
+        assert len(self.whitelist_rpc._discovered) == 1
+        assert self.whitelist_rpc._discovered[0].discovery_ts == update_time
+        assert event_publisher.publish.call_count == 1
+
+    @mock.patch(f'{ROOT_PATH}.Whitelist.is_whitelisted', return_value=True)
+    def test_discovered_when_whitelisted(self, _, event_publisher):
+        for i in range(MAX_IMAGES):
+            self.whitelist_rpc._docker_image_discovered(name=f'repo/{i}')
+
+        assert event_publisher.publish.call_count == 0
+        assert not self.whitelist_rpc._discovered
+
+    @mock.patch(f'{ROOT_PATH}.Whitelist.is_whitelisted', return_value=False)
+    def test_refresh(self, _, event_publisher):
+        for i in range(MAX_IMAGES):
+            self.whitelist_rpc._docker_image_discovered(name=f'repo/{i}')
+
+        assert event_publisher.publish.call_count == MAX_IMAGES
+        assert len(self.whitelist_rpc._discovered) == MAX_IMAGES
+
+        def is_whitelisted(name: str) -> bool:
+            return not name.startswith('test')
+
+        with mock.patch(
+            f'{ROOT_PATH}.Whitelist.is_whitelisted', side_effect=is_whitelisted
+        ):
+            self.whitelist_rpc._docker_image_discovered(name='test/0')
+
+        assert len(self.whitelist_rpc._discovered) == 1
+
+
+@mock.patch(f'{ROOT_PATH}.MAX_DISCOVERED_IMAGES', MAX_IMAGES)
+@mock.patch(f'{ROOT_PATH}.Whitelist')
+class TestAppManagerRPCMethods(TestWithDatabase):
+
+    def setUp(self) -> None:
+        super().setUp()
+        self.whitelist_rpc = DockerWhitelistRPC()
+
+        with mock.patch(f'{ROOT_PATH}.EventPublisher'):
+            for i in range(MAX_IMAGES):
+                self.whitelist_rpc._docker_image_discovered(name=f'repo/{i}')
+
+    def test_docker_discovered_get(self, _):
+        discovered = self.whitelist_rpc._docker_discovered_get()
+        assert isinstance(discovered, dict)
+        assert len(discovered) == MAX_IMAGES
+        assert all(
+            isinstance(key, str) and isinstance(value, dict)
+            for key, value in discovered.items())
+
+    def test_docker_whitelist_get(self, whitelist):
+        self.whitelist_rpc._docker_whitelist_get()
+        assert whitelist.get.call_count == 1
+
+    def test_docker_whitelist_add(self, whitelist):
+        self.whitelist_rpc._docker_refresh_discovered = mock.Mock()
+        self.whitelist_rpc._docker_whitelist_add('repo/0')
+        assert whitelist.add.call_count == 1
+        assert self.whitelist_rpc._docker_refresh_discovered.call_count == 1
+
+    def test_docker_whitelist_remove(self, whitelist):
+        self.whitelist_rpc._docker_whitelist_remove('repo/0')
+        assert whitelist.remove.call_count == 1

--- a/tests/golem/task/server/test_whitelist.py
+++ b/tests/golem/task/server/test_whitelist.py
@@ -38,9 +38,8 @@ class TestDiscoveryStorage(TestWithDatabase):
         assert event_publisher.publish.call_count == MAX_IMAGES * 2
         assert len(self.whitelist_rpc._discovered) == MAX_IMAGES
 
-        for i in range(MAX_IMAGES):
-            discovered_app = self.whitelist_rpc._discovered[i]
-            assert discovered_app.name == f'repo/{MAX_IMAGES + i}'
+        for i, name in enumerate(self.whitelist_rpc._discovered.keys()):
+            assert name == f'repo/{MAX_IMAGES + i}'
 
     def test_discovered_twice(self, event_publisher):
 
@@ -49,7 +48,7 @@ class TestDiscoveryStorage(TestWithDatabase):
             self.whitelist_rpc._docker_image_discovered(name=f'repo/0')
 
         assert len(self.whitelist_rpc._discovered) == 1
-        discovered = self.whitelist_rpc._discovered[0]
+        discovered = next(iter(self.whitelist_rpc._discovered.values()))
         assert discovered.discovery_ts == initial_time
         assert discovered.last_seen_ts == initial_time
         assert discovered.times_seen == 1
@@ -60,7 +59,7 @@ class TestDiscoveryStorage(TestWithDatabase):
             self.whitelist_rpc._docker_image_discovered(name=f'repo/0')
 
         assert len(self.whitelist_rpc._discovered) == 1
-        discovered = self.whitelist_rpc._discovered[0]
+        discovered = next(iter(self.whitelist_rpc._discovered.values()))
         assert discovered.discovery_ts == initial_time
         assert discovered.last_seen_ts == update_time
         assert discovered.times_seen == 2
@@ -113,9 +112,9 @@ class TestAppManagerRPCMethods(TestWithDatabase):
             isinstance(key, str) and isinstance(value, dict)
             for key, value in discovered.items())
 
-    def test_docker_whitelist_get(self, whitelist):
-        self.whitelist_rpc._docker_whitelist_get()
-        assert whitelist.get.call_count == 1
+    def test_docker_whitelist_get_all(self, whitelist):
+        self.whitelist_rpc._docker_whitelist_get_all()
+        assert whitelist.get_all.call_count == 1
 
     def test_docker_whitelist_add(self, whitelist):
         self.whitelist_rpc._docker_refresh_discovered_images = mock.Mock()

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -883,25 +883,31 @@ class TaskServerTaskHeaderTest(TaskServerTestBase):
         )
 
         ts = self.ts
+        ts._docker_image_discovered = Mock()
 
         task_header = get_example_task_header(keys_auth_2.public_key)
+        task_header.environment_prerequisites = dict(image='test/0')
 
         self.assertFalse(ts.add_task_header(task_header))
         self.assertEqual(len(ts.get_others_tasks_headers()), 0)
+        self.assertEqual(ts._docker_image_discovered.call_count, 0)
 
         task_header.sign(private_key=keys_auth_2._private_key)  # noqa pylint:disable=no-value-for-parameter
 
         self.assertTrue(ts.add_task_header(task_header))
         self.assertEqual(len(ts.get_others_tasks_headers()), 1)
+        self.assertEqual(ts._docker_image_discovered.call_count, 1)
 
         task_header = get_example_task_header(keys_auth_2.public_key)
         task_header.sign(private_key=keys_auth_2._private_key)  # noqa pylint:disable=no-value-for-parameter
 
         self.assertTrue(ts.add_task_header(task_header))
         self.assertEqual(len(ts.get_others_tasks_headers()), 2)
+        self.assertEqual(ts._docker_image_discovered.call_count, 1)
 
         self.assertTrue(ts.add_task_header(task_header))
         self.assertEqual(len(ts.get_others_tasks_headers()), 2)
+        self.assertEqual(ts._docker_image_discovered.call_count, 1)
 
     def test_add_task_header_past_deadline(self):
         keys_auth_2 = KeysAuth(
@@ -911,12 +917,15 @@ class TaskServerTaskHeaderTest(TaskServerTestBase):
         )
 
         ts = self.ts
+        ts._docker_image_discovered = Mock()
 
         with freezegun.freeze_time(datetime.utcnow() - timedelta(hours=2)):
             task_header = get_example_task_header(keys_auth_2.public_key)
+            task_header.environment_prerequisites = dict(image='test/0')
             task_header.sign(private_key=keys_auth_2._private_key)  # noqa pylint:disable=no-value-for-parameter
 
         self.assertFalse(ts.add_task_header(task_header))
+        self.assertFalse(ts._docker_image_discovered.called)
 
 
 class TaskServerBase(TestDatabaseWithReactor, testutils.TestWithClient):


### PR DESCRIPTION
- new: `DockerWhitelistRPC` for exposing Whitelist methods via RPC
- emit events when new images are discovered
- remember recently discovered images (including basic stats)