### PR TITLE
Updated Docker images to use base image 1.8

### DIFF
--- a/apps/blender/blenderenvironment.py
+++ b/apps/blender/blenderenvironment.py
@@ -9,7 +9,7 @@ from golem.environments.environment import SupportStatus, UnsupportReason
 
 class BlenderEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/blender"
-    DOCKER_TAG = "1.12"
+    DOCKER_TAG = "1.12.1"
     ENV_ID = "BLENDER"
     SHORT_DESCRIPTION = "Blender (www.blender.org)"
 
@@ -17,7 +17,7 @@ class BlenderEnvironment(DockerEnvironment):
 class BlenderNVGPUEnvironment(BlenderEnvironment):
 
     DOCKER_IMAGE = "golemfactory/blender_nvgpu"
-    DOCKER_TAG = "1.6"
+    DOCKER_TAG = "1.7"
     ENV_ID = "BLENDER_NVGPU"
     SHORT_DESCRIPTION = "Blender + NVIDIA GPU (www.blender.org)"
 

--- a/apps/blender/resources/images/blender.Dockerfile
+++ b/apps/blender/resources/images/blender.Dockerfile
@@ -2,7 +2,7 @@
 # Blender setup is based on
 # https://github.com/ikester/blender-docker/blob/master/Dockerfile
 
-FROM golemfactory/base:1.7
+FROM golemfactory/base:1.8
 
 MAINTAINER Golem Tech <tech@golem.network>
 

--- a/apps/blender/resources/images/blender_nvgpu.Dockerfile
+++ b/apps/blender/resources/images/blender_nvgpu.Dockerfile
@@ -1,4 +1,4 @@
-FROM golemfactory/nvgpu:1.6
+FROM golemfactory/nvgpu:1.7
 
 # Contents of blender.Dockerfile
 

--- a/apps/blender/resources/images/blender_verifier.Dockerfile
+++ b/apps/blender/resources/images/blender_verifier.Dockerfile
@@ -1,4 +1,4 @@
-FROM golemfactory/blender:1.12
+FROM golemfactory/blender:1.12.1
 
 # Install scripts requirements first, then add scripts.
 ADD entrypoints/scripts/verifier_tools/requirements.txt /golem/work/

--- a/apps/core/resources/images/base.Dockerfile
+++ b/apps/core/resources/images/base.Dockerfile
@@ -1,8 +1,8 @@
 # Dockerfile for a base image for computing tasks in Golem.
 # Installs python and sets up directories for Golem tasks.
 
-FROM golang:1.12.7 as stats-builder
-RUN git clone --depth 1 --branch 0.1 https://github.com/golemfactory/docker-cgroups-stats.git /build
+FROM golang:1.13.3 as stats-builder
+RUN git clone --depth 1 --branch 0.2.0 https://github.com/golemfactory/docker-cgroups-stats.git /build
 WORKDIR /build
 RUN go build -o docker-cgroups-stats main.go
 

--- a/apps/core/resources/images/nvgpu.Dockerfile
+++ b/apps/core/resources/images/nvgpu.Dockerfile
@@ -1,8 +1,8 @@
 # Dockerfile for a base image for computing tasks in Golem.
 # Installs python and sets up directories for Golem tasks.
 
-FROM golang:1.12.7 as stats-builder
-RUN git clone --depth 1 --branch 0.1 https://github.com/golemfactory/docker-cgroups-stats.git /build
+FROM golang:1.13.3 as stats-builder
+RUN git clone --depth 1 --branch 0.2.0 https://github.com/golemfactory/docker-cgroups-stats.git /build
 WORKDIR /build
 RUN go build -o docker-cgroups-stats main.go
 

--- a/apps/dummy/dummyenvironment.py
+++ b/apps/dummy/dummyenvironment.py
@@ -3,7 +3,7 @@ from golem.docker.environment import DockerEnvironment
 
 class DummyTaskEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/dummy"
-    DOCKER_TAG = "1.4"
+    DOCKER_TAG = "1.4.1"
     ENV_ID = "DUMMYPOW"
     SHORT_DESCRIPTION = "Dummy task (example app calculating proof-of-work " \
                         "hash)"

--- a/apps/dummy/resources/images/Dockerfile
+++ b/apps/dummy/resources/images/Dockerfile
@@ -1,4 +1,4 @@
-FROM golemfactory/base:1.7
+FROM golemfactory/base:1.8
 
 MAINTAINER Golem Tech <tech@golem.network>
 

--- a/apps/glambda/glambdaenvironment.py
+++ b/apps/glambda/glambdaenvironment.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 class GLambdaTaskEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/glambda"
-    DOCKER_TAG = "1.7"
+    DOCKER_TAG = "1.7.1"
     ENV_ID = "glambda"
     SHORT_DESCRIPTION = "GLambda PoC"
 

--- a/apps/glambda/resources/images/Dockerfile
+++ b/apps/glambda/resources/images/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update && \
     make install && \
     chmod -R 757 ${RASPA_DIR}/
 
-FROM golemfactory/base:1.7
+FROM golemfactory/base:1.8
 ENV RASPA_DIR=/opt/RASPA
 
 RUN set -x \

