### PR TITLE
Update to Task API v0.23.0

### DIFF
--- a/golem/apps/default.py
+++ b/golem/apps/default.py
@@ -7,11 +7,11 @@ from pathvalidate import sanitize_filename
 from golem.apps import AppId, AppDefinition, save_app_to_json_file
 from golem.marketplace import RequestorBrassMarketStrategy
 
-BlenderAppDefinition_v0_5_0 = AppDefinition(
+BlenderAppDefinition_v0_6_0 = AppDefinition(
     name='golemfactory/blenderapp',
     author='Golem Factory GmbH',
     license='GPLv3',
-    version='0.5.0',
+    version='0.6.0',
     description=(
         'Rendering with Blender, the free and open source '
         '3D creation suite'
@@ -19,14 +19,14 @@ BlenderAppDefinition_v0_5_0 = AppDefinition(
     requestor_env=DOCKER_CPU_ENV_ID,
     requestor_prereq=dict(
         image='golemfactory/blenderapp',
-        tag='0.5.0',
+        tag='0.6.0',
     ),
     market_strategy=RequestorBrassMarketStrategy,
     max_benchmark_score=10000.,
 )
 
 APPS = [
-    BlenderAppDefinition_v0_5_0,
+    BlenderAppDefinition_v0_6_0,
 ]
 
 

--- a/golem/apps/default.py
+++ b/golem/apps/default.py
@@ -7,7 +7,7 @@ from pathvalidate import sanitize_filename
 from golem.apps import AppId, AppDefinition, save_app_to_json_file
 from golem.marketplace import RequestorBrassMarketStrategy
 
-BlenderAppDefinition_v0_6_0 = AppDefinition(
+BlenderAppDefinition = AppDefinition(
     name='golemfactory/blenderapp',
     author='Golem Factory GmbH',
     license='GPLv3',
@@ -26,7 +26,7 @@ BlenderAppDefinition_v0_6_0 = AppDefinition(
 )
 
 APPS = [
-    BlenderAppDefinition_v0_6_0,
+    BlenderAppDefinition,
 ]
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -40,7 +40,7 @@ eventlet==0.24.1
 fs==2.4.4
 Golem-Messages==3.14.0
 Golem-Smart-Contracts-Interface==1.10.3
-golem_task_api==0.22.0
+golem_task_api==0.23.0
 greenlet==0.4.15
 h2==3.0.1
 hpack==3.0.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -20,7 +20,7 @@ eth-utils==1.0.3
 ethereum==1.6.1
 Golem-Messages==3.14.0
 Golem-Smart-Contracts-Interface==1.10.3
-golem_task_api==0.22.0
+golem_task_api==0.23.0
 html2text==2018.1.9
 humanize==0.5.1
 incremental==17.5.0

--- a/scripts/node_integration_tests/tasks/__init__.py
+++ b/scripts/node_integration_tests/tasks/__init__.py
@@ -1,6 +1,7 @@
 import copy
 import typing
 
+from golem.apps.default import BlenderAppDefinition
 
 _TASK_SETTINGS = {
     'default': {
@@ -165,7 +166,7 @@ _TASK_SETTINGS = {
         },
     },
     'task_api_blender': {
-        'app_id': 'c1e99170aa73521af6937f6680065e31',
+        'app_id': BlenderAppDefinition.id,
         'name': '',  # leave empty: Task API output does not contain this name
         'resources': [],
         'max_price_per_hour': str(10 ** 18),


### PR DESCRIPTION
Task API v0.23.0 provider AbortSubtask call which is now invoked when a subtask times out. Subtasks in verification are not timed out. Updated the Blender app to v0.6.0 which is compatible with Task API v0.23.0