### PR TITLE
Fixed recovery logic for DockerMachineHypervisor

### DIFF
--- a/golem/docker/commands/docker.py
+++ b/golem/docker/commands/docker.py
@@ -37,19 +37,22 @@ class DockerCommandHandler:
         return bool(shutil.which('docker'))
 
     @classmethod
-    def run(cls,
+    def run(
+            cls,
             command_name: str,
             vm_name: Optional[str] = None,
             args: Optional[Union[Tuple, List[str]]] = None,
-            shell: bool = False) -> Optional[str]:
+            shell: bool = False,
+            timeout: Optional[float] = None
+    ) -> Optional[str]:
 
         command = cls.commands.get(command_name)
         if not command:
             logger.error('Unknown command: %s', command_name)
         elif isinstance(command, list):
-            return cls._command(command[:], vm_name, args, shell)
+            return cls._command(command[:], vm_name, args, shell, timeout)
         elif callable(command):
-            return command(vm_name, args, shell)
+            return command(vm_name, args, shell, timeout)
         return None
 
     @classmethod
@@ -73,11 +76,14 @@ class DockerCommandHandler:
                 return
 
     @classmethod
-    def _command(cls,
-                 command: List[str],
-                 vm_name: Optional[str] = None,
-                 args: Optional[Union[Tuple, List[str]]] = None,
-                 shell: bool = False) -> str:
+    def _command(
+            cls,
+            command: List[str],
+            vm_name: Optional[str] = None,
+            args: Optional[Union[Tuple, List[str]]] = None,
+            shell: bool = False,
+            timeout: Optional[float] = None
+    ) -> str:
 
         if args:
             command += list(args)
@@ -95,7 +101,8 @@ class DockerCommandHandler:
                 startupinfo=SUBPROCESS_STARTUP_INFO,
                 shell=shell,
                 stdin=subprocess.DEVNULL,
-                stderr=subprocess.STDOUT
+                stderr=subprocess.STDOUT,
+                timeout=timeout
             )
         except FileNotFoundError as exc:
             raise subprocess.CalledProcessError(127, str(exc))

--- a/golem/docker/commands/docker.py
+++ b/golem/docker/commands/docker.py
@@ -11,7 +11,12 @@ logger = logging.getLogger(__name__)
 
 
 CallableCommand = Callable[
-    [Optional[str], Union[Tuple, List[str], None], Optional[bool]],  # args
+    [
+        Optional[str],
+        Union[Tuple, List[str], None],
+        Optional[bool],
+        Optional[float]
+    ],  # args
     Optional[str]  # return value
 ]
 

--- a/golem/docker/commands/docker.py
+++ b/golem/docker/commands/docker.py
@@ -37,7 +37,7 @@ class DockerCommandHandler:
         return bool(shutil.which('docker'))
 
     @classmethod
-    def run(
+    def run(  # noqa pylint: disable=too-many-arguments
             cls,
             command_name: str,
             vm_name: Optional[str] = None,
@@ -76,7 +76,7 @@ class DockerCommandHandler:
                 return
 
     @classmethod
-    def _command(
+    def _command(  # noqa pylint: disable=too-many-arguments
             cls,
             command: List[str],
             vm_name: Optional[str] = None,

--- a/golem/docker/hypervisor/docker_machine.py
+++ b/golem/docker/hypervisor/docker_machine.py
@@ -84,7 +84,7 @@ class DockerMachineHypervisor(Hypervisor, metaclass=ABCMeta):
             # DON'T use the '-q' option. It doesn't list VMs in invalid state
             output = self.command('list')
         except subprocess.CalledProcessError as e:
-            logger.warning("DockerMachine: failed to list VMs: %r", e)
+            logger.warning("Failed to list VMs: %r", e)
         else:
             if output:
                 # Skip first line (header) and last (empty)
@@ -122,7 +122,7 @@ class DockerMachineHypervisor(Hypervisor, metaclass=ABCMeta):
             output = self.command('env', self._vm_name,
                                   args=('--shell', 'cmd'))
         except subprocess.CalledProcessError as e:
-            logger.warning("DockerMachine: failed to update env for VM: %s", e)
+            logger.warning("Failed to update env for VM: %s", e)
             logger.debug("DockerMachine_output: %s", e.output)
             if not retried:
                 return self._recover()
@@ -145,14 +145,21 @@ Ensure that you try the following before reporting an issue:
             logger.warning('DockerMachine: env update failed')
 
     def _recover(self, restarted=False):
+        def _log_warning(msg, e):
+            logger.warning(
+                "Failed to regenerate certificates: %s -- %s",
+                e,
+                e.output
+            )
+
         try:
             self.command(
                 'regenerate_certs', self._vm_name,
                 timeout=self.REGENERATE_CERTIFICATES_TIMEOUT)
-        except subprocess.SubprocessError as e:
-            logger.warning(
-                "DockerMachine: failed to regenerate certificates: %s -- %s",
-                e, e.output)
+        except subprocess.CalledProcessError as e:
+            _log_warning("Failed to regenerate certificates", e)
+        except subprocess.TimeoutExpired as e:
+            _log_warning("Timeout in regenerate certificates", e)
         else:
             return self._set_env(retried=True)
 
@@ -160,10 +167,10 @@ Ensure that you try the following before reporting an issue:
             try:
                 self.command(
                     'restart', self._vm_name, timeout=self.RESTART_VM_TIMEOUT)
-            except subprocess.SubprocessError as e:
-                logger.warning("DockerMachine:"
-                               " failed to restart the VM: %s -- %s",
-                               e, e.output)
+            except subprocess.CalledProcessError as e:
+                _log_warning("Failed to restart the VM", e)
+            except subprocess.TimeoutExpired as e:
+                _log_warning("Timeout in restart the VM", e)
             else:
                 return self._recover(restarted=True)
 

--- a/tests/golem/docker/test_hyperv.py
+++ b/tests/golem/docker/test_hyperv.py
@@ -249,7 +249,8 @@ class TestHyperVHypervisor(TestCase):
             ['docker-machine', '--native-ssh', 'ssh'],
             None,
             [self.hyperv._vm_name, ANY],
-            False
+            False,
+            None,
         )
         self.assertIn("foo 123", command.call_args[0][2][1])
         logger.error.assert_not_called()


### PR DESCRIPTION
* Set timeout of 120 s for regenerating certificates and restarting the VM (on my machine it takes approx. 60 s so I guess 120 s should be enough for slower PCs). Lack of timeout could cause the command to hang forever.
* After restarting the VM try to regenerate certificates once more.