### PR TITLE
Follow symlinks for sys.executable

### DIFF
--- a/apps/blender/benchmark/benchmark.py
+++ b/apps/blender/benchmark/benchmark.py
@@ -3,7 +3,7 @@ import sys
 import tempfile
 from typing import Type
 
-from os.path import dirname, join
+from os.path import dirname, join, realpath
 from os import close
 
 from apps.blender.blenderenvironment import BlenderEnvironment, \
@@ -22,7 +22,8 @@ class BlenderBenchmark(RenderingBenchmark):
         super(BlenderBenchmark, self).__init__()
         self._normalization_constant = 9360
         if hasattr(sys, 'frozen') and sys.frozen:
-            self.blender_task_path = join(dirname(sys.executable),
+            real_exe_path = realpath(sys.executable)
+            self.blender_task_path = join(dirname(real_exe_path),
                                           'examples', 'blender')
         else:
             this_dir = pathlib.Path(__file__).resolve().parent


### PR DESCRIPTION
After the pyinstaller update to 3.6 the sys.executable no longer follows symlinks. Will make an issue on their side since the docs state it should.

from [docs](https://pyinstaller.readthedocs.io/en/stable/runtime-information.html):
> If the user launches the app by way of a symbolic link, sys.argv[0] uses that symbolic name, while sys.executable is the actual path to the executable. Sometimes the same app is linked under different names and is expected to behave differently depending on the name that is used to launch it. For this case, you would test os.path.basename(sys.argv[0])

