### PR TITLE
Container not shut down on task creation failure

### DIFF
--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -1,13 +1,14 @@
 import asyncio
 import hashlib
 import logging
-from functools import partial
-
 import os
 import shutil
 from datetime import timedelta
+from functools import partial
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
+
+import async_generator
 
 from dataclasses import dataclass
 from golem_messages import idgenerator
@@ -191,18 +192,31 @@ class RequestedTaskManager:
             placed. """
         return self._task_dir(task_id).subtask_outputs_dir(subtask_id)
 
-    def create_task(
+    async def create_task(
             self,
             golem_params: CreateTaskParams,
             app_params: Dict[str, Any],
     ) -> TaskId:
+        task_id = idgenerator.generate_id(self._public_key)
+        app_id = golem_params.app_id
+
+        async with self._task_creation_ctx(task_id, app_id):
+            self._create_task(task_id, golem_params, app_params)
+        return task_id
+
+    def _create_task(
+            self,
+            task_id: TaskId,
+            golem_params: CreateTaskParams,
+            app_params: Dict[str, Any],
+    ):
         """ Creates an entry in the storage about the new task and assigns
         the task_id to it. The task then has to be initialized and started. """
         logger.debug('create_task(golem_params=%r, app_params=%r)',
                      golem_params, app_params)
 
         task = RequestedTask.create(
-            task_id=idgenerator.generate_id(self._public_key),
+            task_id=task_id,
             app_id=golem_params.app_id,
             name=golem_params.name,
             status=TaskStatus.creating,
@@ -236,9 +250,12 @@ class RequestedTaskManager:
         )
         logger.debug('raw_task=%r', task)
         self._notice_task_updated(task, op=TaskOp.CREATED)
-        return task.task_id
 
     async def init_task(self, task_id: TaskId) -> None:
+        async with self._task_creation_ctx(task_id):
+            await self._init_task(task_id)
+
+    async def _init_task(self, task_id: TaskId) -> None:
         """ Initialize the task by calling create_task on the Task API.
         The application performs validation of the params which may result in
         an error marking the task as failed. """
@@ -264,6 +281,32 @@ class RequestedTaskManager:
         task.min_memory = reply.inf_requirements.min_memory_mib * (1024 ** 2)
         task.save()
         logger.debug('init_task(task_id=%r) after', task_id)
+
+    @async_generator.asynccontextmanager
+    @async_generator.async_generator
+    async def _task_creation_ctx(
+            self,
+            task_id: TaskId,
+            app_id: Optional[AppId] = None,
+    ):
+        try:
+            await async_generator.yield_()
+        except Exception:  # pylint: disable=broad-except
+            try:
+                task = RequestedTask.get(task_id=task_id)
+                task.status = TaskStatus.errorCreating
+                task.save()
+                if not app_id:
+                    app_id = task.app_id
+            except RequestedTask.DoesNotExist:
+                pass
+            try:
+                if app_id:
+                    await self._shutdown_app_client(app_id)
+            except Exception:  # pylint: disable=broad-except
+                logger.exception(
+                    'Failed to shut down client. app_id=%r', app_id)
+            raise
 
     def start_task(self, task_id: TaskId) -> None:
         """ Marks an already initialized task as ready for computation. """
@@ -647,7 +690,7 @@ class RequestedTaskManager:
             concent_enabled=task.concent_enabled,
         )
         app_params = task.app_params
-        return self.create_task(golem_params, app_params)
+        return await self.create_task(golem_params, app_params)
 
     async def discard_subtasks(
             self,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 appdirs==1.4.3
 argh==0.26.2
 asn1crypto==0.22.0
+async-generator==1.10
 attrs==17.4.0
 autobahn==19.6.2
 Automat==0.6.0

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -2,6 +2,7 @@
 --extra-index-url https://builds.golem.network
 appdirs>=1.4
 asn1crypto==0.22.0
+async-generator==1.10
 autobahn==19.6.2
 Automat==0.6.0
 base58

--- a/scripts/task_api_tests/basic_integration.py
+++ b/scripts/task_api_tests/basic_integration.py
@@ -81,7 +81,7 @@ async def test_task(
     )
     with open(task_params_path, 'r') as f:
         task_params = json.load(f)
-    task_id = rtm.create_task(golem_params, task_params)
+    task_id = await rtm.create_task(golem_params, task_params)
     print('Task created', task_id)
     await deferred_from_future(rtm.init_task(task_id))
     rtm.start_task(task_id)

--- a/tests/golem/task/test_requestedtaskmanager.py
+++ b/tests/golem/task/test_requestedtaskmanager.py
@@ -82,7 +82,7 @@ class TestRequestedTaskManager:
         self.rtm._time_out_task = Mock()
         self.rtm._time_out_subtask = Mock()
 
-        task_id = self._create_task()
+        task_id = await self._create_task()
         await self.rtm.init_task(task_id)
         self.rtm.start_task(task_id)
         computing_node = self._get_computing_node()
@@ -102,7 +102,7 @@ class TestRequestedTaskManager:
         # given
         self._add_next_subtask_to_client_mock(mock_client)
 
-        task_id = self._create_task(
+        task_id = await self._create_task(
             task_timeout=20,
             subtask_timeout=20)
         await self.rtm.init_task(task_id)
@@ -120,12 +120,13 @@ class TestRequestedTaskManager:
             call(task_id, ANY, ANY),
         ])
 
-    def test_create_task(self):
+    @pytest.mark.asyncio
+    async def test_create_task(self):
         # given
         golem_params = self._build_golem_params()
         app_params = {}
         # when
-        task_id = self.rtm.create_task(golem_params, app_params)
+        task_id = await self.rtm.create_task(golem_params, app_params)
         # then
         row = RequestedTask.get(RequestedTask.task_id == task_id)
         assert row.status == TaskStatus.creating
@@ -135,7 +136,7 @@ class TestRequestedTaskManager:
     @pytest.mark.asyncio
     async def test_init_task(self, mock_client):
         # given
-        task_id = self._create_task()
+        task_id = await self._create_task()
         env_id = 'test_env'
         prerequisites = {'key': 'value'}
         mock_client.create_task.return_value = Mock(
@@ -163,7 +164,7 @@ class TestRequestedTaskManager:
     @pytest.mark.asyncio
     async def test_init_task_wrong_status(self, mock_client):
         # given
-        task_id = self._create_task()
+        task_id = await self._create_task()
         # when
         await self.rtm.init_task(task_id)
         # Start task to change the status
@@ -176,7 +177,7 @@ class TestRequestedTaskManager:
     async def test_start_task(self, mock_client):
         with freeze_time() as freezer:
             # given
-            task_id = self._create_task()
+            task_id = await self._create_task()
             await self.rtm.init_task(task_id)
             # when
             self.rtm.start_task(task_id)
@@ -189,7 +190,7 @@ class TestRequestedTaskManager:
     @pytest.mark.asyncio
     async def test_error_creating(self, mock_client):
         # given
-        task_id = self._create_task()
+        task_id = await self._create_task()
         # when
         await self.rtm.init_task(task_id)
         self.rtm.error_creating(task_id)
@@ -200,7 +201,7 @@ class TestRequestedTaskManager:
     @pytest.mark.asyncio
     async def test_error_creating_wrong_status(self, mock_client):
         # given
-        task_id = self._create_task()
+        task_id = await self._create_task()
         # when
         await self.rtm.init_task(task_id)
         # Start task to change the status
@@ -209,8 +210,9 @@ class TestRequestedTaskManager:
         with pytest.raises(RuntimeError):
             self.rtm.error_creating(task_id)
 
-    def test_task_exists(self):
-        task_id = self._create_task()
+    @pytest.mark.asyncio
+    async def test_task_exists(self):
+        task_id = await self._create_task()
         assert self.rtm.task_exists(task_id) is True
 
     def test_task_not_exists(self):
@@ -343,7 +345,7 @@ class TestRequestedTaskManager:
     @pytest.mark.asyncio
     async def test_task_timeout(self, mock_client):
         task_timeout = 0.1
-        task_id = self._create_task(task_timeout=task_timeout)
+        task_id = await self._create_task(task_timeout=task_timeout)
         await self.rtm.init_task(task_id)
         self.rtm.start_task(task_id)
         assert not self.rtm.is_task_finished(task_id)
@@ -403,7 +405,7 @@ class TestRequestedTaskManager:
     @pytest.mark.asyncio
     async def test_get_started_tasks(self, mock_client):
         # given
-        task_id = self._create_task()
+        task_id = await self._create_task()
         await self.rtm.init_task(task_id)
         # when
         results = self.rtm.get_started_tasks()
@@ -508,7 +510,7 @@ class TestRequestedTaskManager:
             assert row.status == SubtaskStatus.cancelled
 
     async def _start_task(self, **golem_params):
-        task_id = self._create_task(**golem_params)
+        task_id = await self._create_task(**golem_params)
         await self.rtm.init_task(task_id)
         self.rtm.start_task(task_id)
         return task_id
@@ -516,7 +518,7 @@ class TestRequestedTaskManager:
     @pytest.mark.asyncio
     async def test_stop(self, mock_client):
         # given
-        task_id = self._create_task()
+        task_id = await self._create_task()
         await self.rtm.init_task(task_id)
 
         # when
@@ -544,10 +546,10 @@ class TestRequestedTaskManager:
             concent_enabled=False,
         )
 
-    def _create_task(self, **golem_params):
+    async def _create_task(self, **golem_params):
         golem_params = self._build_golem_params(**golem_params)
         app_params = {}
-        task_id = self.rtm.create_task(golem_params, app_params)
+        task_id = await self.rtm.create_task(golem_params, app_params)
         return task_id
 
     @staticmethod

--- a/tests/golem/task/test_rpc_task_api.py
+++ b/tests/golem/task/test_rpc_task_api.py
@@ -61,20 +61,32 @@ class TaskApiBase(DatabaseFixture):
         }
 
 
-class TestTaskApiCreate(TaskApiBase):
+class TestTaskApiCreate(TwistedAsyncioTestCase, TaskApiBase):
 
+    def setUp(self):
+        TwistedAsyncioTestCase.setUp(self)
+        TaskApiBase.setUp(self)
+
+        self.task_id = 'test_task_id'
+
+        create_future = asyncio.Future()
+        create_future.set_result(self.task_id)
+        init_future = asyncio.Future()
+        init_future.set_result(None)
+
+        self.requested_task_manager.create_task.return_value = create_future
+        self.requested_task_manager.init_task.return_value = init_future
+
+    @inlineCallbacks
     def test_success(self):
         app_params = {
             'app_param1': 'value1',
             'app_param2': 'value2',
         }
         golem_params = self.get_golem_params()
-        task_id = 'test_task_id'
-        self.requested_task_manager.create_task.return_value = task_id
-        self.requested_task_manager.init_task.return_value = asyncio.Future()
-        self.requested_task_manager.init_task.return_value.set_result(None)
+        task_id = self.task_id
 
-        new_task_id, _ = self.rpc.create_task({
+        new_task_id, _ = yield self.rpc.create_task({
             'golem': golem_params,
             'app': app_params,
         })
@@ -131,20 +143,22 @@ class TestTaskApiCreate(TaskApiBase):
         self.client.update_setting.assert_called_once_with(
             'accept_tasks', False, False)
 
+    @inlineCallbacks
     def test_has_assigned_task(self):
         self.client.has_assigned_task.return_value = True
 
         with self.assertRaises(RuntimeError):
-            self.rpc._create_task_api_task(self.get_golem_params(), {})
+            yield self.rpc._create_task_api_task(self.get_golem_params(), {})
 
         self.requested_task_manager.create_task.assert_not_called()
         self.requested_task_manager.init_task.assert_not_called()
         self.client.funds_locker.lock_funds.assert_not_called()
 
+    @inlineCallbacks
     def test_failed_init(self):
-        self.requested_task_manager.init_task.side_effect = Exception
+        self.requested_task_manager.init_task = Exception
 
-        task_id, _ = self.rpc.create_task({
+        task_id, _ = yield self.rpc.create_task({
             'golem': self.get_golem_params(),
             'app': {},
         })
@@ -157,12 +171,11 @@ class TestTaskApiCreate(TaskApiBase):
         ))
 
 
-@mock.patch('golem.task.requestedtaskmanager.shutil', Mock())
 class TestTaskOperations(TwistedAsyncioTestCase, TaskApiBase):
 
     def setUp(self):
-        TwistedAsyncioTestCase.setUp(self)
         TaskApiBase.setUp(self)
+        TwistedAsyncioTestCase.setUp(self)
 
         self.requested_task_manager = requestedtaskmanager.RequestedTaskManager(
             env_manager=Mock(),
@@ -175,6 +188,9 @@ class TestTaskOperations(TwistedAsyncioTestCase, TaskApiBase):
             return_value=rtm_factory.MockRequestorAppClient())
         self.client.task_server.requested_task_manager = \
             self.requested_task_manager
+
+        # use TestCase.patch instead of unittest.mock.patch for TwistedTestCase
+        self.patch(requestedtaskmanager, 'shutil', mock.Mock())
 
     @inlineCallbacks
     def test_restart_task(self):
@@ -261,7 +277,7 @@ class TestTaskOperations(TwistedAsyncioTestCase, TaskApiBase):
     def _create_task(self):
         # we need to wait for _init_task_api_task
         with mock.patch.object(self.rpc, '_init_task_api_task'):
-            task_id, _ = self.rpc.create_task({
+            task_id, _ = yield self.rpc.create_task({
                 'golem': self.get_golem_params(),
                 'app': {},
             })


### PR DESCRIPTION
- shuts down the container if no more tasks are pending in order to free resources (i.e. bound ports)
- changes `RequestedTask`'s status to `errorCreating` on failure