### PR TITLE
Bump golemfactory/wasm to 0.6.0

### DIFF
--- a/apps/images.ini
+++ b/apps/images.ini
@@ -4,5 +4,5 @@ golemfactory/blender blender/resources/images/blender.Dockerfile 1.13 blender/re
 golemfactory/blender_verifier blender/resources/images/blender_verifier.Dockerfile 1.9.1 blender/resources/images/
 golemfactory/blender_nvgpu blender/resources/images/blender_nvgpu.Dockerfile 1.7 . apps.core.nvgpu.is_supported
 golemfactory/dummy dummy/resources/images/Dockerfile 1.4.1 dummy/resources/images
-golemfactory/wasm wasm/resources/images/Dockerfile 0.5.4 wasm/resources/images
+golemfactory/wasm wasm/resources/images/Dockerfile 0.6.0 wasm/resources/images
 golemfactory/glambda glambda/resources/images/Dockerfile 1.7.1 .

--- a/apps/wasm/environment.py
+++ b/apps/wasm/environment.py
@@ -3,7 +3,7 @@ from golem.docker.environment import DockerEnvironment
 
 class WasmTaskEnvironment(DockerEnvironment):
     DOCKER_IMAGE = "golemfactory/wasm"
-    DOCKER_TAG = "0.5.4"
+    DOCKER_TAG = "0.6.0"
     ENV_ID = "WASM"
     SHORT_DESCRIPTION = "WASM Sandbox"
 

--- a/apps/wasm/resources/images/Dockerfile
+++ b/apps/wasm/resources/images/Dockerfile
@@ -1,10 +1,10 @@
-FROM rust:1.33 as builder
+FROM rust:1.38 as builder
 RUN echo "deb http://deb.debian.org/debian stretch-backports main" >> /etc/apt/sources.list
 RUN apt -y update && apt -y install autoconf2.13 clang-6.0 --no-install-recommends && rm -rf /var/lib/apt/lists/*
 
 RUN git clone https://github.com/golemfactory/sp-wasm.git
 WORKDIR /sp-wasm
-RUN git checkout tags/v0.4.2
+RUN git checkout tags/v0.5.0
 ENV SHELL=/bin/bash
 ENV CC=clang-6.0
 ENV CPP="clang-6.0 -E"

--- a/scripts/docker_integrity/image_integrity.ini
+++ b/scripts/docker_integrity/image_integrity.ini
@@ -10,4 +10,4 @@ golemfactory/blender_verifier   1.9.1               2370b5b814979f950d8551b23e56
 golemfactory/dummy              1.4.1               0f5518c5b8a83d5f8a291ec609e3a917618fc6729a293602ec95246ba1171fc1
 golemfactory/glambda            1.7.1               58b5306d3990b09a0a33ed5238a16b0d3fb8bc4f432cc90d223eaba077799b6a
 golemfactory/nvgpu              1.7                 7c7a35f25d6936a3dee833849b6927aef5e5cd9312b6c476e44b38d932aa0260
-golemfactory/wasm               0.5.4               d357b3d0e6423fad6ec28ff477411a7e4b3fc78c3db5491d37fae24e2e5bcbc4
+golemfactory/wasm               0.6.0               780bd22d8bd0e92889ca88a1b5a46ca7903c491227bfb9496e1b7b7c30827676


### PR DESCRIPTION
This PR bumps our Wasm sandbox to latest release 0.6.0 in Docker Hub.
The corresponding changes can be found at golemfactory/sp-wasm#38.
For completeness though, here's the summary of major changes to the sandbox:
* port Reqc's change to VM which now makes `BINARYEN_ASYNC_COMPILATION` flag
  obsolete
* refactors the CLI interface for the sandbox (changes `clap` for `structopt`)
* refactors error handling (changes `failure` for `thiserror`)