### PR TITLE
Strip newline from docker-machine ip output

### DIFF
--- a/golem/docker/hypervisor/docker_machine.py
+++ b/golem/docker/hypervisor/docker_machine.py
@@ -99,7 +99,7 @@ class DockerMachineHypervisor(Hypervisor, metaclass=ABCMeta):
             c_config['NetworkSettings']['Ports'][f'{port}/tcp'][0]['HostPort'])
         ip = self.command('ip', self._vm_name)
         assert isinstance(ip, str)
-        return ip, port
+        return ip.strip(), port
 
     @property
     def config_dir(self):

--- a/golem/docker/hypervisor/dummy.py
+++ b/golem/docker/hypervisor/dummy.py
@@ -54,7 +54,7 @@ class DummyHypervisor(Hypervisor):
             vm_ip = DockerMachineCommandHandler.run('ip', DOCKER_VM_NAME)
             if vm_ip is None:
                 raise RuntimeError('Cannot retrieve Docker VM IP address')
-            ip_address = vm_ip
+            ip_address = vm_ip.strip()
         else:
             ip_address = net_config['Networks']['bridge']['IPAddress']
 

--- a/golem/task/task_api/__init__.py
+++ b/golem/task/task_api/__init__.py
@@ -51,10 +51,7 @@ class EnvironmentTaskApiService(TaskApiService):
         )
         self._runtime = self._env.runtime(runtime_payload)
         loop = asyncio.get_event_loop()
-        d = self._runtime.prepare()
-        f = d.asFuture(loop)
-        await f
-        # await self._runtime.prepare().asFuture(loop)
+        await self._runtime.prepare().asFuture(loop)
         await self._runtime.start().asFuture(loop)
         return self._runtime.get_port_mapping(port)
 

--- a/tests/golem/docker/test_hypervisor.py
+++ b/tests/golem/docker/test_hypervisor.py
@@ -182,7 +182,8 @@ class TestDockerMachineHypervisor(LogTestCase):
         }
         hypervisor = MockHypervisor()
         vm_ip = '192.168.64.151'
-        with mock.patch.object(hypervisor, 'command', return_value=vm_ip):
+        cmd_out = vm_ip + '\n'
+        with mock.patch.object(hypervisor, 'command', return_value=cmd_out):
             host, port = hypervisor.get_port_mapping('container_id', 12345)
         self.assertEqual(host, vm_ip)
         self.assertEqual(port, 54321)
@@ -502,7 +503,7 @@ class TestDummyHypervisor(TestCase):
             }
         }
         vm_ip = '10.0.0.3'
-        command_handler.run.return_value = vm_ip
+        command_handler.run.return_value = vm_ip + '\n'
 
         hypervisor = DummyHypervisor(mock.Mock())
         host, port = hypervisor.get_port_mapping('container_id', 12345)


### PR DESCRIPTION
Docker-machine outputs a newline character at the end of command output. In case of `ip` command this results in invalid address string if the trailing newline is not stripped.