### PR TITLE
Transcoding test fixes

### DIFF
--- a/tests/apps/ffmpeg/task/test_ffmpegintegration_all_bundle_files.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegintegration_all_bundle_files.py
@@ -248,12 +248,15 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
 
         try:
             validate_resolution(video["resolution"], resolution)
-            (_input_report, _output_report, diff) = operation.run(video["path"])
-            self.assertEqual(diff, [])
         except InvalidResolution:
             with self.assertRaises(InvalidResolution):
                 operation.run(video["path"])
+
             pytest.skip("Target resolution not supported")
+        else:
+            (_input_report, _output_report, diff) = operation.run(video["path"])
+            self.assertEqual(diff, [])
+
 
     @parameterized.expand(
         (

--- a/tests/apps/ffmpeg/task/test_ffmpegintegration_all_bundle_files.py
+++ b/tests/apps/ffmpeg/task/test_ffmpegintegration_all_bundle_files.py
@@ -242,7 +242,7 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
         if not video['container'].is_supported_video_codec(source_codec.value):
             pytest.skip("Target video codec not supported by the container")
 
-        if source_codec.can_convert(source_codec.value):
+        if not source_codec.can_convert(source_codec.value):
             pytest.skip("Transcoding is not possible for this file without"
                         "also changing the video codec.")
 
@@ -299,7 +299,7 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
         if not video['container'].is_supported_video_codec(source_codec.value):
             pytest.skip("Target video codec not supported by the container")
 
-        if source_codec.can_convert(source_codec.value):
+        if not source_codec.can_convert(source_codec.value):
             pytest.skip("Transcoding is not possible for this file without"
                         "also changing the video codec.")
 
@@ -349,7 +349,7 @@ class TestFfmpegIntegrationFullBundleSet(FfmpegIntegrationBase):
         if not video['container'].is_supported_video_codec(source_codec.value):
             pytest.skip("Target video codec not supported by the container")
 
-        if source_codec.can_convert(source_codec.value):
+        if not source_codec.can_convert(source_codec.value):
             pytest.skip("Transcoding is not possible for this file without"
                         "also changing the video codec.")
 

--- a/tests/apps/ffmpeg/task/utils/test_ffprobe_report.py
+++ b/tests/apps/ffmpeg/task/utils/test_ffprobe_report.py
@@ -789,7 +789,7 @@ class TestFfprobeReportBuild(TempDirFixture):
     def test_build_should_return_list_with_one_ffprobe_format_report_instance(
             self):
         reports = FfprobeFormatReport.build(
-            tmp_dir='/tmp/',
+            tmp_dir=self.tempdir,
             video_paths=[os.path.join(self.resources_dir, 'test_video.mp4')]
         )
         self.assertIsInstance(reports, List)


### PR DESCRIPTION
### Changes
1) Tests for `transcoding-video-bundle` were incorrectly checking if a conversion between codecs is allowed, resulting in valid cases being skipped and invalid being executed.
2) Also one of the exception handlers was too broad and could in theory result in the tested code being run twice if it for some reason raised `InvalidResolution` outside validations (which it should not do but anything is possible if there is a bug).
3) One of the tests was using hard-coded `/tmp/` instead of the correct temporary directory.

### Dependencies
This change is based on #4955 but does not really depend on anything below and could easily be rebased on `master`.

**NOTE**: Base branch of this pull request is not set to `CGI/transcoding/master`. Please remember to change it before merge.