### PR TITLE
Use environment Docker tags in tests

### DIFF
--- a/tests/golem/docker/test_blender_job.py
+++ b/tests/golem/docker/test_blender_job.py
@@ -2,6 +2,7 @@ import os
 import pathlib
 import shutil
 
+from apps.blender.blenderenvironment import BlenderEnvironment
 from golem.core.common import get_golem_path
 from golem.docker.job import DockerJob
 from .test_docker_job import TestDockerJob
@@ -14,7 +15,7 @@ class TestBlenderDockerJob(TestDockerJob):
         return "golemfactory/blender"
 
     def _get_test_tag(self):
-        return "1.10"
+        return BlenderEnvironment.DOCKER_TAG
 
     def test_blender_job(self):
         # copy the scene file to the resources dir

--- a/tests/golem/docker/test_dummy_job.py
+++ b/tests/golem/docker/test_dummy_job.py
@@ -2,6 +2,7 @@ import os
 import shutil
 from os import path
 
+from apps.dummy.dummyenvironment import DummyTaskEnvironment
 from golem.core.common import get_golem_path
 from golem.tools.ci import ci_skip
 from .test_docker_job import TestDockerJob
@@ -15,7 +16,7 @@ class TestDummyTaskDockerJob(TestDockerJob):
         return "golemfactory/dummy"
 
     def _get_test_tag(self):
-        return "1.3"
+        return DummyTaskEnvironment.DOCKER_TAG
 
     def test_dummytask_job(self):
         os.mkdir(os.path.join(self.resources_dir, "data"))


### PR DESCRIPTION
Replaces hardcoded Docker tags in job tests with tags taken from their respective `Environment` classes.