### PR TITLE
b0.22 - task-api - Take peers from resources_options['options']

### DIFF
--- a/golem/resource/resourcemanager.py
+++ b/golem/resource/resourcemanager.py
@@ -24,13 +24,11 @@ class ResourceManager:
 
     def build_client_options(
             self,
-            peers: Optional[Peers] = None,
             **kwargs,
     ) -> ClientOptions:
         """ Return client-specific request options """
 
-        return self._client.build_options(
-            peers=peers, **kwargs)
+        return self._client.build_options(**kwargs)
 
     @inlineCallbacks
     def share(

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -507,7 +507,7 @@ class TaskServer(
             subtask_inputs_dir = self.task_computer.get_subtask_inputs_dir()
             resources_options = msg.resources_options or dict(options={})
             client_options = self.resource_manager.build_client_options(
-                **resources_options['options'])
+                **resources_options.get('options', {}))
 
             deferred_list = [
                 self.new_resource_manager.download(

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -505,9 +505,9 @@ class TaskServer(
 
         if task_header.environment_prerequisites:
             subtask_inputs_dir = self.task_computer.get_subtask_inputs_dir()
-            resources_options = msg.resources_options or dict()
+            resources_options = msg.resources_options or dict(options={})
             client_options = self.resource_manager.build_client_options(
-                **resources_options)
+                **resources_options['options'])
 
             deferred_list = [
                 self.new_resource_manager.download(


### PR DESCRIPTION
otherwise remote addresses are not passed correctly