### PR TITLE
Correct storage of forced payments

### DIFF
--- a/golem/ethereum/incomeskeeper.py
+++ b/golem/ethereum/incomeskeeper.py
@@ -169,7 +169,7 @@ class IncomesKeeper:
             wallet_operation=model.WalletOperation.create(
                 tx_hash=tx_hash,
                 direction=model.WalletOperation.DIRECTION.incoming,
-                operation_type=model.WalletOperation.TYPE.deposit_payment,
+                operation_type=model.WalletOperation.TYPE.task_payment,
                 status=model.WalletOperation.STATUS.confirmed,
                 sender_address=sender_addr,
                 recipient_address="",

--- a/golem/ethereum/paymentprocessor.py
+++ b/golem/ethereum/paymentprocessor.py
@@ -353,7 +353,7 @@ class PaymentProcessor:
                 wallet_operation=model.WalletOperation.create(
                     tx_hash=tx_hash,
                     direction=model.WalletOperation.DIRECTION.outgoing,
-                    operation_type=model.WalletOperation.TYPE.task_payment,
+                    operation_type=model.WalletOperation.TYPE.deposit_payment,
                     sender_address=self._sci.get_eth_address(),
                     recipient_address=receiver,
                     currency=model.WalletOperation.CURRENCY.GNT,
@@ -411,7 +411,7 @@ class PaymentProcessor:
                 wallet_operation=model.WalletOperation.create(
                     tx_hash=tx_hash,
                     direction=model.WalletOperation.DIRECTION.outgoing,
-                    operation_type=model.WalletOperation.TYPE.task_payment,
+                    operation_type=model.WalletOperation.TYPE.deposit_payment,
                     sender_address=self._sci.get_eth_address(),
                     recipient_address=receiver,
                     currency=model.WalletOperation.CURRENCY.GNT,


### PR DESCRIPTION
From requestors perspective, forced payment is a deposit_payment
because it's deducted from GNTDeposit.

From providers perspective it's task_payment because it's added
to users wallet.