### PR TITLE
[P6b] Transcoding: Audio sample rate validation

### DIFF
--- a/apps/transcoding/ffmpeg/ffmpeg_docker_api.py
+++ b/apps/transcoding/ffmpeg/ffmpeg_docker_api.py
@@ -6,6 +6,7 @@ import glob
 from pathlib import Path
 from typing import List, Optional
 from threading import Lock
+from ffmpeg_tools.codecs import AudioCodec
 from ffmpeg_tools.formats import Container
 
 from apps.transcoding.common import ffmpegException, ffmpegExtractSplitError, \
@@ -54,7 +55,9 @@ class FfmpegDockerAPI:
     def extract_video_streams_and_split(self,
                                         input_file_on_host: str,
                                         parts: int,
-                                        target_container: Optional[Container]):
+                                        target_container: Optional[Container],
+                                        target_audio_codec: Optional[AudioCodec
+                                                                    ],):
 
         input_file_basename = os.path.basename(input_file_on_host)
 
@@ -79,12 +82,18 @@ class FfmpegDockerAPI:
         else:
             target_container_str = target_container.value
 
+        if target_audio_codec is None:
+            target_audio_codec_str = None
+        else:
+            target_audio_codec_str = target_audio_codec.value
+
         extra_data = {
             'entrypoint': FFMPEG_ENTRYPOINT,
             'command': Commands.EXTRACT_AND_SPLIT.value[0],
             'input_file': input_file_in_container,
             'parts': parts,
             'target_container': target_container_str,
+            'target_audio_codec': target_audio_codec_str,
         }
 
         logger.debug(

--- a/apps/transcoding/ffmpeg/ffmpeg_docker_api.py
+++ b/apps/transcoding/ffmpeg/ffmpeg_docker_api.py
@@ -40,7 +40,7 @@ class Commands(enum.Enum):
     TRANSCODE = ('transcode', '')
     MERGE_AND_REPLACE = ('merge-and-replace', '')
     COMPUTE_METRICS = ('compute-metrics', '')
-    QUERY_MUXER_INFO = ('compute-metrics', 'query-muxer-info-results.json')
+    QUERY_MUXER_INFO = ('query-muxer-info', 'query-muxer-info-results.json')
     QUERY_ENCODER_INFO = (
         'query-encoder-info',
         'query-encoder-info-results.json')

--- a/apps/transcoding/ffmpeg/ffmpeg_docker_api.py
+++ b/apps/transcoding/ffmpeg/ffmpeg_docker_api.py
@@ -41,6 +41,9 @@ class Commands(enum.Enum):
     MERGE_AND_REPLACE = ('merge-and-replace', '')
     COMPUTE_METRICS = ('compute-metrics', '')
     QUERY_MUXER_INFO = ('compute-metrics', 'query-muxer-info-results.json')
+    QUERY_ENCODER_INFO = (
+        'query-encoder-info',
+        'query-encoder-info-results.json')
 
 
 class FfmpegDockerAPI:

--- a/apps/transcoding/ffmpeg/ffmpeg_docker_api.py
+++ b/apps/transcoding/ffmpeg/ffmpeg_docker_api.py
@@ -54,7 +54,7 @@ class FfmpegDockerAPI:
     def extract_video_streams_and_split(self,
                                         input_file_on_host: str,
                                         parts: int,
-                                        target_container: Container):
+                                        target_container: Optional[Container]):
 
         input_file_basename = os.path.basename(input_file_on_host)
 

--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
@@ -2,8 +2,9 @@ import json
 import re
 import os
 import sys
+from typing import Any, Dict, Optional
 
-from ffmpeg_tools import commands, formats, meta
+from ffmpeg_tools import codecs, commands, formats, meta, validation
 
 OUTPUT_DIR = "/golem/output"
 WORK_DIR = "/golem/work"
@@ -74,9 +75,58 @@ def do_split(path_to_stream, parts):
     return results
 
 
