### PR TITLE
Bump golemfactory/wasm to 0.5.3

### DIFF
--- a/apps/images.ini
+++ b/apps/images.ini
@@ -4,5 +4,5 @@ golemfactory/blender blender/resources/images/blender.Dockerfile 1.12 blender/re
 golemfactory/blender_verifier blender/resources/images/blender_verifier.Dockerfile 1.8 blender/resources/images/
 golemfactory/blender_nvgpu blender/resources/images/blender_nvgpu.Dockerfile 1.6 . apps.core.nvgpu.is_supported
 golemfactory/dummy dummy/resources/images/Dockerfile 1.4 dummy/resources/images
-golemfactory/wasm wasm/resources/images/Dockerfile 0.5.2 wasm/resources/images
+golemfactory/wasm wasm/resources/images/Dockerfile 0.5.3 wasm/resources/images
 golemfactory/glambda glambda/resources/images/Dockerfile 1.7 .

--- a/apps/wasm/environment.py
+++ b/apps/wasm/environment.py
@@ -3,6 +3,6 @@ from golem.docker.environment import DockerEnvironment
 
 class WasmTaskEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/wasm"
-    DOCKER_TAG = "0.5.2"
+    DOCKER_TAG = "0.5.3"
     ENV_ID = "WASM"
     SHORT_DESCRIPTION = "WASM Sandbox"

--- a/apps/wasm/resources/images/Dockerfile
+++ b/apps/wasm/resources/images/Dockerfile
@@ -4,7 +4,7 @@ RUN apt -y update && apt -y install autoconf2.13 clang-6.0 --no-install-recommen
 
 RUN git clone https://github.com/golemfactory/sp-wasm.git
 WORKDIR /sp-wasm
-RUN git checkout tags/0.4.1
+RUN git checkout tags/v0.4.2
 ENV SHELL=/bin/bash
 ENV CC=clang-6.0
 ENV CPP="clang-6.0 -E"

--- a/scripts/docker_integrity/image_integrity.ini
+++ b/scripts/docker_integrity/image_integrity.ini
@@ -10,4 +10,4 @@ golemfactory/blender_verifier   1.8                 54c533b4d543d580e2d78f572571
 golemfactory/dummy              1.4                 70e9289a1abec564ce382eed328f385a75afbee549a376ece80e073a023e3138
 golemfactory/glambda            1.7                 8bde6311defcd5fab4a1f1eafa7496d5ca73a6f2a8cf26512412f19c5b6f09a7
 golemfactory/nvgpu              1.6                 820c20605d03bbe14b79048395ce23d6be3b150807f28a646ce1b26490e177c2
-golemfactory/wasm               0.5.2               1ac6b20185333bf3161bbc30f6a233cb80425b29024368fe6b1ab11baf385577
+golemfactory/wasm               0.5.3               48519c1ac994fe1826b9f7360d50c1c5798dfc9a7ba817ef3442fe99f95555d6


### PR DESCRIPTION
This PR bumps our Wasm sandbox to latest release `0.5.3` in Docker Hub. The corresponding changes can be found at golemfactory/sp-wasm#37. For completeness though, here's the summary of major changes to the sandbox:
* polyfill time functions with a stub that always returns the same time of day
* modify the default Emscripten `_usleep` function with a custom function which underneath uses `std::thread::sleep` to perform the actual sleeping of the running thread