### PR TITLE
Add deadlines to message queue entries

### DIFF
--- a/golem/database/database.py
+++ b/golem/database/database.py
@@ -61,7 +61,7 @@ class GolemSqliteDatabase(peewee.SqliteDatabase):
 
 
 class Database:
-    SCHEMA_VERSION = 46
+    SCHEMA_VERSION = 47
 
     def __init__(self,  # noqa pylint: disable=too-many-arguments
                  db: peewee.Database,

--- a/golem/database/schemas/047_msg_queue_deadline.py
+++ b/golem/database/schemas/047_msg_queue_deadline.py
@@ -1,0 +1,13 @@
+# pylint: disable=no-member
+# pylint: disable=unused-argument
+import peewee as pw
+
+SCHEMA_VERSION = 47
+
+
+def migrate(migrator, database, fake=False, **kwargs):
+    migrator.add_fields('queuedmessage', deadline=pw.UTCDateTimeField(null=True))
+
+
+def rollback(migrator, database, fake=False, **kwargs):
+    migrator.remove_fields('queuedmessage', 'deadline')

--- a/golem/database/schemas/047_msg_queue_deadline.py
+++ b/golem/database/schemas/047_msg_queue_deadline.py
@@ -6,7 +6,8 @@ SCHEMA_VERSION = 47
 
 
 def migrate(migrator, database, fake=False, **kwargs):
-    migrator.add_fields('queuedmessage', deadline=pw.UTCDateTimeField(null=True))
+    migrator.add_fields(
+        'queuedmessage', deadline=pw.UTCDateTimeField(null=True))
 
 
 def rollback(migrator, database, fake=False, **kwargs):

--- a/golem/database/schemas/047_msg_queue_deadline.py
+++ b/golem/database/schemas/047_msg_queue_deadline.py
@@ -2,12 +2,16 @@
 # pylint: disable=unused-argument
 import peewee as pw
 
+from golem.model import default_msg_deadline
+
 SCHEMA_VERSION = 47
 
 
 def migrate(migrator, database, fake=False, **kwargs):
     migrator.add_fields(
-        'queuedmessage', deadline=pw.UTCDateTimeField(null=True))
+        'queuedmessage',
+        deadline=pw.UTCDateTimeField(default=default_msg_deadline())
+    )
 
 
 def rollback(migrator, database, fake=False, **kwargs):

--- a/golem/model.py
+++ b/golem/model.py
@@ -653,6 +653,7 @@ class NetworkMessage(BaseModel):
 def default_msg_deadline() -> datetime.datetime:
     return default_now() + MESSAGE_QUEUE_MAX_AGE
 
+
 class QueuedMessage(BaseModel):
     node = CharField(null=False, index=True)
     msg_version = VersionField(null=False)

--- a/golem/model.py
+++ b/golem/model.py
@@ -32,6 +32,7 @@ import semantic_version
 from golem.core import common
 from golem.core.common import datetime_to_timestamp, default_now
 from golem.core.simpleserializer import DictSerializable
+from golem.core.variables import MESSAGE_QUEUE_MAX_AGE
 from golem.database import GolemSqliteDatabase
 from golem.ranking.helper.trust_const import NEUTRAL_TRUST
 from golem.ranking import ProviderEfficacy
@@ -649,12 +650,18 @@ class NetworkMessage(BaseModel):
         return msg
 
 
+def default_msg_deadline() -> datetime.datetime:
+    return default_now() + MESSAGE_QUEUE_MAX_AGE
+
 class QueuedMessage(BaseModel):
     node = CharField(null=False, index=True)
     msg_version = VersionField(null=False)
     msg_cls = CharField(null=False)
     msg_data = BlobField(null=False)
-    deadline = UTCDateTimeField(null=True)
+    deadline = UTCDateTimeField(
+        null=False,
+        default=default_msg_deadline()
+    )
 
     class Meta:
         database = db
@@ -674,7 +681,7 @@ class QueuedMessage(BaseModel):
             golem_messages.__version__,
         )
         instance.msg_data = golem_messages.dump(msg, None, None)
-        instance.deadline = deadline    # type: ignore
+        instance.deadline = deadline or default_msg_deadline()  # type: ignore
         return instance
 
     def as_message(self) -> message.base.Message:

--- a/golem/model.py
+++ b/golem/model.py
@@ -654,12 +654,17 @@ class QueuedMessage(BaseModel):
     msg_version = VersionField(null=False)
     msg_cls = CharField(null=False)
     msg_data = BlobField(null=False)
+    deadline = UTCDateTimeField(null=True)
 
     class Meta:
         database = db
 
     @classmethod
