### PR TITLE
b0.22 - task-api - disable providing while requesting without config

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -1431,6 +1431,12 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
                 'environment': environment
             }
 
+        # computing a task
+        if self.task_server.requested_task_manager.has_unfinished_tasks():
+            return {
+                'status': 'Requesting a task',
+            }
+
         # not accepting tasks
         if not self.config_desc.accept_tasks:
             return {

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -581,8 +581,6 @@ class ClientProvider:
             create_task_params.max_subtasks,
         )
 
-        self.client.update_setting('accept_tasks', False)
-
         # Do not yield, this is a fire and forget deferred as it may take long
         # time to complete and shouldn't block the RPC call.
         d = self._init_task_api_task(task_id)
@@ -597,7 +595,6 @@ class ClientProvider:
                 self.requested_task_manager.init_task(task_id))
         except Exception:
             self.client.funds_locker.remove_task(task_id)
-            self.client.update_setting('accept_tasks', True)
             self.requested_task_manager.error_creating(task_id)
             raise
         else:

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -354,6 +354,9 @@ class TaskServer(
         if not self.task_computer.can_take_work():
             return
 
+        if self.requested_task_manager.has_unfinished_tasks():
+            return
+
         compatible_tasks = self.task_computer.compatible_tasks(
             set(self.task_keeper.supported_tasks))
 
@@ -993,8 +996,6 @@ class TaskServer(
             return
         self.client.p2pservice.remove_task(task_id)
         self.client.funds_locker.remove_task(task_id)
-        if not self.requested_task_manager.has_unfinished_tasks():
-            self.client.update_setting('accept_tasks', True)
 
     def _increase_trust_payment(self, node_id: str, amount: int):
         Trust.PAYMENT.increase(node_id, self.max_trust)

--- a/tests/golem/task/test_rpc_task_api.py
+++ b/tests/golem/task/test_rpc_task_api.py
@@ -128,8 +128,6 @@ class TestTaskApiCreate(TaskApiBase):
         )
 
         self.requested_task_manager.init_task.assert_called_once_with(task_id)
-        self.client.update_setting.assert_called_once_with(
-            'accept_tasks', False)
 
     def test_has_assigned_task(self):
         self.client.has_assigned_task.return_value = True
@@ -151,10 +149,6 @@ class TestTaskApiCreate(TaskApiBase):
 
         self.client.funds_locker.remove_task.assert_called_once_with(task_id)
         self.requested_task_manager.start_task.assert_not_called()
-        self.client.update_setting.assert_has_calls((
-            call('accept_tasks', False),
-            call('accept_tasks', True)
-        ))
 
 
 @mock.patch('golem.task.requestedtaskmanager.shutil', Mock())

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1292,7 +1292,6 @@ class TestRestoreResources(LogTestCase, testutils.DatabaseFixture,
                 event='task_status_updated', task_id=task_id, op=op)
             remove_task.assert_called_once_with(task_id)
             remove_task_funds_lock.assert_called_once_with(task_id)
-            update_setting.assert_called_once_with('accept_tasks', True)
             self.ts.client.reset_mock()
 
 


### PR DESCRIPTION
replace `accept_tasks` config toggle with `requested_task_manager.has_unfinished_tasks()`