### PR TITLE
Fix sorting order in surge detector hottest_args

### DIFF
--- a/golem/decorators.py
+++ b/golem/decorators.py
@@ -61,6 +61,7 @@ def surge_detector(timeout: datetime.timedelta, treshold: int):
                 hottest_args = sorted(
                     [item for item in calls_counters.items()],
                     key=lambda item: item[1],
+                    reverse=True,
                 )[0]
                 log.warning(
                     "Invocation surge detected. func=%s, hottest_args=%s",


### PR DESCRIPTION
The surge_detector decorator includes reporting of most used arguments
for a given surged call. These arguments were being sorted in ascending
order based on the number of calls, resulting in the least used argument
being incorrectly reported. This changes the sorting order to
descending.