### PR TITLE
Reporting exceeded CPU limit

### DIFF
--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -10,7 +10,8 @@ from golem.docker.image import DockerImage
 from golem.docker.job import DockerJob
 from golem.environments.environmentsmanager import EnvironmentsManager
 from golem.envs.docker import DockerBind
-from golem.task.taskthread import TaskThread, JobException, TimeoutException
+from golem.task.taskthread import TaskThread, JobException, TimeoutException, \
+    BudgetExceededException
 from golem.vm.memorychecker import MemoryChecker
 
 if TYPE_CHECKING:
@@ -20,8 +21,10 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+EXIT_CODE_BUDGET_EXCEEDED = 101
 EXIT_CODE_MESSAGE = "Subtask computation failed with exit code {}"
 EXIT_CODE_PROBABLE_CAUSES = {
+    EXIT_CODE_BUDGET_EXCEEDED: "CPU budget exceeded",
     137: "probably killed by out-of-memory killer"
 }
 
@@ -220,7 +223,12 @@ class DockerTaskThread(TaskThread):
                 logger.warning(f'Task error - exit_code={exit_code}\n'
                                f'stderr:\n{std_err}\n'
                                f'tail of stdout:\n{std_out}\n')
-                raise JobException(self._exit_code_message(exit_code))
+
+                if exit_code == EXIT_CODE_BUDGET_EXCEEDED:
+                    raise BudgetExceededException(
+                        self._exit_code_message(exit_code))
+                else:
+                    raise JobException(self._exit_code_message(exit_code))
 
         return estm_mem
 

--- a/golem/docker/task_thread.py
+++ b/golem/docker/task_thread.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-EXIT_CODE_BUDGET_EXCEEDED = 101
+EXIT_CODE_BUDGET_EXCEEDED = 111
 EXIT_CODE_MESSAGE = "Subtask computation failed with exit code {}"
 EXIT_CODE_PROBABLE_CAUSES = {
     EXIT_CODE_BUDGET_EXCEEDED: "CPU budget exceeded",

--- a/golem/task/server/helpers.py
+++ b/golem/task/server/helpers.py
@@ -235,6 +235,7 @@ def send_task_failure(waiting_task_failure) -> None:
         waiting_task_failure.owner.key,
         message.tasks.TaskFailure(
             task_to_compute=task_to_compute,
-            err=waiting_task_failure.err_msg
+            err=waiting_task_failure.err_msg,
+            reason=waiting_task_failure.reason
         ),
     )

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -520,6 +520,7 @@ class TaskComputer:  # pylint: disable=too-many-instance-attributes
 
         if task_thread.error or task_thread.error_msg:
             reason = TaskFailure.DEFAULT_REASON
+            # pylint: disable=unidiomatic-typecheck
             if type(task_thread.error) is TimeoutException:
                 self.stats.increase_stat('tasks_with_timeout')
                 reason = TaskFailure.REASON.TimeExceeded
@@ -574,7 +575,7 @@ class TaskComputer:  # pylint: disable=too-many-instance-attributes
         if not self._is_computing() or self.assigned_subtask is None:
             return None
 
-        c: TaskThread = self.counting_thread
+        c: Optional[TaskThread] = self.counting_thread
         try:
             outfilebasename = c.extra_data.get(  # type: ignore
                 'crops'
@@ -682,8 +683,8 @@ class TaskComputer:  # pylint: disable=too-many-instance-attributes
             docker_images = [DockerImage(**did) for did in docker_images]
             dir_mapping = DockerTaskThread.generate_dir_mapping(resource_dir,
                                                                 temp_dir)
-            tt = DockerTaskThread(docker_images, extra_data,
-                                  dir_mapping, task_timeout)
+            tt: TaskThread = DockerTaskThread(
+                docker_images, extra_data, dir_mapping, task_timeout)
         elif self.support_direct_computation:
             tt = PyTaskThread(extra_data, resource_dir, temp_dir,
                               task_timeout)

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -531,7 +531,7 @@ class TaskComputer:  # pylint: disable=too-many-instance-attributes
                     subtask_id,
                     subtask['task_id'],
                     task_thread.error_msg,
-                    reason=reason
+                    reason
                 )
 
         elif task_thread.result and 'data' in task_thread.result:

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -1029,11 +1029,12 @@ class TaskServer(
         if allowed:
             allowed, reason = self.acl_ip.is_allowed(ip_addr)
         if not allowed:
-            logger.info(f'provider is {reason.value}; {ids}')
+            reason_msg = 'unknown reason' if reason is None else reason.value
+            logger.info(f'provider is {reason_msg}; {ids}')
             self.notify_provider_rejected(
                 node_id=node_id, task_id=task_id,
                 reason=self.RejectedReason.acl,
-                details={'acl_reason': reason.value})
+                details={'acl_reason': reason_msg})
             return False
 
         trust = self.client.get_computing_trust(node_id)

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -616,8 +616,12 @@ class TaskServer(
         ) = result
 
     def send_task_failed(
-            self, subtask_id: str, task_id: str, err_msg: str) -> None:
-
+            self,
+            subtask_id: str,
+            task_id: str,
+            err_msg: str,
+            reason=message.TaskFailure.DEFAULT_REASON
+    ) -> None:
         header = self.task_keeper.task_headers[task_id]
 
         if subtask_id not in self.failures_to_send:
