### PR TITLE
Task API v0.22.0

### DIFF
--- a/golem/apps/default.py
+++ b/golem/apps/default.py
@@ -7,11 +7,11 @@ from pathvalidate import sanitize_filename
 from golem.apps import AppId, AppDefinition, save_app_to_json_file
 from golem.marketplace import RequestorBrassMarketStrategy
 
-BlenderAppDefinition_v0_4_0 = AppDefinition(
+BlenderAppDefinition_v0_5_0 = AppDefinition(
     name='golemfactory/blenderapp',
     author='Golem Factory GmbH',
     license='GPLv3',
-    version='0.4.0',
+    version='0.5.0',
     description=(
         'Rendering with Blender, the free and open source '
         '3D creation suite'
@@ -19,14 +19,14 @@ BlenderAppDefinition_v0_4_0 = AppDefinition(
     requestor_env=DOCKER_CPU_ENV_ID,
     requestor_prereq=dict(
         image='golemfactory/blenderapp',
-        tag='0.4.0',
+        tag='0.5.0',
     ),
     market_strategy=RequestorBrassMarketStrategy,
     max_benchmark_score=10000.,
 )
 
 APPS = [
-    BlenderAppDefinition_v0_4_0,
+    BlenderAppDefinition_v0_5_0,
 ]
 
 

--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -319,9 +319,11 @@ class RequestedTaskManager:
             raise RuntimeError(
                 f"Task not pending, no next subtask. task_id={task_id}")
 
+        subtask_id = idgenerator.generate_id(self._public_key)
         app_client = await self._get_app_client(task.app_id)
         result = await app_client.next_subtask(
             task_id=task.task_id,
+            subtask_id=subtask_id,
             opaque_node_id=hashlib.sha3_256(node.node_id.encode()).hexdigest()  # noqa pylint: disable=no-member
         )
 
@@ -331,7 +333,6 @@ class RequestedTaskManager:
                 "task_id=%r, node_id=%r", task_id, node.node_id)
             return None
 
-        subtask_id = result.subtask_id
         subtask = RequestedSubtask.create(
             task=task,
             subtask_id=subtask_id,

--- a/golem/task/taskkeeper.py
+++ b/golem/task/taskkeeper.py
@@ -233,12 +233,11 @@ class CompTaskKeeper:
 
     def check_comp_task_def(self, comp_task_def):
         task = self.active_tasks[comp_task_def['task_id']]
-        is_task_api_task = bool(task.header.environment_prerequisites)
         key_id: str = self.get_node_for_task_id(comp_task_def['task_id'])
         not_accepted_message = "Cannot accept subtask %s for task %s. %s"
         log_args = [comp_task_def['subtask_id'], comp_task_def['task_id']]
 
-        if not is_task_api_task and not idgenerator.check_id_hex_seed(
+        if not idgenerator.check_id_hex_seed(
                 comp_task_def['subtask_id'],
                 key_id,):
             logger.info(not_accepted_message, *log_args, "Subtask id was not "

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,9 +38,9 @@ eth-utils==1.0.3
 ethereum==1.6.1
 eventlet==0.24.1
 fs==2.4.4
-git+https://github.com/golemfactory/golem-messages@no_subtask_id_validation#egg=golem-messages
+Golem-Messages==3.13.0
 Golem-Smart-Contracts-Interface==1.10.3
-golem_task_api==0.21.0
+golem_task_api==0.22.0
 greenlet==0.4.15
 h2==3.0.1
 hpack==3.0.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -18,9 +18,9 @@ docker==3.5.0
 enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
-Golem-Messages
+Golem-Messages==3.13.0
 Golem-Smart-Contracts-Interface==1.10.3
-golem_task_api==0.21.0
+golem_task_api==0.22.0
 html2text==2018.1.9
 humanize==0.5.1
 incremental==17.5.0

--- a/scripts/node_integration_tests/tasks/__init__.py
+++ b/scripts/node_integration_tests/tasks/__init__.py
@@ -165,10 +165,10 @@ _TASK_SETTINGS = {
         },
     },
     'task_api_blender': {
-        'app_id': 'a6efc03aa659a16980fd5f079ae9b01b',
+        'app_id': 'c1e99170aa73521af6937f6680065e31',
         'name': '',  # leave empty: Task API output does not contain this name
         'resources': [],
-        'max_price_per_hour': str(50 * 10 ** 18),
+        'max_price_per_hour': str(10 ** 18),
         'max_subtasks': 1,
         'min_memory': 0,
         'task_timeout': 600000,  # 00:10:00

--- a/tests/golem/envs/localhost.py
+++ b/tests/golem/envs/localhost.py
@@ -108,6 +108,7 @@ class LocalhostAppHandler(RequestorAppHandler, ProviderAppHandler):
     async def next_subtask(
             self,
             task_work_dir: Path,
+            subtask_id: str,
             opaque_node_id: str
     ) -> Optional[Subtask]:
         return await self._prereq.next_subtask()  # type: ignore

--- a/tests/golem/envs/test_localhost_env.py
+++ b/tests/golem/envs/test_localhost_env.py
@@ -116,9 +116,8 @@ class TestLocalhostEnv(TwistedAsyncioTestCase):
     @inlineCallbacks
     def test_subtasks(self):
         subtask = Subtask(
-            subtask_id='test_subtask',
             params={'param': 'value'},
-            resources=['test_resource']
+            resources=['test_resource'],
         )
         subtasks = [subtask]
 
@@ -144,7 +143,7 @@ class TestLocalhostEnv(TwistedAsyncioTestCase):
         self.assertTrue(pending_subtasks)
 
         subtask_future = asyncio.ensure_future(client.next_subtask(
-            'whatever', 'whatever'))
+            'whatever', 'whatever', 'whatever'))
         result = yield deferred_from_future(subtask_future)
         self.assertEqual(result, subtask)
 

--- a/tests/golem/task/test_requestedtaskmanager.py
+++ b/tests/golem/task/test_requestedtaskmanager.py
@@ -169,6 +169,7 @@ class TestRequestedTaskManager:
         assert row.computing_node.name == computing_node.name
         mock_client.next_subtask.assert_called_once_with(
             task_id=task_id,
+            subtask_id=res.subtask_id,
             opaque_node_id=ANY
         )
 
@@ -328,7 +329,7 @@ class TestRequestedTaskManager:
             task_id,
             self._get_computing_node(),
         )
-        self._add_next_subtask_to_client_mock(mock_client, subtask_id='123')
+        self._add_next_subtask_to_client_mock(mock_client)
         subtask2 = await self.rtm.get_next_subtask(
             task_id,
             self._get_computing_node(node_id='testnodeid2'),
@@ -392,11 +393,8 @@ class TestRequestedTaskManager:
         return task_id
 
     @staticmethod
-    def _add_next_subtask_to_client_mock(
-            client_mock,
-            subtask_id='testsubtaskid'
-    ):
-        result = Subtask(subtask_id=subtask_id, params={}, resources=[])
+    def _add_next_subtask_to_client_mock(client_mock):
+        result = Subtask(params={}, resources=[])
         client_mock.next_subtask.return_value = result
         client_mock.has_pending_subtasks.return_value = True
 

--- a/tests/golem/task/test_taskkeeper.py
+++ b/tests/golem/task/test_taskkeeper.py
@@ -690,6 +690,13 @@ class TestCompTaskKeeper(LogTestCase, PEP8MixIn, TempDirFixture):
         del ctk.active_tasks[task_id].subtasks[subtask_id]
         assert ctk.check_comp_task_def(comp_task_def)
 
+        comp_task_def['subtask_id'] = "abc"
+        with self.assertLogs(logger, level="INFO") as log_:
+            assert not ctk.check_comp_task_def(comp_task_def)
+        assert "Cannot accept subtask abc for task %s. " \
+               "Subtask id was not generated from requestor's " \
+               "key." % (task_id) in log_.output[0]
+
     def test_add_package_paths(self):
         ctk = CompTaskKeeper(self.new_path)
         task_id = 'veryimportanttask'


### PR DESCRIPTION
- reverts `Golem-Messages` to the release version
- brings back `subtask_id` validation

~This PR requires new Blender App to be released~

Update to Task API 0.23 and the newest Blender App will be done separately.