### PR TITLE
ACL Database

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -1364,16 +1364,21 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
     @rpc_utils.expose('net.peer.block')
     def block_node(
             self,
-            node_id: str,
+            node_id: Union[str, list],
             timeout_seconds: int = -1,
     ) -> Tuple[bool, Optional[str]]:
         if not self.task_server:
             return False, 'Client is not ready'
 
         try:
-            self.task_server.disallow_node(node_id,
-                                           timeout_seconds=timeout_seconds,
-                                           persist=True)
+            if isinstance(node_id, str):
+                node_id = [node_id]
+
+            for item in node_id:
+                self.task_server.disallow_node(item,
+                                               timeout_seconds=timeout_seconds,
+                                               persist=True)
+
             return True, None
         except Exception as e:  # pylint: disable=broad-except
             return False, str(e)

--- a/golem/database/database.py
+++ b/golem/database/database.py
@@ -61,7 +61,7 @@ class GolemSqliteDatabase(peewee.SqliteDatabase):
 
 
 class Database:
-    SCHEMA_VERSION = 35
+    SCHEMA_VERSION = 36
 
     def __init__(self,  # noqa pylint: disable=too-many-arguments
                  db: peewee.Database,

--- a/golem/database/schemas/036_create_acl.py
+++ b/golem/database/schemas/036_create_acl.py
@@ -2,41 +2,8 @@
 # pylint: disable=unused-argument
 import datetime as dt
 import peewee as pw
-from pathlib import Path
-from typing import Set
 
 SCHEMA_VERSION = 36
-
-
-def migrate_txt(database):
-
-    def _read_set_from_file(path: Path) -> Set[str]:
-        try:
-            with path.open() as f:
-                return set(line.strip() for line in f)
-        except OSError:
-            return set()
-
-    def _remove_file(path: Path) -> None:
-        if(path.exists()):
-            path.unlink()
-
-    DENY_LIST_NAME = "deny.txt"
-    ALL_EXCEPT_ALLOWED = "ALL_EXCEPT_ALLOWED"
-    nodes_ids = []
-    datadir = Path(database.database).parent
-    deny_list_path = datadir / DENY_LIST_NAME
-    nodes_ids = _read_set_from_file(deny_list_path)
-    if(len(nodes_ids) > 0):
-        if ALL_EXCEPT_ALLOWED in nodes_ids:
-            nodes_ids.remove(ALL_EXCEPT_ALLOWED)
-            nodes = [{'node_id': node_id, 'node_name': None}
-                     for node_id in nodes_ids]
-            ACLAllowedNodes.insert_many(nodes).execute()
-        nodes = [{'node_id': node_id, 'node_name': None}
-                 for node_id in nodes_ids]
-        ACLDeniedNodes.insert_many(nodes).execute()
-    self._remove_file()
 
 
 def migrate(migrator, database, fake=False, **kwargs):
@@ -59,8 +26,6 @@ def migrate(migrator, database, fake=False, **kwargs):
 
         class Meta:
             db_table = "acldeniednodes"
-
-    migrator.python(migrate_txt, database)
 
 
 def rollback(migrator, database, fake=False, **kwargs):

--- a/golem/database/schemas/036_create_acl.py
+++ b/golem/database/schemas/036_create_acl.py
@@ -3,7 +3,7 @@
 import datetime as dt
 import peewee as pw
 
-SCHEMA_VERSION = 27
+SCHEMA_VERSION = 36
 
 
 def migrate(migrator, database, fake=False, **kwargs):

--- a/golem/database/schemas/036_create_acl.py
+++ b/golem/database/schemas/036_create_acl.py
@@ -1,9 +1,50 @@
 # pylint: disable=no-member
 # pylint: disable=unused-argument
+from pathlib import Path
+from typing import Set
 import datetime as dt
 import peewee as pw
 
 SCHEMA_VERSION = 36
+
+
+def migrate_txt(database):
+
+    def _read_set_from_file(path: Path) -> Set[str]:
+        try:
+            with path.open() as f:
+                return set(line.strip() for line in f)
+        except OSError:
+            return set()
+
+    def _remove_file(path: Path) -> None:
+        if path.exists():
+            path.unlink()
+
+    DENY_LIST_NAME = "deny.txt"
+    ALL_EXCEPT_ALLOWED = "ALL_EXCEPT_ALLOWED"
+    nodes_ids = []
+    datadir = Path(database.database).parent
+    deny_list_path = datadir / DENY_LIST_NAME
+    nodes_ids = _read_set_from_file(deny_list_path)
+    if nodes_ids:
+        table = 'acldeniednodes'
+        if ALL_EXCEPT_ALLOWED in nodes_ids:
+            nodes_ids.remove(ALL_EXCEPT_ALLOWED)
+            table = 'aclallowednodes'
+        for node_id in nodes_ids:
+            write_into_db(database, table, node_id)
+    _remove_file(deny_list_path)
+
+
+def write_into_db(database, table, node_id):
+    database.execute_sql(
+        f"INSERT INTO {table}"
+        " (created_date, modified_date, node_id)"
+        " VALUES (datetime('now'), datetime('now'), ?)",
+        (
+            node_id,
+        ))
 
 
 def migrate(migrator, database, fake=False, **kwargs):
@@ -12,7 +53,7 @@ def migrate(migrator, database, fake=False, **kwargs):
         created_date = pw.DateTimeField(default=dt.datetime.now)
         modified_date = pw.DateTimeField(default=dt.datetime.now)
         node_id = pw.CharField(max_length=255, unique=True)
-        node_name = pw.CharField(max_length=255)
+        node_name = pw.CharField(max_length=255, null=True)
 
         class Meta:
             db_table = "aclallowednodes"
@@ -22,10 +63,12 @@ def migrate(migrator, database, fake=False, **kwargs):
         created_date = pw.DateTimeField(default=dt.datetime.now)
         modified_date = pw.DateTimeField(default=dt.datetime.now)
         node_id = pw.CharField(max_length=255, unique=True)
-        node_name = pw.CharField(max_length=255)
+        node_name = pw.CharField(max_length=255, null=True)
 
         class Meta:
             db_table = "acldeniednodes"
+
+    migrator.python(migrate_txt, database)
 
 
 def rollback(migrator, database, fake=False, **kwargs):

--- a/golem/database/schemas/036_create_acl.py
+++ b/golem/database/schemas/036_create_acl.py
@@ -2,8 +2,41 @@
 # pylint: disable=unused-argument
 import datetime as dt
 import peewee as pw
+from pathlib import Path
+from typing import Set
 
 SCHEMA_VERSION = 36
+
+
+def migrate_txt(database):
+
+    def _read_set_from_file(path: Path) -> Set[str]:
+        try:
+            with path.open() as f:
+                return set(line.strip() for line in f)
+        except OSError:
+            return set()
+
+    def _remove_file(path: Path) -> None:
+        if(path.exists()):
+            path.unlink()
+
+    DENY_LIST_NAME = "deny.txt"
+    ALL_EXCEPT_ALLOWED = "ALL_EXCEPT_ALLOWED"
+    nodes_ids = []
+    datadir = Path(database.database).parent
+    deny_list_path = datadir / DENY_LIST_NAME
+    nodes_ids = _read_set_from_file(deny_list_path)
+    if(len(nodes_ids) > 0):
+        if ALL_EXCEPT_ALLOWED in nodes_ids:
+            nodes_ids.remove(ALL_EXCEPT_ALLOWED)
+            nodes = [{'node_id': node_id, 'node_name': None}
+                     for node_id in nodes_ids]
+            ACLAllowedNodes.insert_many(nodes).execute()
+        nodes = [{'node_id': node_id, 'node_name': None}
+                 for node_id in nodes_ids]
+        ACLDeniedNodes.insert_many(nodes).execute()
+    self._remove_file()
 
 
 def migrate(migrator, database, fake=False, **kwargs):
@@ -26,6 +59,8 @@ def migrate(migrator, database, fake=False, **kwargs):
 
         class Meta:
             db_table = "acldeniednodes"
+
+    migrator.python(migrate_txt, database)
 
 
 def rollback(migrator, database, fake=False, **kwargs):

--- a/golem/database/schemas/036_create_acl.py
+++ b/golem/database/schemas/036_create_acl.py
@@ -1,0 +1,33 @@
+# pylint: disable=no-member
+# pylint: disable=unused-argument
+import datetime as dt
+import peewee as pw
+
+SCHEMA_VERSION = 27
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    @migrator.create_model
+    class ACLAllowedNodes(pw.Model):
+        created_date = pw.DateTimeField(default=dt.datetime.now)
+        modified_date = pw.DateTimeField(default=dt.datetime.now)
+        node_id = pw.CharField(max_length=255, unique=True)
+        node_name = pw.CharField(max_length=255)
+
+        class Meta:
+            db_table = "aclallowednodes"
+
+    @migrator.create_model
+    class ACLDeniedNodes(pw.Model):
+        created_date = pw.DateTimeField(default=dt.datetime.now)
+        modified_date = pw.DateTimeField(default=dt.datetime.now)
+        node_id = pw.CharField(max_length=255, unique=True)
+        node_name = pw.CharField(max_length=255)
+
+        class Meta:
+            db_table = "acldeniednodes"
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.remove_model('acldeniednodes')
+    migrator.remove_model('aclallowednodes')

--- a/golem/model.py
+++ b/golem/model.py
@@ -561,6 +561,31 @@ class DockerWhitelist(BaseModel):
     class Meta:
         database = db
 
+class ACLAllowedNodes(BaseModel):
+    node_name = CharField(null=True)
+    node_id = CharField(null=False, index=True, unique=True)
+
+    def to_dict(self):
+        return {
+            'node_name': str(self.node_name),
+            'node_id': self.node_id
+        }
+
+    class Meta:
+        database = db
+
+class ACLDeniedNodes(BaseModel):
+    node_name = CharField(null=True)
+    node_id = CharField(null=False, index=True, unique=True)
+
+    def to_dict(self):
+        return {
+            'node_name': str(self.node_name),
+            'node_id': self.node_id
+        }
+
+    class Meta:
+        database = db
 
 ##################
 # MESSAGE MODELS #

--- a/golem/model.py
+++ b/golem/model.py
@@ -303,16 +303,14 @@ class WalletOperation(BaseModel):
         return cls.select() \
             .where(
                 WalletOperation.operation_type
-                == WalletOperation.TYPE.deposit_transfer,
-            )
+                == WalletOperation.TYPE.deposit_transfer)
 
     @classmethod
     def transfers(cls):
         return cls.select() \
             .where(
                 WalletOperation.operation_type
-                == WalletOperation.TYPE.transfer,
-            )
+                == WalletOperation.TYPE.transfer)
 
     @classmethod
     def unconfirmed_payments(cls):
