### PR TITLE
Introduced app IDs and added app loading

### DIFF
--- a/golem/app_manager.py
+++ b/golem/app_manager.py
@@ -1,13 +1,16 @@
+import hashlib
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List, Iterator
+from typing import Any, Dict, List, Iterator, Tuple
 
 from dataclasses import dataclass, field
 from dataclasses_json import config, dataclass_json
 from marshmallow import fields as mm_fields
 
 logger = logging.getLogger(__name__)
+
+AppId = str
 
 
 @dataclass_json
@@ -26,22 +29,28 @@ class AppDefinition:
     author: str = ''
     license: str = ''
 
+    @classmethod
+    def from_json(cls, json_str: str) -> 'AppDefinition':
+        raise NotImplementedError  # A stub to silence the linters
 
-def load_app_from_json_file(json_file: Path) -> AppDefinition:
+    def to_json(self) -> str:
+        raise NotImplementedError  # A stub to silence the linters
+
+
+def load_app_from_json_file(json_file: Path) -> Tuple[AppId, AppDefinition]:
     """ Parse application definition from the given JSON file. Raise ValueError
         if the given file doesn't contain a valid definition. """
     try:
         app_json = json_file.read_text(encoding='utf-8')
-        # pylint: disable=no-member
-        return AppDefinition.from_json(app_json)  # type: ignore
-        # pylint: enable=no-member
+        app_id = hashlib.md5(app_json.encode('utf-8')).hexdigest()
+        return app_id, AppDefinition.from_json(app_json)
     except (OSError, ValueError, KeyError):
         msg = f"Error parsing app definition from file '{json_file}'."
         logger.exception(msg)
         raise ValueError(msg)
 
 
-def load_apps_from_dir(app_dir: Path) -> Iterator[AppDefinition]:
+def load_apps_from_dir(app_dir: Path) -> Iterator[Tuple[AppId, AppDefinition]]:
     """ Read every file in the given directory and attempt to parse it. Ignore
         files which don't contain valid app definitions. """
     for json_file in app_dir.iterdir():
@@ -55,38 +64,40 @@ class AppManager:
     """ Manager class for applications using Task API. """
 
     def __init__(self) -> None:
-        self._apps: Dict[str, AppDefinition] = {}
-        self._state: Dict[str, bool] = {}
+        self._apps: Dict[AppId, AppDefinition] = {}
+        self._state: Dict[AppId, bool] = {}
 
-    def register_app(self, app: AppDefinition) -> None:
+    def register_app(self, app_id: AppId, app: AppDefinition) -> None:
         """ Register an application in the manager. """
-        if app.name in self._apps:
-            raise ValueError(f"Application '{app.name}' already registered.")
-        self._apps[app.name] = app
-        self._state[app.name] = False
-        logger.info("Application '%s' registered.", app.name)
+        if app_id in self._apps:
+            raise ValueError(
+                f"Application already registered. "
+                f"app_name={app.name} app_id={app_id}")
+        self._apps[app_id] = app
+        self._state[app_id] = False
+        logger.info(
+            "Application registered. app_name=%r app_id=%r", app.name, app_id)
 
