### PR TITLE
Use broader check for task timeouts

### DIFF
--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -406,7 +406,7 @@ class RequestedTaskManager:
     @staticmethod
     def _check_task_timeout(task_id: TaskId) -> None:
         task = RequestedTask.get(RequestedTask.task_id == task_id)
-        if task.status != TaskStatus.finished:
+        if task.status.is_active():
             logger.info("Task timed out. task_id=%r", task_id)
             task.status = TaskStatus.timeout
             task.save()


### PR DESCRIPTION
Not to include aborted tasks, etc.