### PR TITLE
fix mainnet RPC node integration test

### DIFF
--- a/scripts/node_integration_tests/playbooks/golem/rpc_test/concent/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/rpc_test/concent/test_config.py
@@ -1,9 +1,8 @@
-from scripts.node_integration_tests.playbooks.test_config_base import (
-    TestConfigBase, CONCENT_STAGING,
-)
+from ....test_config_base import CONCENT_STAGING
+from ..test_config import TestConfig as RpcTestConfigBase
 
 
-class TestConfig(TestConfigBase):
+class TestConfig(RpcTestConfigBase):
     def __init__(self):
         super().__init__()
         for node_config in self.nodes.values():

--- a/scripts/node_integration_tests/playbooks/golem/rpc_test/mainnet/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/rpc_test/mainnet/test_config.py
@@ -1,9 +1,10 @@
-from scripts.node_integration_tests.playbooks.test_config_base import \
-    TestConfigBase
+from ....test_config_base import CONCENT_MAIN
+from ..test_config import TestConfig as RpcTestConfigBase
 
 
-class TestConfig(TestConfigBase):
+class TestConfig(RpcTestConfigBase):
     def __init__(self):
         super().__init__()
         for node_config in self.nodes.values():
             node_config.mainnet = True
+            node_config.concent = CONCENT_MAIN

--- a/scripts/node_integration_tests/playbooks/golem/rpc_test/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/rpc_test/playbook.py
@@ -7,6 +7,7 @@ from ...test_config_base import NodeId
 class Playbook(NodeTestPlaybook):
     def step_verify_deposit_balance_call(self):
         def on_success(_):
+            print("Deposit balance retrieved correctly.")
             self.next()
 
         def on_error(error):
@@ -17,14 +18,5 @@ class Playbook(NodeTestPlaybook):
 
     steps = (
         partial(NodeTestPlaybook.step_get_key, node_id=NodeId.provider),
-        partial(NodeTestPlaybook.step_get_key, node_id=NodeId.requestor),
-        partial(NodeTestPlaybook.step_get_network_info,
-                node_id=NodeId.provider),
-        partial(NodeTestPlaybook.step_get_network_info,
-                node_id=NodeId.requestor),
-        partial(NodeTestPlaybook.step_connect, node_id=NodeId.requestor,
-                target_node=NodeId.provider),
-        partial(NodeTestPlaybook.step_verify_connection,
-                node_id=NodeId.requestor, target_node=NodeId.provider),
         step_verify_deposit_balance_call,
     )

--- a/scripts/node_integration_tests/playbooks/golem/rpc_test/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/rpc_test/test_config.py
@@ -1,5 +1,10 @@
-from ...test_config_base import TestConfigBase
+from ...test_config_base import CONCENT_DISABLED
+from ...test_config_base import TestConfigBase, NodeId
 
 
 class TestConfig(TestConfigBase):
-    pass
+    def __init__(self):
+        super().__init__()
+        del self.nodes[NodeId.requestor]
+        for node_config in self.nodes.values():
+            node_config.concent = CONCENT_DISABLED

--- a/scripts/node_integration_tests/playbooks/test_config_base.py
+++ b/scripts/node_integration_tests/playbooks/test_config_base.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
 
 CONCENT_STAGING = 'staging'
 CONCENT_DISABLED = 'disabled'
+CONCENT_MAIN = 'main'
 
 
 class NodeConfig:

--- a/scripts/node_integration_tests/run_test.py
+++ b/scripts/node_integration_tests/run_test.py
@@ -90,7 +90,6 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         '--concent',
         choices=variables.CONCENT_CHOICES,
-        default='staging',
         help="choose concent option",
     )
     return parser.parse_args()


### PR DESCRIPTION
+ simplify RPC test base playbook
+ set the default `run_test` concent parameter to None so that it doesn't override the `TestConfig` value