### PR TITLE
docs: fix simple typo, wheter -> whether

### DIFF
--- a/golem/network/concent/handlers_library.py
+++ b/golem/network/concent/handlers_library.py
@@ -44,7 +44,7 @@ class HandlersLibrary():
             except KeyError:
                 pass
 
-            # It check wheter f is boundmethod not method/class function
+            # It check whether f is boundmethod not method/class function
             ref: typing.Optional[weakref.ref] = None
             if inspect.ismethod(f):
                 ref = weakref.WeakMethod(f)


### PR DESCRIPTION
There is a small typo in golem/network/concent/handlers_library.py.

Should read `whether` rather than `wheter`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md