-    def from_message(cls, node_id: str, msg: message.base.Message):
+    def from_message(
+            cls,
+            node_id: str,
+            msg: message.base.Message,
+            deadline: Optional[datetime.datetime] = None):
         instance = cls()
         instance.node = node_id
         instance.msg_cls = '.'.join(
@@ -669,6 +674,7 @@ class QueuedMessage(BaseModel):
             golem_messages.__version__,
         )
         instance.msg_data = golem_messages.dump(msg, None, None)
+        instance.deadline = deadline
         return instance
 
     def as_message(self) -> message.base.Message:

--- a/golem/model.py
+++ b/golem/model.py
@@ -674,7 +674,7 @@ class QueuedMessage(BaseModel):
             golem_messages.__version__,
         )
         instance.msg_data = golem_messages.dump(msg, None, None)
-        instance.deadline = deadline
+        instance.deadline = deadline    # type: ignore
         return instance
 
     def as_message(self) -> message.base.Message:

--- a/golem/network/transport/msg_queue.py
+++ b/golem/network/transport/msg_queue.py
@@ -109,12 +109,14 @@ def waiting() -> typing.Iterator[str]:
 def sweep() -> None:
     """Sweep messages"""
     with READ_LOCK:
+        now = default_now()
         count = 0
+
         count += model.QueuedMessage.delete().where(
-            model.QueuedMessage.deadline <= default_now()
+            model.QueuedMessage.deadline <= now
         ).execute()
 
-        oldest_allowed = default_now() \
+        oldest_allowed = now \
             - variables.MESSAGE_QUEUE_MAX_AGE
         count += model.QueuedMessage.delete().where(
             model.QueuedMessage.created_date < oldest_allowed,

--- a/golem/network/transport/msg_queue.py
+++ b/golem/network/transport/msg_queue.py
@@ -29,7 +29,7 @@ def put(
         node_id: str,
         msg: message.base.Message,
         timeout: typing.Optional[datetime.timedelta] = None
-    ) -> None:
+) -> None:
     assert not isinstance(msg, FORBIDDEN_CLASSES),\
         "Disconnect message shouldn't be in a queue"
     logger.debug("saving into queue node_id=%s, msg=%r",

--- a/golem/network/transport/msg_queue.py
+++ b/golem/network/transport/msg_queue.py
@@ -11,7 +11,6 @@ import peewee
 
 from golem import decorators
 from golem import model
-from golem.core import variables
 from golem.core.common import default_now, short_node_id
 
 
@@ -109,17 +108,8 @@ def waiting() -> typing.Iterator[str]:
 def sweep() -> None:
     """Sweep messages"""
     with READ_LOCK:
-        now = default_now()
-        count = 0
-
-        count += model.QueuedMessage.delete().where(
-            model.QueuedMessage.deadline <= now
-        ).execute()
-
-        oldest_allowed = now \
-            - variables.MESSAGE_QUEUE_MAX_AGE
-        count += model.QueuedMessage.delete().where(
-            model.QueuedMessage.created_date < oldest_allowed,
+        count = model.QueuedMessage.delete().where(
+            model.QueuedMessage.deadline <= default_now()
         ).execute()
 
     if count:

--- a/golem/task/server/resources.py
+++ b/golem/task/server/resources.py
@@ -1,3 +1,4 @@
+import datetime
 import logging
 import os
 from typing import (
@@ -286,6 +287,7 @@ class TaskResourcesMixin:
             msg=message.resources.ResourceHandshakeStart(
                 resource=handshake.hash, options=options.__dict__,
             ),
+            timeout=datetime.timedelta(seconds=self.HANDSHAKE_TIMEOUT)
         )
 
     def _share_handshake_nonce(self, key_id):

--- a/golem/task/taskserver.py
+++ b/golem/task/taskserver.py
@@ -2,6 +2,7 @@
 # pylint: disable=too-many-lines
 
 import asyncio
+import datetime
 import functools
 import itertools
 import logging
@@ -516,6 +517,8 @@ class TaskServer(
             msg_queue.put(
                 node_id=theader.task_owner.key,
                 msg=wtct,
+                timeout=datetime.timedelta(
+                    seconds=deadline_to_timeout(theader.deadline))
             )
 
             timer.ProviderTTCDelayTimers.start(wtct.task_id)

--- a/tests/golem/network/transport/test_msg_queue.py
+++ b/tests/golem/network/transport/test_msg_queue.py
@@ -10,6 +10,7 @@ from golem_messages.factories import tasks as tasks_factories
 
 from golem import model
 from golem import testutils
+from golem.core.common import default_now
 from golem.network.transport import msg_queue
 
 
@@ -27,9 +28,19 @@ class TestMsqQueue(testutils.DatabaseFixture):
             'golem_messages.message.tasks.WantToComputeTask',
         )
         self.assertEqual(str(row.msg_version), golem_messages.__version__)
+        self.assertIsNone(row.deadline)
         row_msg = row.as_message()
         self.assertEqual(row_msg.slots(), self.msg.slots())
         self.assertIsNone(row_msg.sig)
+
+    @freeze_time()
+    def test_put_timeout(self):
+        timeout = datetime.timedelta(seconds=1)
+        msg_queue.put(self.node_id, self.msg, timeout)
+
+        row = model.QueuedMessage.get()
+
+        self.assertEqual(row.deadline, default_now() + timeout)
 
     def test_get(self):
         msg_queue.put(self.node_id, self.msg)
@@ -37,6 +48,17 @@ class TestMsqQueue(testutils.DatabaseFixture):
         self.assertEqual(len(msgs), 1)
         msg = msgs[0]
         self.assertEqual(msg.slots(), self.msg.slots())
+        self.assertEqual(len(list(msg_queue.get(self.node_id))), 0)
+
+    @freeze_time()
+    def test_get_timeout(self):
+        timeout = datetime.timedelta(seconds=1)
+        msg_queue.put(self.node_id, self.msg, timeout)
+
+        with freeze_time(default_now() + timeout):
+            msgs = list(msg_queue.get(self.node_id))
+
+        self.assertEqual(len(msgs), 0)
         self.assertEqual(len(list(msg_queue.get(self.node_id))), 0)
 
     def test_waiting(self):
@@ -67,11 +89,31 @@ class TestMsqQueue(testutils.DatabaseFixture):
         waiting = frozenset(msg_queue.waiting())
         self.assertEqual(waiting, set())
 
+    @freeze_time()
+    def test_waiting_timeout(self):
+        timeout = datetime.timedelta(hours=1)
+        node_id2 = str(uuid.uuid4())
+        node_id_timeout = str(uuid.uuid4())
+        msg_queue.put(self.node_id, self.msg)
+        msg_queue.put(node_id2, self.msg)
+        msg_queue.put(node_id_timeout, self.msg, timeout)
+
+        with freeze_time(default_now() + datetime.timedelta(hours=2)):
+            waiting = frozenset(msg_queue.waiting())
+
+        self.assertEqual(
+            waiting,
+            set([
+                self.node_id,
+                node_id2
+            ]),
+        )
+
     def test_sweep(self):
         def put_explicit_now():
             instance = model.QueuedMessage.from_message(self.node_id, self.msg)
             # peewee/sqlite is freezegun resistant
-            instance.created_date = datetime.datetime.now()
+            instance.created_date = default_now()
             instance.save()
         put_explicit_now()
         msg_queue.sweep()
@@ -84,7 +126,7 @@ class TestMsqQueue(testutils.DatabaseFixture):
             model.QueuedMessage.select().count(),
             0,
         )
-        now = datetime.datetime.now()
+        now = default_now()
         with freeze_time(now-relativedelta(months=6, seconds=1)):
             put_explicit_now()
         msg_queue.sweep()
@@ -92,3 +134,16 @@ class TestMsqQueue(testutils.DatabaseFixture):
             model.QueuedMessage.select().count(),
             0,
         )
