### PR TITLE
Report CannotTakeWork instead of None

### DIFF
--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -598,6 +598,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
         )
 
         def _cannot_compute(reason):
+            assert isinstance(reason, message.tasks.CannotComputeTask.REASON)
             logger.info(
                 "Cannot compute subtask. subtask_id: %r, reason: %r",
                 ctd["subtask_id"],
@@ -698,7 +699,7 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
             return
 
         if not self.task_server.task_given(msg):
-            _cannot_compute(None)
+            _cannot_compute(reasons.CannotTakeWork)
             return
 
     # pylint: enable=too-many-return-statements, too-many-branches

--- a/requirements.txt
+++ b/requirements.txt
@@ -48,7 +48,7 @@ eventlet==0.24.1
 fasteners==0.15
 flatbuffers==1.11
 fs==2.4.4
-Golem-Messages==3.14.1
+Golem-Messages==3.15.0
 Golem-Smart-Contracts-Interface==1.11.1
 Golem-Task-Api==0.24.1
 greenlet==0.4.15

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -19,7 +19,7 @@ docker==3.5.0
 enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
-Golem-Messages==3.14.1
+Golem-Messages==3.15.0
 Golem-Smart-Contracts-Interface==1.11.1
 Golem-Task-Api==0.24.1
 html2text==2018.1.9

--- a/tests/golem/task/test_tasksession.py
+++ b/tests/golem/task/test_tasksession.py
@@ -495,6 +495,17 @@ class TaskSessionReactToTaskToComputeTest(TaskSessionTestBase):
         self.task_session.task_server.task_given.assert_called_with(ttc)
         self.conn.close.assert_not_called()
 
+    def test_react_to_task_to_compute_task_not_give(self):
+        self.task_session.task_server.task_given.return_value = False
+        ctd = self.ctd()
+        ttc: message.tasks.TaskToCompute = self.ttc_prepare_and_react(ctd)
+        self.task_session.send.assert_called_once_with(
+            message.tasks.CannotComputeTask(
+                task_to_compute=ttc,
+                reason=message.tasks.CannotComputeTask.REASON.CannotTakeWork,
+            ),
+        )
+
     def test_no_ctd(self, *_):
         # ComputeTaskDef is None -> failure
         self.ttc_prepare_and_react(None)


### PR DESCRIPTION
Provide reason for CannotComputeTask when TaskServer rejects TTC.