### PR TITLE
Upgrade to Task API v0.18.3 and some fixes

### DIFF
--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -1,11 +1,11 @@
 import asyncio
-import json
+import hashlib
 from datetime import timedelta
 import logging
 import os
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from dataclasses import dataclass
 from golem_messages import idgenerator
@@ -188,7 +188,7 @@ class RequestedTaskManager:
             task.app_params,
         )
         task.env_id = reply.env_id
-        task.prerequisites = json.loads(reply.prerequisites_json)
+        task.prerequisites = reply.prerequisites
         task.save()
         logger.debug('init_task(task_id=%r) after', task_id)
 
@@ -254,7 +254,7 @@ class RequestedTaskManager:
             self,
             task_id: TaskId,
             computing_node: ComputingNodeDefinition
-    ) -> SubtaskDefinition:
+    ) -> Optional[SubtaskDefinition]:
         """ Return a set of data required for subtask computation. """
         logger.debug(
             'get_next_subtask(task_id=%r, computing_node=%r)',
@@ -265,7 +265,7 @@ class RequestedTaskManager:
         task = RequestedTask.get(RequestedTask.task_id == task_id)
         node, _ = ComputingNode.get_or_create(
             node_id=computing_node.node_id,
-            name=computing_node.name
+            defaults={'name': computing_node.name}
         )
 
         # Check not providing for own task
@@ -283,7 +283,17 @@ class RequestedTaskManager:
                 f"Task not pending, no next subtask. task_id={task_id}")
 
         app_client = await self._get_app_client(task.app_id)
-        result = await app_client.next_subtask(task.task_id)
+        result = await app_client.next_subtask(
+            task_id=task.task_id,
+            opaque_node_id=hashlib.sha3_256(node.node_id.encode()).hexdigest()  # noqa pylint: disable=no-member
+        )
+
+        if result is None:
+            logger.info(
+                "Application refused to assign subtask to provider node. "
+                "task_id=%r, node_id=%r", task_id, node.node_id)
+            return None
+
         subtask = RequestedSubtask.create(
             task=task,
             subtask_id=result.subtask_id,

--- a/requirements.txt
+++ b/requirements.txt
@@ -41,7 +41,7 @@ eventlet==0.24.1
 fs==2.4.4
 Golem-Messages==3.11.0
 Golem-Smart-Contracts-Interface==1.10.3
-golem_task_api==0.16.1
+golem_task_api==0.18.3
 greenlet==0.4.15
 h2==3.0.1
 hpack==3.0.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -20,7 +20,7 @@ eth-utils==1.0.3
 ethereum==1.6.1
 Golem-Messages==3.11.0
 Golem-Smart-Contracts-Interface==1.10.3
-golem_task_api==0.16.1
+golem_task_api==0.18.3
 html2text==2018.1.9
 humanize==0.5.1
 incremental==17.5.0

--- a/tests/golem/task/test_tasksession_task_api.py
+++ b/tests/golem/task/test_tasksession_task_api.py
@@ -1,5 +1,5 @@
+import asyncio
 import tempfile
-import unittest
 from unittest import mock
 from pathlib import Path
 
@@ -8,13 +8,14 @@ from golem_messages.message import tasks as msg_tasks
 
 from twisted.internet import defer
 
-from golem.core.deferred import sync_wait
 from golem.resource import resourcemanager
 from golem.task import requestedtaskmanager
 from golem.task import tasksession
+from tests.utils.asyncio import TwistedAsyncioTestCase
 
 
-class TestTaskApiReactToWantToComputeTask(unittest.TestCase):
+class TestTaskApiReactToWantToComputeTask(TwistedAsyncioTestCase):
+
     def setUp(self):
         self.ts = tasksession.TaskSession(mock.Mock())
         self.ts.key_id = 'testid'
@@ -65,6 +66,7 @@ class TestTaskApiReactToWantToComputeTask(unittest.TestCase):
             msg_tasks.CannotAssignTask.REASON.TaskFinished,
         )
 
+    @defer.inlineCallbacks
     def test_offer_chosen(self):
         random_dir = Path(tempfile.gettempdir())
         self.rtm.get_subtask_inputs_dir.return_value = random_dir
@@ -74,7 +76,9 @@ class TestTaskApiReactToWantToComputeTask(unittest.TestCase):
             params={'param1': 'value1', 'param2': 'value2'},
             deadline=222,
         )
-        self.rtm.get_next_subtask.return_value = subtask_def
+        subtask_future = asyncio.Future()
+        subtask_future.set_result(subtask_def)
+        self.rtm.get_next_subtask.return_value = subtask_future
         self.rtm.has_pending_subtasks.return_value = True
         shared_resources = []
 
@@ -84,9 +88,12 @@ class TestTaskApiReactToWantToComputeTask(unittest.TestCase):
             return defer.succeed(return_value)
         self.resource_manager.share.side_effect = _share
 
-        sync_wait(self.ts._offer_chosen(True, self.wtct))
+        yield self.ts._offer_chosen(True, self.wtct)
 
-        self.rtm.get_next_subtask.assert_called_once_with(self.wtct.task_id)
+        self.rtm.get_next_subtask.assert_called_once_with(
+            task_id=self.wtct.task_id,
+            computing_node=mock.ANY
+        )
         for r in subtask_def.resources:
             self.resource_manager.share.assert_any_call(random_dir / r)
         self.assertEqual(


### PR DESCRIPTION
* `RequestorAppClient.create_task` reply has `prerequisites` dictionary, not `prerequisites_json`.
* `RequestorAppClient.next_subtask` requires `opaque_node_id` parameter.
* `RequestorAppClient.next_subtask` may return `None` when the application refuses to assign a subtask to a particular given node. Such situation has to be handled by `RequestedTaskManager`.
* Node name should not belong to the search query when checking `ComputingNode` because it may change.
* When calling `RequestedTaskManager.get_next_subtask` in `TaskSession`, `computing_node` parameter has to be provided and the result has to be properly awaited.