### PR TITLE
explicitly pass the stats dict as `ProviderStats`

### DIFF
--- a/golem/task/server/helpers.py
+++ b/golem/task/server/helpers.py
@@ -2,6 +2,7 @@ import logging
 import typing
 
 from golem_messages import message
+from golem_messages.datastructures.stats import ProviderStats
 from golem_messages import helpers as msg_helpers
 from golem_messages import utils as msg_utils
 
@@ -145,7 +146,7 @@ def send_report_computed_task(
         multihash=waiting_task_result.result_hash,
         secret=waiting_task_result.result_secret,
         options=client_options.__dict__,
-        stats=waiting_task_result.stats,
+        stats=ProviderStats(**waiting_task_result.stats),
     )
 
     signed_report_computed_task = msg_utils.copy_and_sign(


### PR DESCRIPTION
explicitly pass the stats dict as `ProviderStats` instead of a plain dict to make the serialization and deserialization consistent

fixes the issue with Concent's Force Report node integration test