### PR TITLE
Set correct state when creating task with no funds

### DIFF
--- a/golem/ethereum/exceptions.py
+++ b/golem/ethereum/exceptions.py
@@ -42,7 +42,7 @@ class NotEnoughFunds(EthereumError):
         ])
 
     def __str__(self) -> str:
-        return "Not enough funds available.\n" + self._missing_funds_to_str()
+        return "Not enough funds available." + self._missing_funds_to_str()
 
     def to_dict(self) -> dict:
         err_dict = super().to_dict()
@@ -54,15 +54,15 @@ class NotEnoughFunds(EthereumError):
     def _missing_funds_to_str(self) -> str:
         res = ""
         for required, available, currency in self.missing_funds:
-            res += f"Required {currency}: {required / denoms.ether:f}, " \
-                f"available: {available / denoms.ether:f}\n"
+            res += f" Required {currency}: {required / denoms.ether:f}, " \
+                f"available: {available / denoms.ether:f}."
 
         return res
 
 
 class NotEnoughDepositFunds(NotEnoughFunds):
     def __str__(self) -> str:
-        return "Not enough funds for Concent deposit." \
+        return "Not enough funds for Concent deposit. " \
                "Top up your account or create the task with Concent disabled." \
                + self._missing_funds_to_str()
 

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -530,7 +530,8 @@ class ClientProvider:
             self,
             task_dict: dict,
             force: bool = False,
-    ) -> typing.Tuple[TaskId, typing.Optional[str]]:
+    ) -> typing.Tuple[typing.Optional[TaskId],
+            typing.Optional[typing.Union[str, typing.Dict]]]:
         logger.info('Creating task. task_dict=%r', task_dict)
         logger.debug('force=%r', force)
 

--- a/golem/task/rpc.py
+++ b/golem/task/rpc.py
@@ -531,7 +531,7 @@ class ClientProvider:
             task_dict: dict,
             force: bool = False,
     ) -> typing.Tuple[typing.Optional[TaskId],
-            typing.Optional[typing.Union[str, typing.Dict]]]:
+                      typing.Optional[typing.Union[str, typing.Dict]]]:
         logger.info('Creating task. task_dict=%r', task_dict)
         logger.debug('force=%r', force)
 

--- a/golem/task/taskmanager.py
+++ b/golem/task/taskmanager.py
@@ -994,7 +994,6 @@ class TaskManager(TaskEventListener):
             task_status=TaskStatus.errorCreating,
     ) -> None:
         assert not task_status.is_active()
-        assert not task_status.is_completed()
         task_state = self.tasks_states[task_id]
         if task_state.status.is_completed():
             logger.debug(

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -197,7 +197,7 @@ TASK_STATUS_COMPLETED = [
     TaskStatus.aborted,
     TaskStatus.timeout,
     TaskStatus.restarted,
-    TaskStatus.errorCreating
+    TaskStatus.errorCreating,
 ]
 
 

--- a/golem/task/taskstate.py
+++ b/golem/task/taskstate.py
@@ -196,7 +196,8 @@ TASK_STATUS_COMPLETED = [
     TaskStatus.finished,
     TaskStatus.aborted,
     TaskStatus.timeout,
-    TaskStatus.restarted
+    TaskStatus.restarted,
+    TaskStatus.errorCreating
 ]
 
 

--- a/tests/golem/ethereum/test_exceptions.py
+++ b/tests/golem/ethereum/test_exceptions.py
@@ -14,8 +14,8 @@ class TestNotEnoughFunds(TestCase):
                 currency='GNT'
             )
         except NotEnoughFunds as err:
-            expected = f'Not enough funds available.\n' \
-                f'Required GNT: 5.000000, available: 1.000000\n'
+            expected = f'Not enough funds available. ' \
+                f'Required GNT: 5.000000, available: 1.000000.'
             self.assertIn(str(err), expected)
 
     def test_error_message_multiple_currencies(self):
@@ -35,9 +35,9 @@ class TestNotEnoughFunds(TestCase):
         try:
             raise NotEnoughFunds(missing_funds)
         except NotEnoughFunds as err:
-            expected = f'Not enough funds available.\n' \
-                f'Required ETH: 5.000000, available: 1.000000\n' \
-                f'Required GNT: 1.000000, available: 0.000000\n'
+            expected = f'Not enough funds available. ' \
+                f'Required ETH: 5.000000, available: 1.000000. ' \
+                f'Required GNT: 1.000000, available: 0.000000.'
             self.assertIn(str(err), expected)
 
     def test_error_to_dict(self):

--- a/tests/golem/task/test_rpc.py
+++ b/tests/golem/task/test_rpc.py
@@ -205,9 +205,9 @@ class TestCreateTask(ProviderBase, TestClientBase):
         error = result[1]
         # noqa pylint:disable=unsubscriptable-object
         self.assertEqual(error['error_type'], 'NotEnoughFunds')
-        self.assertEqual(error['error_msg'], 'Not enough funds available.\n'
+        self.assertEqual(error['error_msg'], 'Not enough funds available. '
                                              'Required GNT: '
-                                             '0.166667, available: 0.000000\n')
+                                             '0.166667, available: 0.000000.')
 
     @mock.patch('golem.task.rpc.ClientProvider.'
                 '_validate_enough_funds_to_pay_for_task')
@@ -277,11 +277,11 @@ class ConcentDepositLockPossibilityTest(unittest.TestCase):
                 subtask_price=required_gnt,
                 subtask_count=1
             )
-        expected = f'Not enough funds available.\n' \
+        expected = f'Not enough funds available. ' \
             f'Required GNT: {required_gnt / denoms.ether:f}, ' \
-            f'available: {available_gnt / denoms.ether:f}\n' \
+            f'available: {available_gnt / denoms.ether:f}. ' \
             f'Required ETH: {required_eth / denoms.ether:f}, ' \
-            f'available: {available_eth / denoms.ether:f}\n'
+            f'available: {available_eth / denoms.ether:f}. '
         self.assertIn(str(e.exception), expected)
 
 


### PR DESCRIPTION
Resolves: https://github.com/golemfactory/golem/issues/5012

When task creation fails due to insufficient funds, the task's state is
now set to errorCreating. This commit also changes that state to be
considered final.