### PR TITLE
Fixed integration test for DockerCPUEnvironment

### DIFF
--- a/golem/docker/hypervisor/__init__.py
+++ b/golem/docker/hypervisor/__init__.py
@@ -22,11 +22,13 @@ class Hypervisor(ABC):
 
     _instance = None
 
-    def __init__(self,
-                 get_config: GetConfigFunction,
-                 vm_name: str = DOCKER_VM_NAME) -> None:
+    def __init__(
+            self,
+            get_config_fn: GetConfigFunction,
+            vm_name: str = DOCKER_VM_NAME
+    ) -> None:
 
-        self._get_config = get_config
+        self._get_config = get_config_fn
         self._vm_name = vm_name
         self._work_dirs: List[Path] = []
 

--- a/tests/golem/envs/docker/cpu/test_integration.py
+++ b/tests/golem/envs/docker/cpu/test_integration.py
@@ -23,13 +23,13 @@ class TestIntegration(TestCase, DatabaseFixture):
         hypervisor_cls = DockerCPUEnvironment._get_hypervisor_class()
         assert hypervisor_cls is not None, "No supported hypervisor found"
 
-        cls.hypervisor = hypervisor_cls(get_config=lambda: {})
+        cls.hypervisor = hypervisor_cls(get_config_fn=lambda: {})
         cls.vm_was_running = cls.hypervisor.vm_running
 
     @classmethod
     def tearDownClass(cls) -> None:
         if cls.vm_was_running:
-            cls.hypervisor.start_vm()
+            cls.hypervisor.restore_vm()
         super().tearDownClass()
 
     @inlineCallbacks


### PR DESCRIPTION
* Wrong keyword had been used: `get_config` instead of `get_config_fn`.
* Wrong method had been used to resume MV: `start_vm` instead of  `restore_vm`. The first one assumes that VM is stopped and will fail in case of suspended Hyper-V machine. The second one on the other hand will gracefully fall back to starting VM if it cannot be restored.