### PR TITLE
Properly handle timeouts/cancellations of Task API subtasks

### DIFF
--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -710,12 +710,14 @@ class TaskServer(
             subtask_id: str,
             task_id: str,
             err_msg: str,
-            reason=message.TaskFailure.DEFAULT_REASON
+            reason=message.TaskFailure.DEFAULT_REASON,
+            decrease_trust=True
     ) -> None:
         header = self.task_keeper.task_headers[task_id]
 
         if subtask_id not in self.failures_to_send:
-            Trust.REQUESTED.decrease(header.task_owner.key)
+            if decrease_trust:
+                Trust.REQUESTED.decrease(header.task_owner.key)
 
             self.failures_to_send[subtask_id] = WaitingTaskFailure(
                 task_id=task_id,

--- a/tests/golem/task/test_newtaskcomputer.py
+++ b/tests/golem/task/test_newtaskcomputer.py
@@ -220,9 +220,9 @@ class TestCompute(NewTaskComputerTestBase):
         self._assign_task(subtask_deadline=time.time())
         self.compute_future = asyncio.sleep(10)
 
-        result = yield self.task_computer.compute()
+        with self.assertRaisesRegex(RuntimeError, "Task computation timed out"):
+            yield self.task_computer.compute()
 
-        self.assertIsNone(result)
         self.logger.error.assert_called_once()
         self.stats_keeper.increase_stat.assert_called_once_with(
             'tasks_with_timeout')

--- a/tests/golem/task/test_taskcomputeradapter.py
+++ b/tests/golem/task/test_taskcomputeradapter.py
@@ -186,6 +186,22 @@ class TestHandleComputationResults(TaskComputerAdapterTestBase):
         self.finished_callback.assert_called_once_with()
 
     @defer.inlineCallbacks
+    def test_cancelled(self):
+        yield self.adapter._handle_computation_results(
+            task_id='test_task',
+            subtask_id='test_subtask',
+            computation=defer.succeed(None)
+        )
+        self.task_server.send_task_failed.assert_called_once_with(
+            task_id='test_task',
+            subtask_id='test_subtask',
+            err_msg='Subtask cancelled',
+            decrease_trust=False
+        )
+        self.task_server.send_results.assert_not_called()
+        self.finished_callback.assert_called_once_with()
+
+    @defer.inlineCallbacks
     def test_error(self):
         error = RuntimeError('test_error')
         yield self.adapter._handle_computation_results(


### PR DESCRIPTION
If task gets timed out or cancelled a failure message should be sent to requestor. In case of timeout requestor trust should be decreased but not in case of cancellation (it's not requestor's fault that provider has cancelled computation).