@@ -328,8 +326,7 @@ class WalletOperation(BaseModel):
                 cls.operation_type.in_([
                     cls.TYPE.transfer,
                     cls.TYPE.deposit_transfer,
-                ]),
-            )
+                ]))
 
     def on_confirmed(self, gas_cost: int):
         if self.operation_type not in (
@@ -374,8 +371,7 @@ class TaskPayment(BaseModel):
                 WalletOperation.operation_type
                 == WalletOperation.TYPE.task_payment,
                 WalletOperation.direction
-                == WalletOperation.DIRECTION.incoming,
-            )
+                == WalletOperation.DIRECTION.incoming)
 
     @classmethod
     def payments(cls):
@@ -385,8 +381,7 @@ class TaskPayment(BaseModel):
                 WalletOperation.operation_type
                 == WalletOperation.TYPE.task_payment,
                 WalletOperation.direction
-                == WalletOperation.DIRECTION.outgoing,
-            )
+                == WalletOperation.DIRECTION.outgoing)
 
     @property
     def missing_amount(self):
@@ -561,6 +556,7 @@ class DockerWhitelist(BaseModel):
     class Meta:
         database = db
 
+
 class ACLAllowedNodes(BaseModel):
     node_name = CharField(null=True)
     node_id = CharField(null=False, index=True, unique=True)
@@ -573,6 +569,7 @@ class ACLAllowedNodes(BaseModel):
 
     class Meta:
         database = db
+
 
 class ACLDeniedNodes(BaseModel):
     node_name = CharField(null=True)
@@ -600,6 +597,7 @@ class Actor(enum.Enum):
 
 class ActorField(StringEnumField):
     """ Database field that stores Actor objects as strings. """
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, enum_type=Actor, **kwargs)
 

--- a/golem/model.py
+++ b/golem/model.py
@@ -563,7 +563,7 @@ class ACLAllowedNodes(BaseModel):
 
     def to_dict(self):
         return {
-            'node_name': str(self.node_name),
+            'node_name': self.node_name,
             'node_id': self.node_id
         }
 
@@ -577,7 +577,7 @@ class ACLDeniedNodes(BaseModel):
 
     def to_dict(self):
         return {
-            'node_name': str(self.node_name),
+            'node_name': self.node_name,
             'node_id': self.node_id
         }
 

