### PR TITLE
Add task-api-dev mode setting

### DIFF
--- a/golem/appconfig.py
+++ b/golem/appconfig.py
@@ -152,6 +152,7 @@ class AppConfig:
             opt_peer_num=OPTIMAL_PEER_NUM,
             # flags
             in_shutdown=0,
+            task_api_dev_mode=0,
             accept_tasks=ACCEPT_TASKS,
             send_pings=SEND_PINGS,
             enable_talkback=ENABLE_TALKBACK,
@@ -195,7 +196,7 @@ class AppConfig:
             disallow_ip_timeout_seconds=DISALLOW_IP_TIMEOUT_SECONDS,
             disallow_id_max_times=DISALLOW_ID_MAX_TIMES,
             disallow_ip_max_times=DISALLOW_IP_MAX_TIMES,
-            #hyperg
+            # hyperg
             hyperdrive_port=DEFAULT_HYPERDRIVE_PORT,
             hyperdrive_address=DEFAULT_HYPERDRIVE_ADDRESS,
             hyperdrive_rpc_port=DEFAULT_HYPERDRIVE_RPC_PORT,

--- a/golem/appconfig.py
+++ b/golem/appconfig.py
@@ -152,7 +152,6 @@ class AppConfig:
             opt_peer_num=OPTIMAL_PEER_NUM,
             # flags
             in_shutdown=0,
-            task_api_dev_mode=0,
             accept_tasks=ACCEPT_TASKS,
             send_pings=SEND_PINGS,
             enable_talkback=ENABLE_TALKBACK,