+    
+    @freeze_time()
+    def test_sweep_timeout(self):
+        timeout = datetime.timedelta(seconds=1)
+        msg_queue.put(self.node_id, self.msg)
+        msg_queue.put(self.node_id, self.msg, timeout)
+
+        msg_queue.sweep()
+        self.assertEqual(model.QueuedMessage.select().count(), 2)
+        with freeze_time(default_now() + datetime.timedelta(minutes=1)):
+            msg_queue.sweep()
+
+        self.assertEqual(model.QueuedMessage.select().count(), 1)

--- a/tests/golem/network/transport/test_msg_queue.py
+++ b/tests/golem/network/transport/test_msg_queue.py
@@ -134,7 +134,7 @@ class TestMsqQueue(testutils.DatabaseFixture):
             model.QueuedMessage.select().count(),
             0,
         )
-    
+
     @freeze_time()
     def test_sweep_timeout(self):
         timeout = datetime.timedelta(seconds=1)

--- a/tests/golem/task/server/test_resources.py
+++ b/tests/golem/task/server/test_resources.py
@@ -74,7 +74,8 @@ class TestResourceHandhsake(TestWithClient):
         if exception:
             raise Exception(exception)
 
-        mock_queue.assert_called_once_with(node_id=self.key_id, msg=mock.ANY)
+        mock_queue.assert_called_once_with(
+            node_id=self.key_id, msg=mock.ANY, timeout=mock.ANY)
 
     def test_start_handshake_nonce_errback(self, *_):
         deferred = Deferred()


### PR DESCRIPTION
Adds a deadline field to the the database model QueuedMessage. Extends
message queue logic to discard messages which are past their deadline.
When putting new messages to the queue an optional timeout parameter
can be specified. A message's deadline is derived from this timeout.

This change also adds a timeout for ResourceHandshakeStart and
WantToComputeTask messages.

fixes: #5105 