--- a/golem/node.py
+++ b/golem/node.py
@@ -49,6 +49,7 @@ from golem.rpc.session import (
 from golem import terms
 from golem.tools.uploadcontroller import UploadController
 from golem.tools.remotefs import RemoteFS
+from golem.task.acl import migrate_txt
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
@@ -135,6 +136,9 @@ class Node(HardwarePresetsMixin):
         # Initialize database
         self._db = Database(
             db, fields=DB_FIELDS, models=DB_MODELS, db_dir=datadir)
+
+        # ACL txt migration
+        migrate_txt(Path(datadir))
 
         self.client: Optional[Client] = None
 

--- a/golem/node.py
+++ b/golem/node.py
@@ -49,7 +49,6 @@ from golem.rpc.session import (
 from golem import terms
 from golem.tools.uploadcontroller import UploadController
 from golem.tools.remotefs import RemoteFS
-from golem.task.acl import migrate_txt
 
 if TYPE_CHECKING:
     # pylint:disable=unused-import
@@ -136,9 +135,6 @@ class Node(HardwarePresetsMixin):
         # Initialize database
         self._db = Database(
             db, fields=DB_FIELDS, models=DB_MODELS, db_dir=datadir)
-
-        # ACL txt migration
-        migrate_txt(Path(datadir))
 
         self.client: Optional[Client] = None
 

--- a/golem/task/acl.py
+++ b/golem/task/acl.py
@@ -3,16 +3,13 @@ import logging
 import operator
 import time
 from enum import Enum
-from pathlib import Path
-from typing import Dict, Set, Union, Iterable, Optional, Tuple, List, cast
+from typing import Dict, Union, Iterable, Optional, Tuple, List, cast
 from sortedcontainers import SortedList
+from golem.model import ACLAllowedNodes, ACLDeniedNodes, GenericKeyValue
 
 from golem.core import common
 
 logger = logging.getLogger(__name__)
-
-DENY_LIST_NAME = "deny.txt"
-ALL_EXCEPT_ALLOWED = "ALL_EXCEPT_ALLOWED"
 
 
 class AclRule(Enum):
@@ -20,13 +17,27 @@ class AclRule(Enum):
     deny = "deny"
 
 
+ACL_MODE_KEY = "ACL_MODE"
+DEFAULT = AclRule.allow
+
+
 class AclStatus:
     default_rule: AclRule
-    rules: List[Tuple[str, AclRule, Optional[int]]]
+    rules: List[
+        Tuple[
+            Union[ACLAllowedNodes, ACLDeniedNodes],
+            AclRule, Optional[int]
+        ]
+    ]
 
     def __init__(self,
                  default_rule: AclRule,
-                 rules: List[Tuple[str, AclRule, Optional[int]]]) \
+                 rules: List[
+                     Tuple[
+                         Union[ACLAllowedNodes, ACLDeniedNodes],
+                         AclRule, Optional[int]
+                     ]
+                 ]) \
             -> None:
         self.default_rule = default_rule
         self.rules = rules
@@ -35,8 +46,13 @@ class AclStatus:
         return {
             'default_rule': self.default_rule.value,
             'rules': [
-                (ident, rule.value, deadline)
-                for (ident, rule, deadline) in self.rules
+                {
+                    'node_id': identity.node_id,
+                    'node_name': identity.node_name,
+                    'rule': rule.value,
+                    'deadline': deadline
+                }
+                for (identity, rule, deadline) in self.rules
             ]
         }
 
@@ -74,27 +90,39 @@ class _DenyAcl(Acl):
     _max_times: int
     # SortedList of floats = deadlines
     _deny_deadlines: Dict[str, Union[_Always, SortedList]]
-    _list_path: Optional[Path]
 
     @classmethod
-    def new_from_rules(cls, deny_coll: List[str],
-                       list_path: Optional[Path]) -> '_DenyAcl':
-        deny_set = set(deny_coll)
-        if list_path is not None:
-            _write_set_to_file(list_path, deny_set)
-        return cls(deny_coll, list_path)
+    def new_from_rules(cls, client, deny_coll: List[str]) -> '_DenyAcl':
+        if len(deny_coll) > 0:
+            peers = client.p2pservice.incoming_peers or dict()
+            deny_list = []
 
-    def __init__(self, deny_coll: Optional[Iterable[str]] = None,
-                 list_path: Optional[Path] = None, max_times: int = 1) -> None:
+            for key in deny_coll:
+                node = peers[key]
+                if node:
+                    deny_list.append(ACLDeniedNodes(
+                        {'node_id': key, 'node_name': node.name}))
+            if len(deny_list) > 0:
+                ACLDeniedNodes.insert_many(deny_list).execute()
+
+        return cls(client)
+
+    def __init__(self, client, max_times: int = 1) -> None:
         """
         :param max_times: how many times node_id must be disallowed to be
                           actually disallowed
         """
-        if deny_coll is None:
-            deny_coll = []
+        self._deny_list = []
+        self._client = client
         self._max_times = max_times
-        self._deny_deadlines = dict((key, self._always) for key in deny_coll)
-        self._list_path = list_path
+        self.read_list()
+
+        self._deny_deadlines = dict((item.node_id, self._always)
+                                    for item in self._deny_list)
+
+    def read_list(self) -> None:
+        nodes = ACLDeniedNodes.select().execute()
+        self._deny_list = list(nodes)
 
     def is_allowed(self, node_id: str) -> Tuple[bool, Optional[DenyReason]]:
         if node_id not in self._deny_deadlines:
@@ -126,21 +154,31 @@ class _DenyAcl(Acl):
             timeout_seconds,
             persist,
         )
+
         if timeout_seconds < 0:
             self._deny_deadlines[node_id] = self._always
         else:
             if node_id not in self._deny_deadlines:
                 self._deny_deadlines[node_id] = SortedList(key=operator.neg)
             node_deadlines = self._deny_deadlines[node_id]
+
             if node_deadlines is self._always:
                 return
+
             assert isinstance(node_deadlines, SortedList)
             node_deadlines.add(self._deadline(timeout_seconds))
 
-        if persist and timeout_seconds == -1 and self._list_path:
-            deny_set = _read_set_from_file(self._list_path)
-            if node_id not in deny_set:
-                _write_set_to_file(self._list_path, deny_set | {node_id})
+        if persist and timeout_seconds == -1:
+            try:
+                existNode = ACLDeniedNodes.get(node_id=node_id)
+            except ACLDeniedNodes.DoesNotExist:
+                existNode = None
+            if not existNode:
+                peers = self._client.p2pservice.incoming_peers or dict()
+                node = peers[node_id]
+                node_db = ACLDeniedNodes(
+                    node_id=node_id, node_name=node['node_name'])
+                node_db.save()
 
     def allow(self, node_id: str, persist: bool = False) -> None:
         logger.info(
@@ -149,19 +187,30 @@ class _DenyAcl(Acl):
             persist,
         )
         del self._deny_deadlines[node_id]
-        if persist and self._list_path:
-            deny_set = _read_set_from_file(self._list_path)
-            if node_id in deny_set:
-                _write_set_to_file(self._list_path, deny_set - {node_id})
+
+        if persist:
+            deny_list = ACLDeniedNodes.select().execute()
+
+            if node_id in list(deny_list):
+                ACLDeniedNodes \
+                    .delete() \
+                    .where(ACLDeniedNodes.node_id == node_id) \
+                    .execute()
 
     def status(self) -> AclStatus:
         _always = self._always
         now = time.time()
 
+        self.read_list()
+
         def decode_deadline(deadline):
             if deadline is _always:
                 return None
             return deadline[0]
+
+        def get_node_by_id(node_id):
+            return next((node for node in self._deny_list
+                         if node.node_id == node_id), None)
 
         rules_to_remove = []
         for (identity, deadlines) in self._deny_deadlines.items():
@@ -175,7 +224,7 @@ class _DenyAcl(Acl):
             del self._deny_deadlines[identity]
 
         rules = [
-            (identity,
+            (get_node_by_id(identity),
              AclRule.deny,
              decode_deadline(deadline), )
             for (identity, deadline) in self._deny_deadlines.items()]
@@ -189,25 +238,35 @@ class _DenyAcl(Acl):
 class _AllowAcl(Acl):
 
     @classmethod
-    def new_from_rules(cls, allow_coll: List[str],
-                       list_path: Optional[Path]) -> '_AllowAcl':
-        allow_set = set(allow_coll) | {ALL_EXCEPT_ALLOWED}
-        if list_path is not None:
-            _write_set_to_file(list_path, allow_set)
-        return cls(set(allow_coll), list_path)
+    def new_from_rules(cls, client, allow_coll: List[str]) -> '_AllowAcl':
+        if len(allow_coll) > 0:
+            peers = client.p2pservice.incoming_peers or dict()
+            allow_list = []
 
-    def __init__(
-            self,
-            allow_set: Optional[Set[str]] = None,
-            list_path: Optional[Path] = None,
-    ) -> None:
-        if allow_set is None:
-            allow_set = set()
-        self._allow_set = allow_set
-        self._list_path = list_path
+            for key in allow_coll:
+                node = peers[key]
+
+                if node:
+                    allow_list.append(ACLAllowedNodes(
+                        {'node_id': key, 'node_name': node.name}))
+
+            if len(allow_list) > 0:
+                ACLAllowedNodes.insert_many(allow_list).execute()
+
+        return cls(client)
+
+    def __init__(self, client) -> None:
+
+        self._allow_list = []
+        self._client = client
+        self.read_list()
+
+    def read_list(self) -> None:
+        nodes = ACLAllowedNodes.select().execute()
+        self._allow_list = list(nodes)
 
     def is_allowed(self, node_id: str) -> Tuple[bool, Optional[DenyReason]]:
-        if node_id in self._allow_set:
+        if any(node for node in self._allow_list if node == node_id):
             return True, None
 
         return False, DenyReason.not_whitelisted
@@ -221,12 +280,20 @@ class _AllowAcl(Acl):
             timeout_seconds,
             persist,
         )
-        self._allow_set.discard(node_id)
+        self._allow_list = [x for x in self._allow_list if not (
+            node_id == x.get('node_id'))]
 
