### PR TITLE
Moved slogger fix for ethereum package to SCI

### DIFF
--- a/golemapp.py
+++ b/golemapp.py
@@ -10,7 +10,6 @@ import click
 import humanize
 import psutil
 from cpuinfo import get_cpu_info
-from ethereum import slogging
 from portalocker import Lock, LockException
 
 # Export pbr version for peewee_migrate user
@@ -34,19 +33,6 @@ from golem.rpc import (  # noqa
 )
 
 logger = logging.getLogger('golemapp')  # using __name__ gives '__main__' here
-
-# ethereum.slogging and logging compatibility patch
-orig_getLogger = slogging.SManager.getLogger
-
-
-def monkey_patched_getLogger(*args, **kwargs):
-    orig_class = logging.getLoggerClass()
-    result = orig_getLogger(*args, **kwargs)
-    logging.setLoggerClass(orig_class)
-    return result
-
-
-slogging.SManager.getLogger = monkey_patched_getLogger
 
 
 @click.command()

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ fasteners==0.15
 flatbuffers==1.11
 fs==2.4.4
 Golem-Messages==3.15.0
-Golem-Smart-Contracts-Interface==1.11.1
+Golem-Smart-Contracts-Interface==1.11.2
 Golem-Task-Api==0.24.5
 greenlet==0.4.15
 grpclib==0.2.4

--- a/requirements_to-freeze.txt
+++ b/requirements_to-freeze.txt
@@ -20,7 +20,7 @@ enforce==0.3.4
 eth-utils==1.0.3
 ethereum==1.6.1
 Golem-Messages==3.15.0
-Golem-Smart-Contracts-Interface==1.11.1
+Golem-Smart-Contracts-Interface==1.11.2
 Golem-Task-Api==0.24.5
 html2text==2018.1.9
 humanize==0.5.1


### PR DESCRIPTION
this hack was called too late, disabling unfortunate loggers in our project.

Moved it before the first import of `ethereum` inside golem_sci