### PR TITLE
Use get_expected_extension in integration test

### DIFF
--- a/scripts/node_integration_tests/playbooks/golem/task_api/playbook.py
+++ b/scripts/node_integration_tests/playbooks/golem/task_api/playbook.py
@@ -1,0 +1,10 @@
+from apps.blender.resources.images.entrypoints.scripts.verifier_tools\
+    .file_extension import matcher
+from ...base import NodeTestPlaybook
+
+
+class Playbook(NodeTestPlaybook):
+    @property
+    def output_extension(self):
+        extension = super().output_extension
+        return matcher.get_expected_extension(extension)

--- a/scripts/node_integration_tests/playbooks/golem/task_api/test_config.py
+++ b/scripts/node_integration_tests/playbooks/golem/task_api/test_config.py
@@ -1,9 +1,6 @@
-from scripts.node_integration_tests.playbooks.test_config_base import (
-    TestConfigBase
-)
+from ...test_config_base import TestConfigBase
 
 
 class TestConfig(TestConfigBase):
-
     def __init__(self):
         super().__init__(task_settings='task_api_blender')


### PR DESCRIPTION
Blender app's `.get_expected_extension` is copied in docker
https://github.com/golemfactory/blenderapp used in TaskAPI.