### PR TITLE
Introduced DummyHyperVHypervisor

### DIFF
--- a/golem/docker/hypervisor/docker_for_mac.py
+++ b/golem/docker/hypervisor/docker_for_mac.py
@@ -82,9 +82,6 @@ class DockerForMac(Hypervisor):
 
         return constraints
 
-    def requires_ports_publishing(self) -> bool:
-        return True
-
     def get_port_mapping(self, container_id: str, port: int) -> Tuple[str, int]:
         api_client = local_client()
         c_config = api_client.inspect_container(container_id)

--- a/golem/docker/hypervisor/docker_machine.py
+++ b/golem/docker/hypervisor/docker_machine.py
@@ -89,9 +89,6 @@ class DockerMachineHypervisor(Hypervisor, metaclass=ABCMeta):
                 return [l.strip().split()[0] for l in lines]
         return []
 
-    def requires_ports_publishing(self) -> bool:
-        return True
-
     def get_port_mapping(self, container_id: str, port: int) -> Tuple[str, int]:
         api_client = local_client()
         c_config = api_client.inspect_container(container_id)

--- a/golem/envs/docker/non_hypervised.py
+++ b/golem/envs/docker/non_hypervised.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict
 
-from golem.docker.hypervisor.dummy import DummyHypervisor
+from golem.core.common import is_windows
+from golem.docker.hypervisor.dummy import DummyHypervisor, DummyHyperVHypervisor
 from golem.envs.docker.cpu import DockerCPUEnvironment
 from golem.envs.docker.gpu import DockerGPUEnvironment, DockerGPUConfig
 
@@ -14,6 +15,8 @@ class NonHypervisedDockerCPUEnvironment(DockerCPUEnvironment):
 
     @classmethod
     def _get_hypervisor_class(cls):
+        if is_windows():
+            return DummyHyperVHypervisor
         return DummyHypervisor
 
 

--- a/tests/golem/docker/test_hypervisor.py
+++ b/tests/golem/docker/test_hypervisor.py
@@ -5,7 +5,7 @@ import uuid
 from contextlib import contextmanager
 from subprocess import CalledProcessError
 from typing import Optional, Dict
-from unittest import mock, TestCase
+from unittest import mock, TestCase, skipIf
 
 from golem.core.common import is_osx, is_windows
 from golem.docker.commands.docker_machine import DockerMachineCommandHandler
@@ -482,11 +482,11 @@ class TestDockerForMacHypervisor(TempDirFixture):
         self.assertEqual(port, 54321)
 
 
+@skipIf(is_windows(), 'Linux & macOS only')
 class TestDummyHypervisor(TestCase):
 
-    @mock.patch('golem.docker.hypervisor.dummy.DockerMachineCommandHandler')
     @mock.patch('golem.docker.hypervisor.dummy.local_client')
-    def test_get_port_mapping(self, local_client, command_handler):
+    def test_get_port_mapping(self, local_client):
         container_ip = '172.17.0.2'
         local_client().inspect_container.return_value = {
             'NetworkSettings': {
@@ -502,8 +502,6 @@ class TestDummyHypervisor(TestCase):
                 }
             }
         }
-        vm_ip = '10.0.0.3'
-        command_handler.run.return_value = vm_ip + '\n'
 
         hypervisor = DummyHypervisor(mock.Mock())
         host, port = hypervisor.get_port_mapping('container_id', 12345)
@@ -511,8 +509,5 @@ class TestDummyHypervisor(TestCase):
         self.assertEqual(port, 12345)
         if is_osx():
             self.assertEqual(host, '127.0.0.1')
-        elif is_windows():
-            self.assertEqual(host, vm_ip)
-            command_handler.run.assert_called_once_with('ip', VM_NAME)
         else:
             self.assertEqual(host, container_ip)


### PR DESCRIPTION
DummyHypervisor is not suitable for use on Windows because it doesn't have the file sharing logic. Introduced DummyHyperVHypervisor to be used by NonHypervisedDockerCPUEnvironment on Windows instead.