### PR TITLE
Only allow one offer per provider_id per task in queue

### DIFF
--- a/golem/marketplace/pooling_marketplace.py
+++ b/golem/marketplace/pooling_marketplace.py
@@ -14,12 +14,14 @@ class RequestorPoolingMarketStrategy(RequestorMarketStrategy):
     def add(cls, task_id: str, offer: Offer):
         if task_id not in cls._pools:
             cls._pools[task_id] = []
-        cls._pools[task_id].append(offer)
+        task_pool = cls._pools[task_id]
+        if offer.provider_id not in [o.provider_id for o in task_pool]:
+            task_pool.append(offer)
 
-        logger.debug(
-            "Offer accepted & added to pool. offer=%s",
-            offer,
-        )
+            logger.debug(
+                "Offer accepted & added to pool. offer=%s",
+                offer,
+            )
 
     @classmethod
     def get_task_offer_count(cls, task_id: str) -> int:

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -383,6 +383,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             for offer in market_strategy.resolve_task_offers(task_id):
                 try:
                     offer.callback()
+                    break
                 except Exception as e:
                     logger.error(e)
 
@@ -419,7 +420,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             self._cannot_assign_task(msg.task_id, reasons.NoMoreSubtasks)
             return
 
-        logger.info("Offer confirmed, assigning subtask(s)")
+        logger.info("Offer confirmed, assigning subtask(s). %r", task_node_info)
 
         task_class = self._get_task_class(msg.task_header)
         budget = task_class.REQUESTOR_MARKET_STRATEGY.calculate_budget(msg)

--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -383,7 +383,6 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             for offer in market_strategy.resolve_task_offers(task_id):
                 try:
                     offer.callback()
-                    break
                 except Exception as e:
                     logger.error(e)
 

--- a/tests/golem/marketplace/test_marketplace.py
+++ b/tests/golem/marketplace/test_marketplace.py
@@ -108,7 +108,7 @@ class TestRequestorBrassMarketStrategy(TestCase):
     TASK_A = 'aaa'
 
     @staticmethod
-    def _mock_offer():
+    def _mock_offer(provider_id='provider_1'):
         mock_offer = MagicMock(spec_set=[
             'provider_id',
             'provider_performance',
@@ -117,7 +117,7 @@ class TestRequestorBrassMarketStrategy(TestCase):
             'reputation',
             'quality',
         ])
-        mock_offer.provider_id = 'provider_1'
+        mock_offer.provider_id = provider_id
         mock_offer.provider_performance = ProviderPerformance(100)
         mock_offer.max_price = 5000
         mock_offer.reputation = 1.0
@@ -131,7 +131,8 @@ class TestRequestorBrassMarketStrategy(TestCase):
     def test_empty_after_choice(self):
         offer = self._mock_offer()
         RequestorBrassMarketStrategy.add(self.TASK_A, offer)
-        RequestorBrassMarketStrategy.add(self.TASK_A, offer)
+        offer2 = self._mock_offer('provider_2')
+        RequestorBrassMarketStrategy.add(self.TASK_A, offer2)
         self.assertEqual(
             RequestorBrassMarketStrategy.get_task_offer_count(self.TASK_A), 2)
 
@@ -142,7 +143,8 @@ class TestRequestorBrassMarketStrategy(TestCase):
     def test_resolution_length_correct(self):
         offer = self._mock_offer()
         RequestorBrassMarketStrategy.add(self.TASK_A, offer)
-        RequestorBrassMarketStrategy.add(self.TASK_A, offer)
+        offer2 = self._mock_offer('provider_2')
+        RequestorBrassMarketStrategy.add(self.TASK_A, offer2)
         self.assertEqual(
             RequestorBrassMarketStrategy.get_task_offer_count(self.TASK_A), 2)
         result = RequestorBrassMarketStrategy.resolve_task_offers(self.TASK_A)


### PR DESCRIPTION
this issue occurs when 2 tasks are requested in a 2 node setup.

```
INFO     [golem.marketplace.brass_marketplace] Ordering providers for task: dbe198b0-20bc-11ea-b92a-43ed6a67ef11
INFO     [golem.task.tasksession             ] Offer confirmed, assigning subtask(s). "task_id='dbe198b0-20bc-11ea-b92a-43ed6a67ef11', node='e57a9382..708bc0dc'"
INFO     [golem.task.tasksession             ] Offer confirmed, assigning subtask(s). "task_id='dbe198b0-20bc-11ea-b92a-43ed6a67ef11', node='e57a9382..708bc0dc'"
INFO     [golem.task.tasksession             ] Offer confirmed, assigning subtask(s). "task_id='dbe198b0-20bc-11ea-b92a-43ed6a67ef11', node='e57a9382..708bc0dc'"
```