### PR TITLE
Decrease log clutter from tcpserver/session

### DIFF
--- a/loggingconfig.py
+++ b/loggingconfig.py
@@ -100,6 +100,14 @@ LOGGING = {
         'golem.network': {'propagate': True},
         'golem.network.concent.received_handler': {'propagate': True},
         'golem.network.transport': {'propagate': True},
+        'golem.network.transport.session': {
+            'level': 'WARNING',
+            'propagate': True,
+        },
+        'golem.network.transport.tcpserver': {
+            'level': 'WARNING',
+            'propagate': True,
+        },
         'apps': {
             'level': 'DEBUG',
             'propagate': True,


### PR DESCRIPTION
Logs are often spammed with non-essential info:
```
2020-01-03 11:59:27 INFO     golem.network.transport.session     Received disconnect message. reason=ProtocolVersion, address=35.158.160.231:40103 
2020-01-03 11:59:28 INFO     golem.network.transport.tcpserver   Connecting to peer. node='ImALumberJack'(839b6556..3adb9cba), adresses=['35.158.160.231:40103'] 
2020-01-03 11:59:29 INFO     golem.network.transport.tcpserver   Connecting to peer. node='SPLYGolem-002'(d5134615..2c67ab42), adresses=['45.73.63.50:40103'] 
2020-01-03 11:59:29 INFO     golem.network.transport.session     Received disconnect message. reason=ProtocolVersion, address=35.158.160.231:40103 
2020-01-03 11:59:30 INFO     golem.network.transport.tcpserver   Connecting to peer. node='ImALumberJack'(839b6556..3adb9cba), adresses=['35.158.160.231:40103'] 
2020-01-03 11:59:31 INFO     golem.network.transport.tcpserver   Connecting to peer. node='SPLYGolem-002'(d5134615..2c67ab42), adresses=['45.73.63.50:40103'] 
2020-01-03 11:59:31 INFO     golem.network.transport.session     Received disconnect message. reason=ProtocolVersion, address=35.158.160.231:40103 
2020-01-03 11:59:32 INFO     golem.network.transport.tcpserver   Connecting to peer. node='ImALumberJack'(839b6556..3adb9cba), adresses=['35.158.160.231:40103'] 
```