+def _fetch_encoder_info_if_requested(
+        target_audio_codec: str,
+        muxer_info: Optional[Dict[str, Any]]) -> Optional[Dict[str, Any]]:
+
+    encoder_info_requested = (
+        target_audio_codec is not None
+        # Even if encoder info was not explicitly requested by specifying an
+        # audio codec,
+        or muxer_info is not None
+        and "default_audio_codec" in muxer_info
+    )
+    if not encoder_info_requested:
+        return None
+
+    if target_audio_codec is not None:
+        audio_codec_name = target_audio_codec
+    else:
+        audio_codec_name = muxer_info["default_audio_codec"]
+
+    try:
+        audio_codec = codecs.AudioCodec(audio_codec_name)
+    except validation.UnsupportedAudioCodec:
+        # Getting an unsupported codec is entirely possible here because
+        # validations have not been performed yet. Now we know that they
+        # won't pass so there's no point in crashing the container.
+        # Just return empty encoder info and let the validations handle
+        # the problem gracefully.
+        print(
+            f"WARNING: Could not fetch encoder info for unsupported codec "
+            f"'{audio_codec_name}'",
+            file=sys.stderr)
+        return None
+
+    encoder = audio_codec.get_encoder()
+    if encoder is None:
+        # There's no encoder assigned to this codec in ffmpeg_tools.
+        # Probably ffmpeg does not even have an encoder for this format.
+        # Again, this is something that should be detected by validations
+        # but they have not been performed yet.
+        print(
+            f"WARNING: Could not fetch encoder info for codec "
+            f"'{audio_codec_name}' because it has no encoder assigned.",
+            file=sys.stderr)
+        return None
+
+    return commands.query_encoder_info(encoder)
+
+
 def do_extract_and_split(input_file,
                          parts,
                          target_container=None,
+                         target_audio_codec=None,
                          intermediate_container=None):
     input_basename = os.path.basename(input_file)
     [input_stem, input_extension] = os.path.splitext(input_basename)
@@ -100,6 +150,13 @@ def do_extract_and_split(input_file,
 
     if target_container is not None:
         results["muxer_info"] = commands.query_muxer_info(target_container)
+
+    encoder_info = _fetch_encoder_info_if_requested(
+        target_audio_codec,
+        results["muxer_info"] if "muxer_info" in results else None,
+    )
+    if encoder_info is not None:
+        results["encoder_info"] = encoder_info
 
     results_file = os.path.join(OUTPUT_DIR, "extract-and-split-results.json")
     with open(results_file, 'w') as f:
@@ -282,6 +339,7 @@ def run_ffmpeg(params):
             params['input_file'],
             params['parts'],
             params.get('target_container'),
+            params.get('target_audio_codec'),
             params.get('intermediate_container'))
     elif params['command'] == "transcode":
         do_transcode(

--- a/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
+++ b/apps/transcoding/ffmpeg/resources/ffmpeg-scripts/ffmpeg_task.py
@@ -259,6 +259,13 @@ def query_muxer_info(muxer):
         json.dump(results, f)
 
 
+def query_encoder_info(encoder):
+    results = {"encoder_info": commands.query_encoder_info(encoder)}
+    results_file = os.path.join(OUTPUT_DIR, "query-encoder-info-results.json")
+    with open(results_file, 'w') as f:
+        json.dump(results, f)
+
+
 def run_ffmpeg(params):
     if params['command'] == "extract":
         do_extract(
@@ -311,6 +318,9 @@ def run_ffmpeg(params):
     elif params['command'] == "query-muxer-info":
         query_muxer_info(
             params["muxer"])
+    elif params['command'] == "query-encoder-info":
+        query_encoder_info(
+            params["encoder"])
     else:
         raise InvalidCommand(f"Invalid command: {params['command']}")
 

--- a/apps/transcoding/ffmpeg/utils.py
+++ b/apps/transcoding/ffmpeg/utils.py
@@ -3,7 +3,8 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from typing import List, Tuple
+from typing import List, Optional, Tuple
+from ffmpeg_tools.codecs import AudioCodec
 from ffmpeg_tools.formats import Container
 
 from apps.transcoding import common
@@ -25,6 +26,8 @@ class StreamOperator:
                                         input_file_on_host: str,
                                         parts: int,
                                         target_container: Container,
+                                        target_audio_codec: Optional[AudioCodec
+                                                                    ],
                                         task_dir: str,
                                         task_id: str):
 
@@ -36,6 +39,7 @@ class StreamOperator:
                 input_file_on_host,
                 parts,
                 target_container,
+                target_audio_codec,
             )
 
         FfmpegDockerAPI.remove_split_intermediate_videos(directory_mapping)
