### PR TITLE
Fix VbR BucketVerifier and add tests

### DIFF
--- a/apps/wasm/vbr.py
+++ b/apps/wasm/vbr.py
@@ -139,6 +139,7 @@ class BucketVerifier(VerificationByRedundancy):
         self.normal_actor_count = redundancy_factor + 1
         self.referee_count = referee_count
         self.majority = (self.normal_actor_count + self.referee_count) // 2 + 1
+        self.max_actor_cnt = self.normal_actor_count + self.referee_count
 
     def validate_actor(self, actor):
         if actor in self.actors:
@@ -208,7 +209,8 @@ class BucketVerifier(VerificationByRedundancy):
                  if actor in winners else fail)
                 for actor in self.actors
             ]
-        elif self.majority - max_popularity <= self.referee_count:
+        elif self.majority - max_popularity <= self.referee_count and \
+                len(self.actors) < self.max_actor_cnt:
             self.verdicts = None
             self.more_actors_needed = True
         else:

--- a/tests/apps/wasm/test_vbr.py
+++ b/tests/apps/wasm/test_vbr.py
@@ -250,3 +250,48 @@ def test_r1_result_already_added_value_error():
 
     with pytest.raises(ValueError):
         verifier.add_result(actors[1], 1)
+
+
+def test_r1_with_referee_all_different():
+    verifier = BucketVerifier(1, SimpleComparator(), 1)
+
+    verifier.add_actor(actors[1])
+    verifier.add_actor(actors[2])
+
+    verifier.add_result(actors[1], 1)
+    verifier.add_result(actors[2], 2)
+
+    verifier.add_actor(actors[3])
+    verifier.add_result(actors[3], 3)
+
+    assert verifier.get_verdicts() is not None
+
+
+def test_r1_with_referee_all_different_with_none():
+    verifier = BucketVerifier(1, SimpleComparator(), 1)
+
+    verifier.add_actor(actors[1])
+    verifier.add_actor(actors[2])
+
+    verifier.add_result(actors[1], 1)
+    verifier.add_result(actors[2], None)
+
+    verifier.add_actor(actors[3])
+    verifier.add_result(actors[3], 3)
+
+    assert verifier.get_verdicts() is not None
+
+
+def test_r1_with_referee_none_result():
+    verifier = BucketVerifier(1, SimpleComparator(), 1)
+
+    verifier.add_actor(actors[1])
+    verifier.add_actor(actors[2])
+
+    verifier.add_result(actors[1], None)
+    verifier.add_result(actors[2], 2)
+
+    verifier.add_actor(actors[3])
+    verifier.add_result(actors[3], None)
+
+    assert verifier.get_verdicts() is not None


### PR DESCRIPTION
Fixing an issue that verification by redundancy was not giving a verdict when all 3 results differ (in case where referee is called into action). 