### PR TITLE
Use subtask timeout status in taskmanager

### DIFF
--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -924,7 +924,7 @@ class TaskManager(TaskEventListener):
                         logger.info("Subtask %r dies with status %r",
                                     s.subtask_id,
                                     s.status.value)
-                        s.status = SubtaskStatus.failure
+                        s.status = SubtaskStatus.timeout
                         nodes_with_timeouts.append(s.node_id)
                         t.computation_failed(s.subtask_id)
                         s.stderr = "[GOLEM] Timeout"

--- a/tests/golem/task/test_taskmanager.py
+++ b/tests/golem/task/test_taskmanager.py
@@ -839,7 +839,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
             )
             self.assertIs(
                 task_state.subtask_states["aabbcc"].status,
-                SubtaskStatus.failure,
+                SubtaskStatus.timeout,
             )
         # Task with task and subtask timeout
         with patch('golem.task.taskbase.Task.needs_computation',
@@ -869,7 +869,7 @@ class TestTaskManager(LogTestCase, TestDatabaseWithReactor,  # noqa # pylint: di
             )
             self.assertIs(
                 task_state.subtask_states["qwerty"].status,
-                SubtaskStatus.failure,
+                SubtaskStatus.timeout,
             )
             checker([("qwe", "qwerty", SubtaskOp.TIMEOUT),
                      ("qwe", None, TaskOp.TIMEOUT)])


### PR DESCRIPTION
Part of: https://github.com/golemfactory/golem/pull/5136
Updates the legacy taskmanager to use `SubtaskStatus.timeout` instead of `failure` for subtasks which have timed out.