### PR TITLE
Return expected amount in unconfirmed incomes

### DIFF
--- a/golem/rpc/api/ethereum_.py
+++ b/golem/rpc/api/ethereum_.py
@@ -64,10 +64,12 @@ class ETSProvider:
 
         def item(o):
             node_id = o.node if not o.node.startswith('0x') else o.node[2:]
+            amount = o.wallet_operation.amount \
+                if o.wallet_operation.amount else o.expected_amount
             return {
                 "subtask": common.to_unicode(o.subtask),
                 "payer": common.to_unicode(node_id),
-                "value": common.to_unicode(o.wallet_operation.amount),
+                "value": common.to_unicode(amount),
                 "status": common.to_unicode(o.wallet_operation.status.name),
                 "transaction": common.to_unicode(o.wallet_operation.tx_hash),
                 "created": common.datetime_to_timestamp_utc(o.created_date),


### PR DESCRIPTION
Return more usable value in old `pay.incomes` rpc. This issue was brought up by a user on *#tech* channel.

<img width="717" alt="awaitingincomes" src="https://user-images.githubusercontent.com/293058/67371387-9b31e900-f57c-11e9-993d-a60156bafc29.png">