--- a/golem/apps/manager.py
+++ b/golem/apps/manager.py
@@ -25,7 +25,12 @@ class AppManager:
         if app_id not in self._state:
             self._state[app_id] = False
         logger.info(
-            "Application registered. app_name=%r app_id=%r", app.name, app_id)
+            "Application registered. app_name=%r:%r, state=%r, app_id=%r",
+            app.name,
+            app.version,
+            self._state[app_id],
+            app_id,
+        )
 
     def enabled(self, app_id: AppId) -> bool:
         """ Check if an application with the given ID is registered in the

--- a/golem/clientconfigdescriptor.py
+++ b/golem/clientconfigdescriptor.py
@@ -59,7 +59,6 @@ class ClientConfigDescriptor(object):
 
         self.accept_tasks = 1
         self.debug_third_party = 0
-        self.task_api_dev_mode = 0
         self.in_shutdown = 0
 
         self.net_masking_enabled = 0

--- a/golem/clientconfigdescriptor.py
+++ b/golem/clientconfigdescriptor.py
@@ -59,6 +59,7 @@ class ClientConfigDescriptor(object):
 
         self.accept_tasks = 1
         self.debug_third_party = 0
+        self.task_api_dev_mode = 0
         self.in_shutdown = 0
 
         self.net_masking_enabled = 0

--- a/golem/core/variables.py
+++ b/golem/core/variables.py
@@ -18,6 +18,7 @@ APP_NAME = "Brass Golem"
 PRIVATE_KEY = "keystore.json"
 DEFAULT_PROC_FILE = "node_processes.ctl"
 MAX_PROC_FILE_SIZE = 1024 * 1024
+ENV_TASK_API_DEV = 'ENV_TASK_API_DEV'
 
 #################
 # NETWORK CONST #

--- a/golem/core/variables.py
+++ b/golem/core/variables.py
@@ -18,7 +18,7 @@ APP_NAME = "Brass Golem"
 PRIVATE_KEY = "keystore.json"
 DEFAULT_PROC_FILE = "node_processes.ctl"
 MAX_PROC_FILE_SIZE = 1024 * 1024
-ENV_TASK_API_DEV = 'ENV_TASK_API_DEV'
+ENV_TASK_API_DEV = 'GOLEM_TASK_API_DEV'
 
 #################
 # NETWORK CONST #

--- a/golem/envs/default.py
+++ b/golem/envs/default.py
@@ -17,10 +17,14 @@ DOCKER_REPOSITORY = "golemfactory"
 
 def _register_docker_cpu_env(
         work_dir: str,
-        env_manager: EnvironmentManager
+        env_manager: EnvironmentManager,
+        dev_mode: bool,
 ) -> None:
     docker_cpu_config = DockerCPUConfig(work_dirs=[Path(work_dir)])
-    docker_cpu_env = NonHypervisedDockerCPUEnvironment(docker_cpu_config)
+    docker_cpu_env = NonHypervisedDockerCPUEnvironment(
+        docker_cpu_config,
+        dev_mode,
+    )
 
     env_manager.register_env(
         docker_cpu_env,
@@ -32,11 +36,14 @@ def _register_docker_cpu_env(
 
 def _register_docker_gpu_env(
         work_dir: str,
-        env_manager: EnvironmentManager
+        env_manager: EnvironmentManager,
+        dev_mode: bool,
 ) -> None:
     docker_config_dict = dict(work_dirs=[work_dir])
-    docker_gpu_env = \
-        NonHypervisedDockerGPUEnvironment.default(docker_config_dict)
+    docker_gpu_env = NonHypervisedDockerGPUEnvironment.default(
+        docker_config_dict,
+        dev_mode,
+    )
 
     env_manager.register_env(
         docker_gpu_env,
@@ -53,14 +60,15 @@ def register_built_in_repositories():
 
 def register_environments(
         work_dir: str,
-        env_manager: EnvironmentManager
+        env_manager: EnvironmentManager,
+        dev_mode: bool,
 ) -> None:
 
     from golem.config.active import TASK_API_ENVS
     if DOCKER_CPU_ENV_ID in TASK_API_ENVS:
         if NonHypervisedDockerCPUEnvironment.supported().supported:
-            _register_docker_cpu_env(work_dir, env_manager)
+            _register_docker_cpu_env(work_dir, env_manager, dev_mode)
 
     if DOCKER_GPU_ENV_ID in TASK_API_ENVS:
         if NonHypervisedDockerGPUEnvironment.supported().supported:
-            _register_docker_gpu_env(work_dir, env_manager)
+            _register_docker_gpu_env(work_dir, env_manager, dev_mode)

--- a/golem/envs/docker/cpu.py
+++ b/golem/envs/docker/cpu.py
@@ -551,6 +551,7 @@ class DockerCPUEnvironment(EnvironmentBase):
     def __init__(
             self,
             config: DockerCPUConfig,
+            dev_mode: bool,
             env_logger: Optional[logging.Logger] = None,
     ) -> None:
         super().__init__(logger=env_logger or logger)
@@ -564,6 +565,7 @@ class DockerCPUEnvironment(EnvironmentBase):
         self._port_mapper = ContainerPortMapper(self._hypervisor)
         self._update_work_dirs(config.work_dirs)
         self._constrain_hypervisor(config)
+        self._dev_mode = dev_mode
 
     def _get_hypervisor_config(self) -> Dict[str, int]:
         return {
@@ -647,7 +649,8 @@ class DockerCPUEnvironment(EnvironmentBase):
                              f"is in invalid state: '{self._status}'")
         self._logger.info("Preparing prerequisites...")
 
-        if not Whitelist.is_whitelisted(prerequisites.image):
+        if not self._dev_mode and \
+                not Whitelist.is_whitelisted(prerequisites.image):
             self._logger.info(
                 "Docker image '%s' is not whitelisted.",
                 prerequisites.image,
@@ -656,11 +659,14 @@ class DockerCPUEnvironment(EnvironmentBase):
 
         def _prepare():
             try:
-                client = local_client()
-                client.pull(
-                    prerequisites.image,
-                    tag=prerequisites.tag
-                )
+                if not self._dev_mode:
+                    client = local_client()
+                    client.pull(
+                        prerequisites.image,
+                        tag=prerequisites.tag
+                    )
+                else:
+                    logger.info('task-api-dev mode enabled, use local images')
             except Exception as e:
                 self._error_occurred(
                     e, "Preparing prerequisites failed.", set_status=False)
@@ -763,7 +769,7 @@ class DockerCPUEnvironment(EnvironmentBase):
             config: Optional[EnvConfig] = None
     ) -> DockerCPURuntime:
         assert isinstance(payload, DockerRuntimePayload)
-        if not Whitelist.is_whitelisted(payload.image):
+        if not self._dev_mode and not Whitelist.is_whitelisted(payload.image):
             raise RuntimeError(f"Image '{payload.image}' is not whitelisted.")
 
         if config is not None:

--- a/golem/envs/docker/gpu.py
+++ b/golem/envs/docker/gpu.py
@@ -96,9 +96,10 @@ class DockerGPUEnvironment(DockerCPUEnvironment):
     def __init__(  # pylint: disable=useless-super-delegation
             self,
             config: DockerGPUConfig,
+            dev_mode: bool,
             env_logger: Optional[Logger] = None,
     ) -> None:
-        super().__init__(config, env_logger or logger)
+        super().__init__(config, dev_mode, env_logger or logger)
 
     @classmethod
     def supported(cls) -> EnvSupportStatus:

--- a/golem/envs/docker/non_hypervised.py
+++ b/golem/envs/docker/non_hypervised.py
@@ -34,7 +34,8 @@ class NonHypervisedDockerGPUEnvironment(DockerGPUEnvironment):
     @classmethod
     def default(
             cls,
-            config_dict: Dict[str, Any]
+            config_dict: Dict[str, Any],
+            dev_mode: bool,
     ) -> 'NonHypervisedDockerGPUEnvironment':
         from golem.envs.docker.vendor import nvidia
         config_dict = dict(config_dict)
@@ -42,4 +43,4 @@ class NonHypervisedDockerGPUEnvironment(DockerGPUEnvironment):
         docker_config = DockerGPUConfig.from_dict(config_dict)
         # Make linters know that docker_config is an instance of DockerGPUConfig
         assert isinstance(docker_config, DockerGPUConfig)
-        return cls(docker_config)
+        return cls(docker_config, dev_mode)

--- a/golem/node.py
+++ b/golem/node.py
@@ -94,7 +94,7 @@ class Node(HardwarePresetsMixin):
                  use_talkback: bool = False,
                  use_docker_manager: bool = True,
                  geth_address: Optional[str] = None,
-                 password: Optional[str] = None
+                 password: Optional[str] = None,
                 ) -> None:
 
         # DO NOT MAKE THIS IMPORT GLOBAL

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -148,7 +148,9 @@ class TaskServer(
         register_built_in_repositories()
         register_environments(
             work_dir=self.get_task_computer_root(),
-            env_manager=new_env_manager)
+            env_manager=new_env_manager,
+            dev_mode=self.config_desc.task_api_dev_mode == 1,
+        )
 
         app_dir = self.get_app_dir()
         built_in_apps = save_built_in_app_definitions(app_dir)

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -146,10 +146,12 @@ class TaskServer(
         runtime_logs_dir = get_log_dir(client.datadir)
         new_env_manager = EnvironmentManager(runtime_logs_dir)
         register_built_in_repositories()
+        task_api_dev_mode = ENV_TASK_API_DEV in os.environ \
+            and os.environ[ENV_TASK_API_DEV] == "1"
         register_environments(
             work_dir=self.get_task_computer_root(),
             env_manager=new_env_manager,
-            dev_mode=os.environ[ENV_TASK_API_DEV] == "1",
+            dev_mode=task_api_dev_mode,
         )
 
         app_dir = self.get_app_dir()

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -50,7 +50,7 @@ from golem.core.deferred import (
     deferred_from_future,
     sync_wait,
 )
-from golem.core.variables import MAX_CONNECT_SOCKET_ADDRESSES
+from golem.core.variables import MAX_CONNECT_SOCKET_ADDRESSES, ENV_TASK_API_DEV
 from golem.environments.environment import (
     Environment as OldEnv,
     SupportStatus,
@@ -149,7 +149,7 @@ class TaskServer(
         register_environments(
             work_dir=self.get_task_computer_root(),
             env_manager=new_env_manager,
-            dev_mode=self.config_desc.task_api_dev_mode == 1,
+            dev_mode=os.environ[ENV_TASK_API_DEV] == "1",
         )
 
         app_dir = self.get_app_dir()

--- a/golemapp.py
+++ b/golemapp.py
@@ -106,11 +106,13 @@ slogging.SManager.getLogger = monkey_patched_getLogger
 @click.option('--enable-talkback', is_flag=True, default=None)
 @click.option('--hyperdrive-port', type=int, help="Hyperdrive public port")
 @click.option('--hyperdrive-rpc-port', type=int, help="Hyperdrive RPC port")
+@click.option('--task-api-dev', is_flag=True, default=False,
+              help="Enable task-api developer mode")
 def start(  # pylint: disable=too-many-arguments, too-many-locals
         monitor, concent, datadir, node_address, rpc_address, peer, mainnet,
         net, geth_address, password, accept_terms, accept_concent_terms,
         accept_all_terms, version, log_level, enable_talkback: bool,
-        hyperdrive_port, hyperdrive_rpc_port,
+        hyperdrive_port, hyperdrive_rpc_port, task_api_dev,
 ):
     if version:
         print("GOLEM version: {}".format(golem.__version__))
@@ -151,6 +153,8 @@ def start(  # pylint: disable=too-many-arguments, too-many-locals
             config_desc.hyperdrive_port = hyperdrive_port
         if hyperdrive_rpc_port:
             config_desc.hyperdrive_rpc_port = hyperdrive_rpc_port
+        if task_api_dev:
+            config_desc.task_api_dev = task_api_dev
 
         # Golem headless
         install_reactor()

--- a/golemapp.py
+++ b/golemapp.py
@@ -153,8 +153,6 @@ def start(  # pylint: disable=too-many-arguments, too-many-locals
             config_desc.hyperdrive_port = hyperdrive_port
         if hyperdrive_rpc_port:
             config_desc.hyperdrive_rpc_port = hyperdrive_rpc_port
-        if task_api_dev:
-            config_desc.task_api_dev = task_api_dev
 
         # Golem headless
         install_reactor()
@@ -169,6 +167,22 @@ def start(  # pylint: disable=too-many-arguments, too-many-locals
         log_platform_info()
         log_ethereum_config(ethereum_config)
         log_concent_choice(ethereum_config.CONCENT_VARIANT)
+
+        # Config variables continued, after logging is enabled
+        if variables.ENV_TASK_API_DEV not in os.environ:
+            if task_api_dev:
+                os.environ[variables.ENV_TASK_API_DEV] = '1'
+            else:
+                os.environ[variables.ENV_TASK_API_DEV] = '0'
+        else:
+            if os.environ[variables.ENV_TASK_API_DEV] not in ['0', '1']:
+                logger.warning(
+                    "Invalid value in ENV[%r]: given %r should be '0' or '1'."
+                    " Using default value = '0'",
+                    variables.ENV_TASK_API_DEV,
+                    os.environ[variables.ENV_TASK_API_DEV],
+                )
+                os.environ[variables.ENV_TASK_API_DEV] = '0'
 
         node = Node(
             datadir=datadir,

--- a/scripts/task_api_tests/basic_integration.py
+++ b/scripts/task_api_tests/basic_integration.py
@@ -50,7 +50,9 @@ async def test_task(
     Whitelist.add(app_definition.requestor_prereq['image'])
     register_environments(
         work_dir=str(work_dir),
-        env_manager=env_manager)
+        env_manager=env_manager,
+        dev_mode=True,
+    )
 
     rtm_work_dir = work_dir / 'rtm'
     rtm_work_dir.mkdir()

--- a/scripts/task_api_tests/basic_integration.py
+++ b/scripts/task_api_tests/basic_integration.py
@@ -25,6 +25,8 @@ from golem.envs.docker.whitelist import Whitelist
 from golem.task import envmanager, requestedtaskmanager, taskcomputer
 
 logging.basicConfig(level=logging.INFO)
+TASK_TIMEOUT = 360
+SUBTASK_TIMEOUT = 60
 
 
 async def test_task(
@@ -71,8 +73,8 @@ async def test_task(
     golem_params = requestedtaskmanager.CreateTaskParams(
         app_id=app_definition.id,
         name='testtask',
-        task_timeout=4,
-        subtask_timeout=4,
+        task_timeout=TASK_TIMEOUT,
+        subtask_timeout=SUBTASK_TIMEOUT,
         output_directory=output_dir,
         resources=list(map(Path, resources)),
         max_subtasks=max_subtasks,
@@ -101,14 +103,14 @@ async def test_task(
             task_id=task_id,
             environment=app_definition.requestor_env,
             environment_prerequisites=env_prerequisites,
-            subtask_timeout=4,
-            deadline=time.time() + 3600,
+            subtask_timeout=SUBTASK_TIMEOUT,
+            deadline=time.time() + TASK_TIMEOUT,
         )
         ctd = {
             'subtask_id': subtask_def.subtask_id,
             'extra_data': subtask_def.params,
             'performance': 0,
-            'deadline': time.time() + 3600,
+            'deadline': time.time() + SUBTASK_TIMEOUT,
         }
         task_computer.task_given(task_header, ctd)
         for resource in subtask_def.resources:

--- a/tests/golem/envs/docker/cpu/test_env.py
+++ b/tests/golem/envs/docker/cpu/test_env.py
@@ -109,13 +109,13 @@ class TestInit(TestCase):
     @patch_env('_validate_config', side_effect=ValueError)
     def test_invalid_config(self, *_):
         with self.assertRaises(ValueError):
-            DockerCPUEnvironment(Mock(spec=DockerCPUConfig))
+            DockerCPUEnvironment(Mock(spec=DockerCPUConfig), dev_mode=False)
 
     @patch_env('_validate_config')
     @patch_env('_get_hypervisor_class', return_value=None)
     def test_no_hypervisor(self, *_):
         with self.assertRaises(EnvironmentError):
-            DockerCPUEnvironment(Mock(spec=DockerCPUConfig))
+            DockerCPUEnvironment(Mock(spec=DockerCPUConfig), dev_mode=False)
 
     @patch_env('_constrain_hypervisor')
     @patch_env('_update_work_dirs')
@@ -140,7 +140,7 @@ class TestInit(TestCase):
             })
         get_hypervisor.return_value.instance = _instance
 
-        DockerCPUEnvironment(config)
+        DockerCPUEnvironment(config, dev_mode=False)
 
         get_hypervisor.assert_called_once()
         validate_config.assert_called_once_with(config)
@@ -160,7 +160,7 @@ class TestDockerCPUEnv(TestCase):
         get_hypervisor.return_value.instance.return_value = self.hypervisor
         self.logger = Mock(spec=Logger)
         with patch_cpu('logger', self.logger):
-            self.env = DockerCPUEnvironment(self.config)
+            self.env = DockerCPUEnvironment(self.config, dev_mode=False)
 
     def _patch_async(self, name, *args, **kwargs):
         patcher = patch_cpu(name, *args, **kwargs)

--- a/tests/golem/envs/docker/cpu/test_integration.py
+++ b/tests/golem/envs/docker/cpu/test_integration.py
@@ -41,7 +41,7 @@ class TestIntegration(TestCase, DatabaseFixture):
         # shared so using self.new_path would result with a pop-up window
         # appearing during every test.
         config = DockerCPUConfig(work_dirs=[self.new_path.parent.parent])
-        self.env = DockerCPUEnvironment(config)
+        self.env = DockerCPUEnvironment(config, dev_mode=False)
         yield self.env.prepare()
 
         # Download busybox image

--- a/tests/golem/envs/docker/gpu/test_env.py
+++ b/tests/golem/envs/docker/gpu/test_env.py
@@ -21,7 +21,7 @@ class TestGPUEnvironment(TestCase):
         return_value=EnvSupportStatus(True)
     )
     def test_supported(self, mock_super_supported, *_):
-        env = DockerGPUEnvironment(DockerNvidiaGPUConfig())
+        env = DockerGPUEnvironment(DockerNvidiaGPUConfig(), dev_mode=False)
         status = env.supported()
 
         self.assertEqual(status, EnvSupportStatus(True))
@@ -30,7 +30,7 @@ class TestGPUEnvironment(TestCase):
     @mock.patch('golem.envs.docker.gpu.nvidia.is_supported', return_value=False)
     @mock.patch('golem.envs.docker.gpu.DockerCPUEnvironment.supported')
     def test_not_supported(self, mock_super_supported, *_):
-        env = DockerGPUEnvironment(DockerNvidiaGPUConfig())
+        env = DockerGPUEnvironment(DockerNvidiaGPUConfig(), dev_mode=False)
         status = env.supported()
         expected_status = EnvSupportStatus(False, "No supported GPU found")
 
@@ -51,7 +51,7 @@ class TestGPUEnvironment(TestCase):
     def test_validate_config_success(self):
         with mock.patch('golem.envs.docker.gpu.DockerGPUConfig.validate'):
             config = DockerGPUConfig()
-            DockerGPUEnvironment(config)
+            DockerGPUEnvironment(config, dev_mode=False)
             # pylint: disable=no-member
             self.assertEqual(config.validate.call_count, 1)
 
@@ -62,7 +62,7 @@ class TestGPUEnvironment(TestCase):
         ):
             config = DockerGPUConfig()
             with self.assertRaises(ValueError):
-                DockerGPUEnvironment(config)
+                DockerGPUEnvironment(config, dev_mode=False)
             # pylint: disable=no-member
             self.assertEqual(config.validate.call_count, 1)
 
@@ -73,7 +73,7 @@ class TestGPUEnvironment(TestCase):
         local_client.return_value = client
 
         config = DockerGPUConfig()
-        env = DockerGPUEnvironment(config)
+        env = DockerGPUEnvironment(config, dev_mode=False)
         container_config = dict(runtime='test')
 
         binds = [DockerBind(source=Path('/tmp'), target='/tmp')]


### PR DESCRIPTION
While writing the [task-api docs](
https://taskapi.docs.golem.network/#running-the-application-locally) i found there are some code hacks needed to run the `tutorialapp` locally. 

Introduced `task-api-dev` mode to make this easier, this new mode disables:
- image whitelist checks
- pulling of images