### PR TITLE
[O3] Transcoding: Validate target FPS even if not specified in the task

### DIFF
--- a/tests/apps/ffmpeg/task/test_ffmpegintegration_all_bundle_files.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegintegration_all_bundle_files.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from ffmpeg_tools.codecs import VideoCodec
-from ffmpeg_tools.formats import Container, list_supported_frame_rates
+from ffmpeg_tools.formats import Container, FrameRate, list_supported_frame_rates
 from ffmpeg_tools.validation import InvalidResolution, \
     UnsupportedVideoCodecConversion, InvalidFrameRate, validate_resolution
 from parameterized import parameterized
@@ -257,7 +257,12 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
         (
             (video, frame_rate)
             for video in VIDEO_FILES  # pylint: disable=undefined-variable
-            for frame_rate in (1, 25, '30000/1001', 60)
+            for frame_rate in (
+                FrameRate(1),
+                FrameRate(25),
+                FrameRate(30000, 1001),
+                FrameRate(60),
+            )
         ),
         name_func=create_split_and_merge_with_frame_rate_change_test_name
     )
@@ -271,14 +276,14 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
             tmp_dir=self.tempdir,
             dont_include_in_option_description=["resolution", "video_codec"])
         operation.attach_to_report_set(self._ffprobe_report_set)
-        operation.request_frame_rate_change(frame_rate)
+        operation.request_frame_rate_change(str(frame_rate))
         operation.request_video_codec_change(source_codec)
         operation.request_container_change(video['container'])
         operation.request_resolution_change(video["resolution"])
         operation.exclude_from_diff(
             FfmpegIntegrationBase.ATTRIBUTES_NOT_PRESERVED_IN_CONVERSIONS)
         operation.exclude_from_diff({'video': {'frame_count'}})
-        fuzzy_rate = FuzzyDuration(parse_ffprobe_frame_rate(frame_rate), 0.5)
+        fuzzy_rate = FuzzyDuration(frame_rate.to_float(), 0.5)
         operation.set_override('video', 'frame_rate', fuzzy_rate)
         operation.enable_treating_missing_attributes_as_unchanged()
 
@@ -296,10 +301,8 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
             pytest.skip("Transcoding is not possible for this file without"
                         "also changing the video codec.")
 
-        frame_rate_as_str_or_int = set([frame_rate, str(frame_rate)])
-        if frame_rate_as_str_or_int & list_supported_frame_rates() != set():
-            (_input_report, _output_report, diff) = operation.run(
-                video["path"])
+        if frame_rate.normalized() in list_supported_frame_rates():
+            (_input_report, _output_report, diff) = operation.run(video["path"])
             self.assertEqual(diff, [])
         else:
             with self.assertRaises(InvalidFrameRate):


### PR DESCRIPTION
This is a simple change that makes Golem use `FrameRate` introduced in https://github.com/golemfactory/ffmpeg-tools/pull/21

### Dependencies
This pull request is based on #4891 (`transcoding-task-p3-validation-fail-if-unsupported-streams` branch) and should be merged after it. It does not really depend on it directly but does depend on its corresponding ffmpeg-tools branch. Please remember to change the base branch back to `CGI/transcoding/master` before you merge. 

https://github.com/golemfactory/ffmpeg-tools/pull/21 needs to get merged and released for this code to work and pass CI tests.