### PR TITLE
Task-api handle `cannot_compute_task` message

### DIFF
--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -996,7 +996,13 @@ class RequestedTaskManager:
         )
         update_provider_efficacy(node_id, op)
         if subtask_timeout is not None:
-            update_provider_efficiency(node_id, subtask_timeout, comp_time)
+            if comp_time:
+                update_provider_efficiency(node_id, subtask_timeout, comp_time)
+            else:
+                logger.warning(
+                    "Could not obtain computation time for subtask: %r",
+                    subtask_id
+                )
             dispatcher.send(
                 signal='golem.subtask',
                 event='finished',

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -259,6 +259,7 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
         ts2 = self._get_requestor_tasksession()
         ts2.task_manager.get_node_id_for_subtask.return_value = ts2.key_id
         ts2.requested_task_manager.get_node_id_for_subtask.return_value = None
+        ts2.requested_task_manager.subtask_exists.return_value = False
         ts2._react_to_cannot_compute_task(message.tasks.CannotComputeTask(
             reason=message.tasks.CannotComputeTask.REASON.WrongCTD,
             task_to_compute=None,
@@ -283,6 +284,7 @@ class TaskSessionTaskToComputeTest(TestDirFixtureWithReactor):
         )
         ts.task_manager.get_node_id_for_subtask.return_value = ts.key_id
         ts.requested_task_manager.get_node_id_for_subtask.return_value = None
+        ts.requested_task_manager.subtask_exists.return_value = False
         ts._react_to_cannot_compute_task(msg)
         ts.task_manager.task_computation_cancelled.assert_called_once_with(
             msg.subtask_id,


### PR DESCRIPTION
Missing check for RTM, added in this PR