### PR TITLE
Restore task-api task timeouts after restarting node

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -530,6 +530,8 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
             listener = ClientTaskComputerEventListener(self)
             self.task_server.task_computer.register_listener(listener)
 
+            self.task_server.requested_task_manager.restore_tasks()
+
             if self.monitor:
                 self.diag_service.register(
                     self.p2pservice,

--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -5,7 +5,7 @@ import os
 import shutil
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Iterable
+from typing import Any, Dict, List, Optional, Iterable
 
 from dataclasses import dataclass
 from golem_messages import idgenerator
@@ -99,6 +99,25 @@ class RequestedTaskManager:
         self._app_clients: Dict[EnvId, RequestorAppClient] = {}
         # Created lazily due to cascading errors in tests
         self._verification_queue: Optional[VerificationQueue] = None
+
+    def restore_tasks(self):
+        logger.debug('restore_tasks()')
+        running_tasks = RequestedTask.select() \
+            .where(RequestedTask.status.not_in(TASK_STATUS_COMPLETED))
+
+        loop = asyncio.get_event_loop()
+        for task in running_tasks:
+            if task.deadline is not None and \
+                    task.deadline.timestamp() < loop.time():
+                logger.info('task in progress. task_id=%r', task.task_id)
+                loop.call_at(
+                    task.deadline,
+                    self._time_out_task,
+                    task.task_id,
+                )
+            else:
+                logger.info('task timed out. task_id=%r', task.task_id)
+                self._time_out_task(task.task_id)
 
     def _app_dir(self, app_id: AppId) -> RequestorDir:
         app_dir = RequestorDir(self._root_path / app_id)
@@ -274,6 +293,7 @@ class RequestedTaskManager:
         logger.debug('has_pending_subtasks(task_id=%r)', task_id)
         task = RequestedTask.get(RequestedTask.task_id == task_id)
         if not task.status.is_active():
+            logger.debug('task not active. task_id=%r', task_id)
             return False
         app_client = await self._get_app_client(task.app_id)
         return await app_client.has_pending_subtasks(task.task_id)
@@ -747,7 +767,11 @@ class RequestedTaskManager:
             RequestedSubtask.task_id == task_id,
             RequestedSubtask.status != SubtaskStatus.finished,
         ).scalar()
-        logger.debug('unfinished subtasks: %r', unfinished_subtask_count)
+        logger.debug(
+            '_get_unfinished_subtasks_for_node. node=%r, count=%r',
+            computing_node.node_id,
+            unfinished_subtask_count
+        )
         return unfinished_subtask_count
 
     @staticmethod

--- a/tests/golem/task/test_requestedtaskmanager.py
+++ b/tests/golem/task/test_requestedtaskmanager.py
@@ -3,7 +3,6 @@
 
 import asyncio
 from pathlib import Path
-import datetime
 
 from freezegun import freeze_time
 from golem_task_api.client import RequestorAppClient
@@ -75,10 +74,9 @@ class TestRequestedTaskManager:
             lambda *_: TaskState())
 
     @pytest.mark.asyncio
-    async def test_restore_tasks_timedout(self, mock_client):
+    @pytest.mark.freeze_time("1000")
+    async def test_restore_tasks_timedout(self, freezer, mock_client):
         # given
-        mock_loop = MagicMock()
-        mock_client.has_pending_subtasks.return_value = True
         self._add_next_subtask_to_client_mock(mock_client)
         self.rtm._time_out_task = Mock()
         self.rtm._time_out_subtask = Mock()
@@ -88,13 +86,9 @@ class TestRequestedTaskManager:
         self.rtm.start_task(task_id)
         computing_node = self._get_computing_node()
         subtask = await self.rtm.get_next_subtask(task_id, computing_node)
-        mock_loop.time.return_value = datetime.datetime.now().timestamp()
+        freezer.move_to("1010")
         # when
-        with patch(
-            'golem.task.requestedtaskmanager.asyncio.get_event_loop',
-            return_value=mock_loop
-        ):
-            self.rtm.restore_tasks()
+        self.rtm.restore_tasks()
         # then
         self.rtm._time_out_task.assert_called_once_with(task_id)
         self.rtm._time_out_subtask.assert_called_once_with(
@@ -103,22 +97,18 @@ class TestRequestedTaskManager:
         )
 
     @pytest.mark.asyncio
-    @pytest.mark.freeze_time("1000")
-    async def test_restore_tasks_schedule(self, freezer, mock_client):
+    async def test_restore_tasks_schedule(self, mock_client):
         # given
         mock_loop = MagicMock()
-        mock_client.has_pending_subtasks.return_value = True
         self._add_next_subtask_to_client_mock(mock_client)
 
         task_id = self._create_task(
-            task_timeout=20,
-            subtask_timeout=20)
+            task_timeout=20000,
+            subtask_timeout=20000)
         await self.rtm.init_task(task_id)
         self.rtm.start_task(task_id)
         computing_node = self._get_computing_node()
         subtask = await self.rtm.get_next_subtask(task_id, computing_node)
-        freezer.move_to("1010")
-        mock_loop.time.return_value = datetime.datetime.now().timestamp()
         # when
         with patch(
             'golem.task.requestedtaskmanager.asyncio.get_event_loop',

--- a/tests/golem/task/test_requestedtaskmanager.py
+++ b/tests/golem/task/test_requestedtaskmanager.py
@@ -75,7 +75,7 @@ class TestRequestedTaskManager:
             lambda *_: TaskState())
 
     @pytest.mark.asyncio
-    async def test_restore_tasks_timedout(self, freezer, mock_client):
+    async def test_restore_tasks_timedout(self, mock_client):
         # given
         mock_loop = MagicMock()
         mock_client.has_pending_subtasks.return_value = True
@@ -91,8 +91,8 @@ class TestRequestedTaskManager:
         mock_loop.time.return_value = datetime.datetime.now().timestamp()
         # when
         with patch(
-                'golem.task.requestedtaskmanager.asyncio.get_event_loop',
-                return_value=mock_loop
+            'golem.task.requestedtaskmanager.asyncio.get_event_loop',
+            return_value=mock_loop
         ):
             self.rtm.restore_tasks()
         # then
@@ -121,8 +121,8 @@ class TestRequestedTaskManager:
         mock_loop.time.return_value = datetime.datetime.now().timestamp()
         # when
         with patch(
-                'golem.task.requestedtaskmanager.asyncio.get_event_loop',
-                return_value=mock_loop
+            'golem.task.requestedtaskmanager.asyncio.get_event_loop',
+            return_value=mock_loop
         ):
             self.rtm.restore_tasks()
         # then


### PR DESCRIPTION
Schedule or trigger the timeouts of task-api tasks when restarting the golem node