### PR TITLE
Extended update-config to allow for only saving without updating config

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -846,12 +846,13 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
         return value
 
     @rpc_utils.expose('env.opt.update')
-    def update_setting(self, key, value):
+    def update_setting(self, key, value, update_config=True):
         logger.debug("updating setting %s = %r", key, value)
         if not hasattr(self.config_desc, key):
             raise KeyError("Unknown setting: {}".format(key))
         setattr(self.config_desc, key, value)
-        self.change_config(self.config_desc)
+        if update_config:
+            self.change_config(self.config_desc)
 
     @rpc_utils.expose('env.opts.update')
     def update_settings(self, settings_dict, run_benchmarks=False):

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -581,7 +581,7 @@ class ClientProvider:
             create_task_params.max_subtasks,
         )
 
-        self.client.update_setting('accept_tasks', False)
+        self.client.update_setting('accept_tasks', False, False)
 
         # Do not yield, this is a fire and forget deferred as it may take long
         # time to complete and shouldn't block the RPC call.
@@ -597,7 +597,7 @@ class ClientProvider:
                 self.requested_task_manager.init_task(task_id))
         except Exception:
             self.client.funds_locker.remove_task(task_id)
-            self.client.update_setting('accept_tasks', True)
+            self.client.update_setting('accept_tasks', True, False)
             self.requested_task_manager.error_creating(task_id)
             raise
         else:

--- a/golem/task/taskcomputer.py
+++ b/golem/task/taskcomputer.py
@@ -77,9 +77,6 @@ class TaskComputerAdapter:
             stats_keeper=self.stats
         )
 
-        # Should this node behave as provider and compute tasks?
-        self.compute_tasks = task_server.config_desc.accept_tasks \
-            and not task_server.config_desc.in_shutdown
         self.runnable = True
         self._listeners = []  # type: ignore
 
@@ -93,6 +90,12 @@ class TaskComputerAdapter:
     def dir_manager(self) -> DirManager:
         # FIXME: This shouldn't be part of the public interface probably
         return self._old_computer.dir_manager
+
+    @property
+    def compute_tasks(self):
+        # Should this node behave as provider and compute tasks?
+        config = self._task_server.config_desc
+        return config.accept_tasks and not config.in_shutdown
 
     def task_given(
             self,
@@ -247,8 +250,6 @@ class TaskComputerAdapter:
             config_desc: ClientConfigDescriptor,
             in_background: bool = True
     ) -> defer.Deferred:
-        self.compute_tasks = config_desc.accept_tasks \
-            and not config_desc.in_shutdown
         work_dir = Path(self._task_server.get_task_computer_root())
         yield self._new_computer.change_config(
             config_desc=config_desc,

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -994,7 +994,7 @@ class TaskServer(
         self.client.p2pservice.remove_task(task_id)
         self.client.funds_locker.remove_task(task_id)
         if not self.requested_task_manager.has_unfinished_tasks():
-            self.client.update_setting('accept_tasks', True)
+            self.client.update_setting('accept_tasks', True, False)
 
     def _increase_trust_payment(self, node_id: str, amount: int):
         Trust.PAYMENT.increase(node_id, self.max_trust)

--- a/tests/golem/task/test_rpc_task_api.py
+++ b/tests/golem/task/test_rpc_task_api.py
@@ -129,7 +129,7 @@ class TestTaskApiCreate(TaskApiBase):
 
         self.requested_task_manager.init_task.assert_called_once_with(task_id)
         self.client.update_setting.assert_called_once_with(
-            'accept_tasks', False)
+            'accept_tasks', False, False)
 
     def test_has_assigned_task(self):
         self.client.has_assigned_task.return_value = True
@@ -152,8 +152,8 @@ class TestTaskApiCreate(TaskApiBase):
         self.client.funds_locker.remove_task.assert_called_once_with(task_id)
         self.requested_task_manager.start_task.assert_not_called()
         self.client.update_setting.assert_has_calls((
-            call('accept_tasks', False),
-            call('accept_tasks', True)
+            call('accept_tasks', False, False),
+            call('accept_tasks', True, False)
         ))
 
 

--- a/tests/golem/task/test_taskcomputeradapter.py
+++ b/tests/golem/task/test_taskcomputeradapter.py
@@ -276,34 +276,32 @@ class TestLockConfig(TaskComputerAdapterTestBase):
 
 class TestChangeConfig(TaskComputerAdapterTestBase):
 
-    @defer.inlineCallbacks
     def _test_compute_tasks(self, accept_tasks, in_shutdown, expected):
         self.task_server.get_task_computer_root.return_value = '/test'
         config_desc = ClientConfigDescriptor()
         config_desc.accept_tasks = accept_tasks
         config_desc.in_shutdown = in_shutdown
 
-        yield self.adapter.change_config(config_desc)
+        self.adapter._task_server.config_desc = config_desc
         self.assertEqual(self.adapter.compute_tasks, expected)
 
-    @defer.inlineCallbacks
     def test_compute_tasks_setting(self):
-        yield self._test_compute_tasks(
+        self._test_compute_tasks(
             accept_tasks=1,
             in_shutdown=1,
             expected=False
         )
-        yield self._test_compute_tasks(
+        self._test_compute_tasks(
             accept_tasks=1,
             in_shutdown=0,
             expected=True
         )
-        yield self._test_compute_tasks(
+        self._test_compute_tasks(
             accept_tasks=0,
             in_shutdown=1,
             expected=False
         )
-        yield self._test_compute_tasks(
+        self._test_compute_tasks(
             accept_tasks=0,
             in_shutdown=0,
             expected=False

--- a/tests/golem/task/test_taskserver.py
+++ b/tests/golem/task/test_taskserver.py
@@ -1292,7 +1292,7 @@ class TestRestoreResources(LogTestCase, testutils.DatabaseFixture,
                 event='task_status_updated', task_id=task_id, op=op)
             remove_task.assert_called_once_with(task_id)
             remove_task_funds_lock.assert_called_once_with(task_id)
-            update_setting.assert_called_once_with('accept_tasks', True)
+            update_setting.assert_called_once_with('accept_tasks', True, False)
             self.ts.client.reset_mock()
 
 


### PR DESCRIPTION
Alternative resolution for #4973

Updates the config dict without triggering a reconfiguration of the docker VM