-        if persist and self._list_path:
-            allow_set = _read_set_from_file(self._list_path)
-            if node_id in allow_set:
-                _write_set_to_file(self._list_path, allow_set - {node_id})
+        if persist:
+            try:
+                existNode = ACLAllowedNodes.get(node_id=node_id)
+            except ACLAllowedNodes.DoesNotExist:
+                existNode = None
+
+            if existNode:
+                ACLAllowedNodes \
+                    .delete() \
+                    .where(ACLAllowedNodes.node_id == node_id) \
+                    .execute()
 
     def allow(self, node_id: str, persist: bool = False) -> None:
         logger.info(
@@ -234,54 +301,54 @@ class _AllowAcl(Acl):
             common.short_node_id(node_id),
             persist,
         )
-        self._allow_set.add(node_id)
-        if persist and self._list_path:
-            allow_set = _read_set_from_file(self._list_path)
-            if node_id not in allow_set:
-                _write_set_to_file(self._list_path, allow_set | {node_id})
+        peers = self._client.p2pservice.incoming_peers or dict()
+        node = peers[node_id]
+        node_model = ACLAllowedNodes(
+            node_id=node_id, node_name=node['node_name'])
+        self._allow_list.append(node_model)
+
+        if persist:
+            try:
+                existNode = ACLAllowedNodes.get(node_id=node_id)
+            except ACLAllowedNodes.DoesNotExist:
+                existNode = None
+
+            if not existNode:
+                node_model.save()
 
     def status(self) -> AclStatus:
+        self.read_list()
         rules = [
             (identity,
              AclRule.allow,
              cast(Optional[int], None))
-            for identity in self._allow_set]
+            for identity in self._allow_list]
 
         return AclStatus(AclRule.deny, rules)
 
 
-def _read_set_from_file(path: Path) -> Set[str]:
+def get_acl(client, max_times: int = 1) -> Union[_DenyAcl, _AllowAcl]:
+
     try:
