### PR TITLE
don't unlock if there's nothing left

### DIFF
--- a/golem/ethereum/transactionsystem.py
+++ b/golem/ethereum/transactionsystem.py
@@ -511,6 +511,8 @@ class TransactionSystem(LoopingCallService):
             (self._payments_locked + self._payment_processor.recipients_count)
 
     def unlock_funds_for_payments(self, price: int, num: int) -> None:
+        if num == 0:
+            return
         gnt = price * num
         if gnt > self._gntb_locked:
             raise Exception("Can't unlock {} GNT, locked: {}".format(


### PR DESCRIPTION
Avoid printing "Unlocking 0.000 GNTB for 0 payments" if task is finished.