### PR TITLE
Start tcpserver inactive, so no pause is needed after init

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -402,9 +402,6 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         self.p2pservice.add_metadata_provider(
             'performance', get_performance_values)
 
-        # Pause p2p and task sessions to prevent receiving messages before
-        # the node is ready
-        self.pause()
         self._restore_locks()
 
         monitoring_publisher_service = MonitoringPublisherService(

--- a/golem/network/transport/tcpserver.py
+++ b/golem/network/transport/tcpserver.py
@@ -29,7 +29,8 @@ class TCPServer:
         """
         self.config_desc = config_desc
         self.network = network
-        self.active = True
+        # Start inactive to prevent receiving messages before the node is ready
+        self.active = False
         self.cur_port = 0  # current listening port
         self.use_ipv6 = config_desc.use_ipv6 if config_desc else False
         self.ipv4_networks = ipv4_networks()

--- a/tests/golem/network/p2p/test_p2pservice.py
+++ b/tests/golem/network/p2p/test_p2pservice.py
@@ -278,6 +278,7 @@ class TestP2PService(TestDatabaseWithReactor):
             p2p_pub_port=10000
         )
 
+        self.service.resume()
         self.service.config_desc.opt_peer_num = 10
         self.service.free_peers.append(node.key)
         self.service.incoming_peers[node.key] = {
@@ -467,6 +468,7 @@ class TestP2PService(TestDatabaseWithReactor):
     @mock.patch('golem.network.p2p.p2pservice.'
                 'P2PService._P2PService__connection_established')
     def test_connect_success(self, connection_established, createSocket):
+        self.service.resume()
         createSocket.return_value = socket = mock.Mock()
         socket.fileno = mock.Mock(return_value=0)
         socket.getsockopt = mock.Mock(return_value=None)
@@ -484,6 +486,7 @@ class TestP2PService(TestDatabaseWithReactor):
     @mock.patch('golem.network.p2p.p2pservice.'
                 'P2PService._P2PService__connection_failure')
     def test_connect_failure(self, connection_failure, createSocket):
+        self.service.resume()
         addr = SocketAddress('127.0.0.1', 40102)
         self.service.connect(addr)
         assert connection_failure.called

--- a/tests/golem/network/transport/test_tcpserver.py
+++ b/tests/golem/network/transport/test_tcpserver.py
@@ -147,6 +147,7 @@ class TestPendingConnectionServer(unittest.TestCase):
         def final_failure(*args, **kwargs):
             final_failure_called[0] = True
 
+        server.resume()
         server.conn_established_for_type[req_type] = lambda x: x
         server.conn_failure_for_type[req_type] = server.final_conn_failure
         server.conn_final_failure_for_type[req_type] = final_failure
@@ -201,6 +202,7 @@ class TestPendingConnectionServer(unittest.TestCase):
         def final_failure(*args, **kwargs):
             final_failure_called[0] = True
 
+        server.resume()
         server.conn_established_for_type[req_type] = lambda x: x
         server.conn_failure_for_type[req_type] = server.final_conn_failure
         server.conn_final_failure_for_type[req_type] = final_failure

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -796,6 +796,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
 
     def test_new_connection(self, *_):
         ts = self.ts
+        ts.resume()
         tss = tasksession.TaskSession(Mock())
         ts.new_connection(tss)
         assert len(ts.task_sessions_incoming) == 1
@@ -853,6 +854,11 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
     def test_pause_and_resume(self, *_):
         from apps.core.task.coretask import CoreTask
 
+        assert not self.ts.active
+        assert not CoreTask.VERIFICATION_QUEUE._paused
+
+        self.ts.resume()
+
         assert self.ts.active
         assert not CoreTask.VERIFICATION_QUEUE._paused
 
@@ -860,11 +866,6 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
 
         assert not self.ts.active
         assert CoreTask.VERIFICATION_QUEUE._paused
-
-        self.ts.resume()
-
-        assert self.ts.active
-        assert not CoreTask.VERIFICATION_QUEUE._paused
 
     def test_add_task_header_invalid_sig(self):
         self.ts._verify_header_sig = lambda _: False


### PR DESCRIPTION
Pause was only called during startup so it would deactivate the TCPServer, removed the pause and start it as `Active = False`