### PR TITLE
Update to Task API v0.16.1

### DIFF
--- a/golem/database/database.py
+++ b/golem/database/database.py
@@ -61,7 +61,7 @@ class GolemSqliteDatabase(peewee.SqliteDatabase):
 
 
 class Database:
-    SCHEMA_VERSION = 36
+    SCHEMA_VERSION = 37
 
     def __init__(self,  # noqa pylint: disable=too-many-arguments
                  db: peewee.Database,

--- a/golem/database/schemas/037_requested_task_env_id.py
+++ b/golem/database/schemas/037_requested_task_env_id.py
@@ -1,0 +1,17 @@
+# pylint: disable=no-member
+# pylint: disable=unused-argument
+# pylint: disable=unused-variable
+
+import peewee as pw
+
+SCHEMA_VERSION = 37
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_fields(
+        'requestedtask',
+        env_id=pw.CharField(max_length=255, null=True))
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.remove_fields('requestedtask', 'env_id')

--- a/golem/envs/docker/cpu.py
+++ b/golem/envs/docker/cpu.py
@@ -10,6 +10,7 @@ from typing import Optional, Any, Dict, List, Type, ClassVar, \
 
 from dataclasses import dataclass, field, asdict
 from docker.errors import APIError
+from golem_task_api.envs import DOCKER_CPU_ENV_ID
 from twisted.internet.defer import Deferred, inlineCallbacks, succeed
 from twisted.internet.threads import deferToThread
 from urllib3.contrib.pyopenssl import WrappedSocket
@@ -47,7 +48,6 @@ logger = logging.getLogger(__name__)
 mem = CONSTRAINT_KEYS['mem']
 cpu = CONSTRAINT_KEYS['cpu']
 
-DOCKER_CPU_ENV_ID = 'docker_cpu'
 DOCKER_CPU_METADATA = EnvMetadata(
     id=DOCKER_CPU_ENV_ID,
     description='Docker environment using CPU'

--- a/golem/envs/docker/gpu.py
+++ b/golem/envs/docker/gpu.py
@@ -3,6 +3,7 @@ from logging import getLogger, Logger
 from typing import Any, Dict, List, Optional
 
 from dataclasses import dataclass, field
+from golem_task_api.envs import DOCKER_GPU_ENV_ID
 
 from golem.core.common import update_dict
 from golem.envs import (
@@ -22,7 +23,6 @@ from golem.envs.docker.vendor import nvidia
 logger = getLogger(__name__)
 
 
-DOCKER_GPU_ENV_ID = 'docker_gpu'
 DOCKER_GPU_METADATA = EnvMetadata(
     id=DOCKER_GPU_ENV_ID,
     description='Docker environment using GPU'

--- a/golem/model.py
+++ b/golem/model.py
@@ -684,6 +684,7 @@ class RequestedTask(BaseModel):
     name = CharField(null=True)
     status = StringEnumField(enum_type=taskstate.TaskStatus, null=False)
 
+    env_id = CharField(null=True)
     prerequisites = JsonField(null=False, default='{}')
 
     task_timeout = IntegerField(null=False)  # milliseconds

--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 from datetime import timedelta
 import logging
 from pathlib import Path
@@ -122,7 +123,6 @@ class RequestedTaskManager:
             app_id=golem_params.app_id,
             name=golem_params.name,
             status=TaskStatus.creating,
-            # prerequisites='{}',
             task_timeout=golem_params.task_timeout,
             subtask_timeout=golem_params.subtask_timeout,
             start_time=default_now(),
@@ -177,11 +177,14 @@ class RequestedTaskManager:
 
         app_client = await self._get_app_client(task.app_id)
         logger.debug('init_task(task_id=%r) - creating task', task_id)
-        await app_client.create_task(
+        reply = await app_client.create_task(
             task.task_id,
             task.max_subtasks,
             task.app_params,
         )
+        task.env_id = reply.env_id
+        task.prerequisites = json.loads(reply.prerequisites_json)
+        task.save()
         logger.debug('init_task(task_id=%r) after', task_id)
 
     @staticmethod

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -11,6 +11,7 @@ from threading import Lock
 from dataclasses import dataclass
 from golem_messages.message.tasks import ComputeTaskDef, TaskHeader
 from golem_task_api import ProviderAppClient, constants as task_api_constants
+from golem_task_api.envs import DOCKER_CPU_ENV_ID, DOCKER_GPU_ENV_ID
 from pydispatch import dispatcher
 from twisted.internet import defer
 
@@ -22,8 +23,8 @@ from golem.docker.image import DockerImage
 from golem.docker.manager import DockerManager
 from golem.docker.task_thread import DockerTaskThread
 from golem.envs import EnvId
-from golem.envs.docker.cpu import DockerCPUConfig, DOCKER_CPU_ENV_ID
-from golem.envs.docker.gpu import DockerGPUConfig, DOCKER_GPU_ENV_ID
+from golem.envs.docker.cpu import DockerCPUConfig
+from golem.envs.docker.gpu import DockerGPUConfig
 from golem.hardware import scale_memory, MemSize
 from golem.manager.nodestatesnapshot import ComputingSubtaskStateSnapshot
 from golem.resource.dirmanager import DirManager

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ eventlet==0.24.1
 fs==2.4.4
 Golem-Messages==3.11.0
 Golem-Smart-Contracts-Interface==1.10.2
-golem_task_api==0.15.1
+golem_task_api==0.16.1
 greenlet==0.4.15
 h2==3.0.1
 hpack==3.0.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -20,7 +20,7 @@ eth-utils==1.0.3
 ethereum==1.6.1
 Golem-Messages==3.11.0
 Golem-Smart-Contracts-Interface==1.10.2
-golem_task_api==0.15.1
+golem_task_api==0.16.1
 html2text==2018.1.9
 humanize==0.5.1
 incremental==17.5.0

--- a/tests/golem/task/test_newtaskcomputer.py
+++ b/tests/golem/task/test_newtaskcomputer.py
@@ -6,16 +6,14 @@ from unittest import mock
 
 from golem_messages.message import ComputeTaskDef
 from golem_task_api import ProviderAppClient, TaskApiService
+from golem_task_api.envs import DOCKER_CPU_ENV_ID
 from twisted.internet import defer
 
 from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.core.deferred import deferred_from_future
 from golem.core.statskeeper import IntStatsKeeper
 from golem.envs import Runtime
-from golem.envs.docker.cpu import (
-    DOCKER_CPU_ENV_ID,
-    DockerCPUConfig
-)
+from golem.envs.docker.cpu import DockerCPUConfig
 from golem.task.envmanager import EnvironmentManager
 from golem.task.taskcomputer import NewTaskComputer
 from golem.testutils import TempDirFixture

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -21,6 +21,7 @@ from golem_messages.datastructures.masking import Mask
 from golem_messages.factories.datastructures import p2p as dt_p2p_factory
 from golem_messages.message import ComputeTaskDef
 from golem_messages.utils import encode_hex as encode_key_id, pubkey_to_address
+from golem_task_api.envs import DOCKER_CPU_ENV_ID
 from requests import HTTPError
 
 from golem import testutils
@@ -34,7 +35,6 @@ from golem.environments.environment import (
     UnsupportReason,
 )
 from golem.envs import Environment as NewEnv
-from golem.envs.docker.cpu import DOCKER_CPU_ENV_ID
 from golem.network.hyperdrive.client import HyperdriveClientOptions, \
     HyperdriveClient, to_hyperg_peer
 from golem.resource import resourcemanager


### PR DESCRIPTION
* Import environment IDs from Task API instead of declaring them in Golem code.
* Read the environment ID and prerequisites from CreateTask reply. Save the obtained values in RequestedTask model.

~Requirements will be updated when https://github.com/golemfactory/task-api/pull/37 is merged and Task API v0.16.0 is released.~