### PR TITLE
Fix: add a `app_id in self._apps` check to AppManager.enabled

### DIFF
--- a/golem/apps/manager.py
+++ b/golem/apps/manager.py
@@ -29,7 +29,9 @@ class AppManager:
     def enabled(self, app_id: AppId) -> bool:
         """ Check if an application with the given ID is registered in the
             manager and enabled. """
-        return app_id in self._state and self._state[app_id]
+        return app_id in self._apps and \
+            app_id in self._state and \
+            self._state[app_id]
 
     def set_enabled(self, app_id: AppId, enabled: bool) -> None:
         """ Enable or disable an application. Raise an error if the application


### PR DESCRIPTION
The method did not check whether an app was registered in the `AppManager`