### PR TITLE
change port used in tests from 4444 to 3333

### DIFF
--- a/tests/golem/envs/docker/cpu/test_env.py
+++ b/tests/golem/envs/docker/cpu/test_env.py
@@ -592,7 +592,7 @@ class TestCreateHostConfig(TestDockerCPUEnv):
     @patch_cpu('local_client')
     def test_published_ports(self, local_client):
         config = Mock(spec=DockerCPUConfig, cpu_count=2)
-        port = 4444
+        port = 3333
         payload = mock_docker_runtime_payload(ports=[port])
         host_config = self.env._create_host_config(config, payload)
 

--- a/tests/golem/envs/docker/cpu/test_integration.py
+++ b/tests/golem/envs/docker/cpu/test_integration.py
@@ -111,7 +111,7 @@ class TestIntegration(TestCase, DatabaseFixture):
         ))
         self.assertTrue(installed)
 
-        port = 4444
+        port = 3333
         runtime = self.env.runtime(DockerRuntimePayload(
             image="busybox",
             tag="latest",

--- a/tests/golem/task/task_api/test_docker.py
+++ b/tests/golem/task/task_api/test_docker.py
@@ -12,7 +12,7 @@ class TestDockerPayloadBuilder(TestCase):
         prereq = DockerPrerequisites(image='image', tag='tag')
         shared_dir = Path('shared_dir')
         command = 'cmd'
-        port = 4444
+        port = 3333
 
         payload = DockerTaskApiPayloadBuilder.create_payload(
             prereq,


### PR DESCRIPTION
4444 is used by I2P http proxy and it makes tests fail with
"listen tcp 0.0.0.0:4444: bind: address already in use"