@@ -627,7 +631,8 @@ class TaskServer(
                 task_id=task_id,
                 subtask_id=subtask_id,
                 err_msg=err_msg,
-                owner=header.task_owner)
+                owner=header.task_owner,
+                reason=reason)
 
     def new_connection(self, session):
         if not self.active:
@@ -1233,3 +1238,4 @@ class WaitingTaskFailure:
     owner: 'dt_p2p.Node'
     subtask_id: str
     task_id: str
+    reason: message.TaskFailure.REASON

--- a/golem/task/taskthread.py
+++ b/golem/task/taskthread.py
@@ -3,7 +3,7 @@ import logging
 import os
 import threading
 import time
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Optional, Tuple, Union
 
 from twisted.internet.defer import Deferred
 
@@ -41,7 +41,7 @@ class TaskThread(threading.Thread):
         self.res_path = res_path
         self.tmp_path = tmp_path
         self.lock = threading.Lock()
-        self.error = None
+        self.error: Optional[Exception] = None
         self.error_msg = ""
         self.start_time = time.time()
         self.end_time = None
@@ -75,7 +75,7 @@ class TaskThread(threading.Thread):
         with self.lock:
             return self.vm.get_progress()
 
-    def get_error(self) -> JobException:
+    def get_error(self) -> Optional[Exception]:
         with self.lock:
             return self.error
 

--- a/golem/task/taskthread.py
+++ b/golem/task/taskthread.py
@@ -19,6 +19,10 @@ class TimeoutException(JobException):
     pass
 
 
+class BudgetExceededException(JobException):
+    pass
+
+
 class TaskThread(threading.Thread):
     result: Union[None, Dict[str, Any], Tuple[Dict[str, Any], int]] = None
 
@@ -37,7 +41,7 @@ class TaskThread(threading.Thread):
         self.res_path = res_path
         self.tmp_path = tmp_path
         self.lock = threading.Lock()
-        self.error = False
+        self.error = None
         self.error_msg = ""
         self.start_time = time.time()
         self.end_time = None
@@ -71,7 +75,7 @@ class TaskThread(threading.Thread):
         with self.lock:
             return self.vm.get_progress()
 
-    def get_error(self):
+    def get_error(self) -> JobException:
         with self.lock:
             return self.error
 
@@ -103,7 +107,7 @@ class TaskThread(threading.Thread):
 
         logger.warning("Task computing error %s", exception)
 
-        self.error = True
+        self.error = exception
         self.error_msg = str(exception)
         self.done = True
         self._deferred.errback(exception)

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,7 +38,7 @@ eth-utils==1.0.3
 ethereum==1.6.1
 eventlet==0.24.1
 fs==2.4.4
-Golem-Messages==3.13.0
+Golem-Messages==3.14.0
 Golem-Smart-Contracts-Interface==1.10.3
 golem_task_api==0.21.0
 greenlet==0.4.15

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -18,7 +18,7 @@ docker==3.5.0
 enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
-Golem-Messages==3.13.0
+Golem-Messages==3.14.0
 Golem-Smart-Contracts-Interface==1.10.3
 golem_task_api==0.21.0
 html2text==2018.1.9

--- a/tests/factories/taskserver.py
+++ b/tests/factories/taskserver.py
@@ -1,6 +1,6 @@
 
 import factory
-from golem_messages import idgenerator
+from golem_messages import idgenerator, message
 
 from golem import clientconfigdescriptor
 from golem.task import taskserver
@@ -74,3 +74,4 @@ class WaitingTaskFailureFactory(factory.Factory):
     owner = factory.SubFactory(
         'golem_messages.factories.datastructures.p2p.Node',
     )
+    reason = message.TaskFailure.DEFAULT_REASON

--- a/tests/golem/docker/test_docker_task_thread.py
+++ b/tests/golem/docker/test_docker_task_thread.py
@@ -86,3 +86,8 @@ class TestExitCodeMessage(TestCase):
         message = DockerTaskThread._exit_code_message(exit_code)
         assert message != EXIT_CODE_MESSAGE.format(exit_code)
         assert "out-of-memory" in message
+
+        exit_code = 111
+        message = DockerTaskThread._exit_code_message(exit_code)
+        assert message != EXIT_CODE_MESSAGE.format(exit_code)
+        assert "CPU budget exceeded" in message

