### PR TITLE
fix payment calculation in BrassMarketplace

### DIFF
--- a/golem/marketplace/brass_marketplace.py
+++ b/golem/marketplace/brass_marketplace.py
@@ -7,6 +7,7 @@ from golem.marketplace import (Offer, ProviderMarketStrategy, ProviderPricing)
 from golem.marketplace.pooling_marketplace import\
     RequestorPoolingMarketStrategy
 from golem.task import timer
+from golem.task.taskkeeper import compute_subtask_value
 import golem.ranking.manager.database_manager as dbm
 
 from .rust import order_providers
@@ -60,7 +61,7 @@ class RequestorBrassMarketStrategy(RequestorPoolingMarketStrategy):
     ) -> Callable[[int], int]:
 
         def payment_computer(price: int):
-            return price * task.header.subtask_timeout
+            return compute_subtask_value(price, task.header.subtask_timeout)
 
         return payment_computer
 

--- a/tests/golem/marketplace/test_marketplace.py
+++ b/tests/golem/marketplace/test_marketplace.py
@@ -49,9 +49,9 @@ class TestRequestorMarketStrategy(TestCase):
         market_strategy = RequestorBrassMarketStrategy
         task = Mock()
         task.header = Mock()
-        task.header.subtask_timeout = 10
+        task.header.subtask_timeout = 360
         payment_computer = market_strategy.get_payment_computer(task, None)
-        self.assertEqual(payment_computer(1), 10)
+        self.assertEqual(payment_computer(100), 10)  # price * timeout / 3600
 
     def test_wasm_payment_computer(self):
         task = Mock()


### PR DESCRIPTION
closes #4808

fix payment calculation in BrassMarketplace -> subtask_timeout is in seconds, not hours