### PR TITLE
Protect asyncio add/remove Reader/Writer against multithreading

### DIFF
--- a/golem/decorators.py
+++ b/golem/decorators.py
@@ -1,13 +1,14 @@
 import functools
 import logging
 
-from golem import model
 
 log = logging.getLogger('golem.decorators')
 
 
 def run_with_db():
     """Run only when DB is active"""
+    from golem import model
+
     def wrapped(f):
         @functools.wraps(f)
         def curry(*args, **kwargs):
@@ -19,5 +20,16 @@ def run_with_db():
                 )
                 return None
             return f(*args, **kwargs)
+        return curry
+    return wrapped
+
+
+def locked(lock):
+    """Run under a threadsafe lock"""
+    def wrapped(f):
+        @functools.wraps(f)
+        def curry(*args, **kwargs):
+            with lock:
+                return f(*args, **kwargs)
         return curry
     return wrapped


### PR DESCRIPTION
Twisteds asyncioreactor uses low level eventloop api to watch file descriptors (sockets in this case). Unfortunatelly some race-condition occurs.