### PR TITLE
Task API RequestorMarketStrategy fetch in VerificationMixin

### DIFF
--- a/golem/marketplace/brass_marketplace.py
+++ b/golem/marketplace/brass_marketplace.py
@@ -56,12 +56,13 @@ class RequestorBrassMarketStrategy(RequestorPoolingMarketStrategy):
     @classmethod
     def get_payment_computer(
             cls,
-            task: 'Task',
-            subtask_id: str
+            subtask_id: str,
+            subtask_timeout: int,
+            subtask_price: int,
     ) -> Callable[[int], int]:
 
         def payment_computer(price: int):
-            return compute_subtask_value(price, task.header.subtask_timeout)
+            return compute_subtask_value(price, subtask_timeout)
 
         return payment_computer
 

--- a/golem/marketplace/marketplace.py
+++ b/golem/marketplace/marketplace.py
@@ -60,8 +60,12 @@ class RequestorMarketStrategy(ABC):
         raise NotImplementedError()
 
     @abstractclassmethod
-    def get_payment_computer(cls, task: 'Task', subtask_id: str)\
-            -> Callable[[int], int]:
+    def get_payment_computer(
+            cls,
+            subtask_id: str,
+            subtask_timeout: int,
+            subtask_price: int,
+    ) -> Callable[[int], int]:
         """Returns a function computing payment based on price in TTC.
         Raises:
             NotImplementedError: [description]

--- a/golem/marketplace/wasm_marketplace.py
+++ b/golem/marketplace/wasm_marketplace.py
@@ -146,12 +146,14 @@ class RequestorWasmMarketStrategy(RequestorPoolingMarketStrategy):
 
     @classmethod
     def get_payment_computer(
-            cls, task: 'Task',
-            subtask_id: str
+            cls,
+            subtask_id: str,
+            subtask_timeout: int,
+            subtask_price: int,
     ) -> Callable[[int], int]:
         def payment_computer(price: int) -> int:
             subtask_usage: float = cls._get_subtask_usage(subtask_id)
-            return min(int(price * subtask_usage / 3600), task.subtask_price)
+            return min(int(price * subtask_usage / 3600), subtask_price)
 
         return payment_computer
 

--- a/golem/task/server/verification.py
+++ b/golem/task/server/verification.py
@@ -162,7 +162,8 @@ class VerificationMixin:
         task = self.requested_task_manager.get_requested_task(task_id)
         if not task:
             raise RuntimeError(
-                f"Completed verification of unknown task {task_id}")
+                f"Completed verification of subtask {subtask_id} "
+                f"within an unknown task {task_id}")
 
         subtask = self.requested_task_manager.get_requested_task_subtask(
             task_id,

--- a/golem/task/server/verification.py
+++ b/golem/task/server/verification.py
@@ -18,7 +18,7 @@ from golem.task.taskbase import TaskResult
 if typing.TYPE_CHECKING:
     # pylint: disable=unused-import
     from golem.core import keysauth
-    from golem.task import taskmanager
+    from golem.task import taskmanager, SubtaskId, TaskId
     from golem.task import requestedtaskmanager
 
 logger = logging.getLogger(__name__)
@@ -84,21 +84,7 @@ class VerificationMixin:
                     timeout_seconds=config_desc.disallow_ip_timeout_seconds,
                 )
 
-            task = self.task_manager.tasks.get(task_id)
-            if task:
-                strat = task.REQUESTOR_MARKET_STRATEGY
-                payment_computer = strat.get_payment_computer(  # type: ignore
-                    task,
-                    subtask_id)
-            else:
-                # FIXME: adjust after merging #4753 (with #4785)
-                def payment_computer(price: int):
-                    return price * subtask_timeout
-
-                task = self.requested_task_manager.get_requested_task(task_id)
-                assert task, "Completed verification for an unknown task"
-                subtask_timeout = task.subtask_timeout
-
+            payment_computer = self._get_payment_computer(task_id, subtask_id)
             payment = self.accept_result(
                 task_id,
                 subtask_id,
@@ -157,6 +143,44 @@ class VerificationMixin:
                 ),
                 verification_finished_old,
             )
+
+    def _get_payment_computer(
+            self,
+            task_id: 'TaskId',
+            subtask_id: 'SubtaskId',
+    ) -> typing.Callable[[int], int]:
+        """ Retrieve the payment computing function for given
+            task_id and subtask_id """
+        task = self.task_manager.tasks.get(task_id)
+        if task:
+            market = task.REQUESTOR_MARKET_STRATEGY
+            return market.get_payment_computer(  # type: ignore
+                subtask_id,
+                subtask_timeout=int(task.header.subtask_timeout),
+                subtask_price=task.subtask_price)
+
+        task = self.requested_task_manager.get_requested_task(task_id)
+        if not task:
+            raise RuntimeError(
+                f"Completed verification of unknown task {task_id}")
+
+        subtask = self.requested_task_manager.get_requested_task_subtask(
+            task_id,
+            subtask_id)
+        if not subtask:
+            raise RuntimeError(
+                f"Completed verification of unknown subtask {subtask_id} "
+                f"within task {task_id}")
+
+        app = self.app_manager.app(task.app_id)
+        if not app:
+            raise RuntimeError(
+                f"Completed verification of task {task_id} "
+                f"created by an unknown app {task.app_id}")
+        return app.market_strategy.get_payment_computer(
+            subtask_id,
+            subtask_timeout=task.subtask_timeout,
+            subtask_price=subtask.price)
 
     def send_result_rejected(
             self,

--- a/golem/task/taskbase.py
+++ b/golem/task/taskbase.py
@@ -147,7 +147,7 @@ class Task(abc.ABC):
         return self.subtask_price * self.get_total_tasks()
 
     @property
-    def subtask_price(self):
+    def subtask_price(self) -> int:
         from golem.task import taskkeeper
         return taskkeeper.compute_subtask_value(
             self.header.max_price,

--- a/tests/golem/marketplace/test_marketplace.py
+++ b/tests/golem/marketplace/test_marketplace.py
@@ -18,13 +18,7 @@ HOUR = 3600
 
 
 def _fake_get_efficacy():
-
-    class A:
-
-        def __init__(self):
-            self.vector = (.0, .0, .0, .0)
-
-    return A()
+    return Mock(vector=(.0, .0, .0, .0))
 
 
 class TestScalePrice(TestCase):
@@ -52,7 +46,10 @@ class TestRequestorMarketStrategy(testutils.DatabaseFixture):
         task = Mock()
         task.header = Mock()
         task.header.subtask_timeout = 360
-        payment_computer = market_strategy.get_payment_computer(task, None)
+        payment_computer = market_strategy.get_payment_computer(
+            None,
+            task.header.subtask_timeout,
+            task.subtask_price)
         self.assertEqual(payment_computer(100), 10)  # price * timeout / 3600
 
     def test_wasm_payment_computer(self):
@@ -66,13 +63,15 @@ class TestRequestorMarketStrategy(testutils.DatabaseFixture):
                           (self.PROVIDER_B, self.SUBTASK_B, 8.0 * HOUR)]
         )
         payment_computer = market_strategy.get_payment_computer(
-            task, self.SUBTASK_A
-        )
+            self.SUBTASK_A,
+            task.header.subtask_timeout,
+            task.subtask_price)
         self.assertEqual(payment_computer(1000 * GWEI), 5000 * GWEI)
 
         payment_computer = market_strategy.get_payment_computer(
-            task, self.SUBTASK_B
-        )
+            self.SUBTASK_B,
+            task.header.subtask_timeout,
+            task.subtask_price)
         self.assertEqual(payment_computer(1000 * GWEI), 6000 * GWEI)
 
     def test_wasm_payment_computer_budget_exceeded(self):
@@ -86,13 +85,15 @@ class TestRequestorMarketStrategy(testutils.DatabaseFixture):
                           (self.PROVIDER_B, self.SUBTASK_B, 8.0 * HOUR)]
         )
         payment_computer = market_strategy.get_payment_computer(
-            task, self.SUBTASK_A
-        )
+            self.SUBTASK_A,
+            task.header.subtask_timeout,
+            task.subtask_price)
         self.assertEqual(payment_computer(1000 * GWEI), 5000 * GWEI)
 
         payment_computer = market_strategy.get_payment_computer(
-            task, self.SUBTASK_B
-        )
+            self.SUBTASK_B,
+            task.header.subtask_timeout,
+            task.subtask_price)
         self.assertEqual(payment_computer(1000 * GWEI), 6000 * GWEI)
 
 

--- a/tests/golem/task/server/test_verification.py
+++ b/tests/golem/task/server/test_verification.py
@@ -70,17 +70,14 @@ class TestGetPaymentComputer(unittest.TestCase):
             subtask_price=10 ** 17)
 
     def test_task_id_invalid(self):
-        with self.assertRaises(RuntimeError) as ctx:
+        with self.assertRaisesRegex(RuntimeError, "unknown task"):
             self.get(task_id='UNKNOWN', subtask_id='subtask_id')
-            self.assertIn(str(ctx.exception), "unknown task")
 
     def test_subtask_id_invalid(self):
-        with self.assertRaises(RuntimeError) as ctx:
+        with self.assertRaisesRegex(RuntimeError, "unknown subtask"):
             self.get(task_id='task_api_task_id', subtask_id='UNKNOWN')
-            self.assertIn(str(ctx.exception), "unknown subtask")
 
     def test_app_id_invalid(self):
         self.apps.clear()
-        with self.assertRaises(RuntimeError) as ctx:
+        with self.assertRaisesRegex(RuntimeError, "unknown app"):
             self.get(task_id='task_api_task_id', subtask_id='subtask_id')
-            self.assertIn(str(ctx.exception), "unknown app")

--- a/tests/golem/task/server/test_verification.py
+++ b/tests/golem/task/server/test_verification.py
@@ -4,10 +4,6 @@ from unittest import mock
 from golem.task.server.verification import VerificationMixin
 
 
-class Verifier(VerificationMixin):
-    pass
-
-
 class TestGetPaymentComputer(unittest.TestCase):
 
     def setUp(self) -> None:
@@ -45,7 +41,7 @@ class TestGetPaymentComputer(unittest.TestCase):
             )
         )
 
-        self.verifier = Verifier()
+        self.verifier = VerificationMixin()
         self.verifier.app_manager = am
         self.verifier.task_manager = tm
         self.verifier.requested_task_manager = rtm

--- a/tests/golem/task/server/test_verification.py
+++ b/tests/golem/task/server/test_verification.py
@@ -1,0 +1,90 @@
+import unittest
+from unittest import mock
+
+from golem.task.server.verification import VerificationMixin
+
+
+class Verifier(VerificationMixin):
+    pass
+
+
+class TestGetPaymentComputer(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.market_legacy = mock.Mock()
+        self.market_task_api = mock.Mock()
+        self.apps = {
+            'app_id': mock.Mock(market_strategy=self.market_task_api)
+        }
+        tasks = {
+            'legacy_task_id': mock.Mock(
+                REQUESTOR_MARKET_STRATEGY=self.market_legacy,
+                header=mock.Mock(subtask_timeout=3600),
+                subtask_price=10 ** 18,
+            )
+        }
+        task_api_tasks = {
+            'task_api_task_id': mock.Mock(
+                app_id='app_id',
+                subtask_timeout=1800,
+            )
+        }
+        task_api_subtasks = {
+            'subtask_id': mock.Mock(price=10 ** 17),
+        }
+
+        am = mock.Mock(app=self.apps.get)
+        tm = mock.Mock(tasks=tasks)
+        rtm = mock.Mock(
+            get_requested_task=task_api_tasks.get,
+            get_requested_task_subtask=mock.Mock(
+                side_effect=(
+                    lambda t, s: task_api_subtasks.get(s)
+                    if t in task_api_tasks else None
+                ),
+            )
+        )
+
+        self.verifier = Verifier()
+        self.verifier.app_manager = am
+        self.verifier.task_manager = tm
+        self.verifier.requested_task_manager = rtm
+        self.get = self.verifier._get_payment_computer
+
+    def test_legacy(self):
+        self.get(
+            task_id='legacy_task_id',
+            subtask_id='subtask_id')
+
+        self.assertFalse(self.market_task_api.get_payment_computer.called)
+        self.market_legacy.get_payment_computer.assert_called_with(
+            'subtask_id',
+            subtask_timeout=3600,
+            subtask_price=10 ** 18)
+
+    def test_task_api(self):
+        self.get(
+            task_id='task_api_task_id',
+            subtask_id='subtask_id')
+
+        self.assertFalse(self.market_legacy.get_payment_computer.called)
+        self.market_task_api.get_payment_computer.assert_called_with(
+            'subtask_id',
+            subtask_timeout=1800,
+            subtask_price=10 ** 17)
+
+    def test_task_id_invalid(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.get(task_id='UNKNOWN', subtask_id='subtask_id')
+            self.assertIn(str(ctx.exception), "unknown task")
+
+    def test_subtask_id_invalid(self):
+        with self.assertRaises(RuntimeError) as ctx:
+            self.get(task_id='task_api_task_id', subtask_id='UNKNOWN')
+            self.assertIn(str(ctx.exception), "unknown subtask")
+
+    def test_app_id_invalid(self):
+        self.apps.clear()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.get(task_id='task_api_task_id', subtask_id='subtask_id')
+            self.assertIn(str(ctx.exception), "unknown app")


### PR DESCRIPTION
- fetches a `RequestorMarketStrategy` class from `AppDefinition` for Task API tasks
- `RequestorMarketStrategy.get_payment_computer` no longer requires a `Task` object argument