### PR TITLE
Warn when a subtask is finished with an empty compute timer

### DIFF
--- a/golem/task/requestedtaskmanager.py
+++ b/golem/task/requestedtaskmanager.py
@@ -1001,7 +1001,9 @@ class RequestedTaskManager:
                 update_provider_efficiency(node_id, subtask_timeout, comp_time)
             else:
                 logger.warning(
-                    "Could not obtain computation time for subtask: %r",
+                    "Subtask finished with empty computation time. "
+                    "task_id=%r, subtask_id=%r",
+                    subtask.task_id,
                     subtask_id
                 )
             dispatcher.send(

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -989,17 +989,25 @@ class TaskServer(
 
         try:
             task_id = keeper.get_task_id_for_subtask(subtask_id)
-            header = keeper.get_task_header(task_id)
-            performance = keeper.active_tasks[task_id].performance
             computation_time = timer.ProviderTimer.time
 
-            update_requestor_efficiency(
-                node_id=keeper.get_node_for_task_id(task_id),
-                timeout=header.subtask_timeout,
-                computation_time=computation_time,
-                performance=performance,
-                min_performance=min_performance,
-            )
+            if computation_time:
+                header = keeper.get_task_header(task_id)
+                performance = keeper.active_tasks[task_id].performance
+                update_requestor_efficiency(
+                    node_id=keeper.get_node_for_task_id(task_id),
+                    timeout=header.subtask_timeout,
+                    computation_time=computation_time,
+                    performance=performance,
+                    min_performance=min_performance,
+                )
+            else:
+                logger.warning(
+                    "Subtask finished with empty computation time. "
+                    "task_id=%r, subtask_id=%r",
+                    task_id,
+                    subtask_id
+                )
 
         except (KeyError, ValueError, AttributeError) as exc:
             logger.error("Finished subtask listener: %r", exc)


### PR DESCRIPTION
Lowered the severity of this error to WARNING

reported on chat:

CRITICAL On current b0.22 when running WASM tasks:
```
Unhandled error in Deferred:
CRITICAL [twisted                            ] Unhandled error in Deferred: 

Traceback (most recent call last):
  File "/home/ben/github/golem/golem/docker/task_thread.py", line 148, in run
    self._task_computed(estm_mem)
  File "/home/ben/github/golem/golem/docker/task_thread.py", line 249, in _task_computed
    self._deferred.callback(self)
  File "/home/ben/.virtualenvs/golem/lib/python3.6/site-packages/twisted/internet/defer.py", line 460, in callback
    self._startRunCallbacks(result)
  File "/home/ben/.virtualenvs/golem/lib/python3.6/site-packages/twisted/internet/defer.py", line 568, in _startRunCallbacks
    self._runCallbacks()
--- <exception caught here> ---
  File "/home/ben/.virtualenvs/golem/lib/python3.6/site-packages/twisted/internet/defer.py", line 654, in _runCallbacks
    current.result = callback(current.result, *args, **kw)
  File "/home/ben/github/golem/golem/task/taskcomputer.py", line 688, in <lambda>
    tt.start().addBoth(lambda _: self.task_computed(tt))
  File "/home/ben/github/golem/golem/task/taskcomputer.py", line 618, in task_computed
    self._task_finished()
  File "/home/ben/github/golem/golem/task/taskcomputer.py", line 621, in _task_finished
    return self.task_computer.task_finished(self)
  File "/home/ben/github/golem/golem/task/taskcomputer.py", line 884, in task_finished
    min_performance=ctd['performance'],
  File "/home/ben/.virtualenvs/golem/lib/python3.6/site-packages/pydispatch/dispatcher.py", line 338, in send
    **named
  File "/home/ben/.virtualenvs/golem/lib/python3.6/site-packages/pydispatch/robustapply.py", line 55, in robustApply
    return receiver(*arguments, **named)
  File "/home/ben/github/golem/golem/task/taskserver.py", line 1001, in finished_subtask_listener
    min_performance=min_performance,
  File "/home/ben/github/golem/golem/ranking/manager/database_manager.py", line 167, in update_requestor_efficiency
    efficiency, timeout, computation_time, REQUESTOR_FORGETTING_FACTOR)
  File "/home/ben/github/golem/golem/ranking/manager/database_manager.py", line 136, in _calculate_efficiency
    v = timeout / computation_time
builtins.TypeError: unsupported operand type(s) for /: 'int' and 'NoneType'
```

