### PR TITLE
add node name from nodeskeeper to subtask

### DIFF
--- a/golem/task/tasksession.py
+++ b/golem/task/tasksession.py
@@ -490,12 +490,15 @@ class TaskSession(BasicSafeSession, ResourceHandshakeSessionMixin):
                 self.requested_task_manager.has_pending_subtasks(task_id))
             if not has_pending_subtasks:
                 return None
-
+            node_name = ''
+            node_info = nodeskeeper.get(self.key_id)
+            if node_info and node_info.node_name:
+                node_name = node_info.node_name
             subtask_definition = yield deferred.deferred_from_future(
                 self.requested_task_manager.get_next_subtask(
                     task_id=task_id,
                     computing_node=ComputingNodeDefinition(
-                        name='',  # FIXME: Provide proper node name
+                        name=node_name,
                         node_id=self.key_id
                     )
                 ))

--- a/tests/golem/task/test_tasksession_task_api.py
+++ b/tests/golem/task/test_tasksession_task_api.py
@@ -96,6 +96,7 @@ class TestTaskApiReactToWantToComputeTask(TwistedAsyncioTestCase):
             shared_resources.append(return_value)
             return defer.succeed(return_value)
         self.resource_manager.share.side_effect = _share
+        tasksession.nodeskeeper.get = mock.Mock(return_value=None)
 
         yield self.ts._offer_chosen(True, self.wtct)
 


### PR DESCRIPTION
fixes the issue:

```
task-api subtasks had no node_name in some CLI commands
```