@@ -70,6 +74,7 @@ class StreamOperator:
                 streams_list,
                 params.get('metadata', {}),
                 params.get('muxer_info', {}),
+                params.get('encoder_info', {}),
             )
 
     def _prepare_merge_job(self,

--- a/apps/transcoding/task.py
+++ b/apps/transcoding/task.py
@@ -105,11 +105,12 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
         # We expect, that there's only one resource.
         input_file = self.task_resources[0]
 
-        (chunks, video_metadata, muxer_info) = StreamOperator().\
+        (chunks, video_metadata, muxer_info, encoder_info) = StreamOperator().\
             extract_video_streams_and_split(
                 input_file,
                 self.get_total_tasks(),
                 self.task_definition.options.output_container,
+                self.task_definition.options.audio_params.codec,
                 self.task_dir,
                 task_id)
 
@@ -139,6 +140,7 @@ class TranscodingTask(CoreTask):  # pylint: disable=too-many-instance-attributes
                 dst_params,
                 video_metadata,
                 muxer_info,
+                encoder_info,
                 self.task_definition.options.strip_unsupported_data_streams,
                 self.task_definition.options.strip_unsupported_subtitle_streams,
             )

--- a/tests/apps/ffmpeg/task/test_ffmpegtranscoding.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegtranscoding.py
@@ -40,10 +40,11 @@ class TestffmpegTranscoding(TempDirFixture):
         for parts in [1, 2]:
             with self.subTest('Testing splitting', parts=parts):
                 task_id = str(uuid.uuid4())
-                chunks, _, _ = self.stream_operator.\
+                chunks, _, _, _ = self.stream_operator.\
                     extract_video_streams_and_split(
                         self.RESOURCE_STREAM,
                         parts,
+                        None,
                         None,
                         self.dir_manager.get_task_temporary_dir(task_id),
                         task_id)
@@ -55,6 +56,7 @@ class TestffmpegTranscoding(TempDirFixture):
             self.stream_operator.extract_video_streams_and_split(
                 os.path.join(self.RESOURCES, 'invalid_test_video2.mp4'),
                 1,
+                None,
                 None,
                 self.dir_manager.get_task_temporary_dir(task_id),
                 task_id)
@@ -69,10 +71,11 @@ class TestffmpegTranscoding(TempDirFixture):
         task_dir = self.dir_manager.get_task_temporary_dir(task_id)
         split_output_dir = os.path.join(task_dir, "output")
 
-        chunks, _, _ = self.stream_operator.extract_video_streams_and_split(
+        chunks, _, _, _ = self.stream_operator.extract_video_streams_and_split(
             self.RESOURCE_STREAM,
             parts,
             output_container,
+            None,
             task_dir,
             task_id)
 


### PR DESCRIPTION
### Changes
Changes are pretty similar to P5b (#4925).
1) `extract-and-split` command can now fetch encoder info for specified codec. The feature is optional and the data is fetched if either the codec name is specified or if we're fetching muxer info anyway (which means that the default audio codec might be used as the target).
    - As requested, there's also a separate command for getting that information (`query-codec-info`).
2) Encoder info is now being passed to `validate_transcoding_params()`.
3) There are two small fixes for P5b: the command name in `QUERY_MUXER_INFO` was wrong and so was one of the type annotations.

### Dependencies
https://github.com/golemfactory/ffmpeg-tools/pull/27 needs to get merged and released for this code to work and pass CI tests.

This pull request is based on #4925 (`transcoding-task-p5b-audio-codec-detection-and-validation` branch) and should be merged after it. Please remember to change the base branch back to `CGI/transcoding/master` before you merge. 