### PR TITLE
fix can not serialize 'ABCMeta' object

### DIFF
--- a/golem/apps/__init__.py
+++ b/golem/apps/__init__.py
@@ -57,6 +57,9 @@ class AppDefinition:
     def to_json(self) -> str:
         raise NotImplementedError  # A stub to silence the linters
 
+    def to_dict(self) -> Any:
+        raise NotImplementedError  # A stub to silence the linters
+
 
 def save_app_to_json_file(app_def: AppDefinition, json_file: Path) -> None:
     """ Save application definition to the given file in JSON format.

--- a/golem/apps/manager.py
+++ b/golem/apps/manager.py
@@ -2,7 +2,6 @@ import logging
 from typing import Dict, List, Tuple
 from pathlib import Path
 
-from dataclasses import asdict
 from requests.exceptions import RequestException
 
 from golem.apps import (
@@ -116,7 +115,7 @@ class AppManager:
                 app_file_path = self.app_dir / app_json_file_name(app)
                 self._app_file_names[app.id] = app_file_path
 
-            EventPublisher.publish(App.evt_new_definiton, asdict(app))
+            EventPublisher.publish(App.evt_new_definiton, app.to_dict())
 
 
 class AppStates:


### PR DESCRIPTION
to_dict method is added by dataclass_json decorator. Unlike asdict
from dataclass package, It uses metadata config encoders and
decoders.

fixes #5118