### PR TITLE
Fix division and limit benchmark-based usage factors

### DIFF
--- a/golem/marketplace/wasm_marketplace.py
+++ b/golem/marketplace/wasm_marketplace.py
@@ -28,6 +28,7 @@ logger = logging.getLogger(__name__)
 
 USAGE_SECOND = 1e9  # Usage is measured in nanoseconds
 
+
 class RequestorWasmMarketStrategy(RequestorPoolingMarketStrategy):
     DEFAULT_USAGE_BENCHMARK: float = 1.0 * USAGE_SECOND
 

--- a/golem/marketplace/wasm_marketplace.py
+++ b/golem/marketplace/wasm_marketplace.py
@@ -26,8 +26,10 @@ UsageReport = Tuple[ProviderId, SubtaskId, Usage]
 logger = logging.getLogger(__name__)
 
 
+USAGE_SECOND = 1e9  # Usage is measured in nanoseconds
+
 class RequestorWasmMarketStrategy(RequestorPoolingMarketStrategy):
-    DEFAULT_USAGE_BENCHMARK: float = 1.0
+    DEFAULT_USAGE_BENCHMARK: float = 1.0 * USAGE_SECOND
 
     _usages: ClassVar[Dict[str, float]] = dict()
     _max_usage_factor: ClassVar[float] = 2.0
@@ -39,6 +41,8 @@ class RequestorWasmMarketStrategy(RequestorPoolingMarketStrategy):
 
     @classmethod
     def set_my_usage_benchmark(cls, benchmark: float) -> None:
+        if benchmark < 1e-6 * USAGE_SECOND:
+            benchmark = cls.DEFAULT_USAGE_BENCHMARK
         logger.info("RWMS: set_my_usage_benchmark %.3f", benchmark)
         cls._my_usage_benchmark = benchmark
 
@@ -47,11 +51,14 @@ class RequestorWasmMarketStrategy(RequestorPoolingMarketStrategy):
         usage_factor = model.UsageFactor.select().where(
             model.UsageFactor.provider_node_id == provider_id).first()
         if usage_factor is None:
-            # Division goes this way since higher benchmark val means
-            # faster processor
-            uf = cls.get_my_usage_benchmark() / usage_benchmark
-            if not uf:
-                uf = 1.0
+            uf = usage_benchmark / cls.get_my_usage_benchmark()
+
+            # Sanity check against misreported benchmarks
+            uf = min(max(uf, 0.25), 1.5)
+            logger.info("RWMS: initial usage factor for %s = %.3f",
+                        provider_id,
+                        uf)
+
             node, _ = model.ComputingNode.get_or_create(
                 node_id=provider_id, defaults={'name': ''})
             usage_factor, _ = model.UsageFactor.get_or_create(

--- a/golem/marketplace/wasm_marketplace.py
+++ b/golem/marketplace/wasm_marketplace.py
@@ -54,7 +54,7 @@ class RequestorWasmMarketStrategy(RequestorPoolingMarketStrategy):
             uf = usage_benchmark / cls.get_my_usage_benchmark()
 
             # Sanity check against misreported benchmarks
-            uf = min(max(uf, 0.25), 1.5)
+            uf = min(max(uf, 0.1), 2.0)
             logger.info("RWMS: initial usage factor for %s = %.3f",
                         provider_id,
                         uf)

--- a/tests/golem/marketplace/test_wasm_marketplace.py
+++ b/tests/golem/marketplace/test_wasm_marketplace.py
@@ -6,7 +6,6 @@ from golem.marketplace import ProviderPerformance
 from golem.marketplace.wasm_marketplace import RequestorWasmMarketStrategy
 
 
-
 USAGE_SECOND = 1e9  # usage is measured in nanoseconds
 
 

--- a/tests/golem/marketplace/test_wasm_marketplace.py
+++ b/tests/golem/marketplace/test_wasm_marketplace.py
@@ -71,11 +71,11 @@ class TestOfferChoice(testutils.DatabaseFixture):
         result = self._resolve_task_offers()
         self.assertEqual(
             RequestorWasmMarketStrategy.get_usage_factor(self.PROVIDER_1, -1),
-            0.00125
+            1.25
         )
         self.assertEqual(
             RequestorWasmMarketStrategy.get_usage_factor(self.PROVIDER_2, -1),
-            0.0008
+            0.8
         )
         RequestorWasmMarketStrategy.report_subtask_usages(
             self.TASK_1, [(self.PROVIDER_1, self.SUBTASK_1, 5.0),

--- a/tests/golem/marketplace/test_wasm_marketplace.py
+++ b/tests/golem/marketplace/test_wasm_marketplace.py
@@ -6,6 +6,10 @@ from golem.marketplace import ProviderPerformance
 from golem.marketplace.wasm_marketplace import RequestorWasmMarketStrategy
 
 
+
+USAGE_SECOND = 1e9  # usage is measured in nanoseconds
+
+
 class TestOfferChoice(testutils.DatabaseFixture):
     TASK_1 = 'task_1'
     TASK_2 = 'task_2'
@@ -22,7 +26,8 @@ class TestOfferChoice(testutils.DatabaseFixture):
         mock_offer_1.quality = (.0, .0, .0, .0)
         mock_offer_1.reputation = .0
         mock_offer_1.price = 5.0
-        mock_offer_1.provider_performance = ProviderPerformance(1000 / 1.25)
+        mock_offer_1.provider_performance = ProviderPerformance(
+            1.25 * USAGE_SECOND)
         self.mock_offer_1 = mock_offer_1
 
         mock_offer_2 = Mock()
@@ -30,15 +35,20 @@ class TestOfferChoice(testutils.DatabaseFixture):
         mock_offer_2.quality = (.0, .0, .0, .0)
         mock_offer_2.reputation = .0
         mock_offer_2.price = 6.0
-        mock_offer_2.provider_performance = ProviderPerformance(1000 / 0.8)
+        mock_offer_2.provider_performance = ProviderPerformance(
+            0.8 * USAGE_SECOND)
         self.mock_offer_2 = mock_offer_2
 
     def test_get_usage_benchmark(self):
         self.assertEqual(
-            RequestorWasmMarketStrategy.get_my_usage_benchmark(), 1.0
+            RequestorWasmMarketStrategy.get_my_usage_benchmark(),
+            RequestorWasmMarketStrategy.DEFAULT_USAGE_BENCHMARK
         )
         self.assertEqual(
-            RequestorWasmMarketStrategy.get_usage_factor(self.PROVIDER_1, 1.0),
+            RequestorWasmMarketStrategy.get_usage_factor(
+                self.PROVIDER_1,
+                RequestorWasmMarketStrategy.DEFAULT_USAGE_BENCHMARK
+            ),
             1.0
         )
 


### PR DESCRIPTION
Sometimes usage benchmark results can get misreported. This PR introduces sanity checks for usage factors based on these benchmark results, limiting them to the [0.1,2] range.

This PR also modifies initial usage factor calculation to take into account the fact that with usage benchmarks, (in contrast to efficiency benchmarks), faster machines correspond to smaller values.

Additionally, we prevent dividing by 0 (or other very small value of the usage benchmark).

Note: this PR is basically #4803 rebased to develop after merging #4802