### PR TITLE
update FrameState when restarting task

### DIFF
--- a/apps/rendering/task/framerenderingtask.py
+++ b/apps/rendering/task/framerenderingtask.py
@@ -236,6 +236,9 @@ class FrameRenderingTask(RenderingTask):
             'frame_count': frame_count
         }})
 
+    def subtask_status_updated(self, subtask_id: str) -> None:
+        self._update_subtask_frame_status(subtask_id)
+
     #########################
     # Specific task methods #
     #########################

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -412,6 +412,9 @@ class Task(abc.ABC):
         """
         return None
 
+    def subtask_status_updated(self, subtask_id: str) -> None:
+        pass
+
 
 class ResultMetadata:
     def __init__(self, compute_time: float) -> None:

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -623,6 +623,7 @@ class TaskManager(TaskEventListener):
                 .status = SubtaskStatus.failure
             new_task.subtasks_given[new_subtask_id]['status'] \
                 = SubtaskStatus.failure
+            new_task.subtask_status_updated(new_subtask_id)
 
         new_task.num_failed_subtasks = \
             new_task.get_total_tasks() - len(subtasks_to_copy)
@@ -687,6 +688,7 @@ class TaskManager(TaskEventListener):
                 new_subtask_id, old_subtask, TaskResult(files=results))
 
             self.__set_subtask_state_finished(new_subtask_id)
+            new_task.subtask_status_updated(new_subtask_id)
 
             self.notice_task_updated(
                 task_id=new_task_id,


### PR DESCRIPTION
Let me tell you a [story](https://github.com/golemfactory/golem/issues/3173) about how much I [hate](https://github.com/golemfactory/golem/pull/4654#discussion_r318589810) implicit [state machines](https://github.com/golemfactory/golem/issues/4767#issuecomment-543758028)...

This solution is absolutely ugly, because it's very `FrameRenderingTask` specific. But on the other hand, we have no generic function for "hey, I just totally messed up with your internal state, so please recalculate whatever you need".

The problem I have is that doing it properly and nicely would require substantial refactoring. But on the other hand we're going to migrate blender to Task API, so I'm not sure if it's worth the effort.

fixes #4767