### PR TITLE
Reporting graceful shutdown via status publisher

### DIFF
--- a/golem/node.py
+++ b/golem/node.py
@@ -373,6 +373,8 @@ class Node(HardwarePresetsMixin):
         if self._config_desc.in_shutdown:
             self.client.update_setting('in_shutdown', False)
             logger.info('Turning off shutdown mode')
+            StatusPublisher.publish(
+                Component.client, 'start', Stage.post)
             return ShutdownResponse.off
 
         # is not providing nor requesting, normal shutdown

--- a/golem/node.py
+++ b/golem/node.py
@@ -384,6 +384,8 @@ class Node(HardwarePresetsMixin):
         # configure in_shutdown
         logger.info('Enabling shutdown mode, no more tasks can be started')
         self.client.update_setting('in_shutdown', True)
+        StatusPublisher.publish(
+            Component.client, 'scheduled_shutdown', Stage.pre)
 
         # subscribe to events
 

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -19,7 +19,7 @@ from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.core import variables
 from golem.network.transport.tcpnetwork_helpers import SocketAddress
 from golem.node import Node, ShutdownResponse
-from golem.report import Component, Stage, StatusPublisher
+from golem.report import Component, Stage
 from golem.testutils import TempDirFixture
 from golem.tools.ci import ci_skip
 from golem.tools.testwithdatabase import TestWithDatabase

--- a/tests/golem/test_opt_node.py
+++ b/tests/golem/test_opt_node.py
@@ -19,6 +19,7 @@ from golem.clientconfigdescriptor import ClientConfigDescriptor
 from golem.core import variables
 from golem.network.transport.tcpnetwork_helpers import SocketAddress
 from golem.node import Node, ShutdownResponse
+from golem.report import Component, Stage, StatusPublisher
 from golem.testutils import TempDirFixture
 from golem.tools.ci import ci_skip
 from golem.tools.testwithdatabase import TestWithDatabase
@@ -839,7 +840,8 @@ class TestOptNode(TempDirFixture):
         assert self.node._is_task_in_progress.called
         assert self.node._reactor.stop.called
 
-    def test_graceful_shutdown_off(self, *_):
+    @patch('golem.node.StatusPublisher')
+    def test_graceful_shutdown_off(self, publisher, *_):
         self.node_kwargs['config_desc'].in_shutdown = True
 
         self.node = Node(**self.node_kwargs)
@@ -853,8 +855,11 @@ class TestOptNode(TempDirFixture):
                                                             False)
         assert self.node._is_task_in_progress.not_called
         assert self.node.quit.not_called
+        publisher.publish.assert_called_with(
+            Component.client, 'start', Stage.post)
 
-    def test_graceful_shutdown_on(self, *_):
+    @patch('golem.node.StatusPublisher')
+    def test_graceful_shutdown_on(self, publisher, *_):
         self.node = Node(**self.node_kwargs)
         self.node.quit = Mock()
         self.node.client = Mock()
@@ -866,6 +871,8 @@ class TestOptNode(TempDirFixture):
                                                             True)
         assert self.node.quit.not_called
         assert self.node._is_task_in_progress.called
+        publisher.publish.assert_called_with(
+            Component.client, 'scheduled_shutdown', Stage.pre)
 
     def test_try_shutdown(self, *_):
         self.node = Node(**self.node_kwargs)


### PR DESCRIPTION
Adds calls to status publisher whenever Golem enters and exits graceful shutdown mode.