### PR TITLE
Windows buildbot fix

### DIFF
--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -1,6 +1,6 @@
 --extra-index-url https://builds.golem.network
 pypiwin32==223
-pywin32==223
 pyreadline==2.1
 pyvbox==1.3.2
+pywin32==223
 vboxapi==5.1.26

--- a/requirements-win.txt
+++ b/requirements-win.txt
@@ -1,5 +1,6 @@
 --extra-index-url https://builds.golem.network
 pypiwin32==223
+pywin32==223
 pyreadline==2.1
 pyvbox==1.3.2
 vboxapi==5.1.26


### PR DESCRIPTION
`pywin32` has been upgraded to version `225`, which hash been preventing windows buildbots from running the test suite. This PR enforces the the previous `223` version.