### PR TITLE
there's no strong rationale behind breaking connection with another n…

### DIFF
--- a/golem/network/p2p/peersession.py
+++ b/golem/network/p2p/peersession.py
@@ -365,10 +365,7 @@ class PeerSession(BasicSafeSession):
         logger.debug("Running handler for `Tasks`. msg=%r", msg)
         for t in msg.tasks:
             logger.debug("Task information received. task header: %r", t)
-            if not self.p2p_service.add_task_header(t):
-                self.disconnect(
-                    message.base.Disconnect.REASON.BadProtocol
-                )
+            self.p2p_service.add_task_header(t)
 
     def _react_to_remove_task(self, msg):
         if not self._verify_remove_task(msg):


### PR DESCRIPTION
…ode just because we couldn't add a single task header that it helped propagate...