### PR TITLE
Changed cpu_usage default to be non-zero

### DIFF
--- a/apps/core/benchmark/benchmarkrunner.py
+++ b/apps/core/benchmark/benchmarkrunner.py
@@ -5,6 +5,7 @@ from golem_messages.datastructures import stats as dt_stats
 
 from apps.core.task.coretaskstate import TaskDefinition
 from golem.envs import BenchmarkResult
+from golem.model import Performance
 from golem.task.localcomputer import LocalComputer
 from golem.task.taskbase import Task
 from golem.task.taskthread import TaskThread
@@ -72,7 +73,7 @@ class BenchmarkRunner(LocalComputer):
         # pylint: disable=no-member
         provider_stats = dt_stats.ProviderStats(**task_thread.stats)
         cpu_usage: int = provider_stats.cpu_stats.cpu_usage['total_usage'] \
-            if provider_stats.cpu_stats else 0
+            if provider_stats.cpu_stats else Performance.DEFAULT_CPU_USAGE
 
         try:
             benchmark_value = \

--- a/golem/database/database.py
+++ b/golem/database/database.py
@@ -61,7 +61,7 @@ class GolemSqliteDatabase(peewee.SqliteDatabase):
 
 
 class Database:
-    SCHEMA_VERSION = 40
+    SCHEMA_VERSION = 41
 
     def __init__(self,  # noqa pylint: disable=too-many-arguments
                  db: peewee.Database,

--- a/golem/database/schemas/041_change_default_performance.py
+++ b/golem/database/schemas/041_change_default_performance.py
@@ -1,19 +1,17 @@
 # pylint: disable=no-member
 # pylint: disable=unused-argument
-from golem.model import Performance
 import peewee as pw
+from golem.model import Performance
 
 SCHEMA_VERSION = 41
 
 
 def migrate(migrator, database, fake=False, **kwargs):
     database.truncate_table(Performance)
-    migrator.remove_fields('performance', 'cpu_usage')
-    migrator.add_fields('performance', cpu_usage=pw.IntegerField(
+    migrator.change_columns(Performance, cpu_usage=pw.IntegerField(
         default=Performance.DEFAULT_CPU_USAGE))
 
 
 def rollback(migrator, database, fake=False, **kwargs):
     database.truncate_table(Performance)
-    migrator.remove_fields('performance', 'cpu_usage')
-    migrator.add_fields('performance', cpu_usage=pw.IntegerField(default=0))
+    migrator.change_columns(Performance, cpu_usage=pw.IntegerField(default=0))

--- a/golem/database/schemas/041_change_default_performance.py
+++ b/golem/database/schemas/041_change_default_performance.py
@@ -1,0 +1,19 @@
+# pylint: disable=no-member
+# pylint: disable=unused-argument
+from golem.model import Performance
+import peewee as pw
+
+SCHEMA_VERSION = 41
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    database.truncate_table(Performance)
+    migrator.remove_fields('performance', 'cpu_usage')
+    migrator.add_fields('performance', cpu_usage=pw.IntegerField(
+        default=Performance.DEFAULT_CPU_USAGE))
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    database.truncate_table(Performance)
+    migrator.remove_fields('performance', 'cpu_usage')
+    migrator.add_fields('performance', cpu_usage=pw.IntegerField(default=0))

--- a/golem/environments/environment.py
+++ b/golem/environments/environment.py
@@ -119,6 +119,7 @@ class Environment():
         logger.info('%s performance is %.2f', cls.get_id(), performance)
 
         if save:
-            Performance.update_or_create(cls.get_id(), performance, 0)
+            Performance.update_or_create(cls.get_id(), performance,
+                                         Performance.DEFAULT_CPU_USAGE)
 
-        return BenchmarkResult(performance, 0)
+        return BenchmarkResult(performance, Performance.DEFAULT_CPU_USAGE)

--- a/golem/environments/environment.py
+++ b/golem/environments/environment.py
@@ -119,7 +119,7 @@ class Environment():
         logger.info('%s performance is %.2f', cls.get_id(), performance)
 
         if save:
-            Performance.update_or_create(cls.get_id(), performance,
-                                         Performance.DEFAULT_CPU_USAGE)
+            Performance.update_or_create(
+                cls.get_id(), performance, Performance.DEFAULT_CPU_USAGE)
 
         return BenchmarkResult(performance, Performance.DEFAULT_CPU_USAGE)

--- a/golem/envs/__init__.py
+++ b/golem/envs/__init__.py
@@ -82,7 +82,7 @@ class EnvSupportStatus(NamedTuple):
 @dataclass
 class BenchmarkResult:
     performance: float = 0.0
-    cpu_usage: int = 0
+    cpu_usage: int = Performance.DEFAULT_CPU_USAGE
 
     @staticmethod
     def from_performance(performance: Performance):

--- a/golem/model.py
+++ b/golem/model.py
@@ -549,10 +549,12 @@ class TaskPreset(BaseModel):
 
 class Performance(BaseModel):
     """ Keeps information about benchmark performance """
+    DEFAULT_CPU_USAGE = 1_000_000_000   # 1 second in nanoseconds
+
     environment_id = CharField(null=False, index=True, unique=True)
     value = FloatField(default=0.0)
     min_accepted_step = FloatField(default=300.0)
-    cpu_usage = IntegerField(default=0)  # total CPU usage in nanoseconds
+    cpu_usage = IntegerField(default=DEFAULT_CPU_USAGE)
 
     class Meta:
         database = db

--- a/scripts/node_integration_tests/nodes/provider/exception_on_computation_attempt.py
+++ b/scripts/node_integration_tests/nodes/provider/exception_on_computation_attempt.py
@@ -48,7 +48,7 @@ def run_benchmark_error_performance_0(self, benchmark, task_builder, env_id,
         Performance.update_or_create(
             env_id=env_id,
             performance=ACCEPTABLE_PERFORMANCE,
-            cpu_usage=0
+            cpu_usage=Performance.DEFAULT_CPU_USAGE
         )
 
         if isinstance(err, str):

--- a/tests/golem/envs/localhost.py
+++ b/tests/golem/envs/localhost.py
@@ -29,6 +29,7 @@ from golem.envs import (
     RuntimePayload
 )
 from golem.envs import BenchmarkResult
+from golem.model import Performance
 from golem.task.task_api import TaskApiPayloadBuilder
 
 logger = logging.getLogger(__name__)
@@ -257,7 +258,8 @@ class LocalhostEnvironment(EnvironmentBase):
         return defer.succeed(None)
 
     def run_benchmark(self) -> defer.Deferred:
-        return defer.succeed(BenchmarkResult(1.0, 1))
+        return defer.succeed(
+            BenchmarkResult(1.0, Performance.DEFAULT_CPU_USAGE))
 
     def metadata(self) -> EnvMetadata:
         return EnvMetadata(

--- a/tests/golem/test_model.py
+++ b/tests/golem/test_model.py
@@ -106,7 +106,7 @@ class TestPerformance(DatabaseFixture):
                                 perf.modified_date)
         self.assertEqual(perf.value, 0.0)
         self.assertEqual(perf.min_accepted_step, 300.0)
-        self.assertEqual(perf.cpu_usage, 0)
+        self.assertEqual(perf.cpu_usage, m.Performance.DEFAULT_CPU_USAGE)
 
     def test_constraints(self):
         perf = m.Performance()


### PR DESCRIPTION
This changes the default value for the CPU usage benchmark to 1 second, preventing division by zero errors when calculating the usage factor.