### PR TITLE
Fix shutdown issues in TaskServer tests

### DIFF
--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -216,6 +216,7 @@ class TaskComputerAdapter:
             in_background=in_background))
 
     def quit(self) -> None:
+        self._new_computer.quit()
         self._old_computer.quit()
 
 
@@ -430,6 +431,10 @@ class NewTaskComputer:
             docker_gpu.update_config(DockerGPUConfig(**config_dict))
 
         return defer.succeed(None)
+
+    def quit(self):
+        if self.has_assigned_task():
+            self.task_interrupted()
 
 
 class TaskComputer:  # pylint: disable=too-many-instance-attributes

--- a/tests/golem/envs/localhost.py
+++ b/tests/golem/envs/localhost.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
+import multiprocessing
 import signal
-from multiprocessing import Process
 from pathlib import Path
 from typing import Optional, Dict, Any, Tuple, List, Awaitable, Callable
 
@@ -150,8 +150,11 @@ class LocalhostRuntime(RuntimeBase):
             payload: LocalhostPayload,
     ) -> None:
         super().__init__(logger)
-
-        self._server_process = Process(
+        # From docs: Start a fresh python interpreter process. Unnecessary
+        # file descriptors and handles from the parent process will not
+        # be inherited.
+        mp_ctx = multiprocessing.get_context('spawn')
+        self._server_process = mp_ctx.Process(
             target=self._spawn_server,
             args=(dill.dumps(payload),),
             daemon=True

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1880,6 +1880,7 @@ class TestNewTaskComputerIntegration(
                 call.task_ended(self.task_id)
             ]
         )
+        yield self.task_server.quit()
 
     @defer.inlineCallbacks
     def test_computation_error(self):
@@ -1918,6 +1919,7 @@ class TestNewTaskComputerIntegration(
                 call.task_ended(self.task_id)
             ]
         )
+        yield self.task_server.quit()
 
     @defer.inlineCallbacks
     def test_computation_timed_out(self):
@@ -1949,3 +1951,4 @@ class TestNewTaskComputerIntegration(
                 call.task_ended(self.task_id)
             ]
         )
+        yield self.task_server.quit()


### PR DESCRIPTION
Start a fresh Python interpreter process in `LocalhostRuntime`