### PR TITLE
Populate output_path with data from Wasm task def

### DIFF
--- a/apps/wasm/task.py
+++ b/apps/wasm/task.py
@@ -1,3 +1,4 @@
+import os
 from dataclasses import dataclass
 from copy import deepcopy
 from pathlib import Path, PurePath
@@ -551,15 +552,14 @@ class WasmTaskBuilder(CoreTaskBuilder):
     def build_full_definition(
             cls, task_type: 'CoreTaskTypeInfo',
             dictionary: Dict[str, Any]) -> TaskDefinition:
+        options = dictionary['options']
+
         # Resources are generated from 'input_dir' later on.
         dictionary['resources'] = []
-        # Output is determined from 'output_dir' later on.
-        dictionary['options']['output_path'] = ''
         # Subtasks count is determined by the amount of subtask info provided.
-        dictionary['subtasks_count'] = len(dictionary['options']['subtasks'])
+        dictionary['subtasks_count'] = len(options['subtasks'])
 
         task_def: Any = super().build_full_definition(task_type, dictionary)
-        options = dictionary['options']
         task_def.options.js_name = options['js_name']
         task_def.options.wasm_name = options['wasm_name']
         task_def.options.input_dir = options['input_dir']
@@ -579,6 +579,20 @@ class WasmTaskBuilder(CoreTaskBuilder):
                            task_def.budget / denoms.ether)
 
         return task_def
+
+    @classmethod
+    def get_output_path(
+            cls,
+            dictionary: Dict[str, Any],
+            definition: 'TaskDefinition') -> str:
+        options = dictionary['options']
+
+        if 'output_path' in options:
+            output_path = options['output_path']
+        else:
+            output_path = options['output_dir']
+
+        return os.path.join(output_path, '/')
 
 
 class WasmBenchmarkTask(WasmTask):


### PR DESCRIPTION
~~This commit populates the so-far unused `TaskBuilder` options field `output_path` with data from the gWasm task definition. This field is now a required field in the gWasm task's manifest. This commit partially addresses golemfactory/g-flite#28.~~

This commit overloads the `TaskBuilder`'s `get_output_path` for gWasm tasks. If the task def consists of `output_path` field, then its value is used as the output path of the task. Otherwise, `get_output_path` returns the value of `output_dir` that is supplied within the task def.

~~cc @lukasz-glen FYI, this is a potentially breaking change for the raw gWasm apps in our `wasm-store`.~~

cc @lukasz-glen I've made this field optional, so this shouldn't be a breaking change anymore.

cc @mdtanrikulu FYI, this commit together with golemfactory/g-flite#33 and golemfactory/gwasm-rust-api#10 should address golemfactory/g-flite#28.