-        with path.open() as f:
-            return set(line.strip() for line in f)
-    except OSError:
-        return set()
+        value = GenericKeyValue.get(key=ACL_MODE_KEY)
+    except GenericKeyValue.DoesNotExist:
+        value = DEFAULT
+
+    if value == AclRule.allow:
+        return _AllowAcl(client)
+    return _DenyAcl(client, max_times)
 
 
-def _write_set_to_file(path: Path, node_set: Set[str]):
-    with path.open('w') as f:
-        for node_id in sorted(node_set):
-            f.write(node_id + '\n')
-
-
-def get_acl(datadir: Path, max_times: int = 1) -> Union[_DenyAcl, _AllowAcl]:
-    deny_list_path = datadir / DENY_LIST_NAME
-    nodes_ids = _read_set_from_file(deny_list_path)
-
-    if ALL_EXCEPT_ALLOWED in nodes_ids:
-        nodes_ids.remove(ALL_EXCEPT_ALLOWED)
-        return _AllowAcl(nodes_ids, deny_list_path)
-
-    return _DenyAcl(nodes_ids, deny_list_path, max_times)
-
-
-def setup_acl(datadir: Optional[Path],
-              default_rule: AclRule,
+def setup_acl(client, default_rule: AclRule,
               exceptions: List[str]) -> Union[_DenyAcl, _AllowAcl]:
-    deny_list_path = datadir / DENY_LIST_NAME if datadir is not None else None
-    if default_rule == AclRule.deny:
-        return _AllowAcl.new_from_rules(exceptions, deny_list_path)
-    if default_rule == AclRule.allow:
-        return _DenyAcl.new_from_rules(exceptions, deny_list_path)
 
-    raise ValueError('invalid acl default rule: %r' % default_rule)  # noqa # pragma: no cover # pylint: disable=line-too-long
+    if not default_rule in AclRule.__members__.values():
+        raise ValueError('invalid acl default %r' % default_rule)
+
+    entry, _ = GenericKeyValue.get_or_create(key=ACL_MODE_KEY)
+    entry.value = default_rule.value
+    entry.save()
+
+    if default_rule == AclRule.deny:
+        return _AllowAcl.new_from_rules(client, exceptions)
+    return _DenyAcl.new_from_rules(client, exceptions)

--- a/golem/task/acl.py
+++ b/golem/task/acl.py
@@ -95,16 +95,16 @@ class _DenyAcl(Acl):
 
     @classmethod
     def new_from_rules(cls, client, deny_coll: List[str]) -> '_DenyAcl':
-        if len(deny_coll) > 0:
+        if deny_coll:
             deny_list = []
 
             for key in deny_coll:
                 node = _get_node_info(client, key)
-                
+
                 if node:
                     deny_list.append(
                         {'node_id': key, 'node_name': node['node_name']})
-            if len(deny_list) > 0:
+            if deny_list:
                 ACLDeniedNodes.insert_many(deny_list).execute()
 
         return cls(client)
@@ -114,7 +114,7 @@ class _DenyAcl(Acl):
         :param max_times: how many times node_id must be disallowed to be
                           actually disallowed
         """
-        self._deny_list = [] # type: List[ACLDeniedNodes]
+        self._deny_list = []  # type: List[ACLDeniedNodes]
         self._client = client
         self._max_times = max_times
         self._read_list()
@@ -241,21 +241,21 @@ class _AllowAcl(Acl):
 
     @classmethod
     def new_from_rules(cls, client, allow_coll: List[str]) -> '_AllowAcl':
-        if len(allow_coll) > 0:
+        if allow_coll:
             allow_list = []
             for key in allow_coll:
                 node = _get_node_info(client, key)
                 if node:
                     allow_list.append(
                         {'node_id': key, 'node_name': node['node_name']})
-            if len(allow_list) > 0:
+            if allow_list:
                 ACLAllowedNodes.insert_many(allow_list).execute()
 
         return cls(client)
 
     def __init__(self, client) -> None:
 
-        self._allow_list = [] # type: List[ACLAllowedNodes]
+        self._allow_list = []  # type: List[ACLAllowedNodes]
         self._client = client
         self._read_list()
 
@@ -340,7 +340,7 @@ def get_acl(client, max_times: int = 1) -> Union[_DenyAcl, _AllowAcl]:
 def setup_acl(client, default_rule: AclRule,
               exceptions: List[str]) -> Union[_DenyAcl, _AllowAcl]:
 
-    if not default_rule in AclRule.__members__.values():
+    if default_rule not in AclRule.__members__.values():
         raise ValueError('invalid acl default %r' % default_rule)
 
     entry, _ = GenericKeyValue.get_or_create(key=ACL_MODE_KEY)
@@ -362,9 +362,9 @@ def _get_node_info(client, key: str) -> Dict:
     except ValueError:
         node = peers[key] if key in peers else {
             'node_id': key, 'node_name': None}
-        pass
 
     return node
+
 
 def migrate_txt(datadir):
 
@@ -376,7 +376,7 @@ def migrate_txt(datadir):
             return set()
 
     def _remove_file(path: Path) -> None:
-        if(path.exists()):
+        if path.exists():
             path.unlink()
 
     DENY_LIST_NAME = "deny.txt"
@@ -385,7 +385,7 @@ def migrate_txt(datadir):
 
     deny_list_path = datadir / DENY_LIST_NAME
     nodes_ids = _read_set_from_file(deny_list_path)
-    if(len(nodes_ids) > 0):
+    if nodes_ids:
         if ALL_EXCEPT_ALLOWED in nodes_ids:
             nodes_ids.remove(ALL_EXCEPT_ALLOWED)
             nodes = [{'node_id': node_id, 'node_name': None}

--- a/golem/task/acl.py
+++ b/golem/task/acl.py
@@ -4,7 +4,8 @@ import operator
 import time
 import ipaddress
 from enum import Enum
-from typing import Dict, Union, Iterable, Optional, Tuple, List, cast
+from pathlib import Path
+from typing import Dict, Set, Union, Iterable, Optional, Tuple, List, cast
 from sortedcontainers import SortedList
 from golem.model import ACLAllowedNodes, ACLDeniedNodes, GenericKeyValue
 
@@ -364,3 +365,33 @@ def _get_node_info(client, key: str) -> Dict:
         pass
 
     return node
+
+def migrate_txt(datadir):
+
+    def _read_set_from_file(path: Path) -> Set[str]:
+        try:
+            with path.open() as f:
+                return set(line.strip() for line in f)
+        except OSError:
+            return set()
+
+    def _remove_file(path: Path) -> None:
+        if(path.exists()):
+            path.unlink()
+
+    DENY_LIST_NAME = "deny.txt"
+    ALL_EXCEPT_ALLOWED = "ALL_EXCEPT_ALLOWED"
+    nodes_ids = []
+
+    deny_list_path = datadir / DENY_LIST_NAME
+    nodes_ids = _read_set_from_file(deny_list_path)
+    if(len(nodes_ids) > 0):
+        if ALL_EXCEPT_ALLOWED in nodes_ids:
+            nodes_ids.remove(ALL_EXCEPT_ALLOWED)
+            nodes = [{'node_id': node_id, 'node_name': None}
+                     for node_id in nodes_ids]
+            ACLAllowedNodes.insert_many(nodes).execute()
+        nodes = [{'node_id': node_id, 'node_name': None}
+                 for node_id in nodes_ids]
+        ACLDeniedNodes.insert_many(nodes).execute()
+    _remove_file(deny_list_path)

--- a/golem/task/acl.py
+++ b/golem/task/acl.py
@@ -48,7 +48,7 @@ class AclStatus:
             'default_rule': self.default_rule.value,
             'rules': [
                 {
-                    'node_id': identity['node_id'],
+                    'identity': identity['node_id'],
                     'node_name': identity['node_name'] or "",
                     'rule': rule.value,
                     'deadline': deadline

--- a/golem/task/acl.py
+++ b/golem/task/acl.py
@@ -303,10 +303,12 @@ class _AllowAcl(Acl):
             persist,
         )
         node = _get_node_info(self._client, node_id)
-
         node_model = ACLAllowedNodes(
             node_id=node_id, node_name=node['node_name'])
-        self._allow_list.append(node_model)
+
+        if not any(node for node in self._allow_list if (
+                node.node_id == node_id)):
+            self._allow_list.append(node_model)
 
         if persist:
             try:

--- a/golem/task/acl.py
+++ b/golem/task/acl.py
@@ -113,7 +113,7 @@ class _DenyAcl(Acl):
         :param max_times: how many times node_id must be disallowed to be
                           actually disallowed
         """
-        self._deny_list = []
+        self._deny_list = [] # type: List[ACLDeniedNodes]
         self._client = client
         self._max_times = max_times
         self._read_list()
@@ -254,7 +254,7 @@ class _AllowAcl(Acl):
 
     def __init__(self, client) -> None:
 
-        self._allow_list = []
+        self._allow_list = [] # type: List[ACLAllowedNodes]
         self._client = client
         self._read_list()
 

--- a/golem/task/acl.py
+++ b/golem/task/acl.py
@@ -189,9 +189,12 @@ class _DenyAcl(Acl):
         del self._deny_deadlines[node_id]
 
         if persist:
-            deny_list = ACLDeniedNodes.select().execute()
+            try:
+                existNode = ACLDeniedNodes.get(node_id=node_id)
+            except ACLDeniedNodes.DoesNotExist:
+                existNode = None
 
-            if node_id in list(deny_list):
+            if existNode:
                 ACLDeniedNodes \
                     .delete() \
                     .where(ACLDeniedNodes.node_id == node_id) \

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -1035,21 +1035,21 @@ class TaskServer(
         if isinstance(ip, str):
                 ip = [ip]
         for item in ip:
-            self.acl_ip.disallow(ip, timeout_seconds)
+            self.acl_ip.disallow(item, timeout_seconds)
 
     @rpc_utils.expose('net.peer.allow')
     def allow_node(self, node_id: Union[str, list], persist: bool = True) -> None:
         if isinstance(node_id, str):
                 node_id = [node_id]
         for item in node_id:
-            self.acl.allow(node_id, persist)
+            self.acl.allow(item, persist)
 
     @rpc_utils.expose('net.peer.allow_ip')
     def allow_ip(self, ip: Union[str, list], persist: bool = True) -> None:
         if isinstance(ip, str):
                 ip = [ip]
         for item in ip:
-            self.acl_ip.allow(ip, persist)
+            self.acl_ip.allow(item, persist)
 
     @rpc_utils.expose('net.peer.acl')
     def acl_status(self) -> Dict:

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -1045,11 +1045,11 @@ class TaskServer(
             self.acl.allow(node_id, persist)
 
     @rpc_utils.expose('net.peer.allow_ip')
-    def allow_ip(self, node_id: Union[str, list], persist: bool = True) -> None:
-        if isinstance(node_id, str):
-                node_id = [node_id]
-        for item in node_id:
-            self.acl_ip.allow(node_id, persist)
+    def allow_ip(self, ip: Union[str, list], persist: bool = True) -> None:
+        if isinstance(ip, str):
+                ip = [ip]
+        for item in ip:
+            self.acl_ip.allow(ip, persist)
 
     @rpc_utils.expose('net.peer.acl')
     def acl_status(self) -> Dict:

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -224,9 +224,8 @@ class TaskServer(
         self.forwarded_session_request_timeout = \
             config_desc.waiting_for_task_session_timeout
         self.forwarded_session_requests = {}
-        self.acl = get_acl(Path(client.datadir),
-                           max_times=config_desc.disallow_id_max_times)
-        self.acl_ip = DenyAcl([], max_times=config_desc.disallow_ip_max_times)
+        self.acl = get_acl(self.client, max_times=config_desc.disallow_id_max_times)
+        self.acl_ip = DenyAcl(self.client, max_times=config_desc.disallow_ip_max_times)
         self.resource_handshakes = {}
         self.requested_tasks: Set[str] = set()
         self._last_task_request_time: float = time.time()
@@ -1053,7 +1052,7 @@ class TaskServer(
 
     @rpc_utils.expose('net.peer.acl.new')
     def acl_setup(self, default_rule: str, exceptions: List[str]) -> None:
-        new_acl = setup_acl(Path(self.client.datadir),
+        new_acl = setup_acl(self.client,
                             AclRule[default_rule],
                             exceptions)
         self.acl = new_acl

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -1025,11 +1025,14 @@ class TaskServer(
     @rpc_utils.expose('net.peer.disallow')
     def disallow_node(
             self,
-            node_id: str,
+            node_id: Union[str, list],
             timeout_seconds: int = -1,
             persist: bool = False
     ) -> None:
-        self.acl.disallow(node_id, timeout_seconds, persist)
+        if isinstance(node_id, str):
+            node_id = [node_id]
+        for item in node_id:
+            self.acl.disallow(item, timeout_seconds, persist)
 
     @rpc_utils.expose('net.peer.block_ip')
     def disallow_ip(self, ip: Union[str, list],

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -1031,16 +1031,25 @@ class TaskServer(
         self.acl.disallow(node_id, timeout_seconds, persist)
 
     @rpc_utils.expose('net.peer.block_ip')
-    def disallow_ip(self, ip: str, timeout_seconds: int = -1) -> None:
-        self.acl_ip.disallow(ip, timeout_seconds)
+    def disallow_ip(self, ip: Union[str, list], timeout_seconds: int = -1) -> None:
+        if isinstance(ip, str):
+                ip = [ip]
+        for item in ip:
+            self.acl_ip.disallow(ip, timeout_seconds)
 
     @rpc_utils.expose('net.peer.allow')
-    def allow_node(self, node_id: str, persist: bool = True) -> None:
-        self.acl.allow(node_id, persist)
+    def allow_node(self, node_id: Union[str, list], persist: bool = True) -> None:
+        if isinstance(node_id, str):
+                node_id = [node_id]
+        for item in node_id:
+            self.acl.allow(node_id, persist)
 
     @rpc_utils.expose('net.peer.allow_ip')
-    def allow_ip(self, node_id: str, persist: bool = True) -> None:
-        self.acl_ip.allow(node_id, persist)
+    def allow_ip(self, node_id: Union[str, list], persist: bool = True) -> None:
+        if isinstance(node_id, str):
+                node_id = [node_id]
+        for item in node_id:
+            self.acl_ip.allow(node_id, persist)
 
     @rpc_utils.expose('net.peer.acl')
     def acl_status(self) -> Dict:

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -89,7 +89,7 @@ from .taskmanager import TaskManager
 from .tasksession import TaskSession
 
 if TYPE_CHECKING:
-    from golem_messages.datastructures import p2p as dt_p2p # noqa pylint: disable=unused-import,ungrouped-imports
+    from golem_messages.datastructures import p2p as dt_p2p  # noqa pylint: disable=unused-import,ungrouped-imports
 
 logger = logging.getLogger(__name__)
 
@@ -224,8 +224,10 @@ class TaskServer(
         self.forwarded_session_request_timeout = \
             config_desc.waiting_for_task_session_timeout
         self.forwarded_session_requests = {}
-        self.acl = get_acl(self.client, max_times=config_desc.disallow_id_max_times)
-        self.acl_ip = DenyAcl(self.client, max_times=config_desc.disallow_ip_max_times)
+        self.acl = get_acl(
+            self.client, max_times=config_desc.disallow_id_max_times)
+        self.acl_ip = DenyAcl(
+            self.client, max_times=config_desc.disallow_ip_max_times)
         self.resource_handshakes = {}
         self.requested_tasks: Set[str] = set()
         self._last_task_request_time: float = time.time()
@@ -479,8 +481,7 @@ class TaskServer(
             defer.gatherResults(deferreds, consumeErrors=True)\
                 .addCallbacks(
                     lambda _: self.resource_collected(msg.task_id),
-                    lambda e: self.resource_failure(msg.task_id, e),
-                )
+                    lambda e: self.resource_failure(msg.task_id, e))
         else:
             self.request_resource(
                 msg.task_id,
@@ -1031,23 +1032,25 @@ class TaskServer(
         self.acl.disallow(node_id, timeout_seconds, persist)
 
     @rpc_utils.expose('net.peer.block_ip')
-    def disallow_ip(self, ip: Union[str, list], timeout_seconds: int = -1) -> None:
+    def disallow_ip(self, ip: Union[str, list],
+                    timeout_seconds: int = -1) -> None:
         if isinstance(ip, str):
-                ip = [ip]
+            ip = [ip]
         for item in ip:
             self.acl_ip.disallow(item, timeout_seconds)
 
     @rpc_utils.expose('net.peer.allow')
-    def allow_node(self, node_id: Union[str, list], persist: bool = True) -> None:
+    def allow_node(self, node_id: Union[str, list],
+                   persist: bool = True) -> None:
         if isinstance(node_id, str):
-                node_id = [node_id]
+            node_id = [node_id]
         for item in node_id:
             self.acl.allow(item, persist)
 
     @rpc_utils.expose('net.peer.allow_ip')
     def allow_ip(self, ip: Union[str, list], persist: bool = True) -> None:
         if isinstance(ip, str):
-                ip = [ip]
+            ip = [ip]
         for item in ip:
             self.acl_ip.allow(item, persist)
 

--- a/tests/golem/resource/test_resourcehandshake.py
+++ b/tests/golem/resource/test_resourcehandshake.py
@@ -20,7 +20,7 @@ from golem.resource.hyperdrive.resourcesmanager import HyperdriveResourceManager
 from golem.resource.resourcehandshake import ResourceHandshake, \
     ResourceHandshakeSessionMixin
 from golem.task.acl import get_acl
-from golem.testutils import TempDirFixture
+from golem.testutils import DatabaseFixture, TempDirFixture
 
 
 class TestResourceHandshake(TempDirFixture):
@@ -73,7 +73,7 @@ class TestResourceHandshake(TempDirFixture):
 
 @patch('twisted.internet.reactor', create=True)
 @patch('twisted.internet.task', create=True)
-class TestResourceHandshakeSessionMixin(TempDirFixture):
+class TestResourceHandshakeSessionMixin(DatabaseFixture):
 
     def setUp(self):
         super().setUp()
@@ -371,7 +371,7 @@ class MockTaskSession(ResourceHandshakeSessionMixin):
         self.task_server = Mock(
             client=Mock(datadir=data_dir),
             node=Mock(key=str(uuid.uuid4())),
-            acl=get_acl(Path(data_dir)),
+            acl=get_acl(Mock()),
             resource_handshakes=dict(),
             get_key_id=lambda: None,
             task_manager=Mock(

--- a/tests/golem/task/test_acl.py
+++ b/tests/golem/task/test_acl.py
@@ -1,43 +1,53 @@
 # pylint: disable=protected-access
 
+import unittest
 from freezegun import freeze_time
 
-from golem.task.acl import get_acl, DENY_LIST_NAME, ALL_EXCEPT_ALLOWED, \
+from golem.task.acl import get_acl, \
     DenyReason, AclRule, setup_acl, _DenyAcl, _AllowAcl
-from golem.testutils import TempDirFixture
+from golem.model import ACLAllowedNodes, ACLDeniedNodes, GenericKeyValue
+from golem.testutils import DatabaseFixture
 
 
-class TestAcl(TempDirFixture):
+class TestAcl(DatabaseFixture):
+
+    def setUp(self):
+        super().setUp()
+        self.client = unittest.mock.MagicMock()
+        self.client.p2pservice.incoming_peers = {
+            'Node1': { 'node_id': 'Node1', 'node_name': 'Node1', 'address': '34.107.145.130'},
+            'Node2': { 'node_id': 'Node2', 'node_name': 'Node2', 'address': '122.32.144.197'},
+            'Node3': { 'node_id': 'Node3', 'node_name': 'Node3', 'address': '175.5.104.123'},
+            'Node4': { 'node_id': 'Node4', 'node_name': 'Node4', 'address': '92.212.33.20'},
+            'Node5': { 'node_id': 'Node5', 'node_name': 'Node5', 'address': '23.62.179.16'}
+        }
+
     def test_no_file(self):
-        acl = get_acl(self.new_path)
+        acl = get_acl(self.client)
         assert acl._deny_deadlines == dict()
         self.assertEqual((True, None),
                          acl.is_allowed("some node"))
 
-    @property
-    def deny_list_path(self):
-        return self.new_path / DENY_LIST_NAME
-
-    def test_file_empty(self):
-        self.deny_list_path.touch()
-        acl = get_acl(self.new_path)
+    def database_empty(self):
+        acl = get_acl(self.client)
         assert acl._deny_deadlines == dict()
 
     def test_deny(self):
-        self.deny_list_path.write_text(
-            "Node1 \nNode2\nNode3\n\tNode4 ")
 
-        acl = get_acl(self.new_path)
+        node_1 = ACLDeniedNodes(node_id="node_1", node_name="node_1")
+        node_1.save()
+
+        acl = get_acl(self.client)
         keys = set(acl._deny_deadlines.keys())
-        assert keys == {"Node1", "Node2", "Node3", "Node4"}
+        assert keys == {"node_1"}
 
         self.assertEqual((False, DenyReason.blacklisted),
-                         acl.is_allowed("Node1"))
+                         acl.is_allowed("node_1"))
         self.assertEqual((True, None),
                          acl.is_allowed("some other node"))
 
     def test_deny_always(self):
-        acl = get_acl(self.new_path)
+        acl = get_acl(self.client)
 
         assert acl.is_allowed("Node1")[0]
         assert acl.is_allowed("Node2")[0]
@@ -54,7 +64,7 @@ class TestAcl(TempDirFixture):
     @freeze_time("2018-01-01 00:00:00", as_arg=True)
     def test_deny_timeout(frozen_time, self):
         assert isinstance(self, TestAcl)
-        acl = get_acl(self.new_path)
+        acl = get_acl(self.client)
 
         acl.disallow("Node1", timeout_seconds=10)
         self.assertEqual((False, DenyReason.temporarily_blocked),
@@ -68,7 +78,7 @@ class TestAcl(TempDirFixture):
 
     def test_timeout_in_status(self):
         with freeze_time('2016-09-29 18:18:01') as frozen_time:
-            acl = get_acl(self.new_path)
+            acl = get_acl(self.client)
             s = acl.status()
             assert s.rules == [] and s.default_rule == AclRule.allow
             acl.disallow('Node1')
@@ -86,49 +96,43 @@ class TestAcl(TempDirFixture):
             assert acl.is_allowed('Node2') == (True, None)
 
     def test_setup_new_all_except(self):
-        acl = setup_acl(None, AclRule.allow, ['Node1', 'Node3'])
+        acl = setup_acl(self.client, AclRule.allow, ['Node1', 'Node3'])
         assert acl.is_allowed('Node1') == (False, DenyReason.blacklisted)
         assert acl.is_allowed('Node2') == (True, None)
         assert acl.is_allowed('Node3') == (False, DenyReason.blacklisted)
 
     def test_setup_new_only_allowed(self):
-        acl = setup_acl(None, AclRule.deny, ['Node1', 'Node3'])
+        acl = setup_acl(self.client, AclRule.deny, ['Node1', 'Node3'])
         assert acl.is_allowed('Node1') == (True, None)
         assert acl.is_allowed('Node2') == (False, DenyReason.not_whitelisted)
         assert acl.is_allowed('Node3') == (True, None)
 
     def test_setup_new_persist(self):
-        acl = setup_acl(self.new_path, AclRule.allow, ['Node1', 'Node3'])
+        acl = setup_acl(self.client, AclRule.allow, ['Node1', 'Node3'])
         assert acl.is_allowed('Node1') == (False, DenyReason.blacklisted)
         assert acl.is_allowed('Node2') == (True, None)
         assert acl.is_allowed('Node3') == (False, DenyReason.blacklisted)
 
-        acl = get_acl(self.new_path)
-        assert acl.is_allowed('Node1') == (False, DenyReason.blacklisted)
-        assert acl.is_allowed('Node2') == (True, None)
-        assert acl.is_allowed('Node3') == (False, DenyReason.blacklisted)
-
-        setup_acl(self.new_path, AclRule.deny, ['Node2'])
-        acl = get_acl(self.new_path)
+        acl = setup_acl(self.client, AclRule.deny, ['Node2'])
         assert acl.is_allowed('Node1') == (False, DenyReason.not_whitelisted)
         assert acl.is_allowed('Node3') == (False, DenyReason.not_whitelisted)
         assert acl.is_allowed('Node2') == (True, None)
 
     def test_DenyAcl_no_exceptions(self):
-        acl = _DenyAcl()
+        acl = _DenyAcl(self.client)
         assert acl.status().default_rule == AclRule.allow
         assert not acl.status().rules
         assert acl.is_allowed('Node1') == (True, None)
 
     def test_AllowAcl_no_exceptions(self):
-        acl = _AllowAcl()
+        acl = _AllowAcl(self.client)
         assert acl.status().default_rule == AclRule.deny
         assert not acl.status().rules
         assert acl.is_allowed('Node1') == (False, DenyReason.not_whitelisted)
 
     def test_deny_max_times(self):
         with freeze_time('2016-09-29 18:18:01') as frozen_time:
-            acl = get_acl(self.new_path, max_times=3)
+            acl = get_acl(self.client, max_times=3)
             node_id = "Node1"
 
             assert acl.is_allowed(node_id) == (True, None)
@@ -139,9 +143,8 @@ class TestAcl(TempDirFixture):
             acl.disallow(node_id, timeout_seconds=10)
             assert acl.is_allowed(node_id) == \
                 (False, DenyReason.temporarily_blocked)
-
             disallowed_nodes = [r[0] for r in acl.status().rules]
-            self.assertCountEqual(disallowed_nodes, [node_id])
+            self.assertCountEqual([node['node_id'] for node in disallowed_nodes], [node_id])
 
             frozen_time.tick(15)
 
@@ -164,21 +167,26 @@ class TestAcl(TempDirFixture):
                 (False, DenyReason.temporarily_blocked)
 
     def test_allow_allow_dissalow(self):
-        self.deny_list_path.write_text(
-            "{}\nNode1 \nNode2\nNode3\n\tNode4 ".format(ALL_EXCEPT_ALLOWED))
+        allowed_node_list = [
+            ACLDeniedNodes(node_id="Node1", node_name="Node1").to_dict(),
+            ACLDeniedNodes(node_id="Node2", node_name="Node2").to_dict(),
+            ACLDeniedNodes(node_id="Node3", node_name="Node3").to_dict(),
+            ACLDeniedNodes(node_id="Node4", node_name="Node4").to_dict()
+        ]
+        ACLAllowedNodes.insert_many(allowed_node_list).execute()
 
-        acl = get_acl(self.new_path)
+        acl = setup_acl(self.client, AclRule.deny, [])
         acl.allow('Node5', persist=True)
-        acl.disallow('Node4')
+        acl.disallow('Node4', persist=True)
 
         allowed_nodes = [r[0] for r in acl.status().rules]
         self.assertCountEqual(
-            allowed_nodes, ["Node1", "Node2", "Node3", "Node5"])
+            [node.node_id for node in allowed_nodes], ["Node1", "Node2", "Node3", "Node5"])
 
-        saved_nodes = self.deny_list_path.read_text().split()
+        saved_nodes = ACLAllowedNodes.select().execute()
         self.assertCountEqual(
-            saved_nodes,
-            [ALL_EXCEPT_ALLOWED, "Node1", "Node2", "Node3", "Node4", "Node5"]
+            [node.node_id for node in saved_nodes],
+            ["Node1", "Node2", "Node3", "Node5"]
         )
 
         self.assertEqual((True, None),
@@ -187,52 +195,77 @@ class TestAcl(TempDirFixture):
                          acl.is_allowed("some other node"))
 
     def test_deny_disallow_allow_persistence(self):
-        self.deny_list_path.write_text('node_id4')
+        node_4 = ACLDeniedNodes(node_id='Node4', node_name='Node4')
+        node_4.save()
 
-        acl = get_acl(self.new_path)
-        acl.disallow('node_id1', persist=True)
-        acl.disallow('node_id2', persist=True)
-        acl.disallow('node_id1', persist=True)
-        acl.allow('node_id1')
-        acl.allow('node_id4', persist=True)
+        acl = get_acl(self.client)
+        acl.disallow('Node1', persist=True)
+        acl.disallow('Node2', persist=True)
+        acl.disallow('Node1', persist=True)
+        acl.allow('Node1')
+        acl.allow('Node4', persist=True)
 
         disallowed_nodes = [r[0] for r in acl.status().rules]
-        self.assertCountEqual(disallowed_nodes, ['node_id2'])
+        self.assertCountEqual([node['node_id'] for node in disallowed_nodes], ['Node2'])
 
-        saved_nodes = self.deny_list_path.read_text().split()
-        self.assertCountEqual(saved_nodes, ['node_id1', 'node_id2'])
+        saved_nodes = ACLDeniedNodes.select()
+        self.assertCountEqual([node.node_id for node in saved_nodes], ['Node1', 'Node2'])
 
         self.assertEqual((True, None),
-                         acl.is_allowed("node_id1"))
+                         acl.is_allowed("Node1"))
         self.assertEqual((False, DenyReason.blacklisted),
-                         acl.is_allowed("node_id2"))
+                         acl.is_allowed("Node2"))
         self.assertEqual((True, None),
-                         acl.is_allowed("node_id3"))
+                         acl.is_allowed("Node3"))
 
     def test_allow_disallow_persistence(self):
-        self.deny_list_path.write_text('\n'.join((
-            ALL_EXCEPT_ALLOWED,
-            'node_id1',
-            'node_id2')))
 
-        acl = get_acl(self.new_path)
-        acl.disallow('node_id1', persist=True)
-        acl.disallow('node_id3', persist=True)
-        acl.disallow('node_id1', persist=True)
-        acl.allow('node_id4')
+        acl = setup_acl(self.client, AclRule.deny, ['Node1', 'Node2'])
+
+        acl.disallow('Node1', persist=True)
+        acl.disallow('Node3', persist=True)
+        acl.disallow('Node1', persist=True)
+        acl.allow('Node4')
 
         allowed_nodes = [r[0] for r in acl.status().rules]
-        self.assertCountEqual(allowed_nodes, ['node_id2', 'node_id4'])
+        self.assertCountEqual([node.node_id for node in allowed_nodes], ['Node2', 'Node4'])
 
-        saved_allowed_nodes = self.deny_list_path.read_text().split()
-        self.assertCountEqual(saved_allowed_nodes,
-                              [ALL_EXCEPT_ALLOWED, 'node_id2'])
+        #Node which is not in p2pservice incoming peer list
+        acl.allow('Node6')
+
+        allowed_nodes = [r[0] for r in acl.status().rules]
+        self.assertCountEqual([node.node_id for node in allowed_nodes], ['Node2', 'Node4', 'Node6'])
+
+        saved_allowed_nodes = ACLAllowedNodes.select().execute()
+        self.assertCountEqual([node.node_id for node in saved_allowed_nodes],
+                              ['Node2'])
 
         self.assertEqual((False, DenyReason.not_whitelisted),
-                         acl.is_allowed("node_id1"))
+                         acl.is_allowed("Node1"))
         self.assertEqual((True, None),
-                         acl.is_allowed("node_id2"))
+                         acl.is_allowed("Node2"))
         self.assertEqual((False, DenyReason.not_whitelisted),
-                         acl.is_allowed("node_id3"))
+                         acl.is_allowed("Node3"))
         self.assertEqual((True, None),
-                         acl.is_allowed("node_id4"))
+                         acl.is_allowed("Node4"))
+
+    def test_allow_disallow_ip_persistence(self):
+        # Test for IP which  is exist in p2pservice incoming peer list
+        acl = setup_acl(self.client, AclRule.deny, ['122.32.144.197', '34.107.145.130'])
+        self.assertEqual((True, None),
+                         acl.is_allowed("34.107.145.130"))
+        allowed_ips = [r[0] for r in acl.status().rules]
+        self.assertCountEqual([node.node_name for node in allowed_ips], ['Node1', 'Node2'])
+        # Test for IP which doesn't exist in p2pservice incoming peer list
+        acl.allow('4.247.45.93', persist=True)
+        allowed_ips = [r[0] for r in acl.status().rules]
+        self.assertCountEqual([node.node_name for node in allowed_ips], ['Node1', 'Node2', None])
+        # Remove uknown IP
+        acl.disallow('4.247.45.93', persist=True)
+        allowed_ips = [r[0] for r in acl.status().rules]
+        self.assertCountEqual([node.node_name for node in allowed_ips], ['Node1', 'Node2'])
+        # Remove known IP
+        acl.disallow('34.107.145.130', persist=True)
+        allowed_ips = [r[0] for r in acl.status().rules]
+        self.assertCountEqual([node.node_name for node in allowed_ips], ['Node2'])
+

--- a/tests/golem/task/test_acl.py
+++ b/tests/golem/task/test_acl.py
@@ -202,7 +202,7 @@ class TestAcl(DatabaseFixture):
 
         allowed_nodes = [r[0] for r in acl.status().rules]
         self.assertCountEqual(
-            [node.node_id for node in allowed_nodes],
+            [node['node_id'] for node in allowed_nodes],
             ["Node1", "Node2", "Node3", "Node5"]
         )
 
@@ -254,13 +254,13 @@ class TestAcl(DatabaseFixture):
 
         allowed_nodes = [r[0] for r in acl.status().rules]
         self.assertCountEqual(
-            [node.node_id for node in allowed_nodes], ['Node2', 'Node4'])
+            [node['node_id'] for node in allowed_nodes], ['Node2', 'Node4'])
 
         # Node which is not in p2pservice incoming peer list
         acl.allow('Node6')
 
         allowed_nodes = [r[0] for r in acl.status().rules]
-        self.assertCountEqual([node.node_id for node in allowed_nodes],
+        self.assertCountEqual([node['node_id'] for node in allowed_nodes],
                               ['Node2', 'Node4', 'Node6'])
 
         saved_allowed_nodes = ACLAllowedNodes.select().execute()
@@ -284,19 +284,19 @@ class TestAcl(DatabaseFixture):
                          acl.is_allowed("34.107.145.130"))
         allowed_ips = [r[0] for r in acl.status().rules]
         self.assertCountEqual(
-            [node.node_name for node in allowed_ips], ['Node1', 'Node2'])
+            [node['node_name'] for node in allowed_ips], ['Node1', 'Node2'])
         # Test for IP which doesn't exist in p2pservice incoming peer list
         acl.allow('4.247.45.93', persist=True)
         allowed_ips = [r[0] for r in acl.status().rules]
-        self.assertCountEqual([node.node_name for node in allowed_ips],
-                              ['Node1', 'Node2', None])
+        self.assertCountEqual([node['node_name'] for node in allowed_ips],
+                              ['Node2', 'Node1', None])
         # Remove uknown IP
         acl.disallow('4.247.45.93', persist=True)
         allowed_ips = [r[0] for r in acl.status().rules]
         self.assertCountEqual(
-            [node.node_name for node in allowed_ips], ['Node1', 'Node2'])
+            [node['node_name'] for node in allowed_ips], ['Node1', 'Node2'])
         # Remove known IP
         acl.disallow('34.107.145.130', persist=True)
         allowed_ips = [r[0] for r in acl.status().rules]
         self.assertCountEqual(
-            [node.node_name for node in allowed_ips], ['Node2'])
+            [node['node_name'] for node in allowed_ips], ['Node2'])

--- a/tests/golem/test_client.py
+++ b/tests/golem/test_client.py
@@ -1141,6 +1141,9 @@ class TestClientRPCMethods(TestClientBase, LogTestCase):
         self.client.block_node('node_id')
         self.client.task_server.acl.disallow.assert_called_once_with(
             'node_id', -1, True)
+        self.client.block_node(['node_id_1', 'node_id_2'])
+        self.client.task_server.acl.disallow.assert_called_with(
+            'node_id_2', -1, True)
 
     @classmethod
     def __new_incoming_peer(cls):


### PR DESCRIPTION
- Moves ACL deny/allow list from text file to database to keep persistence.
- `node_name` parameter added to the list, to provide clear recognition for users.
- type of `node_id` parameter in `net.peer.block`, `net.peer.allow`, `net.peer.block_ip` and `net.peer.allow_ip` changed as union (string, list) so it will accept list of node id's as well.