### PR TITLE
Fix: Task API 'comp.task.subtask' RPC call compatibility

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -961,17 +961,15 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
     def get_subtask(
             self,
             subtask_id: str,
-            task_id: Optional[str] = None,
     ) -> Tuple[Optional[Dict], Optional[str]]:
         try:
             assert isinstance(self.task_server, TaskServer)
             tm = self.task_server.task_manager
             rtm = self.task_server.requested_task_manager
 
-            if task_id:
-                subtask = rtm.get_requested_task_subtask(task_id, subtask_id)
-                if subtask:
-                    return subtask.to_dict(), None
+            subtask = rtm.get_requested_subtask(subtask_id)
+            if subtask:
+                return subtask.to_dict(), None
             subtask = tm.get_subtask_dict(subtask_id)
             return subtask, None
         except (AttributeError, KeyError):

--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -496,13 +496,11 @@ class RequestedTaskManager:
             .execute()
 
     @staticmethod
-    def get_requested_task_subtask(
-            task_id: TaskId,
-            subtask_id: SubtaskId
+    def get_requested_subtask(
+            subtask_id: SubtaskId,
     ) -> Optional[RequestedSubtask]:
         try:
             return RequestedSubtask.get(
-                RequestedSubtask.task == task_id,
                 RequestedSubtask.subtask_id == subtask_id)
         except RequestedSubtask.DoesNotExist:
             return None

--- a/golem/task/server/verification.py
+++ b/golem/task/server/verification.py
@@ -176,9 +176,7 @@ class VerificationMixin:
                 f"Completed verification of subtask {subtask_id} "
                 f"within an unknown task {task_id}")
 
-        subtask = self.requested_task_manager.get_requested_task_subtask(
-            task_id,
-            subtask_id)
+        subtask = self.requested_task_manager.get_requested_subtask(subtask_id)
         if not subtask:
             raise RuntimeError(
                 f"Completed verification of unknown subtask {subtask_id} "

--- a/tests/golem/task/server/test_verification.py
+++ b/tests/golem/task/server/test_verification.py
@@ -33,10 +33,9 @@ class TestGetMarketStrategy(unittest.TestCase):
         tm = mock.Mock(tasks=tasks)
         rtm = mock.Mock(
             get_requested_task=task_api_tasks.get,
-            get_requested_task_subtask=mock.Mock(
+            get_requested_subtask=mock.Mock(
                 side_effect=(
-                    lambda t, s: task_api_subtasks.get(s)
-                    if t in task_api_tasks else None
+                    lambda s: task_api_subtasks.get(s)
                 ),
             )
         )


### PR DESCRIPTION
Since `subtask_id`s are unique, there is no need to extend RPC calls and identify subtasks by a `(task_id, subtask_id)` tuple.