--- a/apps/images.ini
+++ b/apps/images.ini
@@ -1,8 +1,8 @@
-golemfactory/base core/resources/images/base.Dockerfile 1.7 .
-golemfactory/nvgpu core/resources/images/nvgpu.Dockerfile 1.6 . apps.core.nvgpu.is_supported
-golemfactory/blender blender/resources/images/blender.Dockerfile 1.12 blender/resources/images/
-golemfactory/blender_verifier blender/resources/images/blender_verifier.Dockerfile 1.8.1 blender/resources/images/
-golemfactory/blender_nvgpu blender/resources/images/blender_nvgpu.Dockerfile 1.6 . apps.core.nvgpu.is_supported
-golemfactory/dummy dummy/resources/images/Dockerfile 1.4 dummy/resources/images
-golemfactory/wasm wasm/resources/images/Dockerfile 0.5.3 wasm/resources/images
-golemfactory/glambda glambda/resources/images/Dockerfile 1.7 .
+golemfactory/base core/resources/images/base.Dockerfile 1.8 .
+golemfactory/nvgpu core/resources/images/nvgpu.Dockerfile 1.7 . apps.core.nvgpu.is_supported
+golemfactory/blender blender/resources/images/blender.Dockerfile 1.12.1 blender/resources/images/
+golemfactory/blender_verifier blender/resources/images/blender_verifier.Dockerfile 1.8.2 blender/resources/images/
+golemfactory/blender_nvgpu blender/resources/images/blender_nvgpu.Dockerfile 1.6.1 . apps.core.nvgpu.is_supported
+golemfactory/dummy dummy/resources/images/Dockerfile 1.4.1 dummy/resources/images
+golemfactory/wasm wasm/resources/images/Dockerfile 0.5.4 wasm/resources/images
+golemfactory/glambda glambda/resources/images/Dockerfile 1.7.1 .

--- a/apps/wasm/environment.py
+++ b/apps/wasm/environment.py
@@ -3,6 +3,6 @@ from golem.docker.environment import DockerEnvironment
 
 class WasmTaskEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/wasm"
-    DOCKER_TAG = "0.5.3"
+    DOCKER_TAG = "0.5.4"
     ENV_ID = "WASM"
     SHORT_DESCRIPTION = "WASM Sandbox"

--- a/apps/wasm/resources/images/Dockerfile
+++ b/apps/wasm/resources/images/Dockerfile
@@ -12,7 +12,7 @@ ENV CXX=clang++-6.0
 RUN cargo install --path . --root /usr
 RUN cargo clean
 
-FROM golemfactory/base:1.7
+FROM golemfactory/base:1.8
 WORKDIR /
 COPY --from=builder /usr/bin/wasm-sandbox /
 COPY scripts/ /golem/scripts/

--- a/golem/verifier/blender_verifier.py
+++ b/golem/verifier/blender_verifier.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 # pylint: disable=R0902
 class BlenderVerifier(FrameRenderingVerifier):
     DOCKER_NAME = 'golemfactory/blender_verifier'
-    DOCKER_TAG = '1.8.1'
+    DOCKER_TAG = '1.8.2'
 
     def __init__(self, verification_data, docker_task_cls: Type) -> None:
         super().__init__(verification_data)

--- a/scripts/docker_integrity/image_integrity.ini
+++ b/scripts/docker_integrity/image_integrity.ini
@@ -3,11 +3,11 @@
 #
 # Hash is a result of docker inspect --format='{{index .Id}}' $IMAGE
 # repository                    tag                 hash
-golemfactory/base               1.7                 3dab93cb88094fdfc441399cf43767babcb7c0b36fc83490ee3561fbcc98b81c
-golemfactory/blender            1.12                9654677d197fd3fb2b4b344fad7b70775c3c4819fb8b50e42eaee261dda70aa4
-golemfactory/blender_nvgpu      1.6                 9b120257c9fa5f8736ad482f6bd42db7a5fadb04bbdf483521ed6b392d8178ba
-golemfactory/blender_verifier   1.8.1               0e3dd069358b7f874fc54503c9ada48ed6cfd3ee467188dcc612320c6b5a9eeb
-golemfactory/dummy              1.4                 70e9289a1abec564ce382eed328f385a75afbee549a376ece80e073a023e3138
-golemfactory/glambda            1.7                 8bde6311defcd5fab4a1f1eafa7496d5ca73a6f2a8cf26512412f19c5b6f09a7
-golemfactory/nvgpu              1.6                 820c20605d03bbe14b79048395ce23d6be3b150807f28a646ce1b26490e177c2
-golemfactory/wasm               0.5.3               48519c1ac994fe1826b9f7360d50c1c5798dfc9a7ba817ef3442fe99f95555d6
+golemfactory/base               1.8                 e694ebfb3679b12e39b633f35d477a322c778db5f35f5497b9d5c5590009edf1
+golemfactory/blender            1.12.1              5e2b4bdd0ccacbc49174e999320cfe78d03c552028c409c95aa882d98c42a213
+golemfactory/blender_nvgpu      1.6.1               7b627c839dc8a499fd4bc4e29bdf66916cc1686f0926323adc44857e954e0e92
+golemfactory/blender_verifier   1.8.2               6393fc66ae1f268faee3bb84f8e2f14ca347cca6f3b6fe844b6424f33355547e
+golemfactory/dummy              1.4.1               0f5518c5b8a83d5f8a291ec609e3a917618fc6729a293602ec95246ba1171fc1
+golemfactory/glambda            1.7.1               58b5306d3990b09a0a33ed5238a16b0d3fb8bc4f432cc90d223eaba077799b6a
+golemfactory/nvgpu              1.7                 7c7a35f25d6936a3dee833849b6927aef5e5cd9312b6c476e44b38d932aa0260
+golemfactory/wasm               0.5.4               d357b3d0e6423fad6ec28ff477411a7e4b3fc78c3db5491d37fae24e2e5bcbc4


### PR DESCRIPTION
The image `golemfactory/base:1.8` now includes an updated version of `docker-cgroups-stats` with support for subprocess CPU limiting (https://github.com/golemfactory/docker-cgroups-stats/pull/1).