### PR TITLE
Fix default benchmark reported value

### DIFF
--- a/golem/task/benchmarkmanager.py
+++ b/golem/task/benchmarkmanager.py
@@ -139,10 +139,13 @@ class BenchmarkManager(object):
 
     @staticmethod
     def run_default_benchmark(callback, errback):
-        kwargs = {'func': DefaultEnvironment.run_default_benchmark,
-                  'callback': callback,
-                  'errback': errback,
-                  'save': True}
+        kwargs = {
+            'func': lambda **kwargs: DefaultEnvironment.run_default_benchmark(
+                **kwargs).performance,
+            'callback': callback,
+            'errback': errback,
+            'save': True
+        }
         Thread(target=callback_wrapper, kwargs=kwargs).start()
 
 


### PR DESCRIPTION
When running a benchmark via RPC (`comp.environment.benchmark`), the result reported back to the client (CLI or Electron app) is expected to be a single floating-point value being the performance rating.

In the case of the default benchmark a `BenchmarkResult` object was being returned, resulting in WAMP message serialization failing. This changes the default benchmark callback to return the underlying `performance` value.