### PR TITLE
Provider/requestor switch

### DIFF
--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -577,6 +577,8 @@ class ClientProvider:
             create_task_params.max_subtasks,
         )
 
+        self.client.update_setting('accept_tasks', False)
+
         @defer.inlineCallbacks
         def init_task():
             try:
@@ -584,6 +586,7 @@ class ClientProvider:
                     self.requested_task_manager.init_task(task_id))
             except Exception:
                 self.client.funds_locker.remove_task(task_id)
+                self.client.update_setting('accept_tasks', True)
                 raise
             else:
                 self.requested_task_manager.start_task(task_id)

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -903,10 +903,12 @@ class TaskServer(
         if not (event == 'task_status_updated'
                 and self.client.p2pservice):
             return
-        if not (op in [TaskOp.FINISHED, TaskOp.TIMEOUT]):
+        if not (op in [TaskOp.FINISHED, TaskOp.TIMEOUT, TaskOp.ABORTED]):
             return
         self.client.p2pservice.remove_task(task_id)
         self.client.funds_locker.remove_task(task_id)
+        if not self.requested_task_manager.has_unfinished_tasks():
+            self.client.update_setting('accept_tasks', True)
 
     def _increase_trust_payment(self, node_id: str, amount: int):
         Trust.PAYMENT.increase(node_id, self.max_trust)

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -68,18 +68,26 @@ class SubtaskStatus(Enum):
     failure = "Failure"
     restarted = "Restart"
     cancelled = "Cancelled"
+    timeout = "Timeout"
 
     def is_computed(self) -> bool:
         return self in [self.starting, self.downloading]
 
     def is_active(self) -> bool:
-        return self in [self.starting, self.downloading, self.verifying]
+        return self in SUBTASK_STATUS_ACTIVE
 
     def is_finished(self) -> bool:
         return self == self.finished
 
     def is_finishing(self) -> bool:
         return self in {self.downloading, self.verifying}
+
+
+SUBTASK_STATUS_ACTIVE = [
+    SubtaskStatus.starting,
+    SubtaskStatus.downloading,
+    SubtaskStatus.verifying
+]
 
 
 validate_varchar_inf = functools.partial(
@@ -169,8 +177,7 @@ class TaskStatus(Enum):
         return self in [self.creating, self.errorCreating]
 
     def is_completed(self) -> bool:
-        return self in [self.finished, self.aborted,
-                        self.timeout, self.restarted]
+        return self in TASK_STATUS_COMPLETED
 
     def is_preparing(self) -> bool:
         return self in (
@@ -181,6 +188,14 @@ class TaskStatus(Enum):
 
     def is_active(self) -> bool:
         return self in TASK_STATUS_ACTIVE
+
+
+TASK_STATUS_COMPLETED = [
+    TaskStatus.finished,
+    TaskStatus.aborted,
+    TaskStatus.timeout,
+    TaskStatus.restarted
+]
 
 
 TASK_STATUS_ACTIVE = [

--- a/tests/golem/task/test_rpc_task_api.py
+++ b/tests/golem/task/test_rpc_task_api.py
@@ -3,7 +3,7 @@ from pathlib import Path
 import tempfile
 import unittest
 from unittest import mock
-from mock import Mock
+from mock import Mock, call
 
 from golem.client import Client
 from golem.ethereum import fundslocker, transactionsystem
@@ -113,6 +113,8 @@ class TestTaskApiCreate(unittest.TestCase):
         )
 
         self.requested_task_manager.init_task.assert_called_once_with(task_id)
+        self.client.update_setting.assert_called_once_with(
+            'accept_tasks', False)
 
     def test_failed_init(self):
         self.requested_task_manager.init_task.side_effect = Exception
@@ -121,3 +123,7 @@ class TestTaskApiCreate(unittest.TestCase):
 
         self.client.funds_locker.remove_task.assert_called_once_with(task_id)
         self.requested_task_manager.start_task.assert_not_called()
+        self.client.update_setting.assert_has_calls((
+            call('accept_tasks', False),
+            call('accept_tasks', True)
+        ))

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1203,29 +1203,39 @@ class TestRestoreResources(LogTestCase, testutils.DatabaseFixture,
         self.ts.client = Mock()
         remove_task = self.ts.client.p2pservice.remove_task
         remove_task_funds_lock = self.ts.client.funds_locker.remove_task
+        update_setting = self.ts.client.update_setting
 
-        values = dict(TaskOp.__members__)
-        values.pop('FINISHED')
-        values.pop('TIMEOUT')
+        self.ts.requested_task_manager = Mock()
+        self.ts.requested_task_manager.has_unfinished_tasks.return_value = False
 
-        for value in values:
-            self.ts.finished_task_listener(op=value)
-            assert not remove_task.called
+        # Listener should ignore events other than 'task_status_updated'
+        for op in TaskOp:
+            self.ts.finished_task_listener(op=op)
 
-        for value in values:
-            self.ts.finished_task_listener(event='task_status_updated',
-                                           op=value)
-            assert not remove_task.called
+        remove_task.assert_not_called()
+        remove_task_funds_lock.assert_not_called()
+        update_setting.assert_not_called()
 
-        self.ts.finished_task_listener(event='task_status_updated',
-                                       op=TaskOp.FINISHED)
-        assert remove_task.called
-        assert remove_task_funds_lock.called
+        relevant_ops = {TaskOp.FINISHED, TaskOp.TIMEOUT, TaskOp.ABORTED}
+        irrelevant_ops = set(TaskOp) - relevant_ops
 
-        self.ts.finished_task_listener(event='task_status_updated',
-                                       op=TaskOp.TIMEOUT)
-        assert remove_task.call_count == 2
-        assert remove_task_funds_lock.call_count == 2
+        # Listener should ignore irrelevant operations
+        for op in irrelevant_ops:
+            self.ts.finished_task_listener(event='task_status_updated', op=op)
+
+        remove_task.assert_not_called()
+        remove_task_funds_lock.assert_not_called()
+        update_setting.assert_not_called()
+
+        # Listener should fire for relevant operations
+        task_id = 'test_task'
+        for op in relevant_ops:
+            self.ts.finished_task_listener(
+                event='task_status_updated', task_id=task_id, op=op)
+            remove_task.assert_called_once_with(task_id)
+            remove_task_funds_lock.assert_called_once_with(task_id)
+            update_setting.assert_called_once_with('accept_tasks', True)
+            self.ts.client.reset_mock()
 
 
 class TestSendResults(TaskServerTestBase):


### PR DESCRIPTION
* Stop accepting tasks when a Task API task is requested.
* Resume accepting tasks when no more Task API tasks are requested.