### PR TITLE
Use utc timestamp when checking task deadline

### DIFF
--- a/golem/client.py
+++ b/golem/client.py
@@ -897,7 +897,7 @@ class Client:  # noqa pylint: disable=too-many-instance-attributes,too-many-publ
                 return None
             subtask_ids = rtm.get_requested_task_subtask_ids(task_id)
             if task.start_time is None:
-                time_started = model.default_now().timestamp()
+                time_started = get_timestamp_utc()
             else:
                 time_started = task.start_time.timestamp()
             task_dict = {

--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -5,7 +5,7 @@ import subprocess
 import sys
 import threading
 from calendar import timegm
-from datetime import datetime
+from datetime import datetime, timezone
 from functools import wraps
 from pathlib import Path
 from typing import Any, Callable, cast, List, TypeVar, Optional
@@ -14,7 +14,6 @@ import pytz
 
 from golem.core import simpleenv
 from golem.decorators import locked
-from golem.model import default_now
 
 F = TypeVar('F', bound=Callable[..., Any])
 
@@ -118,6 +117,16 @@ def unix_pipe(source_cmd: List[str], sink_cmd: List[str]) -> str:
     source.stdout.close()
     stdout, _ = sink.communicate()
     return stdout.strip()
+
+
+# Use proxy function to always use current .utcnow() (allows mocking)
+def default_now():
+    return datetime.now(tz=timezone.utc)
+
+
+# Bug in peewee_migrate 0.14.0 induces setting __self__
+# noqa SEE: https://github.com/klen/peewee_migrate/blob/c55cb8c3664c3d59e6df3da7126b3ddae3fb7b39/peewee_migrate/auto.py#L64  # pylint: disable=line-too-long
+default_now.__self__ = datetime  # type: ignore
 
 
 def get_timestamp_utc():

--- a/golem/core/common.py
+++ b/golem/core/common.py
@@ -14,6 +14,7 @@ import pytz
 
 from golem.core import simpleenv
 from golem.decorators import locked
+from golem.model import default_now
 
 F = TypeVar('F', bound=Callable[..., Any])
 
@@ -120,7 +121,7 @@ def unix_pipe(source_cmd: List[str], sink_cmd: List[str]) -> str:
 
 
 def get_timestamp_utc():
-    now = datetime.now(pytz.utc)
+    now = default_now()
     return datetime_to_timestamp(now)
 
 

--- a/golem/model.py
+++ b/golem/model.py
@@ -30,7 +30,7 @@ from peewee import (
 import semantic_version
 
 from golem.core import common
-from golem.core.common import datetime_to_timestamp
+from golem.core.common import datetime_to_timestamp, default_now
 from golem.core.simpleserializer import DictSerializable
 from golem.database import GolemSqliteDatabase
 from golem.ranking.helper.trust_const import NEUTRAL_TRUST
@@ -44,16 +44,6 @@ db = GolemSqliteDatabase(None, threadlocals=True,
                              ('foreign_keys', True),
                              ('busy_timeout', 1000),
                              ('journal_mode', 'WAL')))
-
-
-# Use proxy function to always use current .utcnow() (allows mocking)
-def default_now():
-    return datetime.datetime.now(tz=datetime.timezone.utc)
-
-
-# Bug in peewee_migrate 0.14.0 induces setting __self__
-# noqa SEE: https://github.com/klen/peewee_migrate/blob/c55cb8c3664c3d59e6df3da7126b3ddae3fb7b39/peewee_migrate/auto.py#L64  # pylint: disable=line-too-long
-default_now.__self__ = datetime.datetime  # type: ignore
 
 
 def default_dict():

--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -24,10 +24,10 @@ from golem.core.golem_async import CallScheduler
 from golem.core.common import (
     datetime_to_timestamp_utc,
     get_timestamp_utc,
+    default_now,
 )
 from golem.model import (
     ComputingNode,
-    default_now,
     RequestedTask,
     RequestedSubtask,
 )
@@ -114,7 +114,7 @@ class RequestedTaskManager:
                 # subtask not started
                 continue
             subtask_id = subtask.subtask_id
-            time_left = subtask.deadline.timestamp() - default_now().timestamp()
+            time_left = subtask.deadline.timestamp() - get_timestamp_utc()
             if time_left > 0:
                 logger.info('restoring subtask. subtask_id=%r', subtask_id)
                 self._schedule_subtask_timeout(subtask, time_left)
@@ -128,7 +128,7 @@ class RequestedTaskManager:
             if task.deadline is None:
                 # task not started
                 continue
-            time_left = task.deadline.timestamp() - default_now().timestamp()
+            time_left = task.deadline.timestamp() - get_timestamp_utc()
             if time_left > 0:
                 logger.info('restoring task. task_id=%r', task.task_id)
                 self._schedule_task_timeout(task, time_left)

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -39,7 +39,12 @@ from golem import constants as gconst
 from golem.apps import manager as app_manager
 from golem.apps.default import save_built_in_app_definitions
 from golem.clientconfigdescriptor import ClientConfigDescriptor
-from golem.core.common import short_node_id, deadline_to_timeout, get_log_dir
+from golem.core.common import (
+    short_node_id,
+    deadline_to_timeout,
+    get_log_dir,
+    get_timestamp_utc,
+)
 from golem.core.deferred import (
     asyncio_main_loop,
     deferred_from_future,
@@ -781,7 +786,7 @@ class TaskServer(
             )
             logger.debug("task_header=%r", task_header)
             return False
-        if task_header.deadline < time.time():
+        if task_header.deadline < get_timestamp_utc():
             logger.info(
                 "Task's deadline already in the past. task_id=%r",
                 task_header.task_id

--- a/tests/golem/task/test_requestedtaskmanager.py
+++ b/tests/golem/task/test_requestedtaskmanager.py
@@ -13,7 +13,8 @@ import pytest
 from twisted.internet import defer
 
 from golem.apps.manager import AppManager
-from golem.model import default_now, RequestedTask, RequestedSubtask
+from golem.core.common import default_now
+from golem.model import RequestedTask, RequestedSubtask
 from golem.task.envmanager import EnvironmentManager
 from golem.task import requestedtaskmanager
 from golem.task.requestedtaskmanager import (


### PR DESCRIPTION
Found by QA team while testing task-api.
`time.time()` was compared to `default_now().timestamp()`

- Made `get_timestamp_utc()` also use `default_now()`
- Moved `default_now` to golem.core.common to avoid circular imports
- Replaced `time.time()` with `get_timestamp_utc()` 