-    def enabled(self, app_name: str) -> bool:
-        """ Check if an application with the given name is registered in the
+    def enabled(self, app_id: AppId) -> bool:
+        """ Check if an application with the given ID is registered in the
             manager and enabled. """
-        return app_name in self._state and self._state[app_name]
+        return app_id in self._state and self._state[app_id]
 
-    def set_enabled(self, app_name: str, enabled: bool) -> None:
+    def set_enabled(self, app_id: AppId, enabled: bool) -> None:
         """ Enable or disable an application. Raise an error if the application
             is not registered or the environment associated with the application
             is not available. """
-        if app_name not in self._apps:
-            raise ValueError(f"Application '{app_name}' not registered.")
-        self._state[app_name] = enabled
+        if app_id not in self._apps:
+            raise ValueError(f"Application not registered. app_id={app_id}")
+        self._state[app_id] = enabled
         logger.info(
-            "Application '%s' %s.",
-            app_name,
-            'enabled' if enabled else 'disabled')
+            "Application %s. app_id=%r",
+            'enabled' if enabled else 'disabled', app_id)
 
-    def apps(self) -> List[AppDefinition]:
+    def apps(self) -> List[Tuple[AppId, AppDefinition]]:
         """ Get all registered apps. """
-        return list(self._apps.values())
+        return list(self._apps.items())
 
-    def app(self, app_name: str) -> AppDefinition:
-        """ Get an app with given name (assuming it is registered). """
-        return self._apps[app_name]
+    def app(self, app_id: AppId) -> AppDefinition:
+        """ Get an app with given ID (assuming it is registered). """
+        return self._apps[app_id]

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -184,8 +184,8 @@ class TaskServer(
         app_mgr = app_manager.AppManager()
         app_dir = self.get_app_dir()
         os.makedirs(app_dir, exist_ok=True)
-        for app_id, app_def in app_manager.load_apps_from_dir(app_dir):
-            app_mgr.register_app(app_id, app_def)
+        for app_def in app_manager.load_apps_from_dir(app_dir):
+            app_mgr.register_app(app_def)
 
         self.requested_task_manager = RequestedTaskManager(
             env_manager=new_env_manager,

--- a/tests/golem/test_app_manager.py
+++ b/tests/golem/test_app_manager.py
@@ -1,3 +1,4 @@
+import hashlib
 from unittest import TestCase
 
 from golem.app_manager import (
@@ -8,9 +9,8 @@ from golem.app_manager import (
 )
 from golem.testutils import TempDirFixture
 
-APP_NAME = 'test_app'
 APP_DEF = AppDefinition(
-    name=APP_NAME,
+    name='test_app',
     requestor_env='test_env',
     requestor_prereq={
         'key1': 'value',
@@ -18,6 +18,7 @@ APP_DEF = AppDefinition(
     },
     max_benchmark_score=1.0
 )
+APP_ID = hashlib.md5(APP_DEF.to_json().encode('utf-8')).hexdigest()
 
 
 class AppManagerTestBase(TestCase):
@@ -30,39 +31,40 @@ class AppManagerTestBase(TestCase):
 class TestRegisterApp(AppManagerTestBase):
 
     def test_register_app(self):
-        self.app_manager.register_app(APP_DEF)
-        self.assertEqual(self.app_manager.apps(), [APP_DEF])
-        self.assertEqual(self.app_manager.app(APP_NAME), APP_DEF)
-        self.assertFalse(self.app_manager.enabled(APP_NAME))
+        self.app_manager.register_app(APP_ID, APP_DEF)
+        self.assertEqual(self.app_manager.apps(), [(APP_ID, APP_DEF)])
+        self.assertEqual(self.app_manager.app(APP_ID), APP_DEF)
+        self.assertFalse(self.app_manager.enabled(APP_ID))
 
     def test_re_register(self):
-        self.app_manager.register_app(APP_DEF)
+        self.app_manager.register_app(APP_ID, APP_DEF)
         with self.assertRaises(ValueError):
-            self.app_manager.register_app(APP_DEF)
+            self.app_manager.register_app(APP_ID, APP_DEF)
 
 
 class TestSetEnabled(AppManagerTestBase):
 
     def test_app_not_registered(self):
         with self.assertRaises(ValueError):
-            self.app_manager.set_enabled(APP_NAME, True)
+            self.app_manager.set_enabled(APP_ID, True)
 
     def test_enable_disable(self):
-        self.app_manager.register_app(APP_DEF)
-        self.assertFalse(self.app_manager.enabled(APP_NAME))
-        self.app_manager.set_enabled(APP_NAME, True)
-        self.assertTrue(self.app_manager.enabled(APP_NAME))
-        self.app_manager.set_enabled(APP_NAME, False)
-        self.assertFalse(self.app_manager.enabled(APP_NAME))
+        self.app_manager.register_app(APP_ID, APP_DEF)
+        self.assertFalse(self.app_manager.enabled(APP_ID))
+        self.app_manager.set_enabled(APP_ID, True)
+        self.assertTrue(self.app_manager.enabled(APP_ID))
+        self.app_manager.set_enabled(APP_ID, False)
+        self.assertFalse(self.app_manager.enabled(APP_ID))
 
 
 class TestLoadAppFromJSONFile(TempDirFixture):
 
     def test_ok(self):
         json_file = self.new_path / 'test_app.json'
-        json_file.write_text(APP_DEF.to_json(), encoding='utf-8')  # noqa pylint: disable=no-member
-        loaded_app = load_app_from_json_file(json_file)
-        self.assertEqual(loaded_app, APP_DEF)
+        json_file.write_text(APP_DEF.to_json(), encoding='utf-8')
+        app_id, app_def = load_app_from_json_file(json_file)
+        self.assertEqual(app_id, APP_ID)
+        self.assertEqual(app_def, APP_DEF)
 
     def test_file_missing(self):
         json_file = self.new_path / 'test_app.json'
@@ -81,7 +83,7 @@ class TestLoadAppsFromDir(TempDirFixture):
     def test_register(self):
         app_file = self.new_path / 'test_app.json'
         bogus_file = self.new_path / 'bogus.json'
-        app_file.write_text(APP_DEF.to_json(), encoding='utf-8')  # noqa pylint: disable=no-member
+        app_file.write_text(APP_DEF.to_json(), encoding='utf-8')
         bogus_file.write_text('(╯°□°）╯︵ ┻━┻', encoding='utf-8')
         loaded_apps = list(load_apps_from_dir(self.new_path))
-        self.assertEqual(loaded_apps, [APP_DEF])
+        self.assertEqual(loaded_apps, [(APP_ID, APP_DEF)])

--- a/tests/golem/test_app_manager.py
+++ b/tests/golem/test_app_manager.py
@@ -1,4 +1,3 @@
-import hashlib
 from unittest import TestCase
 
 from golem.app_manager import (
@@ -18,7 +17,7 @@ APP_DEF = AppDefinition(
     },
     max_benchmark_score=1.0
 )
-APP_ID = hashlib.md5(APP_DEF.to_json().encode('utf-8')).hexdigest()
+APP_ID = APP_DEF.id
 
 
 class AppManagerTestBase(TestCase):
@@ -31,15 +30,15 @@ class AppManagerTestBase(TestCase):
 class TestRegisterApp(AppManagerTestBase):
 
     def test_register_app(self):
-        self.app_manager.register_app(APP_ID, APP_DEF)
+        self.app_manager.register_app(APP_DEF)
         self.assertEqual(self.app_manager.apps(), [(APP_ID, APP_DEF)])
         self.assertEqual(self.app_manager.app(APP_ID), APP_DEF)
         self.assertFalse(self.app_manager.enabled(APP_ID))
 
     def test_re_register(self):
-        self.app_manager.register_app(APP_ID, APP_DEF)
+        self.app_manager.register_app(APP_DEF)
         with self.assertRaises(ValueError):
-            self.app_manager.register_app(APP_ID, APP_DEF)
+            self.app_manager.register_app(APP_DEF)
 
 
 class TestSetEnabled(AppManagerTestBase):
@@ -49,7 +48,7 @@ class TestSetEnabled(AppManagerTestBase):
             self.app_manager.set_enabled(APP_ID, True)
 
     def test_enable_disable(self):
-        self.app_manager.register_app(APP_ID, APP_DEF)
+        self.app_manager.register_app(APP_DEF)
         self.assertFalse(self.app_manager.enabled(APP_ID))
         self.app_manager.set_enabled(APP_ID, True)
         self.assertTrue(self.app_manager.enabled(APP_ID))
@@ -62,8 +61,8 @@ class TestLoadAppFromJSONFile(TempDirFixture):
     def test_ok(self):
         json_file = self.new_path / 'test_app.json'
         json_file.write_text(APP_DEF.to_json(), encoding='utf-8')
-        app_id, app_def = load_app_from_json_file(json_file)
-        self.assertEqual(app_id, APP_ID)
+        app_def = load_app_from_json_file(json_file)
+        self.assertEqual(app_def.id, APP_ID)
         self.assertEqual(app_def, APP_DEF)
 
     def test_file_missing(self):
@@ -77,6 +76,32 @@ class TestLoadAppFromJSONFile(TempDirFixture):
         with self.assertRaises(ValueError):
             load_app_from_json_file(json_file)
 
+    def test_formatting_invariant(self):
+        app_json_1 = '''{
+            "name":               "app",
+            "requestor_env":      "env",
+            "requestor_prereq":   {
+                "x": "y"
+            },
+            "max_benchmark_score": 0.0
+        }'''
+        json_file1 = self.new_path / 'app1.json'
+        json_file1.write_text(app_json_1, encoding='utf-8')
+
+        app_json_2 = '''{
+            "name": "app",
+            "max_benchmark_score": 0.0,
+            "requestor_env": "env",
+            "requestor_prereq": {"x": "y"}
+        }'''
+        json_file2 = self.new_path / 'app2.json'
+        json_file2.write_text(app_json_2)
+
+        app1 = load_app_from_json_file(json_file1)
+        app2 = load_app_from_json_file(json_file2)
+        self.assertEqual(app1, app2)
+        self.assertEqual(app1.id, app2.id)
+
 
 class TestLoadAppsFromDir(TempDirFixture):
 
@@ -86,4 +111,4 @@ class TestLoadAppsFromDir(TempDirFixture):
         app_file.write_text(APP_DEF.to_json(), encoding='utf-8')
         bogus_file.write_text('(╯°□°）╯︵ ┻━┻', encoding='utf-8')
         loaded_apps = list(load_apps_from_dir(self.new_path))
-        self.assertEqual(loaded_apps, [(APP_ID, APP_DEF)])
+        self.assertEqual(loaded_apps, [APP_DEF])


### PR DESCRIPTION
* Apps are no longer identified by names. Instead IDs are used which are computed as MD5 digests of app definitions. This prevents possible name clashes.
* During `TaskServer` setup app directory is created if not existent and all app definitions from that directory are loaded and registered in `AppManager`.