### PR TITLE
show Task API tasks in provider stats

### DIFF
--- a/golem/manager/nodestatesnapshot.py
+++ b/golem/manager/nodestatesnapshot.py
@@ -38,7 +38,7 @@ class ComputingSubtaskStateSnapshot:
         self.running_time_seconds = running_time_seconds
         self.outfilebasename = outfilebasename
         self.output_format = output_format
-        self.scene_file = Path(scene_file).name
+        self.scene_file = Path(scene_file).name if scene_file else None
         self.frames = copy(frames)
         self.start_task = start_task
         self.total_tasks = total_tasks

--- a/tests/golem/task/test_taskcomputeradapter.py
+++ b/tests/golem/task/test_taskcomputeradapter.py
@@ -234,10 +234,20 @@ class TestCheckTimeout(TaskComputerAdapterTestBase):
 class TestGetProgress(TaskComputerAdapterTestBase):
 
     def test_no_assigned_task(self):
+        self.new_computer.has_assigned_task.return_value = False
         self.old_computer.has_assigned_task.return_value = False
         self.assertIsNone(self.adapter.get_progress())
 
+    def test_assigned_new_task(self):
+        self.new_computer.has_assigned_task.return_value = True
+        self.old_computer.has_assigned_task.return_value = False
+        self.assertIs(
+            self.adapter.get_progress(),
+            self.new_computer.get_progress()
+        )
+
     def test_assigned_old_task(self):
+        self.new_computer.has_assigned_task.return_value = False
         self.old_computer.has_assigned_task.return_value = True
         self.assertIs(
             self.adapter.get_progress(),


### PR DESCRIPTION
Progress is always 0, but at least it's something.

I need it for an upcoming integration test, where I need to know when provider is computing a Task API task.