### PR TITLE
Transcoding: Fix duplicate container in extra_data

### DIFF
--- a/apps/transcoding/ffmpeg/task.py
+++ b/apps/transcoding/ffmpeg/task.py
@@ -46,18 +46,21 @@ class ffmpegTask(TranscodingTask):
         resolution = video_params.resolution
         resolution = [resolution[0], resolution[1]] if resolution else None
         vc = video_params.codec.value if video_params.codec else None
-        container = transcoding_options.output_container
+        if transcoding_options.output_container is not None:
+            target_container_str = transcoding_options.output_container.value
+        else:
+            target_container_str = None
+
         extra_data = {
             'track': chunk,
             'targs': {
-                'container': container.value if container is not None else None,
+                'container': target_container_str,
                 'video': {
                     'codec': vc,
                     'bitrate': video_params.bitrate
                 },
                 'resolution': resolution,
                 'frame_rate': video_params.frame_rate,
-                'format': transcoding_options.output_container.value
             },
             'output_stream': output_stream,
             'command': Commands.TRANSCODE.value[0],


### PR DESCRIPTION
The dict contains two fields: `format` and `container`. `format` was there from the beginning but was never actually passed down to the command running in the Docker container. I have later added `container` in many places and looks like I overlooked the fact that this place already had a similar field.

Well, `container` is now used basically everywhere so I'm removing `format`.

### Dependencies
This change does not really depend on branches below and could be easily rebased on master.
https://github.com/golemfactory/ffmpeg-tools/pull/28 contains a similar-looking change in `ffmpeg_tools` but they affect different dicts and don't really depend on each other.

This pull request is based on #4952 (`transcoding-task-p6b-audio-sample-rate-validation` branch) and should be merged after it. Please remember to change the base branch back to `CGI/transcoding/master` before you merge. 