### PR TITLE
[P3] Transcoding: Validations for subtitle and data stream whitelists

### DIFF
--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -135,7 +135,9 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
 
             validation.validate_transcoding_params(
                 dst_params,
-                video_metadata
+                video_metadata,
+                self.task_definition.options.strip_unsupported_data_streams,
+                self.task_definition.options.strip_unsupported_subtitle_streams,
             )
 
         except validation.InvalidVideo as e:

--- a/tests/apps/ffmpeg/task/test_ffmpegintegration.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegintegration.py
@@ -9,12 +9,12 @@ from ffmpeg_tools.formats import list_supported_frame_rates
 from ffmpeg_tools.validation import InvalidResolution, InvalidFrameRate, \
     UnsupportedTargetVideoFormat, UnsupportedVideoFormat, \
     UnsupportedAudioCodec, UnsupportedVideoCodec, \
-    validate_resolution
+    validate_resolution, UnsupportedStream
 from parameterized import parameterized
 
 from apps.transcoding.common import TranscodingTaskBuilderException, \
     ffmpegException, VideoCodecNotSupportedByContainer, \
-    AudioCodecNotSupportedByContainer, ffmpegMergeReplaceError
+    AudioCodecNotSupportedByContainer
 from golem.testutils_app_integration import TestTaskIntegration
 from golem.tools.ci import ci_skip
 from tests.apps.ffmpeg.task.ffmpeg_integration_base import \
@@ -463,5 +463,5 @@ class TestFfmpegIntegration(FfmpegIntegrationBase):
         # We know that if we don't strip subtitles and data streams in this
         # particular case ffmpeg won't be able to convert them and fail. But it
         # is not necessarily the case for non-whitelisted streams in general.
-        with self.assertRaises(ffmpegMergeReplaceError):
+        with self.assertRaises(UnsupportedStream):
             self.execute_task(task_def)


### PR DESCRIPTION
Changes:
1) `strip_unsupported_data_streams`/`strip_unsupported_subtitle_streams` task parameters added in P4 (#4639) are now being passed to `validate_transcoding_params()` so that the new validations can be bypassed if the user requests all unknown streams to be stripped.
2) The test for `UnsupportedStream` has been restored. This case now causes a validation failure instead of crashing the merge step.

### Notes
1) This change of course does not completely eliminate the possibility of an ffmpeg error at the merge step but such errors were possible even before P3/P4 and fixing it is outside of the scope of this pull request. This needs to be fixed separately by adding a new state just like the old comment from the test suggested.

### Dependencies
This pull request has no dependencies on the Golem side. It's directly on `CGI/transcoding/master`.

As for ffmpeg-tools - https://github.com/golemfactory/ffmpeg-tools/pull/20 needs to get merged and released for this code to work and pass CI tests.