### PR TITLE
removed some double log lines

### DIFF
--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -405,8 +405,6 @@ def enqueue_new_task(client, task, force=False) \
             task=task,
             resource_server_result=resource_server_result,
         )
-
-        logger.info("Task started. task_id=%r", task_id)
     except eth_exceptions.EthereumError as e:
         logger.error(
             "Can't enqueue_new_task. task_id=%(task_id)r, e=%(e_name)s: %(e)s",

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -277,7 +277,7 @@ class TaskManager(TaskEventListener):
 
         task_state.status = TaskStatus.waiting
         self.notice_task_updated(task_id, op=TaskOp.STARTED)
-        logger.info("Task %s started", task_id)
+        logger.info("Task started. task_id=%r", task_id)
 
     def _dump_filepath(self, task_id):
         return self.tasks_dir / ('%s.pickle' % (task_id,))

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -798,14 +798,12 @@ class TaskServer(
                 task_header.task_id,
                 task_header.signature,
             )
-            logger.debug("task_header=%r", task_header)
             return False
         if task_header.deadline < get_timestamp_utc():
             logger.info(
                 "Task's deadline already in the past. task_id=%r",
                 task_header.task_id
             )
-            logger.debug("task_header=%r", task_header)
             return False
 
         if task_header.environment_prerequisites:


### PR DESCRIPTION
While debugging the b0.22 branch i found these log messages are duplicated and can be removed to make the logs cleaner

- Task started was printed by rpc and task-manager
- Task header was printed before and after the warning(info) message