--- a/tests/golem/task/test_localcomputer.py
+++ b/tests/golem/task/test_localcomputer.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from golem_messages.message import ComputeTaskDef
 
 from golem.docker.manager import DockerManager
-from golem.docker.task_thread import DockerTaskThread
+from golem.docker.task_thread import DockerTaskThread, JobException
 from golem.task.localcomputer import LocalComputer
 from golem.task.taskbase import Task
 from golem.tools.ci import ci_skip
@@ -26,7 +26,7 @@ class TestLocalComputer(TestDirFixture):
     class TestTaskThread(object):
         def __init__(self, result, error_msg):
             self.result = result
-            self.error = False
+            self.error = None
             self.error_msg = error_msg
 
     def test_computer(self):
@@ -82,7 +82,7 @@ class TestLocalComputer(TestDirFixture):
         assert self.success_counter == 2
 
         tt = self.TestTaskThread({'data': "some data"}, None)
-        tt.error = True
+        tt.error = JobException()
         lc.task_computed(tt)
         assert self.last_error is None
         assert self.error_counter == 4

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -7,7 +7,7 @@ import uuid
 
 from pydispatch import dispatcher
 
-from golem_messages.message import ComputeTaskDef
+from golem_messages.message import ComputeTaskDef, TaskFailure
 from twisted.internet import defer
 from twisted.trial.unittest import TestCase as TwistedTestCase
 
@@ -96,7 +96,10 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         assert tc.counting_thread is None
         assert tc.assigned_subtask is None
         task_server.send_task_failed.assert_called_with(
-            "xxyyzz", "xyz", "Host direct task not supported")
+            "xxyyzz",
+            "xyz",
+            "Host direct task not supported"
+        )
 
         tc.support_direct_computation = True
         tc.task_given(ctd)
@@ -133,7 +136,7 @@ class TestTaskComputer(DatabaseFixture, LogTestCase):
         self.assertIsNone(tc.counting_thread)
         self.assertIsNone(tc.assigned_subtask)
         task_server.send_task_failed.assert_called_with(
-            "aabbcc", "xyz", 'some exception')
+            "aabbcc", "xyz", 'some exception', TaskFailure.DEFAULT_REASON)
         mock_finished.assert_called_once_with()
         mock_finished.reset_mock()
 

--- a/tests/golem/task/test_taskcomputer.py
+++ b/tests/golem/task/test_taskcomputer.py
@@ -18,6 +18,7 @@ from golem.docker.manager import DockerManager
 from golem.envs.docker.cpu import DockerCPUEnvironment
 from golem.task.taskcomputer import TaskComputer, PyTaskThread
 from golem.task.taskserver import TaskServer
+from golem.task.taskthread import JobException
 from golem.testutils import DatabaseFixture
 from golem.tools.ci import ci_skip
 from golem.tools.assertlogs import LogTestCase
@@ -273,12 +274,12 @@ class TestTaskThread(DatabaseFixture):
         tt = self._new_task_thread(mock.Mock())
         tt._fail(first_error)
 
-        assert tt.error is True
+        self.assertIsNotNone(tt.error)
         assert tt.done is True
         assert tt.error_msg == str(first_error)
 
         tt._fail(second_error)
-        assert tt.error is True
+        self.assertIsNotNone(tt.error)
         assert tt.done is True
         assert tt.error_msg == str(first_error)
 
@@ -363,12 +364,12 @@ class TestTaskMonitor(DatabaseFixture):
 
         # error case
         prepare()
-        task_thread.error = True
+        task_thread.error = JobException()
         check(False)
 
         # success case
         prepare()
-        task_thread.error = False
+        task_thread.error = None
         task_thread.error_msg = None
         task_thread.result = {'data': 'oh senora!!!'}
         check(True)

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -18,7 +18,7 @@ from golem_messages import factories as msg_factories
 from golem_messages.datastructures import tasks as dt_tasks
 from golem_messages.datastructures.masking import Mask
 from golem_messages.factories.datastructures import p2p as dt_p2p_factory
-from golem_messages.message import ComputeTaskDef
+from golem_messages.message import ComputeTaskDef, TaskFailure
 from golem_messages.utils import encode_hex as encode_key_id, pubkey_to_address
 from golem_task_api.envs import DOCKER_CPU_ENV_ID
 from requests import HTTPError
@@ -340,6 +340,7 @@ class TestTaskServer(TaskServerTestBase):  # noqa pylint: disable=too-many-publi
             subtask_id=subtask_id,
             owner=dt_p2p_factory.Node(),
             err_msg="Controlled failure",
+            reason=TaskFailure.DEFAULT_REASON
         )
 
         ts.failures_to_send[subtask_id] = wtf


### PR DESCRIPTION
Part of GR-179

Implements informing the requestor about CPU budget overruns during task computation. This fact is reported in the `TaskFailure` message using the `reason` field (with value `BudgetExceeded`).