### PR TITLE
Convert mask from and to bytes while decreasing

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -41,7 +41,6 @@ from golem.core.common import (
     string_to_timeout,
     to_unicode,
 )
-from golem.core.deferred import deferred_from_future
 from golem.core.fileshelper import du
 from golem.core.keysauth import KeysAuth
 from golem.core.service import LoopingCallService
@@ -1635,8 +1634,10 @@ class MaskUpdateService(LoopingCallService):
             requested_task_manager.decrease_task_mask(
                 task_id=db_task.task_id,
                 num_bits=self._update_num_bits)
-            logger.info('Updating mask. task_id=%r, new_mask_size=%r',
-                        db_task.task_id, db_task.mask.num_bits)
+            logger.info(
+                'Updating mask. task_id=%r, new_mask_size=%r',
+                db_task.task_id,
+                msg_datastructures.masking.Mask(db_task.mask).num_bits)
 
 
 class DailyJobsService(LoopingCallService):

--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -9,6 +9,7 @@ from typing import Any, Dict, List, Optional, Tuple, Iterable
 
 from dataclasses import dataclass
 from golem_messages import idgenerator
+from golem_messages.datastructures.masking import Mask
 from golem_task_api.dirutils import RequestorDir, RequestorTaskDir
 from golem_task_api.enums import VerifyResult
 from golem_task_api.client import RequestorAppClient
@@ -574,7 +575,9 @@ class RequestedTaskManager:
         )
         task = RequestedTask.get(RequestedTask.task_id == task_id)
         try:
-            task.mask.decrease(num_bits)
+            mask = Mask(task.mask)
+            mask.decrease(num_bits)
+            task.mask = mask.to_bytes()
             task.save()
         except ValueError:
             logger.exception('Wrong number of bits for mask decrease')


### PR DESCRIPTION
```
2019-11-14 15:55:32 ERROR    golem                               Service Error: Traceback (most recent call last):
  File "/Users/mwu-gol/.pyenv/versions/3.6.8/lib/python3.6/threading.py", line 916, in _bootstrap_inner
    self.run()
  File "/Users/mwu-gol/.pyenv/versions/3.6.8/lib/python3.6/threading.py", line 864, in run
    self._target(*self._args, **self._kwargs)
  File "/Users/mwu-gol/src/golem-project/golem/.venv/lib/python3.6/site-packages/twisted/_threads/_threadworker.py", line 46, in work
    task()
  File "/Users/mwu-gol/src/golem-project/golem/.venv/lib/python3.6/site-packages/twisted/_threads/_team.py", line 190, in doWork
    task()
--- <exception caught here> ---
  File "/Users/mwu-gol/src/golem-project/golem/.venv/lib/python3.6/site-packages/twisted/python/threadpool.py", line 250, in inContext
    result = inContext.theWork()
  File "/Users/mwu-gol/src/golem-project/golem/.venv/lib/python3.6/site-packages/twisted/python/threadpool.py", line 266, in <lambda>
    inContext.theWork = lambda: context.call(ctx, func, *args, **kw)
  File "/Users/mwu-gol/src/golem-project/golem/.venv/lib/python3.6/site-packages/twisted/python/context.py", line 122, in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/Users/mwu-gol/src/golem-project/golem/.venv/lib/python3.6/site-packages/twisted/python/context.py", line 85, in callWithContext
    return func(*args,**kw)
  File "/Users/mwu-gol/src/golem-project/golem/golem/client.py", line 1639, in _run
    num_bits=self._update_num_bits)
  File "/Users/mwu-gol/src/golem-project/golem/golem/task/requestedtaskmanager.py", line 596, in decrease_task_mask
    task.mask.decrease(num_bits)
builtins.AttributeError: 'bytes' object has no attribute 'decrease'
```