### PR TITLE
task-api task timeout bugfix

### DIFF
--- a/golem/model.py
+++ b/golem/model.py
@@ -742,8 +742,8 @@ class RequestedTask(BaseModel):
     env_id = CharField(null=True)
     prerequisites = JsonField(null=False, default=default_dict())
 
-    task_timeout = IntegerField(null=False)  # milliseconds
-    subtask_timeout = IntegerField(null=False)  # milliseconds
+    task_timeout = IntegerField(null=False)  # seconds
+    subtask_timeout = IntegerField(null=False)  # seconds
     start_time = UTCDateTimeField(null=True)
 
     max_price_per_hour = HexIntegerField(null=False)
@@ -764,7 +764,7 @@ class RequestedTask(BaseModel):
             return None
         assert isinstance(self.start_time, datetime.datetime)
         return self.start_time + \
-            datetime.timedelta(milliseconds=self.task_timeout)
+            datetime.timedelta(seconds=self.task_timeout)
 
     @property
     def elapsed_seconds(self) -> Optional[int]:
@@ -777,7 +777,7 @@ class RequestedTask(BaseModel):
         return self.max_price_per_hour * (
             self.subtask_timeout
             * self.max_subtasks
-            / 60 / 1000  # subtask timeout is miliseconds, convert to hour
+            / 60  # subtask timeout is seconds, convert to hour
         )
 
 

--- a/scripts/node_integration_tests/tasks/__init__.py
+++ b/scripts/node_integration_tests/tasks/__init__.py
@@ -172,8 +172,8 @@ _TASK_SETTINGS = {
             'resources': [],
             'max_price_per_hour': str(10 ** 18),
             'max_subtasks': 1,
-            'task_timeout': 600000,  # 00:10:00
-            'subtask_timeout': 590000,  # 00:09:50
+            'task_timeout': 600,  # 00:10:00
+            'subtask_timeout': 590,  # 00:09:50
         },
         'app': {
             'resources': [],

--- a/scripts/task_api_tests/basic_integration.py
+++ b/scripts/task_api_tests/basic_integration.py
@@ -71,8 +71,8 @@ async def test_task(
     golem_params = requestedtaskmanager.CreateTaskParams(
         app_id=app_definition.id,
         name='testtask',
-        task_timeout=3600,
-        subtask_timeout=3600,
+        task_timeout=4,
+        subtask_timeout=4,
         output_directory=output_dir,
         resources=list(map(Path, resources)),
         max_subtasks=max_subtasks,
@@ -101,7 +101,7 @@ async def test_task(
             task_id=task_id,
             environment=app_definition.requestor_env,
             environment_prerequisites=env_prerequisites,
-            subtask_timeout=3600,
+            subtask_timeout=4,
             deadline=time.time() + 3600,
         )
         ctd = {

--- a/tests/golem/task/test_requestedtaskmanager.py
+++ b/tests/golem/task/test_requestedtaskmanager.py
@@ -102,8 +102,8 @@ class TestRequestedTaskManager:
         self._add_next_subtask_to_client_mock(mock_client)
 
         task_id = self._create_task(
-            task_timeout=20000,
-            subtask_timeout=20000)
+            task_timeout=20,
+            subtask_timeout=20)
         await self.rtm.init_task(task_id)
         self.rtm.start_task(task_id)
         computing_node = self._get_computing_node()
@@ -429,7 +429,7 @@ class TestRequestedTaskManager:
 
     @pytest.mark.asyncio
     async def test_restart_task_after_timeout(self, mock_client, monkeypatch):
-        task_timeout = 0.1
+        task_timeout = 1
         task_id = await self._start_task(task_timeout=task_timeout)
 
         # Wait for the task to timeout


### PR DESCRIPTION
- Schedule task timeout from the moment it started, not created
- ~Convert milliseconds to seconds before passing to scheduler~
- Use seconds instead of milliseconds as input parameter, updated tests and comments
- restore_tasks() marks tasks as errorCreating if they are stuck in creating