### PR TITLE
Ignore application errors in ProviderProxy

### DIFF
--- a/golem/ethereum/node.py
+++ b/golem/ethereum/node.py
@@ -3,7 +3,7 @@ import time
 
 from typing import List
 
-from web3 import Web3, HTTPProvider
+from web3 import Web3
 
 from golem.ethereum.web3.providers import ProviderProxy
 from golem.report import report_calls, Component

--- a/golem/ethereum/web3/providers.py
+++ b/golem/ethereum/web3/providers.py
@@ -53,7 +53,7 @@ class ProviderProxy(HTTPProvider):
                     'GETH: request successful %s (%r, %r) -- result = %r',
                     self.provider.endpoint_uri, method, params, response
                 )
-            except (ConnectionError, ValueError,
+            except (ConnectionError,
                     socket.error, CannotHandleRequest) as exc:
                 retries += 1
                 self._register_retry()
@@ -91,8 +91,8 @@ class ProviderProxy(HTTPProvider):
     def _handle_remote_rpc_provider_failure(self, method: str, final: bool):
         if final:
             raise Exception(
-                "GETH: Node limit exhausted, request failed. method='%s'",
-                method
+                "GETH: Node limit exhausted, request failed."
+                f" method='{method}'",
             )
         logger.warning(
             "GETH: '%s' request failed on '%s', "


### PR DESCRIPTION
All `ValueError`s generated in `web3` seem to be application logic errors, not connection issues. Therefore it seems wise to just reraise them in `ProviderProxy`.

Typical `ValueError`s are:
1. missing trie node
1. known transaction
1. nonce too low
1. No matching events found

Some of them are already handled by ŚCI.