### PR TITLE
Check for payment tables existence in migrations

### DIFF
--- a/golem/database/schemas/031_migrate_payment_to_task_payment.py
+++ b/golem/database/schemas/031_migrate_payment_to_task_payment.py
@@ -63,10 +63,15 @@ def migrate_payment(database, db_row):
 
 
 def migrate(migrator, database, fake=False, **kwargs):
+    if 'payment' not in database.get_tables():
+        logger.info('payment table not in DB. Skipping this migration.')
+        return
+
     cursor = database.execute_sql(
         'SELECT details, status, payee, value, subtask, created_date'
         ' FROM payment'
     )
+
     for db_row in cursor.fetchall():
         dict_row = {
             'details': db_row[0],

--- a/golem/database/schemas/032_migrate_income_to_task_payment.py
+++ b/golem/database/schemas/032_migrate_income_to_task_payment.py
@@ -49,6 +49,10 @@ def migrate_income(database, db_row):
 
 
 def migrate(migrator, database, fake=False, **kwargs):
+    if 'income' not in database.get_tables():
+        logger.info('income table not in DB. Skipping this migration.')
+        return
+
     cursor = database.execute_sql(
         'SELECT "transaction", payer_address, value, value_received, subtask,'
         '       created_date,'
@@ -56,6 +60,7 @@ def migrate(migrator, database, fake=False, **kwargs):
         '       overdue, sender_node'
         ' FROM income'
     )
+
     for db_row in cursor.fetchall():
         dict_row = {
             'transaction': db_row[0],

--- a/golem/database/schemas/033_deposit_payment_to_wallet_operation.py
+++ b/golem/database/schemas/033_deposit_payment_to_wallet_operation.py
@@ -37,16 +37,10 @@ def migrate_dp(database, db_row):
 
 
 def migrate(migrator, database, fake=False, **kwargs):
-    try:
-        database.execute_sql('SELECT 1 from depositpayment')
-    except pw.OperationalError as e:
-        if str(e) == 'no such table: depositpayment':
-            logger.info(
-                "depositpayment table missing in DB. Skipping this migration.",
-            )
-            return
-        # Raise unexpected exceptions
-        raise
+    if 'depositpayment' not in database.get_tables():
+        logger.info('depositpayment table not in DB. Skipping this migration.')
+        return
+
     cursor = database.execute_sql(
         'SELECT tx, value, status, fee,'
         '       created_date'


### PR DESCRIPTION
Updated peewee migrations from 31 to 33 to include a check for the existence
of required database